### PR TITLE
fix(config): remove init-based global config initialization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ build:
 install:
 	go install -ldflags "$(LD_FLAGS)"
 
+.PHONY: lint
+lint:
+	golangci-lint run
+
 .PHONY: test
 test:
 	go test ./...

--- a/config/manager.go
+++ b/config/manager.go
@@ -27,15 +27,6 @@ type ConfigManager struct {
 // Global é a instância singleton do ConfigManager.
 var Global *ConfigManager
 
-// init inicializa o gerenciador de configuração global.
-func init() {
-	// Usamos um logger temporário para o bootstrap inicial.
-	// O logger real será injetado depois, se necessário.
-	tempLogger, _ := zap.NewProduction()
-	Global = New(tempLogger)
-	Global.Load()
-}
-
 // New cria uma nova instância do ConfigManager.
 func New(logger *zap.Logger) *ConfigManager {
 	return &ConfigManager{

--- a/main.go
+++ b/main.go
@@ -72,6 +72,8 @@ func main() {
 		os.Exit(1) // Encerrar a aplicação em caso de erro crítico
 	}
 
+	config.Global = config.New(logger)
+	config.Global.Load()
 	utils.LogStartupInfo(logger)
 
 	defer func() {


### PR DESCRIPTION
- Moved `ConfigManager` initialization from `init` function to `main.go` for better control and visibility.
- Added `lint` target in Makefile.