### PR TITLE
develop

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -1,3 +1,8 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: MIT
+ */
 package cli
 
 import (

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,3 +1,8 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: MIT
+ */
 package cli
 
 import (
@@ -1892,8 +1897,36 @@ func (cli *ChatCLI) typewriterEffect(text string, delay time.Duration) {
 	}
 }
 
+// handleVersionCommand exibe informações detalhadas sobre a versão atual
+// do ChatCLI e verifica se há atualizações disponíveis no GitHub.
+//
+// O comando mostra:
+// - Versão atual (tag ou hash do commit)
+// - Hash do commit exato
+// - Data e hora de build
+// - Status de atualização (verificando o GitHub quando possível)
 func (ch *CommandHandler) handleVersionCommand() {
 	versionInfo := version.GetCurrentVersion()
-	formattedInfo := version.FormatVersionInfo(versionInfo, true)
-	fmt.Println(formattedInfo)
+
+	// Primeiro mostrar a versão atual sem verificar atualização
+	fmt.Println(version.FormatVersionInfo(versionInfo, false))
+
+	// Depois verificar atualização em background
+	fmt.Println("Verificando atualizações disponíveis...")
+
+	go func() {
+		latestVersion, hasUpdate, err := version.CheckLatestVersion()
+
+		if err != nil {
+			fmt.Printf("\n⚠️ Não foi possível verificar atualizações: %s\n", err.Error())
+			return
+		}
+
+		if hasUpdate {
+			fmt.Printf("\n🔔 Atualização disponível! Versão mais recente: %s\n", latestVersion)
+			fmt.Println("   Execute 'go install github.com/diillson/chatcli@latest' para atualizar.")
+		} else {
+			fmt.Println("\n✅ Você está usando a versão mais recente.")
+		}
+	}()
 }

--- a/cli/command_handler.go
+++ b/cli/command_handler.go
@@ -1,4 +1,8 @@
-// command_handler.go
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: MIT
+ */
 package cli
 
 import (

--- a/cli/history_manager.go
+++ b/cli/history_manager.go
@@ -1,3 +1,8 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: MIT
+ */
 package cli
 
 import (

--- a/llm/claudeai/claude_client.go
+++ b/llm/claudeai/claude_client.go
@@ -1,3 +1,8 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: MIT
+ */
 package claudeai
 
 import (

--- a/llm/client/llm_client.go
+++ b/llm/client/llm_client.go
@@ -1,4 +1,8 @@
-// llm/llm_client.go
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: MIT
+ */
 package client
 
 import (

--- a/llm/manager/llm_manager.go
+++ b/llm/manager/llm_manager.go
@@ -1,3 +1,8 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: MIT
+ */
 package manager
 
 import (

--- a/llm/openai/openai_client.go
+++ b/llm/openai/openai_client.go
@@ -1,3 +1,8 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: MIT
+ */
 package openai
 
 import (

--- a/llm/openai_assistant/openai_assistant_client.go
+++ b/llm/openai_assistant/openai_assistant_client.go
@@ -1,3 +1,8 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: MIT
+ */
 package openai_assistant
 
 import (

--- a/llm/stackspotai/stackspot_client.go
+++ b/llm/stackspotai/stackspot_client.go
@@ -1,3 +1,8 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: MIT
+ */
 package stackspotai
 
 import (

--- a/llm/token/token_manager.go
+++ b/llm/token/token_manager.go
@@ -1,3 +1,8 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: MIT
+ */
 package token
 
 import (

--- a/main.go
+++ b/main.go
@@ -1,3 +1,8 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: MIT
+ */
 package main
 
 import (
@@ -24,6 +29,8 @@ func main() {
 		return
 	}
 
+	version.PrintStartupVersionInfo()
+
 	// Carregar variáveis de ambiente do arquivo .env
 	envFilePath := os.Getenv("CHATCLI_DOTENV")
 	if envFilePath == "" {
@@ -47,6 +54,9 @@ func main() {
 		fmt.Printf("Não foi possível inicializar o logger: %v\n", err)
 		os.Exit(1) // Encerrar a aplicação em caso de erro crítico
 	}
+
+	utils.LogStartupInfo(logger)
+
 	defer func() {
 		if err := logger.Sync(); err != nil {
 			fmt.Printf("Erro ao fechar logger: %v\n", err)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/diillson/chatcli/config"
+	"github.com/diillson/chatcli/version"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 	"golang.org/x/term"
 	"io"
 	"os"
+	"runtime"
 	"strings"
 )
 
@@ -107,4 +109,15 @@ func CheckProviderEnvVariables(logger *zap.Logger) {
 	if claudeAIModel == "" {
 		fmt.Printf("ATENÇÃO: CLAUDEAI_MODEL não definido, usando valor padrão: %s\n", config.DefaultClaudeAIModel)
 	}
+}
+
+func LogStartupInfo(logger *zap.Logger) {
+	logger.Info("ChatCLI iniciado",
+		zap.String("version", version.Version),
+		zap.String("commit", version.CommitHash),
+		zap.String("buildDate", version.BuildDate),
+		zap.String("goVersion", runtime.Version()),
+		zap.String("os", runtime.GOOS),
+		zap.String("arch", runtime.GOARCH),
+	)
 }


### PR DESCRIPTION
---
fix: Melhorar comparação semântica de versões e gestão de recursos

Este commit resolve problemas na verificação de versões e implementa uma
estratégia mais robusta para comparação semântica, abordando especificamente:

- Adiciona função extractBaseVersion para isolar versões semânticas de sufixos de desenvolvimento
- Desenvolve algoritmo needsUpdate com comparação numérica por componentes (major.minor.patch)
- Refina a lógica de detecção para evitar falsos alertas em builds de desenvolvimento

A implementação agora reconhece corretamente versões no formato "v1.9.0-5-g1b6ecaa-dirty"
como baseadas em v1.9.0, evitando alertas desnecessários quando uma versão mais recente
não está realmente disponível. Também melhora o gerenciamento de recursos HTTP com
fechamento adequado das conexões.