### PR TITLE
fix(ollama): add "thinking" filter with customizable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ O ChatCLI utiliza variáveis de ambiente para se conectar aos provedores de LLM 
     - `OPENAI_API_KEY`, `OPENAI_MODEL`, `OPENAI_ASSISTANT_MODEL`, `OPENAI_MAX_TOKENS`, `OPENAI_USE_RESPONSES`
     - `CLAUDEAI_API_KEY`, `CLAUDEAI_MODEL`, `CLAUDEAI_MAX_TOKENS`, `CLAUDEAI_API_VERSION`
     - `GOOGLEAI_API_KEY`, `GOOGLEAI_MODEL`, `GOOGLEAI_MAX_TOKENS`
-    - `OLLAMA_ENABLED`, `OLLAMA_BASE_URL`, `OLLAMA_MODEL`, `OLLAMA_MAX_TOKENS`
+    - `OLLAMA_ENABLED`, `OLLAMA_BASE_URL`, `OLLAMA_MODEL`, `OLLAMA_MAX_TOKENS`, `OLLAMA_FILTER_THINKING` – **(Opcional)** Filtra "pensamento em voz alta" de modelos como Qwen3 (true/false, padrão: true).
     - `XAI_API_KEY`, `XAI_MODEL`, `XAI_MAX_TOKENS`
     - `CLIENT_ID`, `CLIENT_SECRET`, `SLUG_NAME`, `TENANT_NAME` (para StackSpot)
 - **Agente**:
@@ -184,6 +184,7 @@ OLLAMA_ENABLED=true      #Obrigatório para habilitar API do Ollama
 OLLAMA_BASE_URL=http://localhost:11434
 OLLAMA_MODEL=gpt-oss:20b
 OLLAMA_MAX_TOKENS=5000
+OLLAMA_FILTER_THINKING=false  # Filtra raciocínio intermediário em respostas (ex.: para Qwen3, llama3... - ISSO É NECESSÁRIO TRUE para o modo Agent Funcionar bem com alguns modelos OLLAMA que tem raciocínio em "voz alta")
 ```
 
 -----

--- a/README_EN.md
+++ b/README_EN.md
@@ -123,7 +123,7 @@ ChatCLI uses environment variables to define its behavior and connect to LLM pro
     - `CLAUDEAI_API_KEY`, `CLAUDEAI_MODEL`, `CLAUDEAI_MAX_TOKENS`, `CLAUDEAI_API_VERSION`
     - `GOOGLEAI_API_KEY`, `GOOGLEAI_MODEL`, `GOOGLEAI_MAX_TOKENS`
     - `XAI_API_KEY`, `XAI_MODEL`, `XAI_MAX_TOKENS`
-    - `OLLAMA_ENABLED`, `OLLAMA_BASE_URL`, `OLLAMA_MODEL`, `OLLAMA_MAX_TOKENS`
+    - `OLLAMA_ENABLED`, `OLLAMA_BASE_URL`, `OLLAMA_MODEL`, `OLLAMA_MAX_TOKENS`, `OLLAMA_FILTER_THINKING` – **(Optional)** Filters "thinking aloud" from models like Qwen3 (true/false, default: true)
     - `CLIENT_ID`, `CLIENT_SECRET`, `SLUG_NAME`, `TENANT_NAME` (for StackSpot)
 - **Agente**:
     - `CHATCLI_AGENT_CMD_TIMEOUT` – **(Optional)** Default timeout for each command executed by the Agent Mode. Accepts Go durations (e.g., 30s, 2m, 10m). Default: `10m`.
@@ -181,6 +181,7 @@ OLLAMA_ENABLED=true      #Required for enabled API Ollama
 OLLAMA_BASE_URL=http://localhost:11434
 OLLAMA_MODEL=gpt-oss:20b
 OLLAMA_MAX_TOKENS=5000
+OLLAMA_FILTER_THINKING=true  # Filters intermediate reasoning in responses (e.g. for Qwen3, llama3... - THIS IS REQUIRED TO BE TRUE for Agent mode. Works well with some OLLAMA models that have "out loud" reasoning)
 ```
 
 -----

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -33,8 +33,9 @@ const (
 	XAIAPIURL       = "https://api.x.ai/v1/chat/completions"
 
 	// Valores padrão para Ollama
-	DefaultOllamaModel   = "gpt-oss:20b"
-	OllamaDefaultBaseURL = "http://localhost:11434"
+	DefaultOllamaModel          = "gpt-oss:20b"
+	OllamaDefaultBaseURL        = "http://localhost:11434"
+	OllamaFilterThinkingDefault = "true"
 
 	// Provedor padrão
 	DefaultLLMProvider = "OPENAI"

--- a/llm/ollama/ollama_client_test.go
+++ b/llm/ollama/ollama_client_test.go
@@ -58,3 +58,44 @@ func TestOllamaClient_SendPrompt_RetryOnTemporaryError(t *testing.T) {
 	assert.Equal(t, "Success on retry", out)
 	assert.Equal(t, 2, attempt, "Should have made two attempts")
 }
+
+func TestFilterThinking(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Remove <thinking> tag",
+			input:    "<thinking>Some reasoning here</thinking> Final Answer: Yes",
+			expected: "Final Answer: Yes",
+		},
+		{
+			name:     "Remove Thinking step by step",
+			input:    "Thinking step by step: First, analyze... Final Answer: 42",
+			expected: "Final Answer: 42",
+		},
+		{
+			name:     "No change if no pattern",
+			input:    "Direct answer: Hello",
+			expected: "Direct answer: Hello",
+		},
+		{
+			name:     "Case insensitive",
+			input:    "<THINKING>Ignore this</THINKING> Response: OK",
+			expected: "Response: OK",
+		},
+		{
+			name:     "Remove <think> tag from log example",
+			input:    "<think>\nOkay, the user said \"boa noite!\" which is Portuguese for \"good night!\" So they're probably greeting me in Portuguese. I should respond in Portuguese to be polite and show I understand. Let me make sure the response is friendly and offers help. Maybe say \"Boa noite! Como posso ajudar você hoje?\" That means \"Good night! How can I help you today?\" It's a common way to respond and keeps the conversation open. I should check if there's any cultural nuance I'm missing, but I think that's fine. Let's go with that.\n</think>\n\nBoa noite! Como posso ajudar você hoje? 😊",
+			expected: "Boa noite! Como posso ajudar você hoje? 😊",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := filterThinking(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
- Implemented `filterThinking` function to remove intermediate reasoning from responses.
- Introduced `OLLAMA_FILTER_THINKING` environment variable (default: true) for optional filtering configuration.
- Updated default configuration and README files with descriptions of the new option.
- Enhanced test coverage with multiple cases for filtering logic.