### PR TITLE
fix(security): disable Docker layer cache for Trivy scan builds

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -79,6 +79,7 @@ jobs:
           context: .
           push: false
           load: true
+          no-cache: true
           tags: chatcli:scan
 
       # SARIF upload — informational, all severities, never blocks
@@ -125,6 +126,7 @@ jobs:
           file: ./operator/Dockerfile
           push: false
           load: true
+          no-cache: true
           tags: chatcli-operator:scan
 
       # SARIF upload — informational, all severities, never blocks


### PR DESCRIPTION
## Summary

- Adds `no-cache: true` to both Docker build steps in the security scan workflow
- Fixes CVE-2026-28390 false positive caused by buildx caching the old `apk upgrade` layer

## Problem

The operator Dockerfile has `apk upgrade --no-cache` which correctly pulls `libcrypto3/libssl3 >= 3.5.6-r0`. However, Docker buildx caches the RUN layer from a previous build where `3.5.5-r0` was installed. Trivy scans the cached image and flags the old packages.

## Fix

`no-cache: true` in `docker/build-push-action` ensures each security scan build runs `apk upgrade` fresh, pulling the latest patched packages from the Alpine repository.

## Test Plan

- [x] Verified locally: `docker run --rm alpine:3.23.3 sh -c "apk update && apk upgrade && apk info libcrypto3"` shows `3.5.6-r0`
- [x] CI Trivy scan should pass with 0 HIGH/CRITICAL after this change