### PR TITLE
fix(modeOneshot): extend one-shot mode to support stdin input

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,10 +250,36 @@ chatcli -p "O que este código faz?" --no-anim
 ```bash
 chatcli -p "Analise detalhadamente a arquitetura" --timeout=15m
 ```
+
+### Entrada via stdin (pipes)
+Além de `-p/--prompt`, o ChatCLI aceita entrada via stdin em modo one-shot. Isso permite usar pipes com facilidade:
+    
+- Apenas stdin:
+```bash
+echo "Explique rapidamente este repositório." | chatcli
+```
+- stdin + prompt (concatena os dois):
+```bash
+git diff | chatcli -p "Resuma as mudanças e liste possíveis impactos."
+```
+- Com provider/model override:
+```bash
+cat README.md | chatcli \
+  -p "Resuma o README e sugira melhorias" \
+  --provider=CLAUDEAI \
+  --model=claude-3-5-sonnet-20241022
+```
+- Sem animações (CI-friendly):
+```bash
+echo "O que este código faz?" | chatcli --no-anim
+```
+
 #### Dicas e boas práticas
 
 - Quoting: use aspas duplas sempre no prompt em modo one-shot para evitar expanções do shell, especialmente se usar  >  para adicionar contexto.
-- Pipes: não é necessário pipe/echo no modo one-shot; preferível usar  `-p ou -prompt` .
+- Pipes: não é necessário pipe/echo no modo one-shot; preferível usar  `-p ou -prompt` mas é possível caso necessário como nos exemplos.
+- Se  `-p`  estiver presente e houver stdin, por padrão os textos serão concatenados (o prompt de  `-p`  primeiro, seguido do `stdin`).
+- Se desejar priorizar apenas  `-p`  e ignorar `stdin`, ajuste o código conforme a sua preferência (veja comentários no `main.go`).
 - Saída: por padrão, a resposta é renderizada em Markdown. Para pipelines/parsings estritos, considere desativar animações com `--no-anim`após a mensagem.
 - Exit codes: retorno  `0`  em sucesso,  `1`  em erro de execução,  `2`  em erro de parsing de flags (conforme implementação).
 - Integração com scripts (Makefile):

--- a/README_EN.md
+++ b/README_EN.md
@@ -261,10 +261,35 @@ chatcli -p "What does this code do?" --no-anim
 chatcli -p "Give a detailed architecture analysis" --timeout=15m
 ```
 
+### Stdin input (pipes)
+In addition to `-p/--prompt`, ChatCLI accepts input via stdin in one-shot mode. This allows you to easily use pipes:
+
+- Stdin only:
+```bash
+echo "Briefly explain this repository." | chatcli
+```
+- stdin + prompt (concatenates the two):
+```bash
+git diff | chatcli -p "Summarize the changes and list possible impacts."
+```
+- With provider/model override:
+```bash
+cat README.md | chatcli \
+  -p "Summarize the README and suggest improvements" \
+  --provider=CLAUDEAI \
+  --model=claude-3-5-sonnet-20241022
+```
+- No animations (CI-friendly):
+```bash
+echo "What does this code do?" | chatcli --no-anim
+```
+
 #### Tips and best practices
 
 - Quoting: quote your prompt (especially if using  `>` for extra context).
 - Pipes: no need to use  echo ... | chatcli  in one-shot mode; prefer  `-p ou -prompt` .
+- Auto-detection: when `stdin` is not a TTY (e.g., via a pipe), ChatCLI runs in one-shot mode even without `-p/--prompt`.
+- Combination: if both `-p/--prompt` and `stdin` are present, ChatCLI concatenates them by default (prompt content first, then `stdin` content).
 - Output: Markdown-rendered output by default; consider  `--no-anim`  for strict parsers.
 - Exit codes:  `0`  on success,  `1`  on runtime error,  `2`  on flag parsing errors.
 - Script integration (Makefile):

--- a/cli/oneshot_mode.go
+++ b/cli/oneshot_mode.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/diillson/chatcli/models"
@@ -21,6 +22,16 @@ type Options struct {
 	Model    string        // --model
 	Timeout  time.Duration // --timeout
 	NoAnim   bool          // --no-anim
+}
+
+// Detecta se há dados no stdin (pipe/arquivo ao invés de TTY).
+func HasStdin() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	// Se não for dispositivo de caractere (tty), então veio de pipe/arquivo
+	return (fi.Mode() & os.ModeCharDevice) == 0
 }
 
 func (cli *ChatCLI) RunOnce(ctx context.Context, input string, disableAnimation bool) error {


### PR DESCRIPTION
- Added `HasStdin` function to detect input from stdin (e.g., pipes or files).
- Updated one-shot mode to allow concatenation of `--prompt` and stdin input for flexible usage.
- Adjusted logic to fallback to interactive mode if no input is provided.
- Enhanced README and README_EN with examples and tips for stdin usage.