### PR TITLE
feate(file): Adicionando terraform ao pacote de detect file.

### DIFF
--- a/utils/file_utils.go
+++ b/utils/file_utils.go
@@ -40,7 +40,7 @@ func DefaultDirectoryScanOptions(logger *zap.Logger) DirectoryScanOptions {
 			".go", ".py", ".js", ".ts", ".jsx", ".tsx", ".java", ".c", ".cpp", ".h", ".hpp",
 			".cs", ".rb", ".php", ".html", ".css", ".scss", ".less", ".json", ".xml", ".yaml",
 			".yml", ".md", ".txt", ".sql", ".sh", ".bash", ".zsh", ".env", ".toml", ".ini",
-			".config", ".rs", ".dart", ".swift", ".kt", ".groovy", ".scala", ".pl", ".pm",
+			".config", ".rs", ".dart", ".swift", ".kt", ".groovy", ".scala", ".pl", ".pm", ".tf",
 		},
 		ExcludeDirs: []string{
 			".git", "node_modules", "vendor", "build", "dist", "target",
@@ -61,6 +61,7 @@ func DefaultDirectoryScanOptions(logger *zap.Logger) DirectoryScanOptions {
 func DetectFileType(filePath string) string {
 	fileTypes := map[string]string{
 		".go":     "Go",
+		".tf":     "Terraform",
 		".py":     "Python",
 		".js":     "JavaScript",
 		".ts":     "TypeScript",
@@ -393,7 +394,7 @@ func isCodeFile(fileType string) bool {
 // Retorna o identificador de linguagem para code fences do markdown
 func getLanguageIdentifier(fileType string) string {
 	identifiers := map[string]string{
-		"Go": "go", "Python": "python", "JavaScript": "javascript",
+		"Go": "go", "Terraform": "hcl", "Python": "python", "JavaScript": "javascript",
 		"TypeScript": "typescript", "React JSX": "jsx", "React TSX": "tsx",
 		"Java": "java", "C": "c", "C++": "cpp", "C Header": "c",
 		"C++ Header": "cpp", "C#": "csharp", "Ruby": "ruby",


### PR DESCRIPTION
  ## Nova funcionalidade
  
  Com essas modificações, o usuário agora pode:
  
  1. Carregar um único arquivo:  @file path/to/file.go 
  2. Carregar um diretório inteiro:  @file path/to/directory 
  3. Carregar múltiplos arquivos/diretórios:  @file path1 @file path2 
  
  O sistema irá:
  
  • Processar recursivamente pastas
  • Filtrar arquivos por extensão (mostrando apenas arquivos de código e texto)
  • Limitar o tamanho total para evitar sobrecarregar o modelo LLM
  • Formatar o output de forma organizada e estruturada
  • Mostrar o progresso durante o processamento
  
  ## Observações e Considerações Técnicas
  
  1. Desempenho: Implementei processamento paralelo com goroutines para lidar eficientemente com diretórios grandes.
  2. Limites: Adicionei limites inteligentes para evitar enviar muito conteúdo ao LLM:
    • Número máximo de arquivos (100 por padrão)
    • Tamanho máximo total (10MB por padrão)
  3. Usabilidade: Implementei feedback visual durante o processamento para melhorar a experiência do usuário.
  4. Robustez: A solução:
    • Lida com erros de forma elegante
    • Ignora arquivos binários e diretórios irrelevantes (node_modules, .git, etc.)
    • Trunca conteúdo quando necessário, indicando quando isso ocorre
  5. Extensibilidade: As opções de configuração permitem personalizar facilmente:
    • Quais extensões incluir
    • Quais diretórios excluir
    • Padrões de arquivo a ignorar
  
  
  Esta solução equilibra performance e usabilidade, fornecendo uma experiência robusta ao lidar com projetos de qualquer tamanho, seguindo as boas práticas de desenvolvimento Go.