### PR TITLE
feat(cli): add sensitive data sanitization and enhance configuration …

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/diillson/chatcli?label=Go%20Version)
 ![GitHub](https://img.shields.io/github/license/diillson/chatcli)
 
-O **ChatCLI** é uma aplicação de linha de comando (CLI) avançada que integra modelos de Linguagem de Aprendizado (LLMs) poderosos (como StackSpot, OpenAI e ClaudeAI) para facilitar conversas interativas e contextuais diretamente no seu terminal. Projetado para desenvolvedores, cientistas de dados e entusiastas de tecnologia, o ChatCLI potencializa a produtividade ao agregar diversas fontes de dados contextuais e oferecer uma experiência rica e amigável.
+O **ChatCLI** é uma aplicação de linha de comando (CLI) avançada que integra modelos de Linguagem de Aprendizado (LLMs) poderosos (como OpenAI, StackSpot, GoogleAI e ClaudeAI) para facilitar conversas interativas e contextuais diretamente no seu terminal. Projetado para desenvolvedores, cientistas de dados e entusiastas de tecnologia, o ChatCLI potencializa a produtividade ao agregar diversas fontes de dados contextuais e oferecer uma experiência rica e amigável.
 
 ---
 
@@ -210,6 +210,18 @@ Após a instalação e configuração, o ChatCLI oferece uma série de comandos 
     - `/switch --tenantname <tenant>` – Atualiza somente o `tenantName`.
     - Combinações: `/switch --slugname <slug> --tenantname <tenant>`
     - `/reload` – Recarrega as variáveis de ambiente em tempo real.
+    - `/config` ou `/status` (ou `/settings`) – Exibe as configurações atuais do ChatCLI.
+       - Mostra: provedor e modelo em uso (runtime), nome do modelo reportado pelo client, API preferida (catálogo), MaxTokens efetivo (estimado), overrides de tokens por ENV, caminho do `.env`, provedores disponíveis e (quando aplicável) `slugName`/`tenantName` da StackSpot.
+       - Segurança: nunca imprime valores de segredos (ex.: chaves de API); exibe apenas a presença como `[SET]`/`[NOT SET]` e não envia nada para a LLM.
+       - Exemplo de uso:
+         ```
+         /config
+         ```
+         Saída esperada (resumo):
+         - Provider atual: OPENAI
+         - Modelo atual: gpt-4o-mini (client: GPT-4o mini)
+         - API preferida: chat_completions
+         - MaxTokens efetivo: 50000
 
 - **Iniciar uma Nova Sessão**:
     - `/newsession` – Limpa o histórico atual e inicia uma nova sessão de conversa.
@@ -230,7 +242,9 @@ Após a instalação e configuração, o ChatCLI oferece uma série de comandos 
 - `@env` – Insere variáveis de ambiente no contexto.
 - `@file <caminho>` – Insere o conteúdo de um arquivo ou diretório.
 - `@command <comando>` – Executa um comando do terminal e salva a saída.
-- **Novo**: `@command --ai <comando> > <contexto>` – Envia a saída do comando diretamente para a LLM com contexto adicional.
+- `@command --ai <comando> > <contexto>` – Envia a saída do comando diretamente para a LLM com contexto adicional.
+- - Observação: variáveis sensíveis e saídas são sanitizadas (tokens/segredos são redigidos) antes de irem para a LLM.
+
 
 ### Modo Agente
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -8,7 +8,7 @@
 ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/diillson/chatcli?label=Go%20Version)
 ![GitHub](https://img.shields.io/github/license/diillson/chatcli)
 
-**ChatCLI** is an advanced command-line application (CLI) that integrates powerful Large Language Models (LLMs) like StackSpot, OpenAI, and ClaudeAI, making interactive and contextual conversations accessible directly from your terminal. Designed for developers, data scientists, and tech enthusiasts, ChatCLI supercharges productivity by combining contextual data sources and offering a rich, user-friendly experience.
+**ChatCLI** is an advanced command-line application (CLI) that integrates powerful Large Language Models (LLMs) like OpenAI, StackSpot, GoogleAI and ClaudeAI, making interactive and contextual conversations accessible directly from your terminal. Designed for developers, data scientists, and tech enthusiasts, ChatCLI supercharges productivity by combining contextual data sources and offering a rich, user-friendly experience.
 
 ---
 
@@ -221,6 +221,18 @@ Once installed and configured, ChatCLI offers a suite of commands for seamless L
     * `/switch --tenantname <tenant>` – Update only the `tenantName`.
     * Combine: `/switch --slugname <slug> --tenantname <tenant>`
     * `/reload` – Reload environment variables in real time.
+    * `/config` or `/status` (or `/settings`) – Display current ChatCLI configuration.
+    - Shows: current provider and model (runtime), client-reported model name, preferred API (catalog), effective MaxTokens (estimated), token overrides from ENV, `.env` path, available providers, and (when applicable) StackSpot `slugName`/`tenantName`.
+    - Security: never prints secret values (e.g., API keys). Instead shows presence as `[SET]`/`[NOT SET]` and sends nothing to the LLM.
+    - Example:
+         ```
+         /config
+         ```
+         Expected summary:
+         - Current provider: OPENAI
+         - Current model: gpt-4o-mini (client: GPT-4o mini)
+         - Preferred API: chat_completions
+         - Effective MaxTokens: 50000
 
   * **Start a New Session**:
       * `/newsession` – Clears the current history and starts a new conversation session.
@@ -242,7 +254,8 @@ Once installed and configured, ChatCLI offers a suite of commands for seamless L
 * `@env` – Adds environment variables to the context.
 * `@file <path>` – Inserts the content of a file or directory.
 * `@command <cmd>` – Runs a terminal command and saves the output.
-* **New:** `@command --ai <cmd> > <context>` – Sends the command output straight to the LLM with extra context.
+* `@command --ai <cmd> > <context>` – Sends the command output straight to the LLM with extra context.
+* * Note: sensitive variables and command outputs are sanitized (tokens/secrets are redacted) before sending to the LLM.
 
 ### Agent Mode
 

--- a/cli/command_handler.go
+++ b/cli/command_handler.go
@@ -7,8 +7,9 @@ package cli
 
 import (
 	"fmt"
-	"github.com/diillson/chatcli/models"
 	"strings"
+
+	"github.com/diillson/chatcli/models"
 )
 
 type CommandHandler struct {
@@ -36,6 +37,9 @@ func (ch *CommandHandler) HandleCommand(userInput string) bool {
 		return false
 	case userInput == "/help":
 		ch.cli.showHelp()
+		return false
+	case userInput == "/config" || userInput == "/status" || userInput == "/settings":
+		ch.cli.showConfig()
 		return false
 	case userInput == "/version" || userInput == "/v":
 		ch.handleVersionCommand()

--- a/utils/logging_transport.go
+++ b/utils/logging_transport.go
@@ -303,12 +303,13 @@ func (t *LoggingTransport) sanitizeBody(contentType string, body []byte) []byte 
 	if strings.Contains(contentType, "application/json") {
 		var data map[string]interface{}
 		if err := json.Unmarshal(body, &data); err == nil {
-			// Exemplo: Mascara campos sensíveis
-			if _, exists := data["api_key"]; exists {
-				data["api_key"] = "[REDACTED]"
-			}
-			if _, exists := data["password"]; exists {
-				data["password"] = "[REDACTED]"
+			// Mascara campos sensíveis conhecidos (shallow)
+			for _, k := range []string{
+				"api_key", "password", "token", "access_token", "refresh_token", "client_secret", "authorization",
+			} {
+				if _, exists := data[k]; exists {
+					data[k] = "[REDACTED]"
+				}
 			}
 			sanitized, _ := json.Marshal(data)
 			return sanitized


### PR DESCRIPTION
…commands

- Introduced environment variable and text sanitization methods, ensuring sensitive data like API keys and tokens are redacted across logs, outputs, and LLM prompts.
- Added `/config`, `/status`, and `/settings` commands to display current ChatCLI configurations without exposing secret values.
- Updated `/reload` to preserve runtime provider/model while reloading configurations.
- Improved logging transport for shallow sanitization of JSON payloads in API communications.
- Documentation updates for sanitization and updated commands.