### PR TITLE
feat(cli): introduce session management capabilities and AI-assisted PR generation

### DIFF
--- a/.github/workflows/2-open-pr-develop-to-main.yml
+++ b/.github/workflows/2-open-pr-develop-to-main.yml
@@ -1,4 +1,4 @@
-name: Open PR develop -> main
+name: Open PR develop -> main (AI Assisted)
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
 
 permissions:
   pull-requests: write
-  contents: read
+  contents: write # 'write' é necessário para fazer o checkout e ler o histórico
 
 concurrency:
   group: open-pr-develop-to-main
@@ -15,7 +15,72 @@ concurrency:
 jobs:
   open_pr:
     runs-on: ubuntu-latest
+    env:
+      # Pré-requisito: Adicione o segredo da sua API KEY nas configurações do repositório
+      # Pode ser OPENAI_API_KEY, CLAUDEAI_API_KEY, etc., dependendo do seu provedor padrão.
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      # Garante que o Go instale os binários em um local conhecido
+      GOPATH: ${{ github.workspace }}/go
+
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # fetch-depth: 0 é essencial para buscar todo o histórico e poder comparar as branches
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23' # Use a versão do Go do seu projeto
+
+      - name: Install ChatCLI
+        run: go install github.com/diillson/chatcli@latest
+
+      - name: Add Go bin to PATH
+        run: echo "${{ env.GOPATH }}/bin" >> $GITHUB_PATH
+
+      - name: Generate PR Content with ChatCLI
+        id: generate-pr-content
+        run: |
+          # 1. Coletar o contexto: logs e diff de arquivos entre main e develop
+          LOG_DIFF=$(git log main..develop --pretty=format:"- %s (%h) by %an")
+          FILE_DIFF=$(git diff --stat main..develop)
+          
+          # 2. Criar um prompt detalhado para a IA
+          PROMPT=$(cat <<EOF
+          Você é um expert em engenharia de software e sua tarefa é criar um título e corpo para um Pull Request que irá mesclar a branch 'develop' na 'main'. O projeto usa a estratégia de squash merge, então a mensagem do PR será a mensagem final do commit.
+          
+          Sua resposta DEVE ser estritamente no formato:
+          TÍTULO DO PR
+          ---
+          CORPO DO PR
+          
+          **Diretrizes:**
+          1.  **Título:** Deve seguir o padrão Conventional Commits (ex: 'feat: ...', 'fix: ...', 'chore: ...', 'refactor: ...'). Seja conciso e informativo.
+          2.  **Corpo:** Deve ser um resumo claro e bem escrito das mudanças. Organize em seções se necessário (ex: Novas Funcionalidades, Correções, Melhorias). NÃO inclua o diff de código, apenas a explicação.
+          3.  **Linguagem:** Use Português do Brasil.
+          
+          **Contexto fornecido:**
+          
+          **Log de Commits:**
+          ${LOG_DIFF}
+          
+          **Resumo das Alterações nos Arquivos:**
+          ${FILE_DIFF}
+          EOF
+          )
+          
+          # 3. Executar o chatcli em modo one-shot para gerar o conteúdo
+          # Usamos --no-anim para uma saída limpa no log do CI
+          AI_RESPONSE=$(chatcli -p "$PROMPT" --no-anim --provider OPENAI --model gpt-5)
+          
+          # 4. Salvar a resposta completa para o próximo passo
+          # Usamos a sintaxe recomendada para outputs de múltiplas linhas
+          echo "ai_response<<EOF" >> $GITHUB_OUTPUT
+          echo "$AI_RESPONSE" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Open or reuse PR develop -> main
         uses: actions/github-script@v7
         with:
@@ -23,23 +88,38 @@ jobs:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const head = `${owner}:develop`;
+            const head = 'develop';
             const base = 'main';
             
+            // 1. Verificar se um PR já existe para não criar duplicatas
             const { data: prs } = await github.rest.pulls.list({
-              owner, repo, state: 'open', head, base, per_page: 10
+              owner, repo, state: 'open', head, base, per_page: 1
             });
             
             if (prs.length > 0) {
-              core.info(`PR já existe: #${prs[0].number}`);
+              core.info(`PR já existe: #${prs[0].number}. Nenhuma ação necessária.`);
               return;
             }
             
-            const title = `Merge develop into main`;
-            const body  = `PR automático para promover mudanças da develop à main.`;
+            // 2. Processar a resposta da IA do passo anterior
+            const ai_response = `${{ steps.generate-pr-content.outputs.ai_response }}`;
+            const parts = ai_response.split('\n---\n');
             
+            let title = `chore: Merge develop into main`; // Título de fallback
+            let body = `PR automático para promover mudanças da develop à main.`; // Corpo de fallback
+            
+            if (parts.length >= 2) {
+              title = parts[0].trim();
+              body = parts[1].trim();
+            } else {
+              core.warning("A resposta da IA não estava no formato esperado. Usando título e corpo de fallback.");
+              core.warning(`Resposta recebida: ${ai_response}`);
+            }
+            
+            // 3. Criar o Pull Request com o conteúdo gerado pela IA
             const { data: pr } = await github.rest.pulls.create({
-              owner, repo, head: 'develop', base, title, body
+              owner, repo, head, base, title, body
             });
             
-            core.info(`PR criado: #${pr.number}`);
+            core.info(`PR criado com sucesso: #${pr.number}`);
+            core.info(`Título: ${title}`);

--- a/README.md
+++ b/README.md
@@ -327,9 +327,12 @@ one-shot:
          - API preferida: chat_completions
          - MaxTokens efetivo: 50000
 
-- **Iniciar uma Nova Sessão**:
-    - `/newsession` – Limpa o histórico atual e inicia uma nova sessão de conversa.
-    - **Uso**: Ideal para começar uma conversa do zero sem o contexto anterior, anteriormente recebia um clean no historico de conversa e contexto ao trocar de provider `LLM`, hoje é possível continuar a sessão em novo provider `LLM` sem perder o histórico anterior, com o comando `/newsession` você pode zerar o histórico e contexto atual e iniciar uma nova sessão de conversa no novo provider se assim desejar.
+  - **Gerenciamento de Sessões**:
+      - `/session save <nome>` – Salva a conversa atual com um nome.
+      - `/session load <nome>` – Carrega uma conversa salva anteriormente.
+      - `/session list` – Mostra todas as sessões salvas.
+      - `/session delete <nome>` – Apaga uma sessão salva.
+      - `/session new` ou `/newsession` – Inicia uma nova sessão de conversa (limpa o histórico).
 
 - **Verificar Versão e Atualizações**:
     - `/version` ou `/v` – Mostra a versão atual, o hash do commit e verifica se há atualizações disponíveis.

--- a/README_EN.md
+++ b/README_EN.md
@@ -334,9 +334,12 @@ one-shot:
          - Preferred API: chat_completions
          - Effective MaxTokens: 50000
 
-  * **Start a New Session**:
-      * `/newsession` – Clears the current history and starts a new conversation session.
-      * **Usage**: Ideal for starting a conversation from scratch without previous context. Previously, switching the `LLM` provider would automatically clean the conversation and context history. Now, it's possible to continue the session with a new `LLM` provider without losing the existing history. If desired, you can use the `/newsession` command to reset the current history and context and start a fresh conversation with the new provider.
+  * **Session Management:**
+      * `/session save <name>` – Saves the current conversation with a given name.
+      * `/session load <name>` – Loads a previously saved conversation.
+      * `/session list` – Lists all saved sessions.
+      * `/session delete <name>` – Deletes a saved session.
+      * `/session new` or `/newsession` – Clears the current history and starts a new conversation session.
 
   * **Check Version and Updates:**
       * `/version` or `/v` – Shows current version, commit hash, and checks for available updates.

--- a/cli/command_handler.go
+++ b/cli/command_handler.go
@@ -54,7 +54,11 @@ func (ch *CommandHandler) HandleCommand(userInput string) bool {
 		return ch.cli.handleSkipChunk()
 	case userInput == "/newsession":
 		ch.cli.history = []models.Message{}
+		ch.cli.currentSessionName = ""
 		fmt.Println("Iniciada nova sessão de conversa; histórico foi limpo.")
+		return false
+	case strings.HasPrefix(userInput, "/session"):
+		ch.handleSessionCommand(userInput)
 		return false
 	default:
 		fmt.Println("Comando desconhecido. Use /help para ver os comandos disponíveis.")

--- a/cli/session_manager.go
+++ b/cli/session_manager.go
@@ -1,0 +1,164 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/diillson/chatcli/models"
+	"github.com/diillson/chatcli/utils"
+	"go.uber.org/zap"
+)
+
+// SessionManager gerencia o salvamento e carregamento de sessões de conversa.
+type SessionManager struct {
+	sessionsDir string
+	logger      *zap.Logger
+}
+
+// NewSessionManager cria uma nova instância do SessionManager.
+func NewSessionManager(logger *zap.Logger) (*SessionManager, error) {
+	homeDir, err := utils.GetHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("não foi possível obter o diretório home: %w", err)
+	}
+
+	sessionsDir := filepath.Join(homeDir, ".chatcli", "sessions")
+	if err := os.MkdirAll(sessionsDir, 0755); err != nil {
+		return nil, fmt.Errorf("não foi possível criar o diretório de sessões: %w", err)
+	}
+
+	return &SessionManager{
+		sessionsDir: sessionsDir,
+		logger:      logger,
+	}, nil
+}
+
+// getSessionPath retorna o caminho completo para um arquivo de sessão.
+func (sm *SessionManager) getSessionPath(name string) string {
+	// Sanitiza o nome para evitar problemas com o sistema de arquivos
+	safeName := strings.ReplaceAll(name, "/", "_")
+	safeName = strings.ReplaceAll(safeName, "\\", "_")
+	return filepath.Join(sm.sessionsDir, safeName+".json")
+}
+
+// SaveSession salva o histórico da conversa em um arquivo JSON.
+func (sm *SessionManager) SaveSession(name string, history []models.Message) error {
+	if name == "" {
+		return fmt.Errorf("o nome da sessão não pode ser vazio")
+	}
+
+	filePath := sm.getSessionPath(name)
+	data, err := json.MarshalIndent(history, "", "  ")
+	if err != nil {
+		sm.logger.Error("Erro ao serializar a sessão para JSON", zap.String("session", name), zap.Error(err))
+		return fmt.Errorf("erro ao serializar a sessão: %w", err)
+	}
+
+	if err := os.WriteFile(filePath, data, 0644); err != nil {
+		sm.logger.Error("Erro ao salvar o arquivo da sessão", zap.String("path", filePath), zap.Error(err))
+		return fmt.Errorf("erro ao salvar o arquivo da sessão: %w", err)
+	}
+
+	sm.logger.Info("Sessão salva com sucesso", zap.String("session", name), zap.String("path", filePath))
+	return nil
+}
+
+// LoadSession carrega o histórico de uma conversa de um arquivo JSON.
+func (sm *SessionManager) LoadSession(name string) ([]models.Message, error) {
+	filePath := sm.getSessionPath(name)
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("sessão '%s' não encontrada", name)
+	}
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		sm.logger.Error("Erro ao ler o arquivo da sessão", zap.String("path", filePath), zap.Error(err))
+		return nil, fmt.Errorf("erro ao ler o arquivo da sessão: %w", err)
+	}
+
+	var history []models.Message
+	if err := json.Unmarshal(data, &history); err != nil {
+		sm.logger.Error("Erro ao desserializar a sessão", zap.String("session", name), zap.Error(err))
+		return nil, fmt.Errorf("arquivo de sessão corrompido: %w", err)
+	}
+
+	sm.logger.Info("Sessão carregada com sucesso", zap.String("session", name))
+	return history, nil
+}
+
+// ListSessions lista todas as sessões salvas.
+func (sm *SessionManager) ListSessions() ([]string, error) {
+	entries, err := os.ReadDir(sm.sessionsDir)
+	if err != nil {
+		return nil, fmt.Errorf("erro ao ler o diretório de sessões: %w", err)
+	}
+
+	var sessions []string
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".json") {
+			sessionName := strings.TrimSuffix(entry.Name(), ".json")
+			sessions = append(sessions, sessionName)
+		}
+	}
+	return sessions, nil
+}
+
+// DeleteSession apaga um arquivo de sessão.
+func (sm *SessionManager) DeleteSession(name string) error {
+	filePath := sm.getSessionPath(name)
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		return fmt.Errorf("sessão '%s' não encontrada", name)
+	}
+	return os.Remove(filePath)
+}
+
+func (ch *CommandHandler) handleSessionCommand(userInput string) {
+	args := strings.Fields(userInput)
+	if len(args) < 2 {
+		fmt.Println("Uso do comando /session:")
+		fmt.Println("  /session save <nome>")
+		fmt.Println("  /session load <nome>")
+		fmt.Println("  /session list")
+		fmt.Println("  /session delete <nome>")
+		fmt.Println("  /session new")
+		return
+	}
+
+	command := args[1]
+	var name string
+	if len(args) > 2 {
+		name = args[2]
+	}
+
+	switch command {
+	case "save":
+		if name == "" {
+			fmt.Println("Erro: é necessário fornecer um nome para salvar a sessão.")
+			return
+		}
+		ch.cli.handleSaveSession(name)
+	case "load":
+		if name == "" {
+			fmt.Println("Erro: é necessário fornecer um nome para carregar a sessão.")
+			return
+		}
+		ch.cli.handleLoadSession(name)
+	case "list":
+		ch.cli.handleListSessions()
+	case "delete":
+		if name == "" {
+			fmt.Println("Erro: é necessário fornecer um nome para deletar a sessão.")
+			return
+		}
+		ch.cli.handleDeleteSession(name)
+	case "new":
+		ch.cli.history = []models.Message{}
+		ch.cli.currentSessionName = ""
+		fmt.Println("Iniciada nova sessão de conversa; histórico foi limpo.")
+	default:
+		fmt.Printf("Comando de sessão desconhecido: '%s'. Use /session para ver as opções.\n", command)
+	}
+}


### PR DESCRIPTION
- Added support for saving, loading, listing, and deleting conversation sessions through new commands (`/session`).
- Integrated `SessionManager` to handle session persistence via JSON files.
- Enhanced CLI prompt to display the current session name.
- Updated `/newsession` to clear history and reset active session.

- Implemented AI-assisted PR content generation in GitHub Actions workflow.
- Added ChatCLI setup and integration with OpenAI for automated PR title and body generation based on code diffs and commit logs.
- Updated documentation to reflect changes in session management features.