### PR TITLE
feat(cli): add agent one-shot mode with auto-execution support

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ Após a instalação e configuração, o ChatCLI oferece uma série de comandos 
 ### Modo não-interativo (one-shot via flags)
     
 O ChatCLI agora suporta um modo “one-shot”, no qual você executa um prompt em **uma única linha** e o processo finaliza sem entrar no loop interativo. Esse modo é ideal para scripts, CI/CD, aliases e automações.
+
+Este modo agora também suporta a execução de comandos do **Modo Agente** para automação de tarefas. Veja a seção "Modo Agente One-Shot" para mais detalhes.
     
 #### Flags disponíveis
     
@@ -373,6 +375,50 @@ O Modo Agente permite que a IA execute tarefas no seu sistema através de comand
 - O Modo Agente é uma ferramenta poderosa para aumentar sua produtividade, permitindo que você delegue tarefas ao ChatCLI e obtenha resultados rapidamente.
 - O agente é projetado para ser seguro e respeitar as permissões do sistema, garantindo que apenas comandos autorizados sejam execut
 - O Modo Agente pode ser desativado a qualquer momento, retornando ao modo de conversa normal.
+
+  #### Modo Agente One-Shot (Não-Interativo)
+
+Você pode usar o Modo Agente diretamente da linha de comando, o que é perfeito para scripts e automação.
+
+**1. Modo Padrão (Dry-Run): Apenas Sugestão**
+
+Por padrão, ao chamar o agente no modo one-shot, ele apenas **sugere** o melhor comando para a tarefa e sai, sem executar nada.
+
+# A IA irá analisar o pedido e imprimir o comando `find . -name "*.go"`, depois sairá.
+```bash
+chatcli -p "/agent liste todos os arquivos .go neste diretório"
+```
+
+**2. Modo de Execução Automática**
+
+Para que o  chatcli  execute o comando sugerido, adicione o flag  `--agent-auto-exec` .
+
+- Segurança: Por segurança, o agente executará apenas o primeiro comando sugerido e bloqueará automaticamente a execução de comandos considerados perigosos (como  rm -rf ,  sudo ,  drop database , etc.).
+
+# A IA irá gerar um comando como `touch test_file.txt` e executá-lo imediatamente.
+```bash
+chatcli -p "/agent crie um arquivo chamado test_file.txt" --agent-auto-exec
+```
+
+# Usando stdin
+```bash
+echo "liste todos os arquivos .go e conte suas linhas" | chatcli -p "/agent"
+```
+# Exemplo com contexto:
+```bash
+chatcli -p "/agent @git qual o status do git neste repositório?" --agent-auto-exec
+```
+
+# Exemplo com contexto de arquivo
+```bash
+chatcli -p "/agent @file ./README.md resuma este arquivo em uma frase" --agent-auto-exec
+```
+***3. Comando Perigoso (Será Bloqueado)***
+
+# O chatcli se recusará a executar o comando e sairá com uma mensagem de erro.
+```bash
+chatcli -p "/agent delete todos os arquivos da pasta tmp" --agent-auto-exec
+```
 
 #### Refinando Comandos Antes da Execução
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -2162,3 +2162,30 @@ func (ch *CommandHandler) handleVersionCommand() {
 		}
 	}()
 }
+
+// RunAgentOnce executa o modo agente de forma não-interativa (one-shot)
+func (cli *ChatCLI) RunAgentOnce(ctx context.Context, input string, autoExecute bool) error {
+	var query string
+	if strings.HasPrefix(input, "/agent ") {
+		query = strings.TrimPrefix(input, "/agent ")
+	} else if strings.HasPrefix(input, "/run ") {
+		query = strings.TrimPrefix(input, "/run ")
+	} else {
+		return fmt.Errorf("entrada inválida para o modo agente one-shot: %s", input)
+	}
+
+	// Processar contextos especiais como @file, @git, etc.
+	query, additionalContext := cli.processSpecialCommands(query)
+	fullQuery := query
+	if additionalContext != "" {
+		fullQuery = query + "\n\nContexto adicional:\n" + additionalContext
+	}
+
+	// Assegurar que o modo agente está inicializado
+	if cli.agentMode == nil {
+		cli.agentMode = NewAgentMode(cli, cli.logger)
+	}
+
+	// Chama a nova função não-interativa do AgentMode
+	return cli.agentMode.RunOnce(ctx, fullQuery, autoExecute)
+}

--- a/cli/welcome.go
+++ b/cli/welcome.go
@@ -22,18 +22,19 @@ var tips = []string{
 	"Use o modo agente com " + colorize("/agent <tarefa>", ColorGreen) + " para que a IA execute comandos por você.",
 }
 
-// printLogo exibe o novo logo do ChatCLI em ASCII art.
+const screenWidth = 85 // largura global para tudo
+
 // printLogo exibe o novo logo do ChatCLI em ASCII art.
 func printLogo() {
-	// *** LOGO CORRIGIDO E VERIFICADO FINALMENTE ***
 	logo := `
        ██████╗ ██╗  ██╗ █████╗ ████████╗ ██████╗██╗     ██╗
       ██╔════╝ ██║  ██║██╔══██╗╚══██╔══╝██╔════╝██║     ██║
       ██║      ███████║███████║   ██║   ██║     ██║     ██║
       ██║      ██╔══██║██╔══██║   ██║   ██║     ██║     ██║
       ╚██████╗ ██║  ██║██║  ██║   ██║   ╚██████╗███████╗██║
-       ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝   ╚═╝    ╚═════╝╚══════╝╚═╝
+       ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝   ╚═════╝╚══════╝╚═╝
     `
+
 	coloredLogo := strings.ReplaceAll(logo, "█", colorize("█", ColorLime))
 	coloredLogo = strings.ReplaceAll(coloredLogo, "╗", colorize("╗", ColorGray))
 	coloredLogo = strings.ReplaceAll(coloredLogo, "╔", colorize("╔", ColorGray))
@@ -42,7 +43,20 @@ func printLogo() {
 	coloredLogo = strings.ReplaceAll(coloredLogo, "═", colorize("═", ColorGray))
 	coloredLogo = strings.ReplaceAll(coloredLogo, "║", colorize("║", ColorGray))
 
-	fmt.Println(coloredLogo)
+	width := 80
+	for _, line := range strings.Split(coloredLogo, "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		// calcula padding
+		visible := visibleLen(line)
+		if visible < width {
+			left := (width - visible) / 2
+			fmt.Println(strings.Repeat(" ", left) + line)
+		} else {
+			fmt.Println(line)
+		}
+	}
 }
 
 // --- util: ANSI / largura visível (conta runas, ignora cores) ---
@@ -96,81 +110,42 @@ func wrapStringWithColor(text string, maxWidth int) []string {
 func printTipBox() {
 	tip := tips[rand.Intn(len(tips))]
 
-	width := 80               // largura externa total
-	innerTitle := width - 2   // entre as bordas para o título
-	innerContent := width - 4 // "  " + conteúdo + "  "
-
+	width := screenWidth
+	innerContent := width - 4
 	title := "Você Sabia?"
 
-	// topo
-	fmt.Println(colorize("╭"+strings.Repeat("─", width-2)+"╮", ColorGray))
+	titleWithSpaces := " " + title + " "
+	tl := visibleLen(titleWithSpaces)
+	dash := width - 2 - tl
+	left := dash / 2
+	right := dash - left
 
-	// título centralizado (conta runas, ignora ANSI)
-	tl := visibleLen(title)
-	left := (innerTitle - tl) / 2
-	right := innerTitle - tl - left
-	fmt.Println(colorize("│", ColorGray) + strings.Repeat(" ", left) + title + strings.Repeat(" ", right) + colorize("│", ColorGray))
+	fmt.Println(
+		colorize("╭", ColorGray) +
+			strings.Repeat("─", left) +
+			titleWithSpaces +
+			strings.Repeat("─", right) +
+			colorize("╮", ColorGray),
+	)
 
 	// linha em branco
-	fmt.Println(colorize("│", ColorGray) + strings.Repeat(" ", innerTitle) + colorize("│", ColorGray))
+	fmt.Println(colorize("│", ColorGray) + strings.Repeat(" ", width-2) + colorize("│", ColorGray))
 
-	// conteúdo alinhado à esquerda, com padding correto
+	// conteúdo centralizado
 	for _, line := range wrapStringWithColor(tip, innerContent) {
-		pad := innerContent - visibleLen(line)
-		fmt.Println(colorize("│", ColorGray) + " " + line + strings.Repeat(" ", pad) + " " + colorize("│", ColorGray))
+		l := visibleLen(line)
+		left := (innerContent - l) / 2
+		right := innerContent - l - left
+		fmt.Println(
+			colorize("│", ColorGray) +
+				" " + strings.Repeat(" ", left) + line + strings.Repeat(" ", right) + " " +
+				colorize("│", ColorGray),
+		)
 	}
 
-	// linha em branco + rodapé
-	fmt.Println(colorize("│", ColorGray) + strings.Repeat(" ", innerTitle) + colorize("│", ColorGray))
+	fmt.Println(colorize("│", ColorGray) + strings.Repeat(" ", width-2) + colorize("│", ColorGray))
 	fmt.Println(colorize("╰"+strings.Repeat("─", width-2)+"╯", ColorGray))
 }
-
-// wrapStringWithColor quebra uma string que contém códigos de cor.
-//func wrapStringWithColor(text string, maxWidth int) []string {
-//	var lines []string
-//	words := strings.Fields(text)
-//	if len(words) == 0 {
-//		return []string{}
-//	}
-//
-//	var currentLine strings.Builder
-//	currentLength := 0
-//
-//	for _, word := range words {
-//		cleanWordLen := len(removeColorCodes(word))
-//
-//		if cleanWordLen > maxWidth {
-//			if currentLength > 0 {
-//				lines = append(lines, currentLine.String())
-//				currentLine.Reset()
-//				currentLength = 0
-//			}
-//			lines = append(lines, word)
-//			continue
-//		}
-//
-//		// Verifica se a palavra cabe na linha atual
-//		if currentLength+1+cleanWordLen > maxWidth {
-//			lines = append(lines, currentLine.String())
-//			currentLine.Reset()
-//			currentLength = 0
-//		}
-//
-//		if currentLength > 0 {
-//			currentLine.WriteString(" ")
-//			currentLength++
-//		}
-//
-//		currentLine.WriteString(word)
-//		currentLength += cleanWordLen
-//	}
-//
-//	if currentLine.Len() > 0 {
-//		lines = append(lines, currentLine.String())
-//	}
-//
-//	return lines
-//}
 
 // PrintWelcomeScreen exibe a tela de boas-vindas completa.
 func (cli *ChatCLI) PrintWelcomeScreen() {
@@ -179,20 +154,27 @@ func (cli *ChatCLI) PrintWelcomeScreen() {
 	v, c, _ := version.GetBuildInfo()
 	if v != "" && v != "dev" && v != "unknown" {
 		versionStr := fmt.Sprintf("Versão: %s (commit: %s)", v, c)
-		padding := (80 - len(versionStr)) / 2
+		padding := (screenWidth - len(versionStr)) / 2
 		fmt.Printf("%s%s\n\n", strings.Repeat(" ", padding), colorize(versionStr, ColorGray))
 	}
 
 	printTipBox()
 
-	footer := colorize("/help", ColorGreen) + " para todos os comandos  •  " + colorize("/exit", ColorGreen) + " para sair"
-	separator := colorize(strings.Repeat("─", 80), ColorGray)
+	footer := colorize("/help", ColorGreen) +
+		colorize(" para todos os comandos  •  ", ColorGray) +
+		colorize("/exit", ColorGreen) +
+		colorize(" para sair  •  ", ColorGray) +
+		colorize("/switch --model", ColorGreen) +
+		colorize(" trocar modelo", ColorGray)
+
+	separator := colorize(strings.Repeat("━", screenWidth), ColorGray)
 
 	fmt.Println()
+	// footer alinhado à esquerda
 	fmt.Println(footer)
 	fmt.Println(separator)
 
-	// Mensagem do modelo com cor verde fluorescente
+	// model info alinhado à esquerda
 	modelInfo := fmt.Sprintf("🤖 Você está conversando com %s (%s)", cli.Client.GetModelName(), cli.Provider)
 	fmt.Println(colorize(modelInfo, ColorLime))
 	fmt.Println()


### PR DESCRIPTION
- Introduced `--agent-auto-exec` flag to enable secure automatic execution of suggested commands in agent one-shot mode.
- Enhanced input validation and routing logic for `/agent` and `/run` commands.
- Added optimized LLM prompts for single-command generation.
- Improved CLI user experience with refined welcome screen, logo centering, and updated tips display.