### PR TITLE
fix(cli): split `forceRefreshPrompt` by platform to improve compatibility

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"golang.org/x/sys/unix"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -534,21 +533,6 @@ func (cli *ChatCLI) handleCtrlC(buf *prompt.Buffer) {
 		fmt.Println("\nAté breve!! CTRL + C Duplo...")
 		cli.cleanup()
 		os.Exit(0)
-	}
-}
-
-// forceRefreshPrompt envia um sinal SIGWINCH para o processo atual,
-// forçando a biblioteca go-prompt a redesenhar a interface.
-func (cli *ChatCLI) forceRefreshPrompt() {
-	// Encontrar o processo atual
-	p, err := os.FindProcess(os.Getpid())
-	if err != nil {
-		cli.logger.Warn("Não foi possível encontrar o processo para forçar o refresh", zap.Error(err))
-		return
-	}
-	// Enviar o sinal de redimensionamento de janela
-	if err := p.Signal(unix.SIGWINCH); err != nil {
-		cli.logger.Warn("Não foi possível enviar o sinal SIGWINCH para forçar o refresh", zap.Error(err))
 	}
 }
 

--- a/cli/signal_unix.go
+++ b/cli/signal_unix.go
@@ -1,0 +1,26 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: MIT
+ */
+package cli
+
+import (
+	"os"
+
+	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
+)
+
+// forceRefreshPrompt envia um sinal SIGWINCH para o processo atual no Unix.
+func (cli *ChatCLI) forceRefreshPrompt() {
+	p, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		cli.logger.Warn("Não foi possível encontrar o processo para forçar o refresh", zap.Error(err))
+		return
+	}
+	// Usa unix.SIGWINCH, que está definido neste pacote
+	if err := p.Signal(unix.SIGWINCH); err != nil {
+		cli.logger.Warn("Não foi possível enviar o sinal SIGWINCH para forçar o refresh", zap.Error(err))
+	}
+}

--- a/cli/signal_windows.go
+++ b/cli/signal_windows.go
@@ -1,0 +1,12 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: MIT
+ */
+package cli
+
+// forceRefreshPrompt é um stub para Windows, onde SIGWINCH não se aplica.
+// A função não faz nada, pois não há um equivalente direto.
+func (cli *ChatCLI) forceRefreshPrompt() {
+	// No-op for Windows
+}


### PR DESCRIPTION
- Moved `forceRefreshPrompt` into platform-specific files: `signal_unix.go` and `signal_windows.go`.
- Added a no-op implementation for Windows, aligning with the absence of `SIGWINCH` signal support.
- Cleaned up unused imports and the previous cross-platform implementation in `cli.go`.