### PR TITLE
fix(cli): add command flag suggestions and improve ENV log configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ O ChatCLI utiliza variáveis de ambiente para se conectar aos provedores de LLM 
     - `CHATCLI_DOTENV` – **(Opcional)** Define o caminho do seu arquivo `.env`.
     - `LOG_LEVEL` (`debug`, `info`, `warn`, `error`)
     - `LLM_PROVIDER` (`OPENAI`, `STACKSPOT`, `CLAUDEAI`, `GOOGLEAI`, `XAI`)
+    - `ENV` - **(Opcional)** Define como o log será exibido (`dev`, `prod`), Padrão: `dev`.
+      - `dev` ele mostra os logs direto no terminal e salva no arquivo de log. 
+      - `prod` ele apenas salva no arquivo de log mantendo um terminal mais limpo.
 - **Provedores**:
     - `OPENAI_API_KEY`, `OPENAI_MODEL`, `OPENAI_ASSISTANT_MODEL`, `OPENAI_MAX_TOKENS`, `OPENAI_USE_RESPONSES`
     - `CLAUDEAI_API_KEY`, `CLAUDEAI_MODEL`, `CLAUDEAI_MAX_TOKENS`, `CLAUDEAI_API_VERSION`

--- a/README_EN.md
+++ b/README_EN.md
@@ -113,6 +113,9 @@ ChatCLI uses environment variables to define its behavior and connect to LLM pro
     - `CHATCLI_DOTENV` – **(Optional)** Defines the path to your `.env` file.
     - `LOG_LEVEL` (`debug`, `info`, `warn`, `error`)
     - `LLM_PROVIDER` (`OPENAI`, `STACKSPOT`, `CLAUDEAI`, `GOOGLEAI`, `XAI`)
+    - `ENV` - **(Optional)** Defines how the log will be displayed (`dev`, `prod`). Default: `dev`.
+      - `dev` displays the logs directly in the terminal and saves them to the log file.
+      - `prod` only saves them to the log file, keeping the terminal cleaner.
 - **Providers**:
     - `OPENAI_API_KEY`, `OPENAI_MODEL`, `OPENAI_ASSISTANT_MODEL`, `OPENAI_MAX_TOKENS`, `OPENAI_USE_RESPONSES`
     - `CLAUDEAI_API_KEY`, `CLAUDEAI_MODEL`, `CLAUDEAI_MAX_TOKENS`, `CLAUDEAI_API_VERSION`


### PR DESCRIPTION
- Introduced dynamic suggestions for command flags and their values.
- Added the `ENV` variable to control log display modes (`dev`, `prod`).
- Updated README and README_EN with details on `ENV` behavior and flag options.