### PR TITLE
feat: centraliza valores padrão e padroniza notificações de configura…

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ O ChatCLI agora suporta o ClaudeAI como um provedor adicional de LLM. Veja como 
 - **Geral**:
     - `LOG_LEVEL` - (Opcional) Define o nível de log (`debug`, `info`, `warn`, `error`). Padrão é `info`.
     - `ENV` - (Opcional) Define o ambiente (`prod` para produção, caso contrário, padrão é `dev` desenvolvimento) - Essencial pois muda a forma que o log transacional e exibido no terminal.
-    - `LLM_PROVIDER` - (Opacional) Especifica o provedor de LLM padrão (`OPENAI`, `STACKSPOT` ou `CLAUDEAI`). Padrão é `STACKSPOT`.
+    - `LLM_PROVIDER` - (Opacional) Especifica o provedor de LLM padrão (`OPENAI`, `STACKSPOT` ou `CLAUDEAI`). Padrão é `OPENAI`.
     - `LOG_FILE` - (Opcional) Define o nome do arquivo de log. Padrão é `app.log`.
     - `LOG_MAX_SIZE` (Opacional) Define o tamanho maximo do log antes de realizar o backup (`3`) ao maximo por `28` dias, padrão É `50MB`, pode usar escala de MB KB GB, ex: 10MB, 500KB, 1GB.
     - `HISTORY_MAX_SIZE` - (Opcional) Define o tamanho do historico de comandos do chat `.chatcli_history` padrão é `50MB`, pode usar escala de MB KB GB, ex: 10MB, 500KB, 1GB.

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"github.com/diillson/chatcli/config"
 	"github.com/diillson/chatcli/llm/client"
 	"github.com/diillson/chatcli/llm/manager"
 	"github.com/joho/godotenv"
@@ -21,14 +22,6 @@ import (
 	"github.com/charmbracelet/glamour"
 	"github.com/peterh/liner"
 	"go.uber.org/zap"
-)
-
-const (
-	llmdDefault          = "STACKSPOT"
-	defaultSlugName      = "testeai"
-	defaultTenantName    = "zup"
-	defaultClaudeAIModel = "claude-3-5-sonnet-20241022"
-	defaultOpenAIModel   = "gpt-4o-mini"
 )
 
 // Logger interface para facilitar a testabilidade
@@ -108,7 +101,7 @@ func (cli *ChatCLI) reloadConfiguration() {
 	cli.reconfigureLogger()
 
 	// Recarregar a configuração do LLMManager
-	utils.CheckEnvVariables(cli.logger, defaultSlugName, defaultTenantName)
+	utils.CheckEnvVariables(cli.logger)
 
 	manager, err := manager.NewLLMManager(cli.logger, os.Getenv("SLUG_NAME"), os.Getenv("TENANT_NAME"))
 	if err != nil {
@@ -132,18 +125,18 @@ func (cli *ChatCLI) reloadConfiguration() {
 func (cli *ChatCLI) configureProviderAndModel() {
 	cli.provider = os.Getenv("LLM_PROVIDER")
 	if cli.provider == "" {
-		cli.provider = "STACKSPOT" // Usar padrão se não estiver definido
+		cli.provider = config.DefaultLLMProvider
 	}
 	if cli.provider == "OPENAI" {
 		cli.model = os.Getenv("OPENAI_MODEL")
 		if cli.model == "" {
-			cli.model = defaultOpenAIModel
+			cli.model = config.DefaultOpenAIModel
 		}
 	}
 	if cli.provider == "CLAUDEAI" {
 		cli.model = os.Getenv("CLAUDEAI_MODEL")
 		if cli.model == "" {
-			cli.model = defaultClaudeAIModel
+			cli.model = config.DefaultClaudeAIModel
 		}
 	}
 }
@@ -416,11 +409,11 @@ func (cli *ChatCLI) switchProvider() {
 	newProvider := availableProviders[choiceIndex]
 	var newModel string
 	if newProvider == "OPENAI" {
-		newModel = utils.GetEnvOrDefault("OPENAI_MODEL", defaultOpenAIModel)
+		newModel = utils.GetEnvOrDefault("OPENAI_MODEL", config.DefaultOpenAIModel)
 	}
 
 	if newProvider == "CLAUDEAI" {
-		newModel = utils.GetEnvOrDefault("CLAUDEAI_MODEL", defaultClaudeAIModel)
+		newModel = utils.GetEnvOrDefault("CLAUDEAI_MODEL", config.DefaultClaudeAIModel)
 	}
 
 	newClient, err := cli.manager.GetClient(newProvider, newModel)

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -1,0 +1,15 @@
+package config
+
+// Valores padrão para configuração da aplicação
+const (
+	// Valores padrão para StackSpot
+	DefaultSlugName   = "testeai"
+	DefaultTenantName = "zup"
+
+	// Valores padrão para modelos LLM
+	DefaultOpenAIModel   = "gpt-4o-mini"
+	DefaultClaudeAIModel = "claude-3-5-sonnet-20241022"
+
+	// Provedor padrão
+	DefaultLLMProvider = "OPENAI"
+)

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/diillson/chatcli/config"
 	"github.com/diillson/chatcli/llm/manager"
 	"os"
 	"os/signal"
@@ -12,11 +13,6 @@ import (
 	"github.com/diillson/chatcli/utils"
 	"github.com/joho/godotenv"
 	"go.uber.org/zap"
-)
-
-const (
-	defaultSlugName   = "testeai"
-	defaultTenantName = "zup"
 )
 
 func main() {
@@ -51,11 +47,10 @@ func main() {
 	handleGracefulShutdown(cancel, logger)
 
 	// Verificar variáveis de ambiente e informar o usuário
-	utils.CheckEnvVariables(logger, defaultSlugName, defaultTenantName)
-
-	// Inicializar o LLMManager
-	slugName := utils.GetEnvOrDefault("SLUG_NAME", defaultSlugName)
-	tenantName := utils.GetEnvOrDefault("TENANT_NAME", defaultTenantName)
+	utils.CheckEnvVariables(logger)
+	// Inicializar o LLMManager com as constantes do pacote config
+	slugName := utils.GetEnvOrDefault("SLUG_NAME", config.DefaultSlugName)
+	tenantName := utils.GetEnvOrDefault("TENANT_NAME", config.DefaultTenantName)
 	manager, err := manager.NewLLMManager(logger, slugName, tenantName)
 	if err != nil {
 		logger.Fatal("Erro ao inicializar o LLMManager", zap.Error(err))

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"bytes"
 	"fmt"
+	"github.com/diillson/chatcli/config"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 	"golang.org/x/term"
@@ -52,10 +53,10 @@ func GetTerminalSize() (width int, height int, err error) {
 }
 
 // CheckEnvVariables verifica as variáveis de ambiente necessárias e informa o usuário
-func CheckEnvVariables(logger *zap.Logger, defaultSlugName, defaultTenantName string) {
+func CheckEnvVariables(logger *zap.Logger) {
 	// Verificar SLUG_NAME e TENANT_NAME
-	slugName, slugIsDefault := CheckAndNotifyEnv("SLUG_NAME", defaultSlugName, logger)
-	tenantName, tenantIsDefault := CheckAndNotifyEnv("TENANT_NAME", defaultTenantName, logger)
+	slugName, slugIsDefault := CheckAndNotifyEnv("SLUG_NAME", config.DefaultSlugName, logger)
+	tenantName, tenantIsDefault := CheckAndNotifyEnv("TENANT_NAME", config.DefaultTenantName, logger)
 	if slugIsDefault || tenantIsDefault {
 		fmt.Println("ATENÇÃO: Variáveis de ambiente não definidas, usando valores padrão:")
 		if slugIsDefault {
@@ -75,6 +76,7 @@ func CheckProviderEnvVariables(logger *zap.Logger) {
 	// Verificar STACKSPOT
 	clientID := os.Getenv("CLIENT_ID")
 	clientSecret := os.Getenv("CLIENT_SECRET")
+
 	if clientID == "" || clientSecret == "" {
 		fmt.Println("ATENÇÃO: Variáveis de ambiente necessárias para o provedor STACKSPOT não foram definidas:")
 		if clientID == "" {
@@ -88,12 +90,21 @@ func CheckProviderEnvVariables(logger *zap.Logger) {
 
 	// Verificar OPENAI
 	openAIKey := os.Getenv("OPENAI_API_KEY")
+	openAIModel := os.Getenv("OPENAI_MODEL")
 	if openAIKey == "" {
 		fmt.Println("ATENÇÃO: OPENAI_API_KEY não definida, o provedor OPENAI não estará disponível.")
 	}
-	// Verificar OPENAI
+	if openAIModel == "" {
+		fmt.Printf("ATENÇÃO: OPENAI_MODEL não definido, usando valor padrão: %s\n", config.DefaultOpenAIModel)
+	}
+
+	// Verificar CLAUDEAI
 	claudeAIKey := os.Getenv("CLAUDEAI_API_KEY")
+	claudeAIModel := os.Getenv("CLAUDEAI_MODEL")
 	if claudeAIKey == "" {
 		fmt.Println("ATENÇÃO: CLAUDEAI_API_KEY não definida, o provedor CLAUDEAI não estará disponível.")
+	}
+	if claudeAIModel == "" {
+		fmt.Printf("ATENÇÃO: CLAUDEAI_MODEL não definido, usando valor padrão: %s\n", config.DefaultClaudeAIModel)
 	}
 }


### PR DESCRIPTION
# Padronização de Notificações e Centralização de Valores Padrão.
  
  ## 📝 Descrição
  
  Este PR implementa melhorias na forma como o ChatCLI gerencia seus valores padrão e notificações ao usuário, tornando a experiência mais consistente e o código mais manutenível.
  
  ### Problema Atual
  
  Atualmente, o ChatCLI apresenta comportamentos inconsistentes:
  
  • Para o provedor StackSpot, o sistema exibe alertas quando valores padrão são usados para  SLUG_NAME  e  TENANT_NAME 
  • Para OpenAI e ClaudeAI, os valores padrão para  OPENAI_MODEL  e  CLAUDEAI_MODEL  são aplicados silenciosamente
  • As constantes de valores padrão estão duplicadas em diferentes arquivos, dificultando a manutenção
  
  ### Solução Proposta
  
  1. Centralização de Configurações
    • Cria um pacote  config  único para armazenar todos os valores padrão
    • Elimina duplicação de constantes em arquivos diferentes
  2. Notificações Padronizadas
    • Agora todos os provedores (StackSpot, OpenAI e ClaudeAI) mostram mensagens consistentes quando valores padrão são utilizados
    • As notificações aparecem independentemente de qual provedor esteja configurado como padrão
  
  
  ## 🔄 Mudanças
  
  • Novo: Pacote  config/defaults.go  com todas as constantes padrão centralizadas
  • Modificado:  utils/utils.go  com verificação e notificação padronizada para todos os provedores
  • Modificado:  cli/cli.go  e  main.go  atualizados para usar as constantes do pacote  config 
  • Simplificado: Assinatura da função  CheckEnvVariables  agora recebe apenas o logger como parâmetro
  
  ## 📸 Antes/Depois
  
  Antes:
  
    ATENÇÃO: Variáveis de ambiente não definidas, usando valores padrão:
    - SLUG_NAME não definido, usando valor padrão: testeai
    - TENANT_NAME não definido, usando valor padrão: zup
  
  Depois:
  
    ATENÇÃO: Variáveis de ambiente não definidas, usando valores padrão:
    - SLUG_NAME não definido, usando valor padrão: testeai
    - TENANT_NAME não definido, usando valor padrão: zup
    ATENÇÃO: OPENAI_MODEL não definido, usando valor padrão: gpt-4o-mini
    ATENÇÃO: CLAUDEAI_MODEL não definido, usando valor padrão: claude-3-5-sonnet-20241022
  