### PR TITLE
fix(bedrock): stricter credential detection, IMDS control and SSO support

### DIFF
--- a/llm/bedrock/bedrock_client.go
+++ b/llm/bedrock/bedrock_client.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	bedrocksvc "github.com/aws/aws-sdk-go-v2/service/bedrock"
 	bedrocktypes "github.com/aws/aws-sdk-go-v2/service/bedrock/types"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
@@ -114,6 +115,31 @@ func (c *BedrockClient) getMaxTokens() int {
 	return catalog.GetMaxTokens(catalog.ProviderBedrock, c.model, 4096)
 }
 
+// shouldDisableIMDS returns true when the process is clearly NOT running on
+// EC2/ECS/EKS and thus should not waste time (and noisy errors) trying to
+// reach http://169.254.169.254. The user can force-enable the probe with
+// CHATCLI_BEDROCK_ENABLE_IMDS=1, or force-disable with
+// AWS_EC2_METADATA_DISABLED=true (standard AWS SDK env var).
+func shouldDisableIMDS() bool {
+	if v := strings.ToLower(os.Getenv("AWS_EC2_METADATA_DISABLED")); v == "true" || v == "1" {
+		return true
+	}
+	if v := os.Getenv("CHATCLI_BEDROCK_ENABLE_IMDS"); v == "1" || strings.EqualFold(v, "true") {
+		return false
+	}
+	// Running inside ECS/EKS — IMDS (or its container equivalent) is legit.
+	if os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") != "" ||
+		os.Getenv("AWS_CONTAINER_CREDENTIALS_FULL_URI") != "" ||
+		os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE") != "" ||
+		os.Getenv("ECS_CONTAINER_METADATA_URI") != "" ||
+		os.Getenv("ECS_CONTAINER_METADATA_URI_V4") != "" {
+		return false
+	}
+	// If static creds or a profile are set, IMDS won't be reached anyway,
+	// but disabling it costs nothing and guarantees no hang on misconfig.
+	return true
+}
+
 func (c *BedrockClient) ensureRuntime(ctx context.Context) error {
 	if c.runtime != nil {
 		return nil
@@ -130,6 +156,9 @@ func (c *BedrockClient) ensureRuntime(ctx context.Context) error {
 		if note != "" {
 			c.logger.Warn(note)
 		}
+	}
+	if shouldDisableIMDS() {
+		opts = append(opts, awsconfig.WithEC2IMDSClientEnableState(imds.ClientDisabled))
 	}
 	cfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
 	if err != nil {

--- a/llm/manager/llm_manager.go
+++ b/llm/manager/llm_manager.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -181,7 +182,7 @@ func bedrockCredentialsAvailable() bool {
 // contains at least one aws_access_key_id entry. An empty or region-only file
 // is not enough to activate Bedrock.
 func credentialsFileHasKey(path string) bool {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(filepath.Clean(path)) // #nosec G304 — path built from os.UserHomeDir() + constant
 	if err != nil {
 		return false
 	}
@@ -205,15 +206,15 @@ func credentialsFileHasKey(path string) bool {
 // one profile that can produce credentials without IMDS: SSO, assume-role, or
 // credential_process. A config that only sets region/output does NOT count.
 func configFileHasUsableProfile(path string) bool {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(filepath.Clean(path)) // #nosec G304 — path built from os.UserHomeDir() + constant
 	if err != nil {
 		return false
 	}
 	usableKeys := []string{
-		"sso_start_url",    // legacy SSO profile
-		"sso_session",      // new-style SSO (aws sso login)
-		"sso_account_id",   // ditto
-		"role_arn",         // assume-role profile (source_profile / web identity)
+		"sso_start_url",  // legacy SSO profile
+		"sso_session",    // new-style SSO (aws sso login)
+		"sso_account_id", // ditto
+		"role_arn",       // assume-role profile (source_profile / web identity)
 		"credential_process",
 	}
 	for _, line := range strings.Split(string(data), "\n") {

--- a/llm/manager/llm_manager.go
+++ b/llm/manager/llm_manager.go
@@ -132,32 +132,136 @@ func (m *LLMManagerImpl) configurarBedrockClient(maxRetries int, initialBackoff 
 		if region == "" {
 			region = config.DefaultBedrockRegion
 		}
-		profile := os.Getenv("AWS_PROFILE")
+		profile := resolveAWSProfile()
 		return bedrock.NewBedrockClient(model, region, profile, m.logger, maxRetries, initialBackoff), nil
 	}
 }
 
+// bedrockCredentialsAvailable reports whether there is a credible signal that
+// AWS credentials are usable. It intentionally does NOT treat the mere existence
+// of ~/.aws/config as a credential (that file may hold only region/profile
+// metadata), nor does it treat an empty ~/.aws/credentials as valid — otherwise
+// the AWS SDK falls through to IMDS (169.254.169.254) and hangs with a
+// confusing timeout on non-EC2 machines.
+//
+// Accepted signals (any one is enough):
+//   - Static creds via env (AWS_ACCESS_KEY_ID)
+//   - Profile selection (AWS_PROFILE) — SSO, assume-role, credential_process, etc.
+//   - Web identity / container roles (EKS / ECS)
+//   - ~/.aws/credentials with a non-empty aws_access_key_id
+//   - ~/.aws/config declaring a usable profile: SSO (sso_start_url / sso_session),
+//     assume-role (role_arn), or credential_process
+//   - An active SSO token cache in ~/.aws/sso/cache/
 func bedrockCredentialsAvailable() bool {
 	if os.Getenv("AWS_ACCESS_KEY_ID") != "" ||
 		os.Getenv("AWS_PROFILE") != "" ||
-		os.Getenv("AWS_REGION") != "" ||
-		os.Getenv("BEDROCK_REGION") != "" ||
 		os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE") != "" ||
 		os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") != "" ||
 		os.Getenv("AWS_CONTAINER_CREDENTIALS_FULL_URI") != "" {
+		return true
+	}
+	// Also check .env-sourced config (godotenv doesn't export to os.Environ).
+	if config.Global != nil && config.Global.GetString("AWS_PROFILE") != "" {
 		return true
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return false
 	}
-	if _, err := os.Stat(home + "/.aws/credentials"); err == nil {
+	if credentialsFileHasKey(home + "/.aws/credentials") {
 		return true
 	}
-	if _, err := os.Stat(home + "/.aws/config"); err == nil {
+	if configFileHasUsableProfile(home + "/.aws/config") {
 		return true
+	}
+	return hasActiveSSOCache(home + "/.aws/sso/cache")
+}
+
+// credentialsFileHasKey returns true only if the AWS shared credentials file
+// contains at least one aws_access_key_id entry. An empty or region-only file
+// is not enough to activate Bedrock.
+func credentialsFileHasKey(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, ";") {
+			continue
+		}
+		if strings.HasPrefix(strings.ToLower(trimmed), "aws_access_key_id") {
+			if idx := strings.Index(trimmed, "="); idx >= 0 {
+				if strings.TrimSpace(trimmed[idx+1:]) != "" {
+					return true
+				}
+			}
+		}
 	}
 	return false
+}
+
+// configFileHasUsableProfile returns true if ~/.aws/config declares at least
+// one profile that can produce credentials without IMDS: SSO, assume-role, or
+// credential_process. A config that only sets region/output does NOT count.
+func configFileHasUsableProfile(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	usableKeys := []string{
+		"sso_start_url",    // legacy SSO profile
+		"sso_session",      // new-style SSO (aws sso login)
+		"sso_account_id",   // ditto
+		"role_arn",         // assume-role profile (source_profile / web identity)
+		"credential_process",
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, ";") {
+			continue
+		}
+		lower := strings.ToLower(trimmed)
+		for _, key := range usableKeys {
+			if strings.HasPrefix(lower, key) {
+				if idx := strings.Index(trimmed, "="); idx >= 0 &&
+					strings.TrimSpace(trimmed[idx+1:]) != "" {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// hasActiveSSOCache returns true if ~/.aws/sso/cache contains any JSON token
+// file. A stale/expired token will still be caught later at SDK call time, but
+// its presence means the user has at least run `aws sso login` at some point.
+func hasActiveSSOCache(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".json") {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveAWSProfile returns the AWS profile name from the first available
+// source: env var AWS_PROFILE > .env file (via config.Global).
+func resolveAWSProfile() string {
+	if v := os.Getenv("AWS_PROFILE"); v != "" {
+		return v
+	}
+	if config.Global != nil {
+		if v := config.Global.GetString("AWS_PROFILE"); v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 func firstNonEmptyEnv(keys ...string) string {
@@ -747,7 +851,7 @@ func (m *LLMManagerImpl) CreateClientWithKey(provider, model, apiKey string) (cl
 		if region == "" {
 			region = config.DefaultBedrockRegion
 		}
-		return bedrock.NewBedrockClient(model, region, os.Getenv("AWS_PROFILE"), m.logger, maxRetries, initialBackoff), nil
+		return bedrock.NewBedrockClient(model, region, resolveAWSProfile(), m.logger, maxRetries, initialBackoff), nil
 
 	default:
 		return nil, fmt.Errorf("%s", i18n.T("llm.manager.create_client_unsupported", provider))


### PR DESCRIPTION
## Summary
- **Stricter credential detection**: `bedrockCredentialsAvailable()` no longer activates Bedrock on mere `~/.aws/config` existence. Validates actual credentials (access keys, SSO profiles, assume-role, credential_process, SSO cache).
- **IMDS disabled by default on non-EC2**: prevents the 3x timeout hang on `169.254.169.254` for developers on laptops. New env vars `AWS_EC2_METADATA_DISABLED` and `CHATCLI_BEDROCK_ENABLE_IMDS` for explicit control.
- **SSO + .env support**: `resolveAWSProfile()` reads `AWS_PROFILE` from both `os.Environ` and `.env` file (via `config.Global`), enabling SSO workflows without shell export.

## Test plan
- [x] Verify Bedrock does NOT activate when only `~/.aws/config` with `region` exists (no credentials)
- [x] Verify Bedrock activates with valid `~/.aws/credentials` containing `aws_access_key_id`
- [x] Verify Bedrock activates with SSO profile in `~/.aws/config` (`sso_session` key present)
- [x] Verify `AWS_PROFILE=xxx` in `.env` file is picked up correctly
- [x] Verify no IMDS timeout on local machine (no `169.254.169.254` connection attempt)
- [x] Verify `CHATCLI_BEDROCK_ENABLE_IMDS=1` re-enables IMDS probe
- [x] Verify ECS/EKS env vars (`AWS_CONTAINER_CREDENTIALS_*`) keep IMDS enabled
- [x] `go build ./...` and `go vet ./...` pass