### PR TITLE
feat(cli,llm): implement override for max_tokens across clients and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Execute prompts em uma única linha, ideal para scripts e automações.
     - `-p` ou `--prompt`: texto a enviar para a LLM em uma única execução.
     - `--provider`: sobrescreve o provedor de LLM em tempo de execução (`OPENAI`, `OPENAI_ASSISTANT`, `CLAUDEAI`, `GOOGLEAI`, `STACKSPOT`, `XAI`).
     - `--model`: escolhe o modelo do provedor ativo (ex.: `gpt-4o-mini`, `claude-3-5-sonnet-20241022`, `gemini-2.5-flash`, etc.)
+    - `--max-tokens`: Define a quantidade maxima de tokens usada para provedor ativo.
     - `--timeout` timeout da chamada one-shot (padrão: 5m)
     - `--no-anim` desabilita animações (útil em scripts/CI).
     - `--agent-auto-exec` executa automaticamente o primeiro comando sugerido pelo agente (modo agente).

--- a/README_EN.md
+++ b/README_EN.md
@@ -197,6 +197,7 @@ Execute prompts in a single line, ideal for scripting and automation.
     - `-p` or `--prompt`: The text to send to the LLM for a single execution.
     - `--provider`: Overrides the LLM provider at runtime (`OPENAI`, `OPENAI_ASSISTANT`, `CLAUDEAI`, `GOOGLEAI`, `STACKSPOT`, `XAI`).
     - `--model`: Chooses the model for the active provider (e.g., `gpt-4o-mini`, `claude-3-5-sonnet-20241022`, `gemini-2.5-flash`, etc.).
+    - `--max-tokens`: Defines the maximum amount of tokens used for active provider.
     - `--timeout`: Sets the timeout for the one-shot call (default: `5m`).
     - `--no-anim`: Disables animations (useful in scripts/CI).
     - `--agent-auto-exec`: Automatically executes the first command suggested by the agent (in agent mode).

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -240,7 +240,7 @@ Exemplo de bloco de comando (formato mostrado abaixo):`
 		zap.Int("historyLength", len(a.cli.history)),
 		zap.Int("queryLength", len(fullQuery)))
 
-	aiResponse, err := a.cli.Client.SendPrompt(responseCtx, fullQuery, a.cli.history)
+	aiResponse, err := a.cli.Client.SendPrompt(responseCtx, fullQuery, a.cli.history, 0)
 
 	if err != nil {
 		a.logger.Error("Erro ao obter resposta do LLM", zap.Error(err))
@@ -294,7 +294,10 @@ func (a *AgentMode) RunOnce(ctx context.Context, query string, autoExecute bool)
 	a.cli.animation.ShowThinkingAnimation(a.cli.Client.GetModelName())
 
 	// 2. Enviar para a LLM
-	aiResponse, err := a.cli.Client.SendPrompt(ctx, query, a.cli.history)
+	aiResponse, err := a.cli.Client.SendPrompt(ctx, query, a.cli.history, 0)
+	if err != nil {
+		return fmt.Errorf("erro ao obter resposta da IA: %w", err)
+	}
 	a.cli.animation.StopThinkingAnimation()
 	if err != nil {
 		return fmt.Errorf("erro ao obter resposta da IA: %w", err)
@@ -625,7 +628,7 @@ func (a *AgentMode) requestLLMContinuationWithContext(ctx context.Context, previ
 	})
 
 	a.cli.animation.ShowThinkingAnimation(a.cli.Client.GetModelName())
-	aiResponse, err := a.cli.Client.SendPrompt(newCtx, prompt.String(), a.cli.history)
+	aiResponse, err := a.cli.Client.SendPrompt(newCtx, prompt.String(), a.cli.history, 0)
 	a.cli.animation.StopThinkingAnimation()
 	if err != nil {
 		fmt.Println("❌ Erro ao pedir continuação à IA:", err)
@@ -1520,7 +1523,7 @@ func (a *AgentMode) requestLLMContinuation(ctx context.Context, userQuery, previ
 	})
 
 	a.cli.animation.ShowThinkingAnimation(a.cli.Client.GetModelName())
-	aiResponse, err := a.cli.Client.SendPrompt(ctx, retryPrompt, a.cli.history)
+	aiResponse, err := a.cli.Client.SendPrompt(ctx, retryPrompt, a.cli.history, 0)
 	a.cli.animation.StopThinkingAnimation()
 	if err != nil {
 		fmt.Println("❌ Erro ao pedir continuação à IA:", err)
@@ -1569,7 +1572,7 @@ func (a *AgentMode) requestLLMWithPreExecutionContext(ctx context.Context, origi
 	})
 
 	a.cli.animation.ShowThinkingAnimation(a.cli.Client.GetModelName())
-	aiResponse, err := a.cli.Client.SendPrompt(newCtx, prompt.String(), a.cli.history)
+	aiResponse, err := a.cli.Client.SendPrompt(newCtx, prompt.String(), a.cli.history, 0)
 	a.cli.animation.StopThinkingAnimation()
 	if err != nil {
 		fmt.Println("❌ Erro ao pedir refinamento à IA:", err)

--- a/cli/agent_mode_test.go
+++ b/cli/agent_mode_test.go
@@ -23,8 +23,8 @@ func (m *MockLLMClient) GetModelName() string {
 	return args.String(0)
 }
 
-func (m *MockLLMClient) SendPrompt(ctx context.Context, prompt string, history []models.Message) (string, error) {
-	args := m.Called(ctx, prompt, history)
+func (m *MockLLMClient) SendPrompt(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {
+	args := m.Called(ctx, prompt, history, maxTokens)
 	return args.String(0), args.Error(1)
 }
 
@@ -74,8 +74,7 @@ func TestAgentMode_Run_ExtractsAndHandlesCommands(t *testing.T) {
 
 	// Configurar mocks
 	mockLLM.On("GetModelName").Return("MockGPT")
-	mockLLM.On("SendPrompt", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("[]models.Message")).Return(aiResponse, nil)
-
+	mockLLM.On("SendPrompt", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("[]models.Message"), mock.AnythingOfType("int")).Return(aiResponse, nil)
 	// Mock da execução do comando
 	var executedBlock CommandBlock
 	agentMode.executeCommandsFunc = func(ctx context.Context, block CommandBlock) (string, string) {

--- a/cli/oneshot_mode.go
+++ b/cli/oneshot_mode.go
@@ -32,6 +32,7 @@ type Options struct {
 	NoAnim         bool          // --no-anim
 	PromptFlagUsed bool          // indica se -p/--prompt foi passado explicitamente
 	AgentAutoExec  bool          // --agent-auto-exec
+	MaxTokens      int           // --max-tokens
 }
 
 // HandleOneShotOrFatal executa o modo one-shot se solicitado (flag -p usada ou stdin presente).
@@ -153,8 +154,8 @@ func (cli *ChatCLI) RunOnce(ctx context.Context, input string, disableAnimation 
 		cli.animation.ShowThinkingAnimation(cli.Client.GetModelName())
 	}
 
-	// Faz a chamada ao LLM (com timeout vindo do contexto)
-	aiResponse, err := cli.Client.SendPrompt(ctx, userInput+additionalContext, cli.history)
+	effectiveMaxTokens := cli.getMaxTokensForCurrentLLM()
+	aiResponse, err := cli.Client.SendPrompt(ctx, userInput+additionalContext, cli.history, effectiveMaxTokens)
 
 	if !disableAnimation {
 		cli.animation.StopThinkingAnimation()
@@ -189,6 +190,7 @@ func NewFlagSet() (*flag.FlagSet, *Options) {
 	fs.StringVar(&opts.Model, "model", "", "Override do modelo(LLM)")
 
 	fs.DurationVar(&opts.Timeout, "timeout", 5*time.Minute, "Timeout da chamada one-shot")
+	fs.IntVar(&opts.MaxTokens, "max-tokens", 0, "Override do máximo de tokens para a resposta")
 	fs.BoolVar(&opts.NoAnim, "no-anim", false, "Desabilita animações no modo one-shot")
 
 	fs.BoolVar(&opts.AgentAutoExec, "agent-auto-exec", false, "No modo agente one-shot, executa o primeiro comando sugerido automaticamente se for seguro.")

--- a/cli/signal_unix.go
+++ b/cli/signal_unix.go
@@ -9,6 +9,8 @@ package cli
 
 import (
 	"os"
+	"os/exec"
+	"runtime"
 
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
@@ -16,13 +18,32 @@ import (
 
 // forceRefreshPrompt envia um sinal SIGWINCH para o processo atual no Unix.
 func (cli *ChatCLI) forceRefreshPrompt() {
-	p, err := os.FindProcess(os.Getpid())
-	if err != nil {
-		cli.logger.Warn("Não foi possível encontrar o processo para forçar o refresh", zap.Error(err))
-		return
+	//resetTerminal(cli.logger)
+
+	// 2. Enviar sinal SIGWINCH apenas no Unix (como antes)
+	if runtime.GOOS != "windows" {
+		p, err := os.FindProcess(os.Getpid())
+		if err != nil {
+			cli.logger.Warn("Não foi possível encontrar o processo para forçar o refresh", zap.Error(err))
+			return
+		}
+		if err := p.Signal(unix.SIGWINCH); err != nil {
+			cli.logger.Warn("Não foi possível enviar o sinal SIGWINCH para forçar o refresh", zap.Error(err))
+		}
 	}
-	// Usa unix.SIGWINCH, que está definido neste pacote
-	if err := p.Signal(unix.SIGWINCH); err != nil {
-		cli.logger.Warn("Não foi possível enviar o sinal SIGWINCH para forçar o refresh", zap.Error(err))
+}
+
+func resetTerminal(logger *zap.Logger) {
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		cmd = exec.Command("cmd", "/c", "cls")
+	} else {
+		cmd = exec.Command("stty", "sane")
+	}
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		logger.Warn("Falha ao resetar terminal", zap.Error(err))
 	}
 }

--- a/cli/signal_unix.go
+++ b/cli/signal_unix.go
@@ -9,8 +9,6 @@ package cli
 
 import (
 	"os"
-	"os/exec"
-	"runtime"
 
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
@@ -20,30 +18,12 @@ import (
 func (cli *ChatCLI) forceRefreshPrompt() {
 	//resetTerminal(cli.logger)
 
-	// 2. Enviar sinal SIGWINCH apenas no Unix (como antes)
-	if runtime.GOOS != "windows" {
-		p, err := os.FindProcess(os.Getpid())
-		if err != nil {
-			cli.logger.Warn("Não foi possível encontrar o processo para forçar o refresh", zap.Error(err))
-			return
-		}
-		if err := p.Signal(unix.SIGWINCH); err != nil {
-			cli.logger.Warn("Não foi possível enviar o sinal SIGWINCH para forçar o refresh", zap.Error(err))
-		}
+	p, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		cli.logger.Warn("Não foi possível encontrar o processo para forçar o refresh", zap.Error(err))
+		return
 	}
-}
-
-func resetTerminal(logger *zap.Logger) {
-	var cmd *exec.Cmd
-	if runtime.GOOS == "windows" {
-		cmd = exec.Command("cmd", "/c", "cls")
-	} else {
-		cmd = exec.Command("stty", "sane")
-	}
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		logger.Warn("Falha ao resetar terminal", zap.Error(err))
+	if err := p.Signal(unix.SIGWINCH); err != nil {
+		cli.logger.Warn("Não foi possível enviar o sinal SIGWINCH para forçar o refresh", zap.Error(err))
 	}
 }

--- a/cli/signal_windows.go
+++ b/cli/signal_windows.go
@@ -7,8 +7,32 @@
  */
 package cli
 
-// forceRefreshPrompt é um stub para Windows, onde SIGWINCH não se aplica.
-// A função não faz nada, pois não há um equivalente direto.
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+
+	"go.uber.org/zap"
+)
+
+// forceRefreshPrompt no Windows usa sequências de escape ANSI para limpar a linha.
+// Isso força o go-prompt a redesenhar o prompt na próxima iteração do loop.
 func (cli *ChatCLI) forceRefreshPrompt() {
-	// No-op for Windows
+	// No Windows, a melhor abordagem é limpar a linha atual e retornar o cursor.
+	// O go-prompt irá então redesenhar o prefixo.
+	// \r -> Carriage Return (volta ao início da linha)
+	// \033[K -> Clear line from cursor to end
+	fmt.Print("\r\033[K")
+}
+
+func resetTerminal(logger *zap.Logger) {
+	if runtime.GOOS != "windows" {
+		return
+	}
+	cmd := exec.Command("cmd", "/c", "cls")
+	cmd.Stdout = os.Stdout
+	if err := cmd.Run(); err != nil {
+		logger.Warn("Falha ao limpar a tela no Windows", zap.Error(err))
+	}
 }

--- a/llm/claudeai/claude_client_test.go
+++ b/llm/claudeai/claude_client_test.go
@@ -50,8 +50,7 @@ func TestClaudeClient_SendPrompt_Success(t *testing.T) {
 
 	// 3. Executar o teste
 	history := []models.Message{{Role: "user", Content: "Hello"}}
-	resp, err := client.SendPrompt(context.Background(), "Hello", history)
-
+	resp, err := client.SendPrompt(context.Background(), "Hello", history, 0)
 	// 4. Verificar os resultados
 	assert.NoError(t, err)
 	assert.Equal(t, "Hi there!", resp)
@@ -79,7 +78,7 @@ func TestClaudeClient_SendPrompt_RetryOnRateLimit(t *testing.T) {
 
 	client.apiURL = server.URL
 
-	resp, err := client.SendPrompt(context.Background(), "Test", []models.Message{{Role: "user", Content: "Test"}})
+	resp, err := client.SendPrompt(context.Background(), "Test", []models.Message{{Role: "user", Content: "Test"}}, 0)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "Success on second try", resp)

--- a/llm/client/llm_client.go
+++ b/llm/client/llm_client.go
@@ -32,7 +32,7 @@ type LLMClient interface {
 	// O contexto (ctx) pode ser usado para controlar o tempo de execução e cancelamento.
 	// O histórico (history) contém as mensagens anteriores da conversa.
 	// Retorna uma string com a resposta do modelo e um erro, caso ocorra.
-	SendPrompt(ctx context.Context, prompt string, history []models.Message) (string, error)
+	SendPrompt(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error)
 
 	// (Opcional) Initialize pode ser usado para configurar ou autenticar o cliente LLM.
 	// Caso o cliente precise de configuração ou autenticação, esse método pode ser implementado.

--- a/llm/googleai/gemini_client.go
+++ b/llm/googleai/gemini_client.go
@@ -74,7 +74,12 @@ func (c *GeminiClient) GetModelName() string {
 }
 
 // SendPrompt envia um prompt para o Gemini e retorna a resposta
-func (c *GeminiClient) SendPrompt(ctx context.Context, prompt string, history []models.Message) (string, error) {
+func (c *GeminiClient) SendPrompt(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {
+	effectiveMaxTokens := maxTokens
+	if effectiveMaxTokens <= 0 {
+		effectiveMaxTokens = c.getMaxTokens() // Fallback para a lógica antiga se nada for passado
+	}
+
 	// ... (lógica de build do payload, logs, etc., permanece a mesma)
 	c.logger.Info("Iniciando requisição para Google AI",
 		zap.String("model", c.model),
@@ -94,12 +99,11 @@ func (c *GeminiClient) SendPrompt(ctx context.Context, prompt string, history []
 		}
 	}
 
-	maxTokens := c.getMaxTokens()
 	generationConfig := map[string]interface{}{
 		"temperature":     0.7,
 		"topP":            0.95,
 		"topK":            40,
-		"maxOutputTokens": maxTokens,
+		"maxOutputTokens": effectiveMaxTokens,
 	}
 
 	reqBody := map[string]interface{}{

--- a/llm/googleai/gemini_client_test.go
+++ b/llm/googleai/gemini_client_test.go
@@ -34,7 +34,7 @@ func TestGeminiClient_SendPrompt_Success(t *testing.T) {
 	client.baseURL = server.URL
 
 	history := []models.Message{{Role: "user", Content: "Hi"}}
-	resp, err := client.SendPrompt(context.Background(), "Hi", history)
+	resp, err := client.SendPrompt(context.Background(), "Hi", history, 0)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "Hello from Gemini!", resp)

--- a/llm/ollama/ollama_client.go
+++ b/llm/ollama/ollama_client.go
@@ -63,7 +63,12 @@ func (c *Client) getMaxTokens() int {
 	return catalog.GetMaxTokens(catalog.ProviderOllama, c.model, 0)
 }
 
-func (c *Client) SendPrompt(ctx context.Context, prompt string, history []models.Message) (string, error) {
+func (c *Client) SendPrompt(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {
+	effectiveMaxTokens := maxTokens
+	if effectiveMaxTokens <= 0 {
+		effectiveMaxTokens = c.getMaxTokens() // Fallback para a lógica antiga se nada for passado
+	}
+
 	// Monta mensagens a partir do histórico, sem duplicar o prompt (mesma lógica dos outros clientes)
 	var msgs []map[string]string
 	for _, m := range history {
@@ -88,7 +93,7 @@ func (c *Client) SendPrompt(ctx context.Context, prompt string, history []models
 		"messages": msgs,
 		"stream":   false,
 		"options": map[string]interface{}{
-			"num_predict": c.getMaxTokens(),
+			"num_predict": effectiveMaxTokens,
 			// "temperature": 0.7,
 			// "num_ctx": 8192,
 		},

--- a/llm/ollama/ollama_client.go
+++ b/llm/ollama/ollama_client.go
@@ -66,7 +66,7 @@ func (c *Client) getMaxTokens() int {
 func (c *Client) SendPrompt(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {
 	effectiveMaxTokens := maxTokens
 	if effectiveMaxTokens <= 0 {
-		effectiveMaxTokens = c.getMaxTokens() // Fallback para a lógica antiga se nada for passado
+		effectiveMaxTokens = c.getMaxTokens() // Fallback se nada for passado
 	}
 
 	// Monta mensagens a partir do histórico, sem duplicar o prompt (mesma lógica dos outros clientes)

--- a/llm/ollama/ollama_client_test.go
+++ b/llm/ollama/ollama_client_test.go
@@ -30,7 +30,7 @@ func TestOllamaClient_SendPrompt_Success(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	c := NewClient(srv.URL, "llama3.1:8b", logger, 1, 0)
 
-	out, err := c.SendPrompt(context.Background(), "Hi", []models.Message{{Role: "user", Content: "Hi"}})
+	out, err := c.SendPrompt(context.Background(), "Hi", []models.Message{{Role: "user", Content: "Hi"}}, 0)
 	require.NoError(t, err)
 	assert.Equal(t, "Hello from Ollama!", out)
 }

--- a/llm/openai/openai_client.go
+++ b/llm/openai/openai_client.go
@@ -72,8 +72,11 @@ func (c *OpenAIClient) getMaxTokens() int {
 }
 
 // SendPrompt envia um prompt para o modelo de linguagem e retorna a resposta.
-func (c *OpenAIClient) SendPrompt(ctx context.Context, prompt string, history []models.Message) (string, error) {
-	maxTokens := c.getMaxTokens()
+func (c *OpenAIClient) SendPrompt(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {
+	effectiveMaxTokens := maxTokens
+	if effectiveMaxTokens <= 0 {
+		effectiveMaxTokens = c.getMaxTokens() // valor padrão
+	}
 
 	// Construir o array de mensagens APENAS a partir do history
 	messages := []map[string]string{}
@@ -106,7 +109,7 @@ func (c *OpenAIClient) SendPrompt(ctx context.Context, prompt string, history []
 	payload := map[string]interface{}{
 		"model":      c.model,
 		"messages":   messages,
-		"max_tokens": maxTokens,
+		"max_tokens": effectiveMaxTokens,
 	}
 
 	jsonValue, err := json.Marshal(payload)

--- a/llm/openai/openai_client_test.go
+++ b/llm/openai/openai_client_test.go
@@ -34,7 +34,7 @@ func TestOpenAIClient_SendPrompt_Success(t *testing.T) {
 	defer os.Setenv("OPENAI_API_URL", originalURL)
 
 	history := []models.Message{{Role: "user", Content: "Hi"}}
-	resp, err := client.SendPrompt(context.Background(), "Hi", history)
+	resp, err := client.SendPrompt(context.Background(), "Hi", history, 0)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "Hello from OpenAI!", resp)

--- a/llm/openai_assistant/openai_assistant_client.go
+++ b/llm/openai_assistant/openai_assistant_client.go
@@ -110,7 +110,7 @@ func (c *OpenAIAssistantClient) GetModelName() string {
 }
 
 // SendPrompt envia uma mensagem para o thread atual e retorna a resposta
-func (c *OpenAIAssistantClient) SendPrompt(ctx context.Context, prompt string, history []models.Message) (string, error) {
+func (c *OpenAIAssistantClient) SendPrompt(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {
 	c.mu.Lock()
 
 	// Verificar se já temos um thread ativo, se não, criar um novo

--- a/llm/openai_responses/openai_responses_client_test.go
+++ b/llm/openai_responses/openai_responses_client_test.go
@@ -32,7 +32,7 @@ func TestOpenAIResponsesClient_SendPrompt_Success(t *testing.T) {
 	client := NewOpenAIResponsesClient("test-api-key", "gpt-5", logger, 1, 0)
 
 	history := []models.Message{{Role: "user", Content: "Hi"}}
-	resp, err := client.SendPrompt(context.Background(), "Hi", history)
+	resp, err := client.SendPrompt(context.Background(), "Hi", history, 0)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "Hello from Responses API!", resp)

--- a/llm/stackspotai/stackspot_client.go
+++ b/llm/stackspotai/stackspot_client.go
@@ -62,7 +62,7 @@ func (c *StackSpotClient) GetModelName() string {
 }
 
 // SendPrompt envia um prompt para o modelo de linguagem e retorna a resposta.
-func (c *StackSpotClient) SendPrompt(ctx context.Context, prompt string, history []models.Message) (string, error) {
+func (c *StackSpotClient) SendPrompt(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {
 	// Formatar o histórico da conversa
 	conversationHistory := formatConversationHistory(history)
 

--- a/llm/stackspotai/stackspot_client_test.go
+++ b/llm/stackspotai/stackspot_client_test.go
@@ -56,7 +56,7 @@ func TestStackSpotClient_SendPrompt_Success(t *testing.T) {
 	client.responseTimeout = 10 * time.Millisecond
 
 	history := []models.Message{{Role: "user", Content: "Hi"}}
-	resp, err := client.SendPrompt(context.Background(), "Hi", history)
+	resp, err := client.SendPrompt(context.Background(), "Hi", history, 0)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "Hello from StackSpot!", resp)

--- a/llm/xai/xai_client_test.go
+++ b/llm/xai/xai_client_test.go
@@ -26,7 +26,7 @@ func TestXAIClient_SendPrompt_Success(t *testing.T) {
 	client.apiURL = server.URL // Injeta a URL do servidor mock
 
 	history := []models.Message{{Role: "user", Content: "Hi"}}
-	resp, err := client.SendPrompt(context.Background(), "Hi", history)
+	resp, err := client.SendPrompt(context.Background(), "Hi", history, 0)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "Hello from xAI (Grok)!", resp)

--- a/main.go
+++ b/main.go
@@ -110,7 +110,10 @@ func main() {
 	// Aplicar overrides de provider, model e max-tokens do modo one-shot, se fornecidos
 	chatCLI.UserMaxTokens = opts.MaxTokens
 	if err := chatCLI.ApplyOverrides(llmManager, opts.Provider, opts.Model); err != nil {
-		logger.Fatal("Erro ao aplicar overrides de provider/model via flags", zap.Error(err))
+		// Imprimir no stderr para o usuário e para os testes E2E
+		fmt.Fprintf(os.Stderr, " ❌ Erro ao aplicar overrides: %v\n", err)
+		logger.Error("Erro fatal ao aplicar overrides de provider/model via flags", zap.Error(err))
+		os.Exit(1)
 	}
 
 	// Configurar manipulador de sinais DEPOIS de criar chatCLI

--- a/main.go
+++ b/main.go
@@ -107,6 +107,12 @@ func main() {
 		logger.Fatal("Erro ao inicializar o ChatCLI", zap.Error(err))
 	}
 
+	// Aplicar overrides de provider, model e max-tokens do modo one-shot, se fornecidos
+	chatCLI.UserMaxTokens = opts.MaxTokens
+	if err := chatCLI.ApplyOverrides(llmManager, opts.Provider, opts.Model); err != nil {
+		logger.Fatal("Erro ao aplicar overrides de provider/model via flags", zap.Error(err))
+	}
+
 	// Configurar manipulador de sinais DEPOIS de criar chatCLI
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT)


### PR DESCRIPTION
- Added `--max-tokens` flag to CLI for one-shot mode, allowing user-defined token limits.
- Enhanced LLM clients (OpenAI, xAI, Claude, Gemini, StackSpot, Ollama) to dynamically respect `max_tokens`.
- Updated documentation (README, README_EN) to reflect support for the new flag.
- Improved error handling with detailed logging for incomplete or invalid responses due to token limits.
- Introduced terminal reset functionality for better UX across Unix and Windows environments.