### PR TITLE
develop

### DIFF
--- a/.github/workflows/3-release.yml
+++ b/.github/workflows/3-release.yml
@@ -22,15 +22,17 @@ jobs:
 
       - name: Build binaries
         run: |
-          # COMMIT=$(git rev-parse HEAD)
-          # BUILD_TIME=$(date -u +'%Y-%m-%d %H:%M:%S')
-          # LDFLAGS="-X 'github.com/diillson/chatcli/pkg/version.Commit=${COMMIT}' -X 'github.com/diillson/chatcli/pkg/version.BuildTime=${BUILD_TIME}'"
+          COMMIT_HASH=$(git rev-parse --short HEAD)
+          BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
+          LDFLAGS="-X 'github.com/diillson/chatcli/version.Version=${VERSION}' -X 'github.com/diillson/chatcli/version.CommitHash=${COMMIT_HASH}' -X 'github.com/diillson/chatcli/version.BuildDate=${BUILD_DATE}'"
           # Build para várias plataformas
-          GOOS=linux GOARCH=amd64 go build -o chatcli-linux-amd64 ./main.go
-          GOOS=darwin GOARCH=amd64 go build -o chatcli-darwin-amd64 ./main.go
-          GOOS=windows GOARCH=amd64 go build -o chatcli-windows-amd64.exe ./main.go
+          GOOS=linux GOARCH=amd64 go build -ldflags="${LDFLAGS}" -o chatcli-linux-amd64 ./main.go
+          GOOS=darwin GOARCH=amd64 go build -ldflags="${LDFLAGS}" -o chatcli-darwin-amd64 ./main.go
+          GOOS=darwin GOARCH=arm64 go build -ldflags="${LDFLAGS}" -o chatcli-darwin-arm64 ./main.go
+          GOOS=windows GOARCH=amd64 go build -ldflags="${LDFLAGS}" -o chatcli-windows-amd64.exe ./main.go
           # Verifica a versão do binário
-          # ./chatcli-linux-amd64 --version
+          ./chatcli-linux-amd64 --version
 
       - name: Create GitHub Release
         id: create_release
@@ -39,6 +41,7 @@ jobs:
           files: |
             chatcli-linux-amd64
             chatcli-darwin-amd64
+            chatcli-darwin-arm64
             chatcli-windows-amd64.exe
           draft: false
           prerelease: false

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+# Variáveis de versão
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+COMMIT_HASH ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# Flags para injetar informações de versão
+LD_FLAGS = -X github.com/diillson/chatcli/version.Version=$(VERSION) \
+		   -X github.com/diillson/chatcli/version.CommitHash=$(COMMIT_HASH) \
+		   -X github.com/diillson/chatcli/version.BuildDate=$(BUILD_DATE)
+
+.PHONY: build
+build:
+	go build -ldflags "$(LD_FLAGS)" -o bin/chatcli main.go
+
+.PHONY: install
+install:
+	go install -ldflags "$(LD_FLAGS)"
+
+.PHONY: test
+test:
+	go test ./...

--- a/README.md
+++ b/README.md
@@ -61,28 +61,45 @@ O **ChatCLI** é uma aplicação de linha de comando (CLI) avançada que integra
 
 1. **Clone o Repositório**:
 
-   ```bash
-   git clone https://github.com/diillson/chatcli.git
-   cd chatcli
-   ```
+```bash
+git clone https://github.com/diillson/chatcli.git
+cd chatcli
+```
 
 2. **Instale as Dependências**:
 
-   ```bash
-   go mod tidy
-   ```
+```bash
+go mod tidy
+```
 
 3. **Compile a Aplicação**:
 
-   ```bash
-   go build -o chatcli
-   ```
+```bash
+go build -o chatcli
+```
 
 4. **Execute a Aplicação**:
 
-   ```bash
-   ./chatcli
-   ```
+```bash
+./chatcli
+```
+#### Compilação com Informações de Versão
+
+Para compilar a aplicação com informações completas de versão:
+
+```bash
+VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
+COMMIT_HASH=$(git rev-parse --short HEAD)
+BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+go build -ldflags "\
+  -X github.com/diillson/chatcli/version.Version=${VERSION} \
+  -X github.com/diillson/chatcli/version.CommitHash=${COMMIT_HASH} \
+  -X github.com/diillson/chatcli/version.BuildDate=${BUILD_DATE}" \
+  -o chatcli main.go
+```
+Estas flags injetam informações de versão no binário, permitindo que o comando  /version  exiba dados precisos.
+   
 ### Instalação via Go Install (opcional)
 Para instalar o ChatCLI diretamente via Go, você pode usar o seguinte comando:
 
@@ -178,13 +195,17 @@ Após a instalação e configuração, o ChatCLI oferece uma série de comandos 
     - Combinações: `/switch --slugname <slug> --tenantname <tenant>`
     - `/reload` – Recarrega as variáveis de ambiente em tempo real.
 
-- **Ajuda**:
-    - `/help`
-
-#### Novo Comando: `/newsession`
 - **Iniciar uma Nova Sessão**:
     - `/newsession` – Limpa o histórico atual e inicia uma nova sessão de conversa.
     - **Uso**: Ideal para começar uma conversa do zero sem o contexto anterior, anteriormente recebia um clean no historico de conversa e contexto ao trocar de provider `LLM`, hoje é possível continuar a sessão em novo provider `LLM` sem perder o histórico anterior, com o comando `/newsession` você pode zerar o histórico e contexto atual e iniciar uma nova sessão de conversa no novo provider se assim desejar.
+
+- **Verificar Versão e Atualizações**:
+    - `/version` ou `/v` – Mostra a versão atual, o hash do commit e verifica se há atualizações disponíveis.
+    - **Uso**: Útil para confirmar qual versão está instalada e se há novas versões disponíveis.
+    - **Alternativa**: Execute `chatcli --version` ou `chatcli -v` diretamente do terminal.  
+
+- **Ajuda**:
+    - `/help`
 
 ### Comandos Contextuais
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -64,28 +64,45 @@
 
 1. **Clone the Repository:**
 
-   ```bash
-   git clone https://github.com/diillson/chatcli.git
-   cd chatcli
-   ```
+```bash
+git clone https://github.com/diillson/chatcli.git
+cd chatcli
+```
 
 2. **Install Dependencies:**
 
-   ```bash
-   go mod tidy
-   ```
+```bash
+go mod tidy
+```
 
 3. **Build the Application:**
 
-   ```bash
-   go build -o chatcli
-   ```
+```bash
+go build -o chatcli
+```
 
 4. **Run the Application:**
 
-   ```bash
-   ./chatcli
-   ```
+```bash
+./chatcli
+```
+
+#### Building with Version Information
+
+To compile the application with complete version information:
+
+```bash
+VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
+COMMIT_HASH=$(git rev-parse --short HEAD)
+BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+go build -ldflags "\
+  -X github.com/diillson/chatcli/version.Version=${VERSION} \
+  -X github.com/diillson/chatcli/version.CommitHash=${COMMIT_HASH} \
+  -X github.com/diillson/chatcli/version.BuildDate=${BUILD_DATE}" \
+  -o chatcli main.go
+```
+These flags inject version information into the binary, allowing the  /version  command to display accurate data.   
 
 ### Installation via Go Install (optional)
 To install ChatCLI directly via Go, you can use the following command:
@@ -189,17 +206,18 @@ Once installed and configured, ChatCLI offers a suite of commands for seamless L
     * Combine: `/switch --slugname <slug> --tenantname <tenant>`
     * `/reload` – Reload environment variables in real time.
 
+  * **Start a New Session**:
+      * `/newsession` – Clears the current history and starts a new conversation session.
+      * **Usage**: Ideal for starting a conversation from scratch without previous context. Previously, switching the `LLM` provider would automatically clean the conversation and context history. Now, it's possible to continue the session with a new `LLM` provider without losing the existing history. If desired, you can use the `/newsession` command to reset the current history and context and start a fresh conversation with the new provider.
+
+  * **Check Version and Updates:**
+      * `/version` or `/v` – Shows current version, commit hash, and checks for available updates.
+      * **Usage**: Useful to confirm which version is installed and if there are new versions available.
+      * **Alternative**: Run `chatcli --version` or `chatcli -v` directly from the terminal.
+
 * **Help:**
 
     * `/help`
-
-#### New Command: `/newsession`
-
-* **Start a New Session**:
-
-    * `/newsession` – Clears the current history and starts a new conversation session.
-    * **Usage**: Ideal for starting a conversation from scratch without previous context. Previously, switching the `LLM` provider would automatically clean the conversation and context history. Now, it's possible to continue the session with a new `LLM` provider without losing the existing history. If desired, you can use the `/newsession` command to reset the current history and context and start a fresh conversation with the new provider.
-  
 
 ### Contextual Commands
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -8,6 +8,7 @@ import (
 	"github.com/diillson/chatcli/llm/client"
 	"github.com/diillson/chatcli/llm/manager"
 	"github.com/diillson/chatcli/llm/openai_assistant"
+	"github.com/diillson/chatcli/version"
 	"github.com/joho/godotenv"
 	"os"
 	"os/exec"
@@ -465,6 +466,7 @@ func (cli *ChatCLI) showHelp() {
 	fmt.Println("/agent <consulta> - Inicia o modo agente que analisa e executa comandos para resolver sua tarefa")
 	fmt.Println("/run <consulta> - Alias para /agent")
 	fmt.Println("/newsession - Inicia uma nova sessão de conversa, limpando o histórico atual")
+	fmt.Println("/version ou /v - Mostra informações sobre a versão instalada e verifica por atualizações")
 	fmt.Printf("\n")
 }
 
@@ -1888,4 +1890,10 @@ func (cli *ChatCLI) typewriterEffect(text string, delay time.Duration) {
 
 		time.Sleep(delay) // Ajuste o delay conforme desejado
 	}
+}
+
+func (ch *CommandHandler) handleVersionCommand() {
+	versionInfo := version.GetCurrentVersion()
+	formattedInfo := version.FormatVersionInfo(versionInfo, true)
+	fmt.Println(formattedInfo)
 }

--- a/cli/command_handler.go
+++ b/cli/command_handler.go
@@ -33,6 +33,9 @@ func (ch *CommandHandler) HandleCommand(userInput string) bool {
 	case userInput == "/help":
 		ch.cli.showHelp()
 		return false
+	case userInput == "/version" || userInput == "/v":
+		ch.handleVersionCommand()
+		return false
 	case userInput == "/nextchunk":
 		return ch.cli.handleNextChunk()
 	case userInput == "/retry":

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/diillson/chatcli/config"
 	"github.com/diillson/chatcli/llm/manager"
+	"github.com/diillson/chatcli/version"
 	"os"
 	"os/signal"
 	"syscall"
@@ -16,6 +17,13 @@ import (
 )
 
 func main() {
+	// Exibir versão se especificado como argumento
+	if len(os.Args) > 1 && (os.Args[1] == "--version" || os.Args[1] == "-v") {
+		versionInfo := version.GetCurrentVersion()
+		fmt.Println(version.FormatVersionInfo(versionInfo, true))
+		return
+	}
+
 	// Carregar variáveis de ambiente do arquivo .env
 	envFilePath := os.Getenv("CHATCLI_DOTENV")
 	if envFilePath == "" {

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,186 @@
+package version
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"runtime/debug"
+	"strings"
+	"time"
+)
+
+var (
+	// Essas variáveis serão preenchidas durante a compilação via ldflags
+	Version    = "dev"
+	CommitHash = "unknown"
+	BuildDate  = "unknown"
+
+	// URL para verificar a versão mais recente (GitHub API)
+	LatestVersionURL = "https://api.github.com/repos/diillson/chatcli/releases/latest"
+)
+
+// Info retorna informações estruturadas sobre a versão atual
+type VersionInfo struct {
+	Version    string `json:"version"`
+	CommitHash string `json:"commit_hash"`
+	BuildDate  string `json:"build_date"`
+}
+
+// GetCurrentVersion retorna as informações de versão atuais
+func GetCurrentVersion() VersionInfo {
+	return VersionInfo{
+		Version:    Version,
+		CommitHash: CommitHash,
+		BuildDate:  BuildDate,
+	}
+}
+
+// CheckLatestVersion verifica a versão mais recente disponível no GitHub
+// Retorna a versão mais recente e um booleano indicando se há uma atualização disponível
+func CheckLatestVersion() (string, bool, error) {
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	req, err := http.NewRequest("GET", LatestVersionURL, nil)
+	if err != nil {
+		return "", false, err
+	}
+
+	// Adicionar User-Agent para evitar problemas com a API do GitHub
+	req.Header.Set("User-Agent", "ChatCLI-Version-Checker")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", false, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", false, fmt.Errorf("erro ao verificar versão: status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", false, err
+	}
+
+	var releaseInfo struct {
+		TagName string `json:"tag_name"`
+	}
+
+	if err := json.Unmarshal(body, &releaseInfo); err != nil {
+		return "", false, err
+	}
+
+	// Remover 'v' do início da tag, se houver
+	latestVersion := strings.TrimPrefix(releaseInfo.TagName, "v")
+
+	// Extrai apenas a parte da tag da versão atual
+	// Para transformar algo como "v1.9.0-5-g1b6ecaa-dirty" em "1.9.0"
+	currentVersionBase := Version
+	if strings.Contains(Version, "-") {
+		parts := strings.Split(Version, "-")
+		currentVersionBase = strings.TrimPrefix(parts[0], "v")
+	} else {
+		currentVersionBase = strings.TrimPrefix(Version, "v")
+	}
+
+	// Verifique se estamos em um commit específico (dev build)
+	isDev := Version == "dev" || strings.Contains(Version, "-dirty") || strings.Contains(Version, "-g")
+
+	// Compara versões (simplificado - para uma comparação mais robusta,
+	// considere usar um pacote como "github.com/hashicorp/go-version")
+
+	// Se estamos em modo dev, só indica atualização se a versão base for diferente
+	if isDev {
+		// Se a versão base (como 1.9.0) for exatamente igual à última, não há atualização
+		// pois estamos provavelmente trabalhando na próxima versão
+		return latestVersion, currentVersionBase != latestVersion, nil
+	}
+
+	// Para versões de lançamento estáveis, comparação direta
+	needsUpdate := currentVersionBase != latestVersion
+
+	return latestVersion, needsUpdate, nil
+}
+
+// FormatVersionInfo retorna uma string formatada com as informações de versão
+func FormatVersionInfo(info VersionInfo, includeLatest bool) string {
+	var result strings.Builder
+
+	// Obter informações de build de forma mais robusta
+	version, commitHash, buildDate := GetBuildInfo()
+
+	result.WriteString(fmt.Sprintf("📊 ChatCLI Versão: %s\n", version))
+	result.WriteString(fmt.Sprintf("📌 Commit: %s\n", commitHash))
+
+	if buildDate == "unknown" {
+		// Se ainda não temos a data de build, usar a data de modificação do executável
+		if execPath, err := os.Executable(); err == nil {
+			if info, err := os.Stat(execPath); err == nil {
+				modTime := info.ModTime()
+				buildDate = fmt.Sprintf("%s (aproximado pela data do binário)",
+					modTime.Format("2006-01-02 15:04:05"))
+			}
+		}
+	}
+
+	result.WriteString(fmt.Sprintf("🕒 Build: %s\n", buildDate))
+
+	if includeLatest {
+		latestVersion, hasUpdate, err := CheckLatestVersion()
+		if err == nil {
+			if hasUpdate {
+				result.WriteString(fmt.Sprintf("\n🔔 Atualização disponível! Versão mais recente: %s\n", latestVersion))
+				result.WriteString("   Execute 'go install github.com/diillson/chatcli@latest' para atualizar.\n")
+			} else {
+				result.WriteString("\n✅ Você está usando a versão mais recente.\n")
+			}
+		} else {
+			result.WriteString(fmt.Sprintf("\n⚠️ Não foi possível verificar atualizações: %s\n", err.Error()))
+		}
+	}
+
+	return result.String()
+}
+
+// GetBuildInfo obtém informações de build de forma mais robusta
+func GetBuildInfo() (string, string, string) {
+	version := Version
+	commitHash := CommitHash
+	buildDate := BuildDate
+
+	// Se estamos usando valores padrão, tentar obter do build info
+	if version == "dev" || commitHash == "unknown" || buildDate == "unknown" {
+		if info, ok := debug.ReadBuildInfo(); ok {
+			// Procurar por informações do VCS nas configurações do build
+			for _, setting := range info.Settings {
+				switch setting.Key {
+				case "vcs.revision":
+					if commitHash == "unknown" {
+						commitHash = setting.Value[:8] // Pegar apenas os primeiros 8 caracteres
+					}
+				case "vcs.time":
+					if buildDate == "unknown" {
+						// Converter para formato mais amigável
+						if t, err := time.Parse(time.RFC3339, setting.Value); err == nil {
+							buildDate = t.Format("2006-01-02 15:04:05")
+						} else {
+							buildDate = setting.Value
+						}
+					}
+				}
+			}
+
+			// Se ainda não temos versão mas temos o módulo, usar isso
+			if version == "dev" && info.Main.Version != "" {
+				version = info.Main.Version
+			}
+		}
+	}
+
+	return version, commitHash, buildDate
+}

--- a/version/version.go
+++ b/version/version.go
@@ -56,7 +56,15 @@ func CheckLatestVersion() (string, bool, error) {
 	if err != nil {
 		return "", false, err
 	}
-	defer resp.Body.Close()
+	// Corrigindo o erro de lint: verificar o erro do Close
+	defer func() {
+		err := resp.Body.Close()
+		if err != nil {
+			// Como estamos dentro de um defer, não podemos retornar o erro
+			// Então logamos ou ignoramos silenciosamente
+			fmt.Fprintf(os.Stderr, "Erro ao fechar response body: %v\n", err)
+		}
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		return "", false, fmt.Errorf("erro ao verificar versão: status %d", resp.StatusCode)
@@ -80,7 +88,8 @@ func CheckLatestVersion() (string, bool, error) {
 
 	// Extrai apenas a parte da tag da versão atual
 	// Para transformar algo como "v1.9.0-5-g1b6ecaa-dirty" em "1.9.0"
-	currentVersionBase := Version
+	var currentVersionBase string // Corrigindo o erro de ineffassign
+
 	if strings.Contains(Version, "-") {
 		parts := strings.Split(Version, "-")
 		currentVersionBase = strings.TrimPrefix(parts[0], "v")
@@ -90,9 +99,6 @@ func CheckLatestVersion() (string, bool, error) {
 
 	// Verifique se estamos em um commit específico (dev build)
 	isDev := Version == "dev" || strings.Contains(Version, "-dirty") || strings.Contains(Version, "-g")
-
-	// Compara versões (simplificado - para uma comparação mais robusta,
-	// considere usar um pacote como "github.com/hashicorp/go-version")
 
 	// Se estamos em modo dev, só indica atualização se a versão base for diferente
 	if isDev {

--- a/version/version.go
+++ b/version/version.go
@@ -56,7 +56,6 @@ func CheckLatestVersion() (string, bool, error) {
 	if err != nil {
 		return "", false, err
 	}
-	// Corrigindo o erro de lint: verificar o erro do Close
 	defer func() {
 		err := resp.Body.Close()
 		if err != nil {
@@ -88,7 +87,7 @@ func CheckLatestVersion() (string, bool, error) {
 
 	// Extrai apenas a parte da tag da versão atual
 	// Para transformar algo como "v1.9.0-5-g1b6ecaa-dirty" em "1.9.0"
-	var currentVersionBase string // Corrigindo o erro de ineffassign
+	var currentVersionBase string
 
 	if strings.Contains(Version, "-") {
 		parts := strings.Split(Version, "-")


### PR DESCRIPTION
---

feat(version): adiciona comando para verificar e exibir informações de versão

Este commit implementa um novo comando que permite aos usuários verificarem a versão
instalada do ChatCLI, incluindo o hash do commit e a data de build. Também adiciona
a verificação de atualizações disponíveis, alertando quando há uma versão mais recente.

As principais mudanças incluem:

- Adiciona novo pacote `version` para gerenciar informações de versão
- Implementa o comando `/version` e `/v` no CommandHandler
- Adiciona suporte para ldflags durante compilação para injetar informações de versão
- Implementa verificação robusta de informações de build com fallbacks quando ldflags não estão disponíveis
- Atualiza a documentação de ajuda para incluir o novo comando
- Adiciona suporte para verificação via linha de comando com `--version` ou `-v`