### PR TITLE
fix(ci): comment out pull_request triggers in CI workflow

### DIFF
--- a/.github/workflows/1-ci.yml
+++ b/.github/workflows/1-ci.yml
@@ -1,10 +1,10 @@
 name: CI (Lint, Fmt, Test)
 
 on:
-#  pull_request:
-#    branches: [develop, main]
-  push:
+  pull_request:
     branches: [develop]
+#  push:
+#    branches: [develop]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/1-ci.yml
+++ b/.github/workflows/1-ci.yml
@@ -1,8 +1,8 @@
 name: CI (Lint, Fmt, Test)
 
 on:
-  pull_request:
-    branches: [develop, main]
+#  pull_request:
+#    branches: [develop, main]
   push:
     branches: [develop]
 


### PR DESCRIPTION
- Disabled `pull_request` event triggers in `1-ci.yml`, ensuring the workflow only triggers on `push` to the `develop` branch.