### PR TITLE
feat(cli): add one-shot mode with prompt flags, provider, and model o…

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -20,6 +20,7 @@
 * [Usage and Commands](#usage-and-commands)
 
     * [Starting the Application](#starting-the-application)
+    * [Non-interactive mode (one-shot via flags)](#non-interactive-mode-one-shot-via-flags)
     * [General Commands](#general-commands)
     * [Contextual Commands](#contextual-commands)
 * [Advanced File Processing](#advanced-file-processing)
@@ -204,9 +205,80 @@ Once installed and configured, ChatCLI offers a suite of commands for seamless L
 
 ### Starting the Application
 
+- Interactive mode:
 ```bash
 ./chatcli
 ```
+
+- Non-interactive (one-shot):
+```bash
+./chatcli -p "Your prompt here"
+```
+
+---
+
+### Non-interactive mode (one-shot via flags)
+
+ChatCLI now supports a “one-shot” mode to execute a single prompt on the command line and exit immediately. Perfect for scripts, CI/CD, aliases, and automation.
+
+#### Available flags
+
+- `-p` or `--prompt`: the text to send to the LLM for a one-time run.
+- `--provider`: runtime override of the LLM provider (`OPENAI`, `CLAUDEAI`, `GOOGLEAI`, `OPENAI_ASSISTANT`, `STACKSPOT`).
+- `--model`: choose the model for the selected provider (e.g., `gpt-4o-mini`, `claude-3-5-sonnet-20241022`, `gemini-2.5-flash`).
+- `--timeout`: one-shot call timeout (default: `5m`).
+- `--no-anim`: disable CLI animations (useful in scripts/CI).
+
+Note: the same contextual features can be used inside the `--prompt` text, such as `@file`, `@git`, `@env`, `@command`, and the `>` operator for extra context. Always quote your prompt to avoid shell interpretation issues.
+
+#### Quick examples
+
+- Basic:
+```bash
+chatcli -p "Give a quick explanation of this repository."
+```
+
+- With contextual commands:
+```bash
+chatcli -p "@git @env Please craft a concise release note."
+```
+- Sending files/directories (existing  @file  modes apply):
+```bash
+chatcli -p "@file ./src --mode=summary Provide an architecture overview."
+```
+- Override provider/model at runtime:
+```bash
+chatcli -p "Summarize the CHANGELOG" \
+  --provider=CLAUDEAI \
+  --model=claude-3-5-sonnet-20241022
+```
+- No animations (CI-friendly):
+```bash
+chatcli -p "What does this code do?" --no-anim
+```
+- Custom timeout:
+```bash
+chatcli -p "Give a detailed architecture analysis" --timeout=15m
+```
+
+#### Tips and best practices
+
+- Quoting: quote your prompt (especially if using  `>` for extra context).
+- Pipes: no need to use  echo ... | chatcli  in one-shot mode; prefer  `-p ou -prompt` .
+- Output: Markdown-rendered output by default; consider  `--no-anim`  for strict parsers.
+- Exit codes:  `0`  on success,  `1`  on runtime error,  `2`  on flag parsing errors.
+- Script integration (Makefile):
+```bash
+one-shot:
+    chatcli -p "@file ./ --mode=summary Generate a README overview."
+```
+- Example (GitHub Actions):
+```bash
+- name: ChatCLI one-shot
+  run: |
+    chatcli -p "@file ./ --mode=summary Generate a project overview"
+```
+---
 
 ### General Commands
 
@@ -256,6 +328,8 @@ Once installed and configured, ChatCLI offers a suite of commands for seamless L
 * `@command <cmd>` – Runs a terminal command and saves the output.
 * `@command --ai <cmd> > <context>` – Sends the command output straight to the LLM with extra context.
 * * Note: sensitive variables and command outputs are sanitized (tokens/secrets are redacted) before sending to the LLM.
+
+---
 
 ### Agent Mode
 

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -220,7 +220,7 @@ func (a *AgentMode) Run(ctx context.Context, query string, additionalContext str
 
 	// Adicionar log antes da chamada para SendPrompt
 	a.logger.Debug("Enviando prompt para o LLM",
-		zap.String("provider", a.cli.provider),
+		zap.String("provider", a.cli.Provider),
 		zap.Int("historyLength", len(a.cli.history)),
 		zap.Int("queryLength", len(fullQuery)))
 

--- a/cli/oneshot_mode.go
+++ b/cli/oneshot_mode.go
@@ -1,0 +1,96 @@
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"time"
+
+	"github.com/diillson/chatcli/models"
+)
+
+// Options representa as flags suportadas pelo binário
+type Options struct {
+	// Geral
+	Version bool // --version | -v
+	Help    bool // --help | -h
+
+	// Modo one-shot
+	Prompt   string        // -p | --prompt
+	Provider string        // --provider
+	Model    string        // --model
+	Timeout  time.Duration // --timeout
+	NoAnim   bool          // --no-anim
+}
+
+func (cli *ChatCLI) RunOnce(ctx context.Context, input string, disableAnimation bool) error {
+
+	// Processa comandos especiais (@file, @git, @env, @command, > contexto)
+	userInput, additionalContext := cli.processSpecialCommands(input)
+
+	// Adiciona a mensagem do usuário ao histórico
+	cli.history = append(cli.history, models.Message{
+		Role:    "user",
+		Content: userInput + additionalContext,
+	})
+
+	// Exibe animação (opcional)
+	if !disableAnimation {
+		cli.animation.ShowThinkingAnimation(cli.Client.GetModelName())
+	}
+
+	// Faz a chamada ao LLM (com timeout vindo do contexto)
+	aiResponse, err := cli.Client.SendPrompt(ctx, userInput+additionalContext, cli.history)
+
+	if !disableAnimation {
+		cli.animation.StopThinkingAnimation()
+	}
+
+	if err != nil {
+		return err
+	}
+
+	// Renderiza e imprime a resposta
+	rendered := cli.renderMarkdown(aiResponse)
+	fmt.Println(rendered)
+	return nil
+}
+
+// NewFlagSet cria um FlagSet isolado e as Options para parsing
+func NewFlagSet() (*flag.FlagSet, *Options) {
+	fs := flag.NewFlagSet("chatcli", flag.ContinueOnError)
+	opts := &Options{}
+
+	// Flags
+	fs.BoolVar(&opts.Version, "version", false, "Mostra versão e sai")
+	fs.BoolVar(&opts.Version, "v", false, "Mostra versão e sai (alias)")
+
+	fs.BoolVar(&opts.Help, "help", false, "Mostra ajuda e sai")
+	fs.BoolVar(&opts.Help, "h", false, "Mostra ajuda e sai (alias)")
+
+	fs.StringVar(&opts.Prompt, "p", "", "Prompt a executar uma única vez (modo não interativo) - (alias)")
+	fs.StringVar(&opts.Prompt, "prompt", "", "Prompt a executar uma única vez (modo não interativo)")
+
+	fs.StringVar(&opts.Provider, "provider", "", "Override do provider (OPENAI, CLAUDEAI, GOOGLEAI, OPENAI_ASSISTANT, STACKSPOT)")
+	fs.StringVar(&opts.Model, "model", "", "Override do modelo(LLM)")
+
+	fs.DurationVar(&opts.Timeout, "timeout", 5*time.Minute, "Timeout da chamada one-shot")
+	fs.BoolVar(&opts.NoAnim, "no-anim", false, "Desabilita animações no modo one-shot")
+
+	return fs, opts
+}
+
+// Parse analisa os args, valida e retorna Options
+func Parse(args []string) (*Options, error) {
+	fs, opts := NewFlagSet()
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+
+	// Validações simples
+	if opts.Timeout <= 0 {
+		return nil, fmt.Errorf("timeout inválido: deve ser > 0")
+	}
+
+	return opts, nil
+}


### PR DESCRIPTION
…verrides

- Introduced a non-interactive "one-shot" mode for single line prompt execution with immediate exit.
- Added flags `--prompt`, `--provider`, `--model`, `--timeout`, and `--no-anim` for customizable execution.
- Integrated new functionality into the CLI with proper parsing and validation mechanisms.
- Updated README with usage examples, flag details, and best practices for the one-shot mode.