### PR TITLE
feat(provider): add OpenRouter as LLM provider

### DIFF
--- a/cli/cli_completer.go
+++ b/cli/cli_completer.go
@@ -225,7 +225,7 @@ func (cli *ChatCLI) getConnectSuggestions(d prompt.Document) []prompt.Suggest {
 	if strings.HasPrefix(wordBeforeCursor, "-") {
 		flags := []prompt.Suggest{
 			{Text: "--token", Description: "Token de autenticação do servidor"},
-			{Text: "--provider", Description: "Provedor LLM (OPENAI, CLAUDEAI, GOOGLEAI, XAI, ZAI, MINIMAX, STACKSPOT, OLLAMA, COPILOT, GITHUB_MODELS)"},
+			{Text: "--provider", Description: "Provedor LLM (OPENAI, CLAUDEAI, GOOGLEAI, XAI, ZAI, MINIMAX, STACKSPOT, OLLAMA, COPILOT, GITHUB_MODELS, OPENROUTER)"},
 			{Text: "--model", Description: "Modelo LLM (gpt-4, claude-3, etc.)"},
 			{Text: "--llm-key", Description: "API key/OAuth token para enviar ao servidor"},
 			{Text: "--use-local-auth", Description: "Usar credenciais OAuth locais (de /auth login)"},

--- a/cli/oneshot_mode.go
+++ b/cli/oneshot_mode.go
@@ -196,7 +196,7 @@ func NewFlagSet() (*flag.FlagSet, *Options) {
 
 	fs.StringVar(&opts.Prompt, "p", "", "Prompt a executar uma única vez (modo não interativo) - (alias)")
 	fs.StringVar(&opts.Prompt, "prompt", "", "Prompt a executar uma única vez (modo não interativo)")
-	fs.StringVar(&opts.Provider, "provider", "", "Override do provider (OPENAI, OPENAI_ASSISTANT, CLAUDEAI, GOOGLEAI, XAI, ZAI, MINIMAX, STACKSPOT, OLLAMA, COPILOT, GITHUB_MODELS)")
+	fs.StringVar(&opts.Provider, "provider", "", "Override do provider (OPENAI, OPENAI_ASSISTANT, CLAUDEAI, GOOGLEAI, XAI, ZAI, MINIMAX, STACKSPOT, OLLAMA, COPILOT, GITHUB_MODELS, OPENROUTER)")
 	fs.StringVar(&opts.Model, "model", "", "Override do modelo(LLM)")
 	fs.DurationVar(&opts.Timeout, "timeout", 5*time.Minute, "Timeout da chamada one-shot")
 	fs.IntVar(&opts.MaxTokens, "max-tokens", 0, "Override do máximo de tokens para a resposta")

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -53,6 +53,10 @@ const (
 	DefaultGitHubModelsModel = "gpt-4o"
 	GitHubModelsAPIURL       = "https://models.inference.ai.azure.com/chat/completions"
 
+	// Valores padrão para OpenRouter
+	DefaultOpenRouterModel = "openai/gpt-4o"
+	OpenRouterAPIURL       = "https://openrouter.ai/api/v1/chat/completions"
+
 	// Valores padrão para Ollama
 	DefaultOllamaModel          = "gpt-oss:20b"
 	OllamaDefaultBaseURL        = "http://localhost:11434"

--- a/deploy/helm/chatcli-operator/crds/platform.chatcli.io_instances.yaml
+++ b/deploy/helm/chatcli-operator/crds/platform.chatcli.io_instances.yaml
@@ -115,58 +115,11 @@ spec:
                     minimum: 0
                     type: integer
                 type: object
-              extraEnv:
-                description: |-
-                  ExtraEnv allows passing arbitrary environment variables to the ChatCLI server pod.
-                  Use for security config (CHATCLI_AGENT_SECURITY_MODE, CHATCLI_SESSION_TTL, etc.)
-                  or any other CHATCLI_* env vars not covered by structured fields.
-                  Supports both plain values and valueFrom (secretKeyRef, configMapKeyRef).
-                items:
-                  description: EnvVar represents an environment variable present in a Container.
-                  properties:
-                    name:
-                      description: Name of the environment variable.
-                      type: string
-                    value:
-                      description: Value of the environment variable.
-                      type: string
-                    valueFrom:
-                      description: Source for the environment variable's value.
-                      properties:
-                        configMapKeyRef:
-                          description: Selects a key of a ConfigMap.
-                          properties:
-                            key:
-                              type: string
-                            name:
-                              type: string
-                            optional:
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                        secretKeyRef:
-                          description: Selects a key of a Secret.
-                          properties:
-                            key:
-                              type: string
-                            name:
-                              type: string
-                            optional:
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                      type: object
-                  required:
-                  - name
-                  type: object
-                type: array
               apiKeys:
                 description: |-
                   APIKeys references a Secret containing provider API keys and config.
                   Expected keys: OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLEAI_API_KEY, XAI_API_KEY,
-                  ZAI_API_KEY, MINIMAX_API_KEY, MINIMAX_API_COMPAT, GITHUB_COPILOT_TOKEN, etc.
+                  ZAI_API_KEY, MINIMAX_API_KEY, MINIMAX_API_COMPAT, GITHUB_COPILOT_TOKEN, OPENROUTER_API_KEY, etc.
                   All providers used in the fallback chain must have their API keys in this Secret.
                 properties:
                   name:
@@ -175,6 +128,166 @@ spec:
                 required:
                 - name
                 type: object
+              extraEnv:
+                description: |-
+                  ExtraEnv allows passing arbitrary environment variables to the ChatCLI server pod.
+                  Use this for security configuration (CHATCLI_RATE_LIMIT_RPS, CHATCLI_AGENT_SECURITY_MODE, etc.)
+                  or any other CHATCLI_* env vars not covered by structured fields.
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
               fallback:
                 description: |-
                   Fallback configures automatic provider failover.
@@ -217,7 +330,7 @@ spec:
                         name:
                           description: Name is the provider name (OPENAI, OPENAI_ASSISTANT,
                             CLAUDEAI, GOOGLEAI, XAI, ZAI, MINIMAX, STACKSPOT, OLLAMA,
-                            COPILOT, GITHUB_MODELS).
+                            COPILOT, GITHUB_MODELS, OPENROUTER).
                           enum:
                           - OPENAI
                           - OPENAI_ASSISTANT
@@ -230,6 +343,7 @@ spec:
                           - OLLAMA
                           - COPILOT
                           - GITHUB_MODELS
+                          - OPENROUTER
                           type: string
                       required:
                       - name
@@ -359,7 +473,7 @@ spec:
               provider:
                 description: Provider is the LLM provider (OPENAI, OPENAI_ASSISTANT,
                   CLAUDEAI, GOOGLEAI, XAI, ZAI, MINIMAX, STACKSPOT, OLLAMA, COPILOT,
-                  GITHUB_MODELS).
+                  GITHUB_MODELS, OPENROUTER).
                 type: string
               replicas:
                 default: 1
@@ -673,22 +787,33 @@ spec:
                     description: Port is the gRPC server port.
                     format: int32
                     type: integer
-                  tls:
-                    description: TLS configures TLS for the gRPC server.
-                    properties:
-                      enabled:
-                        description: Enabled enables TLS.
-                        type: boolean
-                      secretName:
-                        description: SecretName is the name of the Secret containing
-                          tls.crt and tls.key.
-                        type: string
-                    type: object
                   security:
                     description: Security configures server security parameters.
                     properties:
+                      auditLogPath:
+                        description: |-
+                          AuditLogPath is the file path for structured audit logs (JSON lines).
+                          Maps to CHATCLI_AUDIT_LOG_PATH env var.
+                        type: string
+                      bindAddress:
+                        description: |-
+                          BindAddress is the address to bind the server to.
+                          Maps to CHATCLI_BIND_ADDRESS env var. Default: "127.0.0.1".
+                          Set to "0.0.0.0" to expose to all interfaces.
+                        type: string
+                      debug:
+                        description: |-
+                          Debug enables verbose logging including stack traces on errors.
+                          Maps to CHATCLI_DEBUG env var.
+                        type: boolean
+                      enableReflection:
+                        description: EnableReflection enables gRPC reflection (requires
+                          also CHATCLI_GRPC_REFLECTION=true).
+                        type: boolean
                       jwtSecretRef:
-                        description: JWTSecretRef references a Secret key containing the JWT signing secret. Maps to CHATCLI_JWT_SECRET.
+                        description: |-
+                          JWTSecretRef references a Secret key containing the JWT signing secret.
+                          Maps to CHATCLI_JWT_SECRET env var.
                         properties:
                           key:
                             description: Key is the key within the Secret.
@@ -700,38 +825,47 @@ spec:
                         - key
                         - name
                         type: object
-                      rateLimitRps:
-                        description: Per-client rate limit in requests per second. Maps to CHATCLI_RATE_LIMIT_RPS. Default 10.
-                        format: int32
-                        type: integer
-                      rateLimitBurst:
-                        description: Maximum burst size for rate limiting. Maps to CHATCLI_RATE_LIMIT_BURST. Default 30.
+                      maxConcurrentStreams:
+                        description: |-
+                          MaxConcurrentStreams limits simultaneous gRPC streams per connection.
+                          Maps to CHATCLI_MAX_CONCURRENT_STREAMS env var. Default: 100.
                         format: int32
                         type: integer
                       maxRecvMsgSize:
-                        description: Maximum message size in bytes the server can receive. Maps to CHATCLI_MAX_RECV_MSG_SIZE. Default 52428800 (50MB).
+                        description: |-
+                          MaxRecvMsgSize is the maximum message size in bytes the server can receive.
+                          Maps to CHATCLI_MAX_RECV_MSG_SIZE env var. Default: 52428800 (50MB).
                         format: int32
                         type: integer
                       maxSendMsgSize:
-                        description: Maximum message size in bytes the server can send. Maps to CHATCLI_MAX_SEND_MSG_SIZE. Default 52428800 (50MB).
+                        description: |-
+                          MaxSendMsgSize is the maximum message size in bytes the server can send.
+                          Maps to CHATCLI_MAX_SEND_MSG_SIZE env var. Default: 52428800 (50MB).
                         format: int32
                         type: integer
-                      maxConcurrentStreams:
-                        description: Limits simultaneous gRPC streams per connection. Maps to CHATCLI_MAX_CONCURRENT_STREAMS. Default 100.
+                      rateLimitBurst:
+                        description: |-
+                          RateLimitBurst is the maximum burst size for rate limiting.
+                          Maps to CHATCLI_RATE_LIMIT_BURST env var. Default: 30.
                         format: int32
                         type: integer
-                      bindAddress:
-                        description: Address to bind the server to. Maps to CHATCLI_BIND_ADDRESS. Default "127.0.0.1". Set "0.0.0.0" to expose.
-                        type: string
-                      auditLogPath:
-                        description: File path for structured audit logs (JSON lines). Maps to CHATCLI_AUDIT_LOG_PATH.
-                        type: string
-                      debug:
-                        description: Enable verbose logging including stack traces. Maps to CHATCLI_DEBUG.
+                      rateLimitRps:
+                        description: |-
+                          RateLimitRPS is the per-client rate limit in requests per second.
+                          Maps to CHATCLI_RATE_LIMIT_RPS env var. Default: 10.
+                        format: int32
+                        type: integer
+                    type: object
+                  tls:
+                    description: TLS configures TLS for the gRPC server.
+                    properties:
+                      enabled:
+                        description: Enabled enables TLS.
                         type: boolean
-                      enableReflection:
-                        description: Enable gRPC reflection (also needs CHATCLI_GRPC_REFLECTION=true).
-                        type: boolean
+                      secretName:
+                        description: SecretName is the name of the Secret containing
+                          tls.crt and tls.key.
+                        type: string
                     type: object
                   token:
                     description: Token references a Secret containing the auth token.

--- a/deploy/helm/chatcli/README.md
+++ b/deploy/helm/chatcli/README.md
@@ -109,7 +109,7 @@ Clients can use their own API keys (personal mode) or the server's configured pr
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `llm.provider` | Default provider: `OPENAI`, `CLAUDEAI`, `GOOGLEAI`, `XAI`, `ZAI`, `MINIMAX`, `STACKSPOT`, `OLLAMA`, `COPILOT` | `""` |
+| `llm.provider` | Default provider: `OPENAI`, `CLAUDEAI`, `GOOGLEAI`, `XAI`, `ZAI`, `MINIMAX`, `STACKSPOT`, `OLLAMA`, `COPILOT`, `OPENROUTER` | `""` |
 | `llm.model` | Model override | `""` |
 | `secrets.openaiApiKey` | OpenAI API key | `""` |
 | `secrets.anthropicApiKey` | Anthropic API key | `""` |
@@ -118,6 +118,7 @@ Clients can use their own API keys (personal mode) or the server's configured pr
 | `secrets.zaiApiKey` | ZAI (Zhipu AI) API key | `""` |
 | `secrets.minimaxApiKey` | MiniMax API key | `""` |
 | `secrets.githubCopilotToken` | GitHub Copilot token | `""` |
+| `secrets.openrouterApiKey` | OpenRouter API key | `""` |
 | `secrets.stackspotClientId` | StackSpot client ID | `""` |
 | `secrets.stackspotClientKey` | StackSpot client key | `""` |
 | `secrets.stackspotRealm` | StackSpot realm | `""` |
@@ -150,6 +151,8 @@ fallback:
       model: glm-4.7
     - name: MINIMAX
       model: MiniMax-M2.7
+    - name: OPENROUTER
+      model: anthropic/claude-sonnet-4
 ```
 
 ### gRPC Server

--- a/deploy/helm/chatcli/crds/platform.chatcli.io_instances.yaml
+++ b/deploy/helm/chatcli/crds/platform.chatcli.io_instances.yaml
@@ -119,7 +119,7 @@ spec:
                 description: |-
                   APIKeys references a Secret containing provider API keys and config.
                   Expected keys: OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLEAI_API_KEY, XAI_API_KEY,
-                  ZAI_API_KEY, MINIMAX_API_KEY, MINIMAX_API_COMPAT, GITHUB_COPILOT_TOKEN, etc.
+                  ZAI_API_KEY, MINIMAX_API_KEY, MINIMAX_API_COMPAT, GITHUB_COPILOT_TOKEN, OPENROUTER_API_KEY, etc.
                   All providers used in the fallback chain must have their API keys in this Secret.
                 properties:
                   name:
@@ -128,6 +128,166 @@ spec:
                 required:
                 - name
                 type: object
+              extraEnv:
+                description: |-
+                  ExtraEnv allows passing arbitrary environment variables to the ChatCLI server pod.
+                  Use this for security configuration (CHATCLI_RATE_LIMIT_RPS, CHATCLI_AGENT_SECURITY_MODE, etc.)
+                  or any other CHATCLI_* env vars not covered by structured fields.
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
               fallback:
                 description: |-
                   Fallback configures automatic provider failover.
@@ -170,7 +330,7 @@ spec:
                         name:
                           description: Name is the provider name (OPENAI, OPENAI_ASSISTANT,
                             CLAUDEAI, GOOGLEAI, XAI, ZAI, MINIMAX, STACKSPOT, OLLAMA,
-                            COPILOT, GITHUB_MODELS).
+                            COPILOT, GITHUB_MODELS, OPENROUTER).
                           enum:
                           - OPENAI
                           - OPENAI_ASSISTANT
@@ -183,6 +343,7 @@ spec:
                           - OLLAMA
                           - COPILOT
                           - GITHUB_MODELS
+                          - OPENROUTER
                           type: string
                       required:
                       - name
@@ -312,7 +473,7 @@ spec:
               provider:
                 description: Provider is the LLM provider (OPENAI, OPENAI_ASSISTANT,
                   CLAUDEAI, GOOGLEAI, XAI, ZAI, MINIMAX, STACKSPOT, OLLAMA, COPILOT,
-                  GITHUB_MODELS).
+                  GITHUB_MODELS, OPENROUTER).
                 type: string
               replicas:
                 default: 1
@@ -626,6 +787,75 @@ spec:
                     description: Port is the gRPC server port.
                     format: int32
                     type: integer
+                  security:
+                    description: Security configures server security parameters.
+                    properties:
+                      auditLogPath:
+                        description: |-
+                          AuditLogPath is the file path for structured audit logs (JSON lines).
+                          Maps to CHATCLI_AUDIT_LOG_PATH env var.
+                        type: string
+                      bindAddress:
+                        description: |-
+                          BindAddress is the address to bind the server to.
+                          Maps to CHATCLI_BIND_ADDRESS env var. Default: "127.0.0.1".
+                          Set to "0.0.0.0" to expose to all interfaces.
+                        type: string
+                      debug:
+                        description: |-
+                          Debug enables verbose logging including stack traces on errors.
+                          Maps to CHATCLI_DEBUG env var.
+                        type: boolean
+                      enableReflection:
+                        description: EnableReflection enables gRPC reflection (requires
+                          also CHATCLI_GRPC_REFLECTION=true).
+                        type: boolean
+                      jwtSecretRef:
+                        description: |-
+                          JWTSecretRef references a Secret key containing the JWT signing secret.
+                          Maps to CHATCLI_JWT_SECRET env var.
+                        properties:
+                          key:
+                            description: Key is the key within the Secret.
+                            type: string
+                          name:
+                            description: Name is the Secret name.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      maxConcurrentStreams:
+                        description: |-
+                          MaxConcurrentStreams limits simultaneous gRPC streams per connection.
+                          Maps to CHATCLI_MAX_CONCURRENT_STREAMS env var. Default: 100.
+                        format: int32
+                        type: integer
+                      maxRecvMsgSize:
+                        description: |-
+                          MaxRecvMsgSize is the maximum message size in bytes the server can receive.
+                          Maps to CHATCLI_MAX_RECV_MSG_SIZE env var. Default: 52428800 (50MB).
+                        format: int32
+                        type: integer
+                      maxSendMsgSize:
+                        description: |-
+                          MaxSendMsgSize is the maximum message size in bytes the server can send.
+                          Maps to CHATCLI_MAX_SEND_MSG_SIZE env var. Default: 52428800 (50MB).
+                        format: int32
+                        type: integer
+                      rateLimitBurst:
+                        description: |-
+                          RateLimitBurst is the maximum burst size for rate limiting.
+                          Maps to CHATCLI_RATE_LIMIT_BURST env var. Default: 30.
+                        format: int32
+                        type: integer
+                      rateLimitRps:
+                        description: |-
+                          RateLimitRPS is the per-client rate limit in requests per second.
+                          Maps to CHATCLI_RATE_LIMIT_RPS env var. Default: 10.
+                        format: int32
+                        type: integer
+                    type: object
                   tls:
                     description: TLS configures TLS for the gRPC server.
                     properties:

--- a/deploy/helm/chatcli/templates/secret.yaml
+++ b/deploy/helm/chatcli/templates/secret.yaml
@@ -46,4 +46,7 @@ stringData:
   {{- if .Values.secrets.githubCopilotToken }}
   GITHUB_COPILOT_TOKEN: {{ .Values.secrets.githubCopilotToken | quote }}
   {{- end }}
+  {{- if .Values.secrets.openrouterApiKey }}
+  OPENROUTER_API_KEY: {{ .Values.secrets.openrouterApiKey | quote }}
+  {{- end }}
 {{- end }}

--- a/deploy/helm/chatcli/values.yaml
+++ b/deploy/helm/chatcli/values.yaml
@@ -34,7 +34,7 @@ tls:
 
 # LLM Provider configuration
 llm:
-  # Default provider: OPENAI, CLAUDEAI, GOOGLEAI, XAI, ZAI, MINIMAX, STACKSPOT, OLLAMA, COPILOT
+  # Default provider: OPENAI, CLAUDEAI, GOOGLEAI, XAI, ZAI, MINIMAX, STACKSPOT, OLLAMA, COPILOT, OPENROUTER
   provider: ""
   model: ""
 
@@ -99,6 +99,8 @@ secrets:
   stackspotAgentId: ""
   # GitHub Copilot
   githubCopilotToken: ""
+  # OpenRouter
+  openrouterApiKey: ""
 
 # GitHub Copilot configuration (if using COPILOT provider)
 # Authenticate via /auth login github-copilot (Device Flow OAuth)

--- a/llm/catalog/catalog.go
+++ b/llm/catalog/catalog.go
@@ -23,6 +23,7 @@ const (
 	ProviderOllama          = "OLLAMA"
 	ProviderCopilot         = "COPILOT"
 	ProviderGitHubModels    = "GITHUB_MODELS"
+	ProviderOpenRouter      = "OPENROUTER"
 )
 
 // PreferredAPI define qual API é preferida para o modelo
@@ -618,6 +619,100 @@ var registry = []ModelMeta{
 		PreferredAPI:    APIChatCompletions,
 		Capabilities:    []string{"json_mode"},
 	},
+
+	// OpenRouter Models (multi-provider gateway)
+	// Models use provider/model-name format. Only popular defaults are listed;
+	// the full catalog is fetched dynamically via ListModels.
+	{
+		ID:              "openai/gpt-4o",
+		Aliases:         []string{"openrouter-gpt-4o"},
+		DisplayName:     "GPT-4o (OpenRouter)",
+		Provider:        ProviderOpenRouter,
+		ContextWindow:   128000,
+		MaxOutputTokens: 16384,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"vision", "tools", "json_mode"},
+	},
+	{
+		ID:              "openai/gpt-4o-mini",
+		Aliases:         []string{"openrouter-gpt-4o-mini"},
+		DisplayName:     "GPT-4o mini (OpenRouter)",
+		Provider:        ProviderOpenRouter,
+		ContextWindow:   128000,
+		MaxOutputTokens: 16384,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"vision", "tools", "json_mode"},
+	},
+	{
+		ID:              "anthropic/claude-sonnet-4",
+		Aliases:         []string{"openrouter-claude-sonnet-4"},
+		DisplayName:     "Claude Sonnet 4 (OpenRouter)",
+		Provider:        ProviderOpenRouter,
+		ContextWindow:   200000,
+		MaxOutputTokens: 64000,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"tools", "json_mode"},
+	},
+	{
+		ID:              "anthropic/claude-opus-4",
+		Aliases:         []string{"openrouter-claude-opus-4"},
+		DisplayName:     "Claude Opus 4 (OpenRouter)",
+		Provider:        ProviderOpenRouter,
+		ContextWindow:   200000,
+		MaxOutputTokens: 32000,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"tools", "json_mode"},
+	},
+	{
+		ID:              "google/gemini-2.5-pro",
+		Aliases:         []string{"openrouter-gemini-2.5-pro"},
+		DisplayName:     "Gemini 2.5 Pro (OpenRouter)",
+		Provider:        ProviderOpenRouter,
+		ContextWindow:   1000000,
+		MaxOutputTokens: 65536,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"vision", "tools", "json_mode"},
+	},
+	{
+		ID:              "google/gemini-2.5-flash",
+		Aliases:         []string{"openrouter-gemini-2.5-flash"},
+		DisplayName:     "Gemini 2.5 Flash (OpenRouter)",
+		Provider:        ProviderOpenRouter,
+		ContextWindow:   1000000,
+		MaxOutputTokens: 65536,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"vision", "tools", "json_mode"},
+	},
+	{
+		ID:              "meta-llama/llama-4-maverick",
+		Aliases:         []string{"openrouter-llama-4-maverick"},
+		DisplayName:     "Llama 4 Maverick (OpenRouter)",
+		Provider:        ProviderOpenRouter,
+		ContextWindow:   1048576,
+		MaxOutputTokens: 65536,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"tools"},
+	},
+	{
+		ID:              "deepseek/deepseek-r1",
+		Aliases:         []string{"openrouter-deepseek-r1"},
+		DisplayName:     "DeepSeek R1 (OpenRouter)",
+		Provider:        ProviderOpenRouter,
+		ContextWindow:   163840,
+		MaxOutputTokens: 65536,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"tools"},
+	},
+	{
+		ID:              "mistralai/mistral-large",
+		Aliases:         []string{"openrouter-mistral-large"},
+		DisplayName:     "Mistral Large (OpenRouter)",
+		Provider:        ProviderOpenRouter,
+		ContextWindow:   128000,
+		MaxOutputTokens: 32768,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"tools", "json_mode"},
+	},
 }
 
 // Resolve procura metadados por provedor e string de modelo (case-insensitive),
@@ -708,6 +803,8 @@ func GetMaxTokens(provider, model string, override int) int {
 		return 16384
 	case ProviderGitHubModels:
 		return 4096
+	case ProviderOpenRouter:
+		return 16384
 	default:
 		return 50000
 	}
@@ -737,6 +834,8 @@ func GetContextWindow(provider, model string) int {
 	case ProviderCopilot:
 		return 128000
 	case ProviderGitHubModels:
+		return 128000
+	case ProviderOpenRouter:
 		return 128000
 	default:
 		return 50000

--- a/llm/manager/llm_manager.go
+++ b/llm/manager/llm_manager.go
@@ -30,6 +30,7 @@ import (
 	"github.com/diillson/chatcli/llm/openai"
 	"github.com/diillson/chatcli/llm/openai_assistant"
 	"github.com/diillson/chatcli/llm/openai_responses"
+	"github.com/diillson/chatcli/llm/openrouter"
 	"github.com/diillson/chatcli/llm/stackspotai"
 	"github.com/diillson/chatcli/llm/token"
 	"github.com/diillson/chatcli/llm/xai"
@@ -105,6 +106,7 @@ func NewLLMManager(logger *zap.Logger) (LLMManager, error) {
 	manager.configurarOllamaClient(maxRetries, initialBackoff)
 	manager.configurarCopilotClient(maxRetries, initialBackoff)
 	manager.configurarGitHubModelsClient(maxRetries, initialBackoff)
+	manager.configurarOpenRouterClient(maxRetries, initialBackoff)
 
 	return manager, nil
 }
@@ -442,6 +444,28 @@ func (m *LLMManagerImpl) configurarGitHubModelsClient(maxRetries int, initialBac
 	}
 }
 
+// configurarOpenRouterClient configura o cliente OpenRouter
+func (m *LLMManagerImpl) configurarOpenRouterClient(maxRetries int, initialBackoff time.Duration) {
+	apiKey := config.Global.GetString("OPENROUTER_API_KEY")
+	if apiKey != "" {
+		m.logger.Info(i18n.T("llm.info.configuring_provider", "OpenRouter"))
+		m.clients["OPENROUTER"] = func(model string) (client.LLMClient, error) {
+			if model == "" {
+				model = config.DefaultOpenRouterModel
+			}
+			return openrouter.NewOpenRouterClient(
+				apiKey,
+				model,
+				m.logger,
+				maxRetries,
+				initialBackoff,
+			), nil
+		}
+	} else {
+		m.logger.Warn(i18n.T("llm.warn.provider_not_available", "OPENROUTER_API_KEY", "OPENROUTER"))
+	}
+}
+
 // GetAvailableProviders retorna uma lista de provedores disponíveis configurados
 func (m *LLMManagerImpl) GetAvailableProviders() []string {
 	var providers []string
@@ -588,6 +612,7 @@ func (m *LLMManagerImpl) RefreshProviders() {
 	m.configurarGitHubModelsClient(maxRetries, initialBackoff)
 	m.configurarZAIClient(maxRetries, initialBackoff)
 	m.configurarMiniMaxClient(maxRetries, initialBackoff)
+	m.configurarOpenRouterClient(maxRetries, initialBackoff)
 }
 
 // CreateClientWithKey creates an LLM client using a caller-provided API key
@@ -649,6 +674,12 @@ func (m *LLMManagerImpl) CreateClientWithKey(provider, model, apiKey string) (cl
 			model = config.DefaultCopilotModel
 		}
 		return copilot.NewClient(apiKey, model, m.logger, maxRetries, initialBackoff), nil
+
+	case "OPENROUTER":
+		if model == "" {
+			model = config.DefaultOpenRouterModel
+		}
+		return openrouter.NewOpenRouterClient(apiKey, model, m.logger, maxRetries, initialBackoff), nil
 
 	default:
 		return nil, fmt.Errorf("%s", i18n.T("llm.manager.create_client_unsupported", provider))

--- a/llm/openrouter/openrouter_client.go
+++ b/llm/openrouter/openrouter_client.go
@@ -1,0 +1,453 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package openrouter
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/diillson/chatcli/auth"
+	"github.com/diillson/chatcli/config"
+	"github.com/diillson/chatcli/i18n"
+	"github.com/diillson/chatcli/llm/catalog"
+	"github.com/diillson/chatcli/llm/client"
+	"github.com/diillson/chatcli/models"
+	"github.com/diillson/chatcli/utils"
+	"go.uber.org/zap"
+)
+
+// OpenRouterClient implements the LLM client for the OpenRouter API.
+// OpenRouter is an OpenAI-compatible gateway that routes requests to
+// multiple LLM providers (OpenAI, Anthropic, Google, Meta, etc.).
+type OpenRouterClient struct {
+	apiKey      string
+	model       string
+	logger      *zap.Logger
+	client      *http.Client
+	maxAttempts int
+	backoff     time.Duration
+}
+
+// NewOpenRouterClient creates a new OpenRouter client instance.
+func NewOpenRouterClient(apiKey, model string, logger *zap.Logger, maxAttempts int, backoff time.Duration) *OpenRouterClient {
+	httpClient := utils.NewHTTPClient(logger, 900*time.Second)
+
+	return &OpenRouterClient{
+		apiKey:      apiKey,
+		model:       model,
+		logger:      logger,
+		client:      httpClient,
+		maxAttempts: maxAttempts,
+		backoff:     backoff,
+	}
+}
+
+// GetModelName returns the display name for the current model via catalog.
+func (c *OpenRouterClient) GetModelName() string {
+	return catalog.GetDisplayName(catalog.ProviderOpenRouter, c.model)
+}
+
+// getMaxTokens resolves max tokens from env override, catalog, or fallback.
+func (c *OpenRouterClient) getMaxTokens() int {
+	if tokenStr := os.Getenv("OPENROUTER_MAX_TOKENS"); tokenStr != "" {
+		if parsedTokens, err := strconv.Atoi(tokenStr); err == nil && parsedTokens > 0 {
+			c.logger.Debug(i18n.T("llm.info.using_custom_max_tokens", "OPENROUTER_MAX_TOKENS"),
+				zap.Int("max_tokens", parsedTokens))
+			return parsedTokens
+		}
+	}
+	return catalog.GetMaxTokens(catalog.ProviderOpenRouter, c.model, 0)
+}
+
+// getAPIURL resolves the OpenRouter API URL from env override or default.
+func (c *OpenRouterClient) getAPIURL() string {
+	return utils.GetEnvOrDefault("OPENROUTER_API_URL", config.OpenRouterAPIURL)
+}
+
+// buildMessages converts the conversation history into the OpenAI-compatible
+// messages format used by OpenRouter.
+func (c *OpenRouterClient) buildMessages(prompt string, history []models.Message) []map[string]interface{} {
+	messages := make([]map[string]interface{}, 0, len(history)+1)
+
+	for _, msg := range history {
+		role := strings.ToLower(strings.TrimSpace(msg.Role))
+		switch role {
+		case "system", "user", "assistant", "tool":
+			// valid roles
+		default:
+			role = "user"
+		}
+
+		msgMap := map[string]interface{}{
+			"role":    role,
+			"content": msg.Content,
+		}
+
+		// Preserve tool_call_id for tool response messages
+		if role == "tool" && msg.ToolCallID != "" {
+			msgMap["tool_call_id"] = msg.ToolCallID
+		}
+
+		messages = append(messages, msgMap)
+	}
+
+	// Fallback: if history doesn't contain the last user prompt, add it
+	if len(history) == 0 || history[len(history)-1].Role != "user" || history[len(history)-1].Content != prompt {
+		if strings.TrimSpace(prompt) != "" {
+			messages = append(messages, map[string]interface{}{
+				"role":    "user",
+				"content": prompt,
+			})
+		}
+	}
+
+	return messages
+}
+
+// buildPayload assembles the request payload with OpenRouter-specific options.
+func (c *OpenRouterClient) buildPayload(messages []map[string]interface{}, maxTokens int) map[string]interface{} {
+	payload := map[string]interface{}{
+		"model":      c.model,
+		"messages":   messages,
+		"max_tokens": maxTokens,
+	}
+
+	// OpenRouter-specific: fallback models (try primary, then fallbacks)
+	if fallbackModels := os.Getenv("OPENROUTER_FALLBACK_MODELS"); fallbackModels != "" {
+		modelList := strings.Split(fallbackModels, ",")
+		trimmed := make([]string, 0, len(modelList))
+		for _, m := range modelList {
+			if s := strings.TrimSpace(m); s != "" {
+				trimmed = append(trimmed, s)
+			}
+		}
+		if len(trimmed) > 0 {
+			// OpenRouter "models" field: first is primary, rest are fallbacks
+			allModels := append([]string{c.model}, trimmed...)
+			payload["models"] = allModels
+			payload["route"] = "fallback"
+		}
+	}
+
+	// OpenRouter-specific: provider ordering preference
+	if providerOrder := os.Getenv("OPENROUTER_PROVIDER_ORDER"); providerOrder != "" {
+		orderList := strings.Split(providerOrder, ",")
+		trimmed := make([]string, 0, len(orderList))
+		for _, p := range orderList {
+			if s := strings.TrimSpace(p); s != "" {
+				trimmed = append(trimmed, s)
+			}
+		}
+		if len(trimmed) > 0 {
+			payload["provider"] = map[string]interface{}{
+				"order": trimmed,
+			}
+		}
+	}
+
+	// OpenRouter-specific: message transforms (e.g., "middle-out" for context overflow)
+	if transforms := os.Getenv("OPENROUTER_TRANSFORMS"); transforms != "" {
+		transformList := strings.Split(transforms, ",")
+		trimmed := make([]string, 0, len(transformList))
+		for _, t := range transformList {
+			if s := strings.TrimSpace(t); s != "" {
+				trimmed = append(trimmed, s)
+			}
+		}
+		if len(trimmed) > 0 {
+			payload["transforms"] = trimmed
+		}
+	}
+
+	// Tool calling support: inject tools from history metadata
+	if tools := c.resolveTools(); tools != nil {
+		payload["tools"] = tools
+	}
+
+	return payload
+}
+
+// resolveTools checks for tool definitions in the OPENROUTER_TOOLS env var.
+// Format: JSON array of OpenAI-compatible tool definitions.
+func (c *OpenRouterClient) resolveTools() []interface{} {
+	toolsJSON := os.Getenv("OPENROUTER_TOOLS")
+	if toolsJSON == "" {
+		return nil
+	}
+
+	var tools []interface{}
+	if err := json.Unmarshal([]byte(toolsJSON), &tools); err != nil {
+		c.logger.Warn("Failed to parse OPENROUTER_TOOLS",
+			zap.Error(err))
+		return nil
+	}
+	return tools
+}
+
+// SendPrompt sends a prompt to the OpenRouter API and returns the response.
+func (c *OpenRouterClient) SendPrompt(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {
+	effectiveMaxTokens := maxTokens
+	if effectiveMaxTokens <= 0 {
+		effectiveMaxTokens = c.getMaxTokens()
+	}
+
+	messages := c.buildMessages(prompt, history)
+	payload := c.buildPayload(messages, effectiveMaxTokens)
+
+	jsonValue, err := json.Marshal(payload)
+	if err != nil {
+		c.logger.Error(i18n.T("llm.error.marshal_payload_for", "OpenRouter"), zap.Error(err))
+		return "", fmt.Errorf("%s: %w", i18n.T("llm.error.prepare_request"), err)
+	}
+
+	response, err := utils.Retry(ctx, c.logger, c.maxAttempts, c.backoff, func(ctx context.Context) (string, error) {
+		resp, err := c.sendRequest(ctx, jsonValue)
+		if err != nil {
+			return "", err
+		}
+		return c.processResponse(resp)
+	})
+
+	if err != nil {
+		c.logger.Error(i18n.T("llm.error.get_response_after_retries", "OpenRouter"), zap.Error(err))
+		return "", err
+	}
+
+	return response, nil
+}
+
+// sendRequest sends the HTTP request to the OpenRouter API with proper headers.
+func (c *OpenRouterClient) sendRequest(ctx context.Context, jsonValue []byte) (*http.Response, error) {
+	apiURL := c.getAPIURL()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, utils.NewJSONReader(jsonValue))
+	if err != nil {
+		c.logger.Error(i18n.T("llm.error.create_request"), zap.Error(err))
+		return nil, fmt.Errorf("%s: %w", i18n.T("llm.error.create_request"), err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+auth.StripAuthPrefix(c.apiKey))
+
+	// OpenRouter-specific headers for attribution and analytics
+	if referer := os.Getenv("OPENROUTER_HTTP_REFERER"); referer != "" {
+		req.Header.Set("HTTP-Referer", referer)
+	}
+	if title := os.Getenv("OPENROUTER_APP_TITLE"); title != "" {
+		req.Header.Set("X-Title", title)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// processResponse parses the OpenRouter API response, handling both
+// standard content responses and tool call responses.
+func (c *OpenRouterClient) processResponse(resp *http.Response) (string, error) {
+	defer func() { _ = resp.Body.Close() }()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		c.logger.Error(i18n.T("llm.error.read_response_for", "OpenRouter"), zap.Error(err))
+		return "", fmt.Errorf("%s: %w", i18n.T("llm.error.read_response_for", "OpenRouter"), err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", &utils.APIError{
+			StatusCode: resp.StatusCode,
+			Message:    utils.SanitizeSensitiveText(string(bodyBytes)),
+		}
+	}
+
+	var result openRouterResponse
+	if err := json.Unmarshal(bodyBytes, &result); err != nil {
+		c.logger.Error(i18n.T("llm.error.decode_response_json_for", "OpenRouter"),
+			zap.Error(err), zap.Int("body_size", len(bodyBytes)))
+		return "", fmt.Errorf("%s: %w", i18n.T("llm.error.decode_response_for", "OpenRouter"), err)
+	}
+
+	// Check for explicit error in response body (OpenRouter may return errors with 200)
+	if result.Error != nil && result.Error.Message != "" {
+		c.logger.Error(i18n.T("llm.error.api_error_payload", "OpenRouter"),
+			zap.String("error_message", result.Error.Message),
+			zap.Int("error_code", result.Error.Code))
+		return "", fmt.Errorf("%s", i18n.T("llm.error.api_error", "OpenRouter", result.Error.Message))
+	}
+
+	if len(result.Choices) == 0 {
+		c.logger.Warn(i18n.T("llm.warn.empty_choices", "OpenRouter"),
+			zap.Int("body_size", len(bodyBytes)))
+		return "", errors.New(i18n.T("llm.error.no_choices", "OpenRouter"))
+	}
+
+	firstChoice := result.Choices[0]
+
+	// Handle tool calls: serialize them as JSON so the caller can process them
+	if len(firstChoice.Message.ToolCalls) > 0 {
+		toolCallsJSON, err := json.Marshal(firstChoice.Message.ToolCalls)
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal tool calls: %w", err)
+		}
+		// Return tool calls as structured JSON with a marker prefix
+		return fmt.Sprintf("[TOOL_CALLS]%s", string(toolCallsJSON)), nil
+	}
+
+	content := firstChoice.Message.Content
+	if content == "" {
+		c.logger.Warn(i18n.T("llm.warn.empty_content", "OpenRouter"),
+			zap.String("finish_reason", firstChoice.FinishReason),
+			zap.Int("body_size", len(bodyBytes)))
+
+		if firstChoice.FinishReason == "length" {
+			return "", errors.New(i18n.T("llm.error.empty_response_max_tokens", "OpenRouter"))
+		}
+		return "", errors.New(i18n.T("llm.error.empty_response_unspecified", "OpenRouter"))
+	}
+
+	// Log usage metadata for cost tracking
+	if result.Usage != nil {
+		c.logger.Debug("OpenRouter usage",
+			zap.Int("prompt_tokens", result.Usage.PromptTokens),
+			zap.Int("completion_tokens", result.Usage.CompletionTokens),
+			zap.Int("total_tokens", result.Usage.TotalTokens))
+	}
+
+	return content, nil
+}
+
+// ListModels fetches available models from the OpenRouter /api/v1/models endpoint.
+// This endpoint does not require authentication.
+func (c *OpenRouterClient) ListModels(ctx context.Context) ([]client.ModelInfo, error) {
+	baseURL := c.getAPIURL()
+	modelsURL := strings.TrimSuffix(baseURL, "/chat/completions") + "/models"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, modelsURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("llm.error.create_request"), err)
+	}
+	// Auth is optional for /models but included for consistency
+	req.Header.Set("Authorization", "Bearer "+auth.StripAuthPrefix(c.apiKey))
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("llm.error.request_failed", "OpenRouter"), err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("llm.error.read_response_for", "OpenRouter"), err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s: %d: %s",
+			i18n.T("llm.error.request_failed", "OpenRouter"),
+			resp.StatusCode,
+			utils.SanitizeSensitiveText(string(bodyBytes)))
+	}
+
+	var result openRouterModelsResponse
+	if err := json.Unmarshal(bodyBytes, &result); err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("llm.error.decode_response_for", "OpenRouter"), err)
+	}
+
+	var modelList []client.ModelInfo
+	for _, m := range result.Data {
+		modelList = append(modelList, client.ModelInfo{
+			ID:          m.ID,
+			DisplayName: m.Name,
+			Source:      client.ModelSourceAPI,
+		})
+
+		// Register dynamically discovered models in the catalog
+		if _, ok := catalog.Resolve(catalog.ProviderOpenRouter, m.ID); !ok {
+			meta := catalog.ModelMeta{
+				ID:           m.ID,
+				Aliases:      []string{m.ID},
+				DisplayName:  m.Name,
+				Provider:     catalog.ProviderOpenRouter,
+				PreferredAPI: catalog.APIChatCompletions,
+			}
+			if m.ContextLength > 0 {
+				meta.ContextWindow = m.ContextLength
+			}
+			if m.TopProvider.MaxCompletionTokens > 0 {
+				meta.MaxOutputTokens = m.TopProvider.MaxCompletionTokens
+			}
+			catalog.Register(meta)
+		}
+	}
+
+	c.logger.Info(i18n.T("llm.info.fetched_models", "OpenRouter"), zap.Int("count", len(modelList)))
+	return modelList, nil
+}
+
+// --- Response types ---
+
+// openRouterResponse represents the chat completion response from OpenRouter.
+type openRouterResponse struct {
+	ID      string `json:"id"`
+	Model   string `json:"model"`
+	Choices []struct {
+		Index   int `json:"index"`
+		Message struct {
+			Role      string         `json:"role"`
+			Content   string         `json:"content"`
+			ToolCalls []toolCallInfo `json:"tool_calls,omitempty"`
+		} `json:"message"`
+		FinishReason string `json:"finish_reason"`
+	} `json:"choices"`
+	Usage *struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+		TotalTokens      int `json:"total_tokens"`
+	} `json:"usage,omitempty"`
+	Error *struct {
+		Message string `json:"message"`
+		Code    int    `json:"code"`
+	} `json:"error,omitempty"`
+}
+
+// toolCallInfo represents a tool call in the OpenRouter response.
+type toolCallInfo struct {
+	ID       string `json:"id"`
+	Type     string `json:"type"`
+	Function struct {
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	} `json:"function"`
+}
+
+// openRouterModelsResponse represents the /models endpoint response.
+type openRouterModelsResponse struct {
+	Data []openRouterModelEntry `json:"data"`
+}
+
+// openRouterModelEntry represents a single model from the /models endpoint.
+type openRouterModelEntry struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	ContextLength int    `json:"context_length"`
+	Pricing       struct {
+		Prompt     string `json:"prompt"`
+		Completion string `json:"completion"`
+	} `json:"pricing"`
+	TopProvider struct {
+		MaxCompletionTokens int `json:"max_completion_tokens"`
+	} `json:"top_provider"`
+}

--- a/llm/openrouter/register.go
+++ b/llm/openrouter/register.go
@@ -1,0 +1,28 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package openrouter
+
+import (
+	"github.com/diillson/chatcli/config"
+	"github.com/diillson/chatcli/llm/client"
+	"github.com/diillson/chatcli/llm/registry"
+)
+
+func init() {
+	registry.Register(registry.ProviderInfo{
+		Name:         "OPENROUTER",
+		DisplayName:  "OpenRouter",
+		RequiresAuth: true,
+		EnvKeys:      []string{"OPENROUTER_API_KEY"},
+		Factory: func(cfg registry.ProviderConfig) (client.LLMClient, error) {
+			model := cfg.Model
+			if model == "" {
+				model = config.DefaultOpenRouterModel
+			}
+			return NewOpenRouterClient(cfg.APIKey, model, cfg.Logger, cfg.MaxRetries, cfg.Backoff), nil
+		},
+	})
+}

--- a/operator/api/v1alpha1/instance_types.go
+++ b/operator/api/v1alpha1/instance_types.go
@@ -15,7 +15,7 @@ type InstanceSpec struct {
 	// +optional
 	Replicas *int32 `json:"replicas,omitempty"`
 
-	// Provider is the LLM provider (OPENAI, OPENAI_ASSISTANT, CLAUDEAI, GOOGLEAI, XAI, ZAI, MINIMAX, STACKSPOT, OLLAMA, COPILOT, GITHUB_MODELS).
+	// Provider is the LLM provider (OPENAI, OPENAI_ASSISTANT, CLAUDEAI, GOOGLEAI, XAI, ZAI, MINIMAX, STACKSPOT, OLLAMA, COPILOT, GITHUB_MODELS, OPENROUTER).
 	Provider string `json:"provider"`
 
 	// Model is the LLM model name.
@@ -59,7 +59,7 @@ type InstanceSpec struct {
 
 	// APIKeys references a Secret containing provider API keys and config.
 	// Expected keys: OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLEAI_API_KEY, XAI_API_KEY,
-	// ZAI_API_KEY, MINIMAX_API_KEY, MINIMAX_API_COMPAT, GITHUB_COPILOT_TOKEN, etc.
+	// ZAI_API_KEY, MINIMAX_API_KEY, MINIMAX_API_COMPAT, GITHUB_COPILOT_TOKEN, OPENROUTER_API_KEY, etc.
 	// All providers used in the fallback chain must have their API keys in this Secret.
 	// +optional
 	APIKeys *SecretRefSpec `json:"apiKeys,omitempty"`
@@ -393,8 +393,8 @@ type FallbackSpec struct {
 
 // FallbackProviderEntry defines a single provider in the fallback chain.
 type FallbackProviderEntry struct {
-	// Name is the provider name (OPENAI, OPENAI_ASSISTANT, CLAUDEAI, GOOGLEAI, XAI, ZAI, MINIMAX, STACKSPOT, OLLAMA, COPILOT, GITHUB_MODELS).
-	// +kubebuilder:validation:Enum=OPENAI;OPENAI_ASSISTANT;CLAUDEAI;GOOGLEAI;XAI;ZAI;MINIMAX;STACKSPOT;OLLAMA;COPILOT;GITHUB_MODELS
+	// Name is the provider name (OPENAI, OPENAI_ASSISTANT, CLAUDEAI, GOOGLEAI, XAI, ZAI, MINIMAX, STACKSPOT, OLLAMA, COPILOT, GITHUB_MODELS, OPENROUTER).
+	// +kubebuilder:validation:Enum=OPENAI;OPENAI_ASSISTANT;CLAUDEAI;GOOGLEAI;XAI;ZAI;MINIMAX;STACKSPOT;OLLAMA;COPILOT;GITHUB_MODELS;OPENROUTER
 	Name string `json:"name"`
 
 	// Model is the LLM model to use for this provider.

--- a/operator/config/crd/bases/platform.chatcli.io_instances.yaml
+++ b/operator/config/crd/bases/platform.chatcli.io_instances.yaml
@@ -115,58 +115,11 @@ spec:
                     minimum: 0
                     type: integer
                 type: object
-              extraEnv:
-                description: |-
-                  ExtraEnv allows passing arbitrary environment variables to the ChatCLI server pod.
-                  Use for security config (CHATCLI_AGENT_SECURITY_MODE, CHATCLI_SESSION_TTL, etc.)
-                  or any other CHATCLI_* env vars not covered by structured fields.
-                  Supports both plain values and valueFrom (secretKeyRef, configMapKeyRef).
-                items:
-                  description: EnvVar represents an environment variable present in a Container.
-                  properties:
-                    name:
-                      description: Name of the environment variable.
-                      type: string
-                    value:
-                      description: Value of the environment variable.
-                      type: string
-                    valueFrom:
-                      description: Source for the environment variable's value.
-                      properties:
-                        configMapKeyRef:
-                          description: Selects a key of a ConfigMap.
-                          properties:
-                            key:
-                              type: string
-                            name:
-                              type: string
-                            optional:
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                        secretKeyRef:
-                          description: Selects a key of a Secret.
-                          properties:
-                            key:
-                              type: string
-                            name:
-                              type: string
-                            optional:
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                      type: object
-                  required:
-                  - name
-                  type: object
-                type: array
               apiKeys:
                 description: |-
                   APIKeys references a Secret containing provider API keys and config.
                   Expected keys: OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLEAI_API_KEY, XAI_API_KEY,
-                  ZAI_API_KEY, MINIMAX_API_KEY, MINIMAX_API_COMPAT, GITHUB_COPILOT_TOKEN, etc.
+                  ZAI_API_KEY, MINIMAX_API_KEY, MINIMAX_API_COMPAT, GITHUB_COPILOT_TOKEN, OPENROUTER_API_KEY, etc.
                   All providers used in the fallback chain must have their API keys in this Secret.
                 properties:
                   name:
@@ -175,6 +128,166 @@ spec:
                 required:
                 - name
                 type: object
+              extraEnv:
+                description: |-
+                  ExtraEnv allows passing arbitrary environment variables to the ChatCLI server pod.
+                  Use this for security configuration (CHATCLI_RATE_LIMIT_RPS, CHATCLI_AGENT_SECURITY_MODE, etc.)
+                  or any other CHATCLI_* env vars not covered by structured fields.
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
               fallback:
                 description: |-
                   Fallback configures automatic provider failover.
@@ -217,7 +330,7 @@ spec:
                         name:
                           description: Name is the provider name (OPENAI, OPENAI_ASSISTANT,
                             CLAUDEAI, GOOGLEAI, XAI, ZAI, MINIMAX, STACKSPOT, OLLAMA,
-                            COPILOT, GITHUB_MODELS).
+                            COPILOT, GITHUB_MODELS, OPENROUTER).
                           enum:
                           - OPENAI
                           - OPENAI_ASSISTANT
@@ -230,6 +343,7 @@ spec:
                           - OLLAMA
                           - COPILOT
                           - GITHUB_MODELS
+                          - OPENROUTER
                           type: string
                       required:
                       - name
@@ -359,7 +473,7 @@ spec:
               provider:
                 description: Provider is the LLM provider (OPENAI, OPENAI_ASSISTANT,
                   CLAUDEAI, GOOGLEAI, XAI, ZAI, MINIMAX, STACKSPOT, OLLAMA, COPILOT,
-                  GITHUB_MODELS).
+                  GITHUB_MODELS, OPENROUTER).
                 type: string
               replicas:
                 default: 1
@@ -673,22 +787,33 @@ spec:
                     description: Port is the gRPC server port.
                     format: int32
                     type: integer
-                  tls:
-                    description: TLS configures TLS for the gRPC server.
-                    properties:
-                      enabled:
-                        description: Enabled enables TLS.
-                        type: boolean
-                      secretName:
-                        description: SecretName is the name of the Secret containing
-                          tls.crt and tls.key.
-                        type: string
-                    type: object
                   security:
                     description: Security configures server security parameters.
                     properties:
+                      auditLogPath:
+                        description: |-
+                          AuditLogPath is the file path for structured audit logs (JSON lines).
+                          Maps to CHATCLI_AUDIT_LOG_PATH env var.
+                        type: string
+                      bindAddress:
+                        description: |-
+                          BindAddress is the address to bind the server to.
+                          Maps to CHATCLI_BIND_ADDRESS env var. Default: "127.0.0.1".
+                          Set to "0.0.0.0" to expose to all interfaces.
+                        type: string
+                      debug:
+                        description: |-
+                          Debug enables verbose logging including stack traces on errors.
+                          Maps to CHATCLI_DEBUG env var.
+                        type: boolean
+                      enableReflection:
+                        description: EnableReflection enables gRPC reflection (requires
+                          also CHATCLI_GRPC_REFLECTION=true).
+                        type: boolean
                       jwtSecretRef:
-                        description: JWTSecretRef references a Secret key containing the JWT signing secret. Maps to CHATCLI_JWT_SECRET.
+                        description: |-
+                          JWTSecretRef references a Secret key containing the JWT signing secret.
+                          Maps to CHATCLI_JWT_SECRET env var.
                         properties:
                           key:
                             description: Key is the key within the Secret.
@@ -700,38 +825,47 @@ spec:
                         - key
                         - name
                         type: object
-                      rateLimitRps:
-                        description: Per-client rate limit in requests per second. Maps to CHATCLI_RATE_LIMIT_RPS. Default 10.
-                        format: int32
-                        type: integer
-                      rateLimitBurst:
-                        description: Maximum burst size for rate limiting. Maps to CHATCLI_RATE_LIMIT_BURST. Default 30.
+                      maxConcurrentStreams:
+                        description: |-
+                          MaxConcurrentStreams limits simultaneous gRPC streams per connection.
+                          Maps to CHATCLI_MAX_CONCURRENT_STREAMS env var. Default: 100.
                         format: int32
                         type: integer
                       maxRecvMsgSize:
-                        description: Maximum message size in bytes the server can receive. Maps to CHATCLI_MAX_RECV_MSG_SIZE. Default 52428800 (50MB).
+                        description: |-
+                          MaxRecvMsgSize is the maximum message size in bytes the server can receive.
+                          Maps to CHATCLI_MAX_RECV_MSG_SIZE env var. Default: 52428800 (50MB).
                         format: int32
                         type: integer
                       maxSendMsgSize:
-                        description: Maximum message size in bytes the server can send. Maps to CHATCLI_MAX_SEND_MSG_SIZE. Default 52428800 (50MB).
+                        description: |-
+                          MaxSendMsgSize is the maximum message size in bytes the server can send.
+                          Maps to CHATCLI_MAX_SEND_MSG_SIZE env var. Default: 52428800 (50MB).
                         format: int32
                         type: integer
-                      maxConcurrentStreams:
-                        description: Limits simultaneous gRPC streams per connection. Maps to CHATCLI_MAX_CONCURRENT_STREAMS. Default 100.
+                      rateLimitBurst:
+                        description: |-
+                          RateLimitBurst is the maximum burst size for rate limiting.
+                          Maps to CHATCLI_RATE_LIMIT_BURST env var. Default: 30.
                         format: int32
                         type: integer
-                      bindAddress:
-                        description: Address to bind the server to. Maps to CHATCLI_BIND_ADDRESS. Default "127.0.0.1". Set "0.0.0.0" to expose.
-                        type: string
-                      auditLogPath:
-                        description: File path for structured audit logs (JSON lines). Maps to CHATCLI_AUDIT_LOG_PATH.
-                        type: string
-                      debug:
-                        description: Enable verbose logging including stack traces. Maps to CHATCLI_DEBUG.
+                      rateLimitRps:
+                        description: |-
+                          RateLimitRPS is the per-client rate limit in requests per second.
+                          Maps to CHATCLI_RATE_LIMIT_RPS env var. Default: 10.
+                        format: int32
+                        type: integer
+                    type: object
+                  tls:
+                    description: TLS configures TLS for the gRPC server.
+                    properties:
+                      enabled:
+                        description: Enabled enables TLS.
                         type: boolean
-                      enableReflection:
-                        description: Enable gRPC reflection (also needs CHATCLI_GRPC_REFLECTION=true).
-                        type: boolean
+                      secretName:
+                        description: SecretName is the name of the Secret containing
+                          tls.crt and tls.key.
+                        type: string
                     type: object
                   token:
                     description: Token references a Secret containing the auth token.

--- a/operator/controllers/cost_tracker.go
+++ b/operator/controllers/cost_tracker.go
@@ -105,6 +105,10 @@ func (ct *CostTracker) getTokenPricing(ctx context.Context, namespace, provider 
 		return tokenPricing{InputPerMillion: 0.3, OutputPerMillion: 1.2}
 	case provider == "COPILOT" || provider == "copilot":
 		return tokenPricing{InputPerMillion: 10.0, OutputPerMillion: 30.0}
+	case provider == "OPENROUTER" || provider == "openrouter":
+		// OpenRouter pricing varies by routed model; use conservative average.
+		// Override via ConfigMap chatcli-cost-config for accurate per-model pricing.
+		return tokenPricing{InputPerMillion: 2.0, OutputPerMillion: 8.0}
 	default:
 		return tokenPricing{InputPerMillion: 1.0, OutputPerMillion: 3.0}
 	}


### PR DESCRIPTION
## Summary

- Add **OpenRouter** (https://openrouter.ai) as a new LLM provider, enabling access to 200+ models from OpenAI, Anthropic, Google, Meta, Mistral, DeepSeek and others through a single API key
- Full feature parity with existing providers: retry, tool calling, dynamic model listing, cost tracking
- OpenRouter-specific features: fallback model routing, provider ordering, message transforms, attribution headers
- Full operator/Helm/CRD support with `OPENROUTER` in provider enum, secrets, and cost tracker

## Changes

### New files
| File | Description |
|------|-------------|
| `llm/openrouter/openrouter_client.go` | Full client: SendPrompt, tool calls, ListModels, fallback routing, transforms |
| `llm/openrouter/register.go` | Auto-registration via init() pattern |

### Modified files (15 total)
| File | Change |
|------|--------|
| `config/defaults.go` | `DefaultOpenRouterModel`, `OpenRouterAPIURL` |
| `llm/catalog/catalog.go` | `ProviderOpenRouter` + 9 popular models + fallback cases |
| `llm/manager/llm_manager.go` | `configurarOpenRouterClient`, `CreateClientWithKey`, `RefreshProviders` |
| `operator/api/v1alpha1/instance_types.go` | `OPENROUTER` in enum + APIKeys comment |
| `operator/config/crd/bases/*.yaml` | CRDs regenerated via controller-gen |
| `deploy/helm/chatcli-operator/crds/*.yaml` | CRD copy |
| `deploy/helm/chatcli/crds/*.yaml` | CRD copy |
| `deploy/helm/chatcli/values.yaml` | `openrouterApiKey` field |
| `deploy/helm/chatcli/templates/secret.yaml` | `OPENROUTER_API_KEY` secret entry |
| `deploy/helm/chatcli/README.md` | Provider docs + fallback example |
| `cli/cli_completer.go` | OPENROUTER in --provider autocomplete |
| `cli/oneshot_mode.go` | OPENROUTER in --provider flag help |
| `operator/controllers/cost_tracker.go` | Default pricing for OPENROUTER |

### Impact analysis performed
- Server handler: generic (no changes needed)
- Fallback chain: generic (no changes needed)
- Agent mode: dynamic registry (no changes needed)
- Proto/gRPC: no provider enum (no changes needed)
- Auth: API key only, no OAuth needed
- i18n: all translation keys already exist (parametric)

## Environment variables

| Variable | Required | Description |
|----------|----------|-------------|
| `OPENROUTER_API_KEY` | Yes | API key from openrouter.ai |
| `OPENROUTER_API_URL` | No | Override base URL (default: `https://openrouter.ai/api/v1/chat/completions`) |
| `OPENROUTER_MAX_TOKENS` | No | Override max tokens |
| `OPENROUTER_FALLBACK_MODELS` | No | Comma-separated fallback models (e.g., `anthropic/claude-sonnet-4,google/gemini-2.5-flash`) |
| `OPENROUTER_PROVIDER_ORDER` | No | Provider routing preference (e.g., `Anthropic,Google`) |
| `OPENROUTER_TRANSFORMS` | No | Message transforms (e.g., `middle-out`) |
| `OPENROUTER_HTTP_REFERER` | No | Attribution header for analytics |
| `OPENROUTER_APP_TITLE` | No | App title for OpenRouter dashboard |

## Test plan

- [x] `go build ./...` passes (main + operator)
- [x] `go vet ./...` passes (main + operator)
- [x] `go test ./...` passes (all 50+ packages)
- [x] Manual test with `OPENROUTER_API_KEY` set: `chatcli -p "hello" --provider OPENROUTER`
- [x] Helm template renders correctly: `helm template chatcli deploy/helm/chatcli/ --set secrets.openrouterApiKey=test --set llm.provider=OPENROUTER`
- [x] Operator: Instance CR with `provider: OPENROUTER` reconciles successfully