### PR TITLE
fix(agent): prevent screen clearing in certain terminal and providers by refining redraw logic

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -833,11 +833,19 @@ func (a *AgentMode) handleCommandBlocks(ctx context.Context, blocks []CommandBlo
 	outputs := make([]*CommandOutput, len(blocks))
 	showFullPlan := false
 	lastExecuted := -1
+	isFirstDraw := true
 
 mainLoop:
 	for {
 		// Redesenha a tela (clear + header + plano + último resultado)
-		clearScreen()
+		//clearScreen() # Comentado para evitar problemas com alguns providers e terminal.
+
+		// Nova logica de limpeza de terminal fix.
+		if !isFirstDraw {
+			clearScreen()
+		}
+		isFirstDraw = false
+
 		fmt.Println("\n" + colorize(" "+strings.Repeat("━", 58), ColorGray))
 		fmt.Println(colorize(" 🤖 MODO AGENTE: PLANO DE AÇÃO", ColorLime+ColorBold))
 		fmt.Println(colorize(" "+strings.Repeat("━", 58), ColorGray))


### PR DESCRIPTION
### Summary
  
  • Refines agent redraw logic to stop unintended screen clearing observed with certain terminal and providers.
  
  ### Changes
  
  • cli/agent_mode.go: 9 insertions, 1 deletion.
  
  ### Rationale
  
  • Improves UX by preserving terminal content during agent-mode updates.
  
  ### Testing
  
  • Manually verified that the screen is no longer cleared unexpectedly in affected terminals.
  • Confirmed no regressions in common terminal environments.
  
  ### Merge Scope
  
  • Merge develop into main including the above fix.
  
  ### Notes
  
  • No breaking changes; scope limited to CLI agent behavior.
  • Related: #287