### PR TITLE
fix(modeOneShot): normalize -p/--prompt flags without values in one-s…

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,8 @@ echo "Explique rapidamente este repositório." | chatcli
 - stdin + prompt (concatena os dois):
 ```bash
 git diff | chatcli -p "Resuma as mudanças e liste possíveis impactos."
+ou
+echo "Explique rapidamente este repositório." | chatcli -p
 ```
 - Com provider/model override:
 ```bash

--- a/README_EN.md
+++ b/README_EN.md
@@ -271,6 +271,8 @@ echo "Briefly explain this repository." | chatcli
 - stdin + prompt (concatenates the two):
 ```bash
 git diff | chatcli -p "Summarize the changes and list possible impacts."
+or
+echo "Briefly explain this repository." | chatcli -p
 ```
 - With provider/model override:
 ```bash

--- a/main.go
+++ b/main.go
@@ -26,7 +26,8 @@ import (
 func main() {
 
 	// Parse das flags
-	opts, err := cli.Parse(os.Args[1:])
+	args := cli.PreprocessArgs(os.Args[1:])
+	opts, err := cli.Parse(args)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(2)


### PR DESCRIPTION
…hot mode

- Added `PreprocessArgs` to handle cases where `-p/--prompt` flags lack explicit values, ensuring compatibility with flag parsing.
- Updated `main.go` to preprocess CLI arguments.
- Enhanced README and README_EN with examples for empty prompt usage.