### PR TITLE
feat(llm): add Ollama provider with support for local models

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # Aproxime seu Terminal da Inteligência Artificial 🕵️‍♂️✨
  
-O **ChatCLI** é uma aplicação de linha de comando (CLI) avançada que integra modelos de Linguagem de Aprendizado (LLMs) poderosos (como OpenAI, StackSpot, GoogleAI, ClaudeAI e xAI) para facilitar conversas interativas e contextuais diretamente no seu terminal. Projetado para desenvolvedores, cientistas de dados e entusiastas de tecnologia, ele potencializa a produtividade ao agregar diversas fontes de dados contextuais e oferecer uma experiência rica e amigável.
+O **ChatCLI** é uma aplicação de linha de comando (CLI) avançada que integra modelos de Linguagem de Aprendizado (LLMs) poderosos (como OpenAI, StackSpot, GoogleAI, ClaudeAI, xAI e Ollama -> `Modelos Locais`) para facilitar conversas interativas e contextuais diretamente no seu terminal. Projetado para desenvolvedores, cientistas de dados e entusiastas de tecnologia, ele potencializa a produtividade ao agregar diversas fontes de dados contextuais e oferecer uma experiência rica e amigável.
 
 <div align="center">
   <img src="https://github.com/diillson/chatcli/actions/workflows/1-ci.yml/badge.svg"/>
@@ -45,7 +45,7 @@ O **ChatCLI** é uma aplicação de linha de comando (CLI) avançada que integra
 
 ## Recursos Principais
 
-- **Suporte a Múltiplos Provedores**: Alterne entre OpenAI, StackSpot, ClaudeAI, GoogleAI e xAI.
+- **Suporte a Múltiplos Provedores**: Alterne entre OpenAI, StackSpot, ClaudeAI, GoogleAI, xAI e Ollama -> `Modelos locais`.
 - **Experiência Interativa na CLI**: Navegação de histórico, auto-completação e feedback visual (`"Pensando..."`).
 - **Comandos Contextuais Poderosos**:
     - `@history` – Insere os últimos 10 comandos do shell (suporta bash, zsh e fish).
@@ -120,6 +120,7 @@ O ChatCLI utiliza variáveis de ambiente para se conectar aos provedores de LLM 
     - `OPENAI_API_KEY`, `OPENAI_MODEL`, `OPENAI_ASSISTANT_MODEL`, `OPENAI_MAX_TOKENS`, `OPENAI_USE_RESPONSES`
     - `CLAUDEAI_API_KEY`, `CLAUDEAI_MODEL`, `CLAUDEAI_MAX_TOKENS`, `CLAUDEAI_API_VERSION`
     - `GOOGLEAI_API_KEY`, `GOOGLEAI_MODEL`, `GOOGLEAI_MAX_TOKENS`
+    - `OLLAMA_ENABLED`, `OLLAMA_BASE_URL`, `OLLAMA_MODEL`, `OLLAMA_MAX_TOKENS`
     - `XAI_API_KEY`, `XAI_MODEL`, `XAI_MAX_TOKENS`
     - `CLIENT_ID`, `CLIENT_SECRET`, `SLUG_NAME`, `TENANT_NAME` (para StackSpot)
 
@@ -163,6 +164,12 @@ GOOGLEAI_MAX_TOKENS=50000
 XAI_API_KEY=sua-chave-xai
 XAI_MODEL=grok-4-latest
 XAI_MAX_TOKENS=50000
+
+# Configurações da Ollama
+OLLAMA_ENABLED=true      #Obrigatório para habilitar API do Ollama
+OLLAMA_BASE_URL=http://localhost:11434
+OLLAMA_MODEL=gpt-oss:20b
+OLLAMA_MAX_TOKENS=5000
 ```
 
 -----

--- a/README_EN.md
+++ b/README_EN.md
@@ -6,7 +6,7 @@
 
 # Bringing Your Terminal Closer to Artificial Intelligence 🕵️‍♂️✨
 
-**ChatCLI** is an advanced command-line application (CLI) that integrates powerful Large Language Models (LLMs) (such as OpenAI, StackSpot, GoogleAI, ClaudeAI, and xAI) to facilitate interactive and contextual conversations directly in your terminal. Designed for developers, data scientists, and tech enthusiasts, it enhances productivity by aggregating various contextual data sources and offering a rich, user-friendly experience.
+**ChatCLI** is an advanced command-line application (CLI) that integrates powerful Large Language Models (LLMs) (such as OpenAI, StackSpot, GoogleAI, ClaudeAI, xAI and Ollama -> `Local models`) to facilitate interactive and contextual conversations directly in your terminal. Designed for developers, data scientists, and tech enthusiasts, it enhances productivity by aggregating various contextual data sources and offering a rich, user-friendly experience.
 
 <div align="center">
   <img src="https://github.com/diillson/chatcli/actions/workflows/1-ci.yml/badge.svg"/>
@@ -45,7 +45,7 @@
 
 ## Key Features
 
-- **Support for Multiple Providers**: Switch between OpenAI, StackSpot, ClaudeAI, GoogleAI, and xAI.
+- **Support for Multiple Providers**: Switch between OpenAI, StackSpot, ClaudeAI, GoogleAI, xAI and Ollama -> `Local models`.
 - **Interactive CLI Experience**: Command history navigation, auto-completion, and visual feedback (`"Thinking..."`).
 - **Powerful Contextual Commands**:
     - `@history` – Inserts the last 10 shell commands (supports bash, zsh, and fish).
@@ -121,6 +121,7 @@ ChatCLI uses environment variables to define its behavior and connect to LLM pro
     - `CLAUDEAI_API_KEY`, `CLAUDEAI_MODEL`, `CLAUDEAI_MAX_TOKENS`, `CLAUDEAI_API_VERSION`
     - `GOOGLEAI_API_KEY`, `GOOGLEAI_MODEL`, `GOOGLEAI_MAX_TOKENS`
     - `XAI_API_KEY`, `XAI_MODEL`, `XAI_MAX_TOKENS`
+    - `OLLAMA_ENABLED`, `OLLAMA_BASE_URL`, `OLLAMA_MODEL`, `OLLAMA_MAX_TOKENS`
     - `CLIENT_ID`, `CLIENT_SECRET`, `SLUG_NAME`, `TENANT_NAME` (for StackSpot)
 
 ### Example `.env`
@@ -162,6 +163,12 @@ GOOGLEAI_MAX_TOKENS=20000
 # xAI Settings
 XAI_API_KEY=your-xai-key
 XAI_MODEL=grok-4-latest
+
+# Ollama Settings
+OLLAMA_ENABLED=true      #Required for enabled API Ollama
+OLLAMA_BASE_URL=http://localhost:11434
+OLLAMA_MODEL=gpt-oss:20b
+OLLAMA_MAX_TOKENS=5000
 ```
 
 -----

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -253,6 +253,12 @@ func (cli *ChatCLI) configureProviderAndModel() {
 			cli.Model = config.DefaultXAIModel
 		}
 	}
+	if cli.Provider == "OLLAMA" {
+		cli.Model = os.Getenv("OLLAMA_MODEL")
+		if cli.Model == "" {
+			cli.Model = config.DefaultOllamaModel
+		}
+	}
 }
 
 // NewChatCLI cria uma nova instância de ChatCLI
@@ -442,6 +448,9 @@ func (cli *ChatCLI) handleProviderSelection(in string) {
 	}
 	if newProvider == "XAI" {
 		newModel = utils.GetEnvOrDefault("XAI_MODEL", config.DefaultXAIModel)
+	}
+	if newProvider == "OLLAMA" {
+		newModel = utils.GetEnvOrDefault("OLLAMA_MODEL", config.DefaultOllamaModel)
 	}
 
 	newClient, err := cli.manager.GetClient(newProvider, newModel)
@@ -1173,6 +1182,18 @@ func (cli *ChatCLI) getMaxTokensForCurrentLLM() int {
 		}
 	} else if strings.ToUpper(cli.Provider) == "GOOGLEAI" {
 		if v := os.Getenv("GOOGLEAI_MAX_TOKENS"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				override = n
+			}
+		}
+	} else if strings.ToUpper(cli.Provider) == "XAI" {
+		if v := os.Getenv("XAI_MAX_TOKENS"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				override = n
+			}
+		}
+	} else if strings.ToUpper(cli.Provider) == "OLLAMA" {
+		if v := os.Getenv("OLLAMA_MAX_TOKENS"); v != "" {
 			if n, err := strconv.Atoi(v); err == nil && n > 0 {
 				override = n
 			}
@@ -2283,6 +2304,7 @@ func (cli *ChatCLI) showConfig() {
 	printItem("CLAUDEAI_MAX_TOKENS", os.Getenv("CLAUDEAI_MAX_TOKENS"))
 	printItem("GOOGLEAI_MAX_TOKENS", os.Getenv("GOOGLEAI_MAX_TOKENS"))
 	printItem("XAI_MAX_TOKENS", os.Getenv("XAI_MAX_TOKENS"))
+	printItem("OLLAMA_MAX_TOKENS", os.Getenv("OLLAMA_MAX_TOKENS"))
 
 	// --- Chaves Sensíveis (Presença Apenas) ---
 	fmt.Printf("\n  %s\n", colorize("Chaves Sensíveis (Presença Apenas)", ColorLime))
@@ -2309,6 +2331,8 @@ func (cli *ChatCLI) showConfig() {
 	//}
 	//if strings.ToUpper(cli.Provider) == "XAI" {
 	printItem("XAI_MODEL", os.Getenv("XAI_MODEL"))
+	printItem("OLLAMA_MODEL", os.Getenv("OLLAMA_MODEL"))
+	printItem("OLLAMA_BASE_URL", utils.GetEnvOrDefault("OLLAMA_BASE_URL", config.OllamaDefaultBaseURL))
 	//}
 	if tm, ok := cli.manager.GetTokenManager(); ok {
 		slug, tenant := tm.GetSlugAndTenantName()

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -43,6 +43,13 @@ const (
 	DefaultXAIModel = "grok-code-fast-1"
 	XAIAPIURL       = "https://api.x.ai/v1/chat/completions"
 
+	// Valores padrão para Ollama
+	DefaultOllamaModel       = "gpt-oss:20b"
+	OllamaDefaultBaseURL     = "http://localhost:11434"
+	OllamaDefaultMaxAttempts = 3
+	OllamaDefaultBackoff     = time.Second
+	OllamaDefaultMaxTokens   = 8192
+
 	// Provedor padrão
 	DefaultLLMProvider = "OPENAI"
 

--- a/llm/catalog/catalog.go
+++ b/llm/catalog/catalog.go
@@ -14,6 +14,7 @@ const (
 	ProviderStackSpot       = "STACKSPOT"
 	ProviderGoogleAI        = "GOOGLEAI"
 	ProviderXAI             = "XAI"
+	ProviderOllama          = "OLLAMA"
 )
 
 // PreferredAPI define qual API é preferida para o modelo
@@ -337,6 +338,8 @@ func GetMaxTokens(provider, model string, override int) int {
 		return 50000
 	case ProviderXAI:
 		return 50000
+	case ProviderOllama:
+		return 8192
 	default:
 		return 50000
 	}

--- a/llm/ollama/ollama_client.go
+++ b/llm/ollama/ollama_client.go
@@ -1,0 +1,149 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/diillson/chatcli/config"
+	"github.com/diillson/chatcli/llm/catalog"
+	"github.com/diillson/chatcli/models"
+	"github.com/diillson/chatcli/utils"
+	"go.uber.org/zap"
+)
+
+type Client struct {
+	baseURL     string
+	model       string
+	logger      *zap.Logger
+	httpClient  *http.Client
+	maxAttempts int
+	backoff     time.Duration
+}
+
+func NewClient(baseURL, model string, logger *zap.Logger, maxAttempts int, backoff time.Duration) *Client {
+	if baseURL == "" {
+		baseURL = config.OllamaDefaultBaseURL
+	}
+	if model == "" {
+		model = config.DefaultOllamaModel
+	}
+	if maxAttempts <= 0 {
+		maxAttempts = config.OllamaDefaultMaxAttempts
+	}
+	if backoff <= 0 {
+		backoff = config.OllamaDefaultBackoff
+	}
+	return &Client{
+		baseURL:     strings.TrimRight(baseURL, "/"),
+		model:       model,
+		logger:      logger,
+		httpClient:  utils.NewHTTPClient(logger, 300*time.Second),
+		maxAttempts: maxAttempts,
+		backoff:     backoff,
+	}
+}
+
+func (c *Client) GetModelName() string {
+	// Caso não tenha cadastro no catálogo, retorna o próprio ID
+	return catalog.GetDisplayName(catalog.ProviderOllama, c.model)
+}
+
+func (c *Client) getMaxTokens() int {
+	if v := os.Getenv("OLLAMA_MAX_TOKENS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return catalog.GetMaxTokens(catalog.ProviderOllama, c.model, 0)
+}
+
+func (c *Client) SendPrompt(ctx context.Context, prompt string, history []models.Message) (string, error) {
+	// Monta mensagens a partir do histórico, sem duplicar o prompt (mesma lógica dos outros clientes)
+	var msgs []map[string]string
+	for _, m := range history {
+		role := strings.ToLower(strings.TrimSpace(m.Role))
+		switch role {
+		case "system", "user", "assistant":
+		default:
+			role = "user"
+		}
+		msgs = append(msgs, map[string]string{"role": role, "content": m.Content})
+	}
+
+	if len(history) == 0 || history[len(history)-1].Role != "user" || history[len(history)-1].Content != prompt {
+		if strings.TrimSpace(prompt) != "" {
+			msgs = append(msgs, map[string]string{"role": "user", "content": prompt})
+		}
+	}
+
+	// Payload /api/chat
+	reqBody := map[string]interface{}{
+		"model":    c.model,
+		"messages": msgs,
+		"stream":   false,
+		"options": map[string]interface{}{
+			"num_predict": c.getMaxTokens(),
+			// "temperature": 0.7,
+			// "num_ctx": 8192,
+		},
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("erro ao preparar payload do Ollama: %w", err)
+	}
+
+	url := c.baseURL + "/api/chat"
+	backoff := c.backoff
+
+	for attempt := 1; attempt <= c.maxAttempts; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, utils.NewJSONReader(body))
+		if err != nil {
+			return "", fmt.Errorf("erro criando requisição Ollama: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			if utils.IsTemporaryError(err) && attempt < c.maxAttempts {
+				c.logger.Warn("Erro temporário ao chamar Ollama",
+					zap.Int("attempt", attempt), zap.Error(err), zap.Duration("backoff", backoff))
+				time.Sleep(backoff)
+				backoff *= 2
+				continue
+			}
+			return "", fmt.Errorf("erro na requisição ao Ollama: %w", err)
+		}
+		defer resp.Body.Close()
+
+		var result struct {
+			Message struct {
+				Role    string `json:"role"`
+				Content string `json:"content"`
+			} `json:"message"`
+			Done  bool   `json:"done"`
+			Error string `json:"error"`
+		}
+
+		dec := json.NewDecoder(resp.Body)
+		if err := dec.Decode(&result); err != nil {
+			return "", fmt.Errorf("erro ao decodificar resposta do Ollama: %w", err)
+		}
+
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return "", fmt.Errorf("erro Ollama (%d): %s", resp.StatusCode, result.Error)
+		}
+		if result.Error != "" {
+			return "", fmt.Errorf("erro Ollama: %s", result.Error)
+		}
+		return result.Message.Content, nil
+	}
+
+	return "", fmt.Errorf("falha ao obter resposta do Ollama após %d tentativas", c.maxAttempts)
+}

--- a/llm/ollama/ollama_client_test.go
+++ b/llm/ollama/ollama_client_test.go
@@ -1,0 +1,36 @@
+package ollama
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestOllamaClient_SendPrompt_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/chat" || r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, err := io.WriteString(w, `{"message":{"role":"assistant","content":"Hello from Ollama!"},"done":true}`)
+		if err != nil {
+			return
+		}
+	}))
+	defer srv.Close()
+
+	logger, _ := zap.NewDevelopment()
+	c := NewClient(srv.URL, "llama3.1:8b", logger, 1, 0)
+
+	out, err := c.SendPrompt(context.Background(), "Hi", []models.Message{{Role: "user", Content: "Hi"}})
+	require.NoError(t, err)
+	assert.Equal(t, "Hello from Ollama!", out)
+}


### PR DESCRIPTION
### New Features
  
  • Added Ollama provider with support for running local models.
  • Implemented Ollama client and integrated it into the LLM manager and provider catalog.
  • Extended CLI to allow selecting/using the Ollama provider.
  
  ### Documentation
  
  • Updated README and README_EN to document the new Ollama provider.
  
  ### Configuration
  
  • Added defaults to enable/configure the Ollama provider.
  
  ### Tests
  
  • Introduced unit tests for the Ollama client.
  
  ### Changes Summary
  
  • 8 files changed, 317 insertions, 4 deletions.
  
  ### Related
  
  • References: #264