### PR TITLE
feat(cli,llm): add global max_tokens override across clients and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Execute prompts em uma única linha, ideal para scripts e automações.
     - `-p` ou `--prompt`: texto a enviar para a LLM em uma única execução.
     - `--provider`: sobrescreve o provedor de LLM em tempo de execução (`OPENAI`, `OPENAI_ASSISTANT`, `CLAUDEAI`, `GOOGLEAI`, `STACKSPOT`, `XAI`).
     - `--model`: escolhe o modelo do provedor ativo (ex.: `gpt-4o-mini`, `claude-3-5-sonnet-20241022`, `gemini-2.5-flash`, etc.)
+    - `--max-tokens`: Define a quantidade maxima de tokens usada para provedor ativo.
     - `--timeout` timeout da chamada one-shot (padrão: 5m)
     - `--no-anim` desabilita animações (útil em scripts/CI).
     - `--agent-auto-exec` executa automaticamente o primeiro comando sugerido pelo agente (modo agente).

--- a/README_EN.md
+++ b/README_EN.md
@@ -197,6 +197,7 @@ Execute prompts in a single line, ideal for scripting and automation.
     - `-p` or `--prompt`: The text to send to the LLM for a single execution.
     - `--provider`: Overrides the LLM provider at runtime (`OPENAI`, `OPENAI_ASSISTANT`, `CLAUDEAI`, `GOOGLEAI`, `STACKSPOT`, `XAI`).
     - `--model`: Chooses the model for the active provider (e.g., `gpt-4o-mini`, `claude-3-5-sonnet-20241022`, `gemini-2.5-flash`, etc.).
+    - `--max-tokens`: Defines the maximum amount of tokens used for active provider.
     - `--timeout`: Sets the timeout for the one-shot call (default: `5m`).
     - `--no-anim`: Disables animations (useful in scripts/CI).
     - `--agent-auto-exec`: Automatically executes the first command suggested by the agent (in agent mode).

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -240,7 +240,7 @@ Exemplo de bloco de comando (formato mostrado abaixo):`
 		zap.Int("historyLength", len(a.cli.history)),
 		zap.Int("queryLength", len(fullQuery)))
 
-	aiResponse, err := a.cli.Client.SendPrompt(responseCtx, fullQuery, a.cli.history)
+	aiResponse, err := a.cli.Client.SendPrompt(responseCtx, fullQuery, a.cli.history, 0)
 
 	if err != nil {
 		a.logger.Error("Erro ao obter resposta do LLM", zap.Error(err))
@@ -294,7 +294,10 @@ func (a *AgentMode) RunOnce(ctx context.Context, query string, autoExecute bool)
 	a.cli.animation.ShowThinkingAnimation(a.cli.Client.GetModelName())
 
 	// 2. Enviar para a LLM
-	aiResponse, err := a.cli.Client.SendPrompt(ctx, query, a.cli.history)
+	aiResponse, err := a.cli.Client.SendPrompt(ctx, query, a.cli.history, 0)
+	if err != nil {
+		return fmt.Errorf("erro ao obter resposta da IA: %w", err)
+	}
 	a.cli.animation.StopThinkingAnimation()
 	if err != nil {
 		return fmt.Errorf("erro ao obter resposta da IA: %w", err)
@@ -625,7 +628,7 @@ func (a *AgentMode) requestLLMContinuationWithContext(ctx context.Context, previ
 	})
 
 	a.cli.animation.ShowThinkingAnimation(a.cli.Client.GetModelName())
-	aiResponse, err := a.cli.Client.SendPrompt(newCtx, prompt.String(), a.cli.history)
+	aiResponse, err := a.cli.Client.SendPrompt(newCtx, prompt.String(), a.cli.history, 0)
 	a.cli.animation.StopThinkingAnimation()
 	if err != nil {
 		fmt.Println("❌ Erro ao pedir continuação à IA:", err)
@@ -1520,7 +1523,7 @@ func (a *AgentMode) requestLLMContinuation(ctx context.Context, userQuery, previ
 	})
 
 	a.cli.animation.ShowThinkingAnimation(a.cli.Client.GetModelName())
-	aiResponse, err := a.cli.Client.SendPrompt(ctx, retryPrompt, a.cli.history)
+	aiResponse, err := a.cli.Client.SendPrompt(ctx, retryPrompt, a.cli.history, 0)
 	a.cli.animation.StopThinkingAnimation()
 	if err != nil {
 		fmt.Println("❌ Erro ao pedir continuação à IA:", err)
@@ -1569,7 +1572,7 @@ func (a *AgentMode) requestLLMWithPreExecutionContext(ctx context.Context, origi
 	})
 
 	a.cli.animation.ShowThinkingAnimation(a.cli.Client.GetModelName())
-	aiResponse, err := a.cli.Client.SendPrompt(newCtx, prompt.String(), a.cli.history)
+	aiResponse, err := a.cli.Client.SendPrompt(newCtx, prompt.String(), a.cli.history, 0)
 	a.cli.animation.StopThinkingAnimation()
 	if err != nil {
 		fmt.Println("❌ Erro ao pedir refinamento à IA:", err)

--- a/cli/agent_mode_test.go
+++ b/cli/agent_mode_test.go
@@ -23,8 +23,8 @@ func (m *MockLLMClient) GetModelName() string {
 	return args.String(0)
 }
 
-func (m *MockLLMClient) SendPrompt(ctx context.Context, prompt string, history []models.Message) (string, error) {
-	args := m.Called(ctx, prompt, history)
+func (m *MockLLMClient) SendPrompt(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {
+	args := m.Called(ctx, prompt, history, maxTokens)
 	return args.String(0), args.Error(1)
 }
 
@@ -74,8 +74,7 @@ func TestAgentMode_Run_ExtractsAndHandlesCommands(t *testing.T) {
 
 	// Configurar mocks
 	mockLLM.On("GetModelName").Return("MockGPT")
-	mockLLM.On("SendPrompt", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("[]models.Message")).Return(aiResponse, nil)
-
+	mockLLM.On("SendPrompt", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("[]models.Message"), mock.AnythingOfType("int")).Return(aiResponse, nil)
 	// Mock da execução do comando
 	var executedBlock CommandBlock
 	agentMode.executeCommandsFunc = func(ctx context.Context, block CommandBlock) (string, string) {

--- a/cli/oneshot_mode.go
+++ b/cli/oneshot_mode.go
@@ -32,6 +32,7 @@ type Options struct {
 	NoAnim         bool          // --no-anim
 	PromptFlagUsed bool          // indica se -p/--prompt foi passado explicitamente
 	AgentAutoExec  bool          // --agent-auto-exec
+	MaxTokens      int           // --max-tokens
 }
 
 // HandleOneShotOrFatal executa o modo one-shot se solicitado (flag -p usada ou stdin presente).
@@ -153,8 +154,8 @@ func (cli *ChatCLI) RunOnce(ctx context.Context, input string, disableAnimation 
 		cli.animation.ShowThinkingAnimation(cli.Client.GetModelName())
 	}
 
-	// Faz a chamada ao LLM (com timeout vindo do contexto)
-	aiResponse, err := cli.Client.SendPrompt(ctx, userInput+additionalContext, cli.history)
+	effectiveMaxTokens := cli.getMaxTokensForCurrentLLM()
+	aiResponse, err := cli.Client.SendPrompt(ctx, userInput+additionalContext, cli.history, effectiveMaxTokens)
 
 	if !disableAnimation {
 		cli.animation.StopThinkingAnimation()
@@ -189,6 +190,7 @@ func NewFlagSet() (*flag.FlagSet, *Options) {
 	fs.StringVar(&opts.Model, "model", "", "Override do modelo(LLM)")
 
 	fs.DurationVar(&opts.Timeout, "timeout", 5*time.Minute, "Timeout da chamada one-shot")
+	fs.IntVar(&opts.MaxTokens, "max-tokens", 0, "Override do máximo de tokens para a resposta")
 	fs.BoolVar(&opts.NoAnim, "no-anim", false, "Desabilita animações no modo one-shot")
 
 	fs.BoolVar(&opts.AgentAutoExec, "agent-auto-exec", false, "No modo agente one-shot, executa o primeiro comando sugerido automaticamente se for seguro.")

--- a/cli/signal_unix.go
+++ b/cli/signal_unix.go
@@ -16,12 +16,13 @@ import (
 
 // forceRefreshPrompt envia um sinal SIGWINCH para o processo atual no Unix.
 func (cli *ChatCLI) forceRefreshPrompt() {
+	//resetTerminal(cli.logger)
+
 	p, err := os.FindProcess(os.Getpid())
 	if err != nil {
 		cli.logger.Warn("Não foi possível encontrar o processo para forçar o refresh", zap.Error(err))
 		return
 	}
-	// Usa unix.SIGWINCH, que está definido neste pacote
 	if err := p.Signal(unix.SIGWINCH); err != nil {
 		cli.logger.Warn("Não foi possível enviar o sinal SIGWINCH para forçar o refresh", zap.Error(err))
 	}

--- a/cli/signal_windows.go
+++ b/cli/signal_windows.go
@@ -7,8 +7,32 @@
  */
 package cli
 
-// forceRefreshPrompt é um stub para Windows, onde SIGWINCH não se aplica.
-// A função não faz nada, pois não há um equivalente direto.
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+
+	"go.uber.org/zap"
+)
+
+// forceRefreshPrompt no Windows usa sequências de escape ANSI para limpar a linha.
+// Isso força o go-prompt a redesenhar o prompt na próxima iteração do loop.
 func (cli *ChatCLI) forceRefreshPrompt() {
-	// No-op for Windows
+	// No Windows, a melhor abordagem é limpar a linha atual e retornar o cursor.
+	// O go-prompt irá então redesenhar o prefixo.
+	// \r -> Carriage Return (volta ao início da linha)
+	// \033[K -> Clear line from cursor to end
+	fmt.Print("\r\033[K")
+}
+
+func resetTerminal(logger *zap.Logger) {
+	if runtime.GOOS != "windows" {
+		return
+	}
+	cmd := exec.Command("cmd", "/c", "cls")
+	cmd.Stdout = os.Stdout
+	if err := cmd.Run(); err != nil {
+		logger.Warn("Falha ao limpar a tela no Windows", zap.Error(err))
+	}
 }

--- a/llm/claudeai/claude_client_test.go
+++ b/llm/claudeai/claude_client_test.go
@@ -50,8 +50,7 @@ func TestClaudeClient_SendPrompt_Success(t *testing.T) {
 
 	// 3. Executar o teste
 	history := []models.Message{{Role: "user", Content: "Hello"}}
-	resp, err := client.SendPrompt(context.Background(), "Hello", history)
-
+	resp, err := client.SendPrompt(context.Background(), "Hello", history, 0)
 	// 4. Verificar os resultados
 	assert.NoError(t, err)
 	assert.Equal(t, "Hi there!", resp)
@@ -79,7 +78,7 @@ func TestClaudeClient_SendPrompt_RetryOnRateLimit(t *testing.T) {
 
 	client.apiURL = server.URL
 
-	resp, err := client.SendPrompt(context.Background(), "Test", []models.Message{{Role: "user", Content: "Test"}})
+	resp, err := client.SendPrompt(context.Background(), "Test", []models.Message{{Role: "user", Content: "Test"}}, 0)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "Success on second try", resp)

--- a/llm/client/llm_client.go
+++ b/llm/client/llm_client.go
@@ -32,7 +32,7 @@ type LLMClient interface {
 	// O contexto (ctx) pode ser usado para controlar o tempo de execução e cancelamento.
 	// O histórico (history) contém as mensagens anteriores da conversa.
 	// Retorna uma string com a resposta do modelo e um erro, caso ocorra.
-	SendPrompt(ctx context.Context, prompt string, history []models.Message) (string, error)
+	SendPrompt(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error)
 
 	// (Opcional) Initialize pode ser usado para configurar ou autenticar o cliente LLM.
 	// Caso o cliente precise de configuração ou autenticação, esse método pode ser implementado.

--- a/llm/googleai/gemini_client.go
+++ b/llm/googleai/gemini_client.go
@@ -74,7 +74,12 @@ func (c *GeminiClient) GetModelName() string {
 }
 
 // SendPrompt envia um prompt para o Gemini e retorna a resposta
-func (c *GeminiClient) SendPrompt(ctx context.Context, prompt string, history []models.Message) (string, error) {
+func (c *GeminiClient) SendPrompt(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {
+	effectiveMaxTokens := maxTokens
+	if effectiveMaxTokens <= 0 {
+		effectiveMaxTokens = c.getMaxTokens() // Fallback para a lógica antiga se nada for passado
+	}
+
 	// ... (lógica de build do payload, logs, etc., permanece a mesma)
 	c.logger.Info("Iniciando requisição para Google AI",
 		zap.String("model", c.model),
@@ -94,12 +99,11 @@ func (c *GeminiClient) SendPrompt(ctx context.Context, prompt string, history []
 		}
 	}
 
-	maxTokens := c.getMaxTokens()
 	generationConfig := map[string]interface{}{
 		"temperature":     0.7,
 		"topP":            0.95,
 		"topK":            40,
-		"maxOutputTokens": maxTokens,
+		"maxOutputTokens": effectiveMaxTokens,
 	}
 
 	reqBody := map[string]interface{}{

--- a/llm/googleai/gemini_client_test.go
+++ b/llm/googleai/gemini_client_test.go
@@ -34,7 +34,7 @@ func TestGeminiClient_SendPrompt_Success(t *testing.T) {
 	client.baseURL = server.URL
 
 	history := []models.Message{{Role: "user", Content: "Hi"}}
-	resp, err := client.SendPrompt(context.Background(), "Hi", history)
+	resp, err := client.SendPrompt(context.Background(), "Hi", history, 0)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "Hello from Gemini!", resp)

--- a/llm/ollama/ollama_client.go
+++ b/llm/ollama/ollama_client.go
@@ -63,7 +63,12 @@ func (c *Client) getMaxTokens() int {
 	return catalog.GetMaxTokens(catalog.ProviderOllama, c.model, 0)
 }
 
-func (c *Client) SendPrompt(ctx context.Context, prompt string, history []models.Message) (string, error) {
+func (c *Client) SendPrompt(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {
+	effectiveMaxTokens := maxTokens
+	if effectiveMaxTokens <= 0 {
+		effectiveMaxTokens = c.getMaxTokens() // Fallback se nada for passado
+	}
+
 	// Monta mensagens a partir do histórico, sem duplicar o prompt (mesma lógica dos outros clientes)
 	var msgs []map[string]string
 	for _, m := range history {
@@ -88,7 +93,7 @@ func (c *Client) SendPrompt(ctx context.Context, prompt string, history []models
 		"messages": msgs,
 		"stream":   false,
 		"options": map[string]interface{}{
-			"num_predict": c.getMaxTokens(),
+			"num_predict": effectiveMaxTokens,
 			// "temperature": 0.7,
 			// "num_ctx": 8192,
 		},

--- a/llm/ollama/ollama_client_test.go
+++ b/llm/ollama/ollama_client_test.go
@@ -30,7 +30,7 @@ func TestOllamaClient_SendPrompt_Success(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	c := NewClient(srv.URL, "llama3.1:8b", logger, 1, 0)
 
-	out, err := c.SendPrompt(context.Background(), "Hi", []models.Message{{Role: "user", Content: "Hi"}})
+	out, err := c.SendPrompt(context.Background(), "Hi", []models.Message{{Role: "user", Content: "Hi"}}, 0)
 	require.NoError(t, err)
 	assert.Equal(t, "Hello from Ollama!", out)
 }

--- a/llm/openai/openai_client.go
+++ b/llm/openai/openai_client.go
@@ -72,8 +72,11 @@ func (c *OpenAIClient) getMaxTokens() int {
 }
 
 // SendPrompt envia um prompt para o modelo de linguagem e retorna a resposta.
-func (c *OpenAIClient) SendPrompt(ctx context.Context, prompt string, history []models.Message) (string, error) {
-	maxTokens := c.getMaxTokens()
+func (c *OpenAIClient) SendPrompt(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {
+	effectiveMaxTokens := maxTokens
+	if effectiveMaxTokens <= 0 {
+		effectiveMaxTokens = c.getMaxTokens() // valor padrão
+	}
 
 	// Construir o array de mensagens APENAS a partir do history
 	messages := []map[string]string{}
@@ -106,7 +109,7 @@ func (c *OpenAIClient) SendPrompt(ctx context.Context, prompt string, history []
 	payload := map[string]interface{}{
 		"model":      c.model,
 		"messages":   messages,
-		"max_tokens": maxTokens,
+		"max_tokens": effectiveMaxTokens,
 	}
 
 	jsonValue, err := json.Marshal(payload)

--- a/llm/openai/openai_client_test.go
+++ b/llm/openai/openai_client_test.go
@@ -34,7 +34,7 @@ func TestOpenAIClient_SendPrompt_Success(t *testing.T) {
 	defer os.Setenv("OPENAI_API_URL", originalURL)
 
 	history := []models.Message{{Role: "user", Content: "Hi"}}
-	resp, err := client.SendPrompt(context.Background(), "Hi", history)
+	resp, err := client.SendPrompt(context.Background(), "Hi", history, 0)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "Hello from OpenAI!", resp)

--- a/llm/openai_assistant/openai_assistant_client.go
+++ b/llm/openai_assistant/openai_assistant_client.go
@@ -110,7 +110,7 @@ func (c *OpenAIAssistantClient) GetModelName() string {
 }
 
 // SendPrompt envia uma mensagem para o thread atual e retorna a resposta
-func (c *OpenAIAssistantClient) SendPrompt(ctx context.Context, prompt string, history []models.Message) (string, error) {
+func (c *OpenAIAssistantClient) SendPrompt(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {
 	c.mu.Lock()
 
 	// Verificar se já temos um thread ativo, se não, criar um novo

--- a/llm/openai_responses/openai_responses_client.go
+++ b/llm/openai_responses/openai_responses_client.go
@@ -12,10 +12,13 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/diillson/chatcli/config"
+	"github.com/diillson/chatcli/llm/catalog"
 	"github.com/diillson/chatcli/models"
 	"github.com/diillson/chatcli/utils"
 	"go.uber.org/zap"
@@ -53,9 +56,22 @@ func (c *OpenAIResponsesClient) GetModelName() string {
 	return c.model
 }
 
-func (c *OpenAIResponsesClient) SendPrompt(ctx context.Context, prompt string, history []models.Message) (string, error) {
-	// Flatten do histórico para um texto coerente, sem duplicar o prompt.
-	// Aqui construímos SOMENTE a partir do history:
+func (c *OpenAIResponsesClient) getMaxTokens() int {
+	if tokenStr := os.Getenv("OPENAI_MAX_TOKENS"); tokenStr != "" {
+		if parsedTokens, err := strconv.Atoi(tokenStr); err == nil && parsedTokens > 0 {
+			c.logger.Debug("Usando OPENAI_MAX_TOKENS personalizado", zap.Int("max_tokens", parsedTokens))
+			return parsedTokens
+		}
+	}
+	// Fallback para catálogo
+	return catalog.GetMaxTokens(catalog.ProviderOpenAI, c.model, 0)
+}
+
+func (c *OpenAIResponsesClient) SendPrompt(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {
+	effectiveMaxTokens := maxTokens
+	if effectiveMaxTokens <= 0 {
+		effectiveMaxTokens = c.getMaxTokens() // valor padrão
+	}
 	input := buildTextFromHistory(history, "")
 
 	// Fallback: se o history não tem o último turno do user (edge-case),
@@ -70,8 +86,9 @@ func (c *OpenAIResponsesClient) SendPrompt(ctx context.Context, prompt string, h
 	}
 
 	reqBody := map[string]interface{}{
-		"model": c.model,
-		"input": input,
+		"model":             c.model,
+		"input":             input,
+		"max_output_tokens": effectiveMaxTokens,
 	}
 
 	jsonValue, err := json.Marshal(reqBody)
@@ -134,6 +151,10 @@ func (c *OpenAIResponsesClient) processResponse(resp *http.Response) (string, er
 		return "", fmt.Errorf("erro ao ler resposta da Responses API: %w", err)
 	}
 
+	// Adicionar log de depuração para sempre vermos o corpo da resposta
+	c.logger.Debug("Corpo da resposta recebido da OpenAI Responses (RAW)",
+		zap.ByteString("body", bodyBytes))
+
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		errMsg := fmt.Sprintf("erro na Responses API: status %d, resposta: %s", resp.StatusCode, string(bodyBytes))
 		c.logger.Error("Resposta de erro da OpenAI Responses",
@@ -143,52 +164,69 @@ func (c *OpenAIResponsesClient) processResponse(resp *http.Response) (string, er
 		return "", errors.New(errMsg)
 	}
 
-	// Estrutura genérica para várias formas de retorno da Responses API
-	var generic struct {
-		// caminho direto mais comum
-		OutputText string `json:"output_text"`
-		// caminho rich
+	// Estrutura de decodificação mais detalhada para capturar todos os casos
+	var response struct {
+		Status            string `json:"status"`
+		OutputText        string `json:"output_text"`
+		IncompleteDetails *struct {
+			Reason string `json:"reason"`
+		} `json:"incomplete_details"`
 		Output []struct {
-			Type    string `json:"type"` // "message"
-			Role    string `json:"role"` // "assistant"
+			Type    string `json:"type"` // "message" ou "reasoning"
 			Content []struct {
-				Type string `json:"type"` // "output_text", "input_text", etc
+				Type string `json:"type"` // "output_text"
 				Text string `json:"text"`
 			} `json:"content"`
 		} `json:"output"`
-		Content any `json:"content"`
+		Error *struct {
+			Message string `json:"message"`
+		} `json:"error"`
 	}
 
-	if err := json.Unmarshal(bodyBytes, &generic); err != nil {
+	if err := json.Unmarshal(bodyBytes, &response); err != nil {
 		return "", fmt.Errorf("erro ao decodificar resposta da Responses API: %w", err)
 	}
 
-	// 1) Se existir output_text, é o mais direto
-	if strings.TrimSpace(generic.OutputText) != "" {
-		return generic.OutputText, nil
+	// Tentar extrair do caminho simples primeiro (comum em mocks e respostas diretas)
+	if response.OutputText != "" {
+		return response.OutputText, nil
 	}
 
-	// 2) Varredura do array "output"
+	// 1. Verificar se a API retornou um erro explícito no corpo
+	if response.Error != nil && response.Error.Message != "" {
+		c.logger.Error("API da OpenAI Responses retornou um erro no payload", zap.String("error_message", response.Error.Message))
+		return "", fmt.Errorf("erro da API OpenAI: %s", response.Error.Message)
+	}
+
+	// 2. Verificar o status da resposta - esta é a nova lógica crucial
+	if response.Status == "incomplete" {
+		if response.IncompleteDetails != nil && response.IncompleteDetails.Reason == "max_output_tokens" {
+			c.logger.Warn("Resposta incompleta devido a max_output_tokens baixo.", zap.ByteString("body", bodyBytes))
+			return "", errors.New("a resposta da OpenAI foi incompleta, o valor de 'max_output_tokens' é muito baixo")
+		}
+		return "", fmt.Errorf("a resposta da OpenAI foi incompleta por um motivo desconhecido (status: %s)", response.Status)
+	}
+
+	// 3. Iterar para encontrar o texto apenas se o status for 'completed'
 	var sb strings.Builder
-	for _, item := range generic.Output {
-		for _, c := range item.Content {
-			if strings.TrimSpace(c.Text) != "" {
-				sb.WriteString(c.Text)
+	for _, item := range response.Output {
+		// Procurar especificamente pelo item do tipo 'message'
+		if item.Type == "message" {
+			for _, content := range item.Content {
+				// E dentro dele, pelo conteúdo do tipo 'output_text'
+				if content.Type == "output_text" && strings.TrimSpace(content.Text) != "" {
+					sb.WriteString(content.Text)
+				}
 			}
 		}
 	}
+
 	if sb.Len() > 0 {
 		return sb.String(), nil
 	}
 
-	// 3) fallback: tentar extrair texto credível de "content" genérico se vier em outro formato
-	if generic.Content != nil {
-		if txt := tryExtractText(generic.Content); txt != "" {
-			return txt, nil
-		}
-	}
-
 	// Se chegou aqui, não foi possível extrair
+	c.logger.Warn("Não foi possível extrair texto da resposta, mesmo com status 'completed'.", zap.ByteString("body", bodyBytes))
 	return "", fmt.Errorf("não foi possível extrair o texto da resposta da Responses API")
 }
 
@@ -211,37 +249,4 @@ func buildTextFromHistory(history []models.Message, prompt string) string {
 	b.WriteString("User: ")
 	b.WriteString(prompt)
 	return b.String()
-}
-
-// tryExtractText tenta extrair texto de uma estrutura arbitrária (best-effort)
-func tryExtractText(v any) string {
-	switch t := v.(type) {
-	case string:
-		return t
-	case []any:
-		var sb strings.Builder
-		for _, it := range t {
-			if s := tryExtractText(it); s != "" {
-				sb.WriteString(s)
-			}
-		}
-		return sb.String()
-	case map[string]any:
-		// procurar chaves prováveis
-		if s, ok := t["text"].(string); ok && strings.TrimSpace(s) != "" {
-			return s
-		}
-		if s, ok := t["output_text"].(string); ok && strings.TrimSpace(s) != "" {
-			return s
-		}
-		// procurar nested
-		for _, val := range t {
-			if s := tryExtractText(val); s != "" {
-				return s
-			}
-		}
-		return ""
-	default:
-		return ""
-	}
 }

--- a/llm/openai_responses/openai_responses_client_test.go
+++ b/llm/openai_responses/openai_responses_client_test.go
@@ -32,7 +32,7 @@ func TestOpenAIResponsesClient_SendPrompt_Success(t *testing.T) {
 	client := NewOpenAIResponsesClient("test-api-key", "gpt-5", logger, 1, 0)
 
 	history := []models.Message{{Role: "user", Content: "Hi"}}
-	resp, err := client.SendPrompt(context.Background(), "Hi", history)
+	resp, err := client.SendPrompt(context.Background(), "Hi", history, 0)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "Hello from Responses API!", resp)

--- a/llm/stackspotai/stackspot_client.go
+++ b/llm/stackspotai/stackspot_client.go
@@ -62,7 +62,7 @@ func (c *StackSpotClient) GetModelName() string {
 }
 
 // SendPrompt envia um prompt para o modelo de linguagem e retorna a resposta.
-func (c *StackSpotClient) SendPrompt(ctx context.Context, prompt string, history []models.Message) (string, error) {
+func (c *StackSpotClient) SendPrompt(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {
 	// Formatar o histórico da conversa
 	conversationHistory := formatConversationHistory(history)
 

--- a/llm/stackspotai/stackspot_client_test.go
+++ b/llm/stackspotai/stackspot_client_test.go
@@ -56,7 +56,7 @@ func TestStackSpotClient_SendPrompt_Success(t *testing.T) {
 	client.responseTimeout = 10 * time.Millisecond
 
 	history := []models.Message{{Role: "user", Content: "Hi"}}
-	resp, err := client.SendPrompt(context.Background(), "Hi", history)
+	resp, err := client.SendPrompt(context.Background(), "Hi", history, 0)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "Hello from StackSpot!", resp)

--- a/llm/xai/xai_client_test.go
+++ b/llm/xai/xai_client_test.go
@@ -26,7 +26,7 @@ func TestXAIClient_SendPrompt_Success(t *testing.T) {
 	client.apiURL = server.URL // Injeta a URL do servidor mock
 
 	history := []models.Message{{Role: "user", Content: "Hi"}}
-	resp, err := client.SendPrompt(context.Background(), "Hi", history)
+	resp, err := client.SendPrompt(context.Background(), "Hi", history, 0)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "Hello from xAI (Grok)!", resp)

--- a/main.go
+++ b/main.go
@@ -107,6 +107,15 @@ func main() {
 		logger.Fatal("Erro ao inicializar o ChatCLI", zap.Error(err))
 	}
 
+	// Aplicar overrides de provider, model e max-tokens do modo one-shot, se fornecidos
+	chatCLI.UserMaxTokens = opts.MaxTokens
+	if err := chatCLI.ApplyOverrides(llmManager, opts.Provider, opts.Model); err != nil {
+		// Imprimir no stderr para o usuário e para os testes E2E
+		fmt.Fprintf(os.Stderr, " ❌ Erro ao aplicar overrides: %v\n", err)
+		logger.Error("Erro fatal ao aplicar overrides de provider/model via flags", zap.Error(err))
+		os.Exit(1)
+	}
+
 	// Configurar manipulador de sinais DEPOIS de criar chatCLI
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT)


### PR DESCRIPTION
### Summary
  
  Introduce a unified max_tokens override that can be set from the CLI and is respected across all supported LLM clients. This enables consistent control over response length without per-provider configuration.
  
  ### Changes
  
  • CLI
      • Add a runtime option to override max_tokens in both agent and oneshot modes.
      • Refactor cli.go and related modes to propagate the override through request flow.
      • Improve signal handling for Unix and Windows for more reliable interruption and cleanup.
  • LLM Clients
      • Update Claude, OpenAI (chat, assistant/responses), Google Gemini, Ollama, X.ai, and StackSpot clients to honor the max_tokens override.
      • Adjust shared LLM client interfaces to pass through the override consistently.
      • Refactor OpenAI responses client for better parameter handling and consistency.
  • Documentation
      • README and README_EN updated to document the new override capability.
  • Tests
      • Update and extend unit tests across clients and CLI to cover the new behavior.
  
  
  ### Why
  
  Provide a single, predictable way to control token limits regardless of the underlying provider, simplifying CLI usage and configuration.
  
  ### Backward Compatibility
  
  • Defaults preserved when no override is provided (falls back to provider/client defaults).
  • Internal client interfaces were adjusted but external behavior remains compatible for typical CLI usage.
  
  ### Usage
  
  • Set max_tokens from the CLI to cap response length for any supported provider.
  • See README for exact flag/config details and examples.
  
  ### Affected Areas
  
  • CLI: agent/oneshot modes, signal handling, core orchestration
  • LLM providers: Claude, OpenAI (incl. assistant/responses), Gemini, Ollama, X.ai, StackSpot
  • Docs and tests
  
  ### Related
  
  • Implements #267