### PR TITLE
docs(readme): add OpenRouter provider to README (PT-BR + EN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <h1 align="center">ChatCLI</h1>
 <p align="center">
   <strong>A plataforma de IA unificada para terminal, servidor e Kubernetes.</strong><br>
-  <sub>11 provedores. 12 agentes autônomos. Um único binário.</sub>
+  <sub>12 provedores. 12 agentes autônomos. Um único binário.</sub>
 </p>
 
 <div align="center">
@@ -52,7 +52,7 @@
 
 | | |
 |---|---|
-| **Multi-provider de verdade** | 11 provedores de LLM com fallback automático, backoff exponencial e cooldown inteligente. |
+| **Multi-provider de verdade** | 12 provedores de LLM com fallback automático, backoff exponencial e cooldown inteligente. |
 | **Agentes autônomos** | 12 agentes especializados com motor ReAct (Reason + Act) e execução em paralelo. |
 | **Production-ready** | gRPC + TLS, JWT + RBAC, AES-256-GCM, rate limiting, audit logging, Prometheus metrics. |
 | **Kubernetes-native** | Operador com 17 CRDs e pipeline AIOps autônomo: 54+ ações de remediação automatizada. |
@@ -94,7 +94,7 @@ go build -ldflags "-X github.com/diillson/chatcli/version.Version=${VERSION}" -o
 Crie um arquivo `.env` na raiz ou exporte as variáveis:
 
 ```bash
-LLM_PROVIDER=OPENAI          # OPENAI, CLAUDEAI, GOOGLEAI, XAI, ZAI, MINIMAX, COPILOT, OLLAMA, STACKSPOT
+LLM_PROVIDER=OPENAI          # OPENAI, CLAUDEAI, GOOGLEAI, XAI, ZAI, MINIMAX, COPILOT, OLLAMA, STACKSPOT, OPENROUTER
 OPENAI_API_KEY=sk-xxx         # Chave do provider escolhido
 ```
 
@@ -112,6 +112,7 @@ OPENAI_API_KEY=sk-xxx         # Chave do provider escolhido
 | GitHub Copilot | `GITHUB_COPILOT_TOKEN` | `COPILOT_MODEL` | ou `/auth login github-copilot` |
 | GitHub Models | `GITHUB_TOKEN` | `GITHUB_MODELS_MODEL` | `GH_TOKEN`, `GITHUB_MODELS_TOKEN` |
 | StackSpot | `CLIENT_ID`, `CLIENT_KEY` | - | `STACKSPOT_REALM`, `STACKSPOT_AGENT_ID` |
+| OpenRouter | `OPENROUTER_API_KEY` | - | `OPENROUTER_MAX_TOKENS`, `OPENROUTER_FALLBACK_MODELS` |
 | Ollama | - | `OLLAMA_MODEL` | `OLLAMA_ENABLED=true`, `OLLAMA_BASE_URL` |
 
 </details>
@@ -221,7 +222,7 @@ helm install chatcli oci://ghcr.io/diillson/charts/chatcli \
 
 ## Provedores suportados
 
-> 11 provedores com interface unificada. Fallback automático entre providers com classificação inteligente de erros.
+> 12 provedores com interface unificada. Fallback automático entre providers com classificação inteligente de erros.
 
 | Provider | Default Model | Tool Calling | Vision |
 |---|---|---|---|
@@ -234,12 +235,13 @@ helm install chatcli oci://ghcr.io/diillson/charts/chatcli \
 | **GitHub Copilot** | gpt-4o | Nativo | Sim |
 | **GitHub Models** | gpt-4o | Nativo | Sim |
 | **StackSpot AI** | StackSpotAI | - | - |
+| **OpenRouter** | openai/gpt-4o | Nativo | Sim |
 | **Ollama** | (local) | XML fallback | - |
 | **OpenAI Assistants** | gpt-4o | Assistants API | - |
 
 ```bash
 # Fallback chain configurável
-CHATCLI_FALLBACK_PROVIDERS=OPENAI,CLAUDEAI,ZAI,MINIMAX
+CHATCLI_FALLBACK_PROVIDERS=OPENAI,CLAUDEAI,ZAI,MINIMAX,OPENROUTER
 ```
 
 Classificação de erros (rate limit, timeout, auth, context overflow), backoff exponencial e cooldown por provider.
@@ -343,7 +345,7 @@ Credenciais armazenadas com **AES-256-GCM** em `~/.chatcli/auth-profiles.json`.
 
 | Feature | Descrição |
 |---|---|
-| **Tool calling nativo** | Chamadas estruturadas via API da OpenAI, Anthropic, Google, ZAI e MiniMax. Cache `ephemeral` para Anthropic. XML fallback automático para providers sem suporte nativo. |
+| **Tool calling nativo** | Chamadas estruturadas via API da OpenAI, Anthropic, Google, ZAI, MiniMax e OpenRouter. Cache `ephemeral` para Anthropic. XML fallback automático para providers sem suporte nativo. |
 | **MCP (Model Context Protocol)** | Integração com servidores MCP via stdio e SSE para contexto expandido. |
 | **Contextos persistentes** | `/context create`, `/context attach` — injeta projetos inteiros no system prompt com cache hints. |
 | **Bootstrap e Memoria** | `SOUL.md`, `USER.md`, `IDENTITY.md`, `RULES.md` + memoria de longo prazo com facts e decay. |
@@ -389,7 +391,7 @@ Credenciais armazenadas com **AES-256-GCM** em `~/.chatcli/auth-profiles.json`.
 ```
 chatcli/
   cli/            Interface TUI (Bubble Tea), modo agente, multi-agent workers
-  llm/            11 providers, registry auto-registro, fallback chain, catalog
+  llm/            12 providers, registry auto-registro, fallback chain, catalog
   server/         Servidor gRPC com TLS, JWT auth, metrics e MCP
   operator/       Kubernetes Operator — 17 CRDs, pipeline AIOps autônomo
   k8s/            Watcher (collectors, store, summarizer)

--- a/README_EN.md
+++ b/README_EN.md
@@ -6,7 +6,7 @@
 
 <h1 align="center">ChatCLI</h1>
 <p align="center"><strong>Multi-provider AI platform for terminal, server, and Kubernetes</strong></p>
-<p align="center"><em>11 providers. 12 agents. One interface.</em></p>
+<p align="center"><em>12 providers. 12 agents. One interface.</em></p>
 
 <div align="center">
   <img src="https://github.com/diillson/chatcli/actions/workflows/1-ci.yml/badge.svg"/>
@@ -44,9 +44,9 @@
 
 ## Overview
 
-ChatCLI is a CLI, gRPC server, and Kubernetes operator that connects **11 LLM providers** to a single, unified interface. It ships with autonomous agents, native tool calling, automatic failover, enterprise-grade security, and a full AIOps pipeline -- all from your terminal.
+ChatCLI is a CLI, gRPC server, and Kubernetes operator that connects **12 LLM providers** to a single, unified interface. It ships with autonomous agents, native tool calling, automatic failover, enterprise-grade security, and a full AIOps pipeline -- all from your terminal.
 
-> **Why ChatCLI?** &mdash; Most AI tools lock you into one provider. ChatCLI gives you a consistent experience across OpenAI, Anthropic, Google, xAI, and seven more, with transparent failover, cost tracking, and the ability to run entirely on-prem via Ollama.
+> **Why ChatCLI?** &mdash; Most AI tools lock you into one provider. ChatCLI gives you a consistent experience across OpenAI, Anthropic, Google, xAI, and eight more -- including OpenRouter with access to 200+ models -- with transparent failover, cost tracking, and the ability to run entirely on-prem via Ollama.
 
 <br>
 
@@ -63,6 +63,7 @@ ChatCLI is a CLI, gRPC server, and Kubernetes operator that connects **11 LLM pr
 | **GitHub Copilot** | gpt-4o | Native | Yes |
 | **GitHub Models** | gpt-4o | Native | Yes |
 | **StackSpot AI** | StackSpotAI | -- | -- |
+| **OpenRouter** | openai/gpt-4o | Native | Yes |
 | **Ollama** | (local) | XML fallback | -- |
 | **OpenAI Assistants** | gpt-4o | Assistants API | -- |
 
@@ -103,7 +104,7 @@ go build -ldflags "-X github.com/diillson/chatcli/version.Version=${VERSION}" -o
 Create a `.env` file or export the variables:
 
 ```bash
-LLM_PROVIDER=OPENAI          # OPENAI, CLAUDEAI, GOOGLEAI, XAI, ZAI, MINIMAX, COPILOT, OLLAMA, STACKSPOT
+LLM_PROVIDER=OPENAI          # OPENAI, CLAUDEAI, GOOGLEAI, XAI, ZAI, MINIMAX, COPILOT, OLLAMA, STACKSPOT, OPENROUTER
 OPENAI_API_KEY=sk-xxx         # Key for the chosen provider
 ```
 
@@ -121,6 +122,7 @@ OPENAI_API_KEY=sk-xxx         # Key for the chosen provider
 | GitHub Copilot | `GITHUB_COPILOT_TOKEN` | `COPILOT_MODEL` | or `/auth login github-copilot` |
 | GitHub Models | `GITHUB_TOKEN` | `GITHUB_MODELS_MODEL` | `GH_TOKEN`, `GITHUB_MODELS_TOKEN` |
 | StackSpot | `CLIENT_ID`, `CLIENT_KEY` | -- | `STACKSPOT_REALM`, `STACKSPOT_AGENT_ID` |
+| OpenRouter | `OPENROUTER_API_KEY` | -- | `OPENROUTER_MAX_TOKENS`, `OPENROUTER_FALLBACK_MODELS` |
 | Ollama | -- | `OLLAMA_MODEL` | `OLLAMA_ENABLED=true`, `OLLAMA_BASE_URL` |
 
 </details>
@@ -217,7 +219,7 @@ chatcli -p "Create tests for the utils package" --agent-auto-exec
 
 ### Native Tool Calling
 
-Structured tool calls via OpenAI, Anthropic, Google, ZAI, and MiniMax native APIs. Ephemeral cache support for Anthropic. Automatic XML fallback for providers without native support.
+Structured tool calls via OpenAI, Anthropic, Google, ZAI, MiniMax, and OpenRouter native APIs. Ephemeral cache support for Anthropic. Automatic XML fallback for providers without native support.
 
 ### Built-in OAuth
 
@@ -233,7 +235,7 @@ Credentials stored with **AES-256-GCM** encryption in `~/.chatcli/auth-profiles.
 ### Provider Fallback
 
 ```bash
-CHATCLI_FALLBACK_PROVIDERS=OPENAI,CLAUDEAI,ZAI,MINIMAX
+CHATCLI_FALLBACK_PROVIDERS=OPENAI,CLAUDEAI,ZAI,MINIMAX,OPENROUTER
 ```
 
 Error classification (rate limit, timeout, auth, context overflow), exponential backoff, and per-provider cooldown.
@@ -311,7 +313,7 @@ Error classification (rate limit, timeout, auth, context overflow), exponential 
 ```
 chatcli/
   cli/            TUI interface (Bubble Tea), agent mode, multi-agent workers
-  llm/            11 providers, auto-register registry, fallback chain, catalog
+  llm/            12 providers, auto-register registry, fallback chain, catalog
   server/         gRPC server with TLS, auth, metrics, and MCP
   operator/       Kubernetes Operator -- 17 CRDs, autonomous AIOps pipeline
   k8s/            Watcher (collectors, store, summarizer)


### PR DESCRIPTION
## Summary

- Update `README.md` (PT-BR) and `README_EN.md` (EN) to include OpenRouter as the 12th LLM provider
- All provider counts updated from 11 to 12
- OpenRouter added to supported providers table, env var reference, fallback examples, tool calling list, and architecture section

## Changes per file

### README.md (PT-BR)
| Section | Change |
|---------|--------|
| Header subtitle | 11 → 12 provedores |
| "Por que o ChatCLI?" | 11 → 12 provedores |
| Quick setup `.env` | `OPENROUTER` added to `LLM_PROVIDER` comment |
| Provider reference table | New row: OpenRouter with `OPENROUTER_API_KEY`, `OPENROUTER_MAX_TOKENS`, `OPENROUTER_FALLBACK_MODELS` |
| Supported providers table | New row: OpenRouter, openai/gpt-4o, Nativo, Sim |
| Fallback example | `OPENROUTER` added to chain |
| Tool calling feature | OpenRouter added to native providers list |
| Architecture | `llm/` updated to 12 providers |

### README_EN.md (EN)
| Section | Change |
|---------|--------|
| Header subtitle | 11 → 12 providers |
| Overview | 11 → 12 LLM providers |
| "Why ChatCLI?" | Added OpenRouter with 200+ models mention |
| Quick setup `.env` | `OPENROUTER` added to `LLM_PROVIDER` comment |
| Provider reference table | New row: OpenRouter |
| Supported providers table | New row: OpenRouter, openai/gpt-4o, Native, Yes |
| Fallback example | `OPENROUTER` added to chain |
| Tool calling | OpenRouter added to native providers list |
| Architecture | `llm/` updated to 12 providers |

## Test plan

- [x] No code changes — documentation only
- [x] Verify markdown renders correctly on GitHub