### PR TITLE
fix(operator): stop creating ClusterRoles at runtime (H5 hardening)

### DIFF
--- a/deploy/helm/chatcli-operator/templates/rbac.yaml
+++ b/deploy/helm/chatcli-operator/templates/rbac.yaml
@@ -134,10 +134,28 @@ rules:
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["roles", "rolebindings"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  # Security (H5): ClusterRoles/ClusterRoleBindings read-only to prevent privilege escalation
+  # Security (H5): ClusterRoles are read-only — never create/update/delete at runtime.
+  # Shared ClusterRoles (chatcli-watcher, chatcli-role-*) are pre-provisioned by this chart
+  # and referenced by per-Instance ClusterRoleBindings via the "bind" verb below.
   - apiGroups: ["rbac.authorization.k8s.io"]
-    resources: ["clusterroles", "clusterrolebindings"]
+    resources: ["clusterroles"]
     verbs: ["get", "list", "watch"]
+  # "bind" allowed only on the pre-provisioned ClusterRoles — prevents an attacker who
+  # compromises the operator from referencing a more-privileged ClusterRole in a new CRB.
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles"]
+    resourceNames:
+      - chatcli-watcher
+      - chatcli-role-viewer
+      - chatcli-role-operator
+      - chatcli-role-admin
+      - chatcli-role-superadmin
+    verbs: ["bind"]
+  # ClusterRoleBindings: the operator creates one per Instance (watcher) and one per user
+  # (platform roles). Each binding can only reference the whitelisted ClusterRoles above.
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterrolebindings"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
   # ──────────────────────────────────────────────────
   # Leader election
@@ -160,4 +178,164 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "chatcli-operator.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+---
+# ──────────────────────────────────────────────────
+# Shared ClusterRole: chatcli-watcher
+# Referenced by ClusterRoleBindings the operator creates per-Instance when a Watcher
+# spans multiple namespaces. Pre-provisioned here so the operator never needs privilege
+# escalation rights on ClusterRoles (Security H5).
+# ──────────────────────────────────────────────────
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chatcli-watcher
+  labels:
+    {{- include "chatcli-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: watcher
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "events", "services", "endpoints"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+---
+# ──────────────────────────────────────────────────
+# Platform role ClusterRoles (viewer / operator / admin / superadmin)
+# Referenced by RoleBindings the operator creates when granting a user a platform role.
+# ──────────────────────────────────────────────────
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chatcli-role-viewer
+  labels:
+    {{- include "chatcli-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+rules:
+  - apiGroups: ["platform.chatcli.io"]
+    resources:
+      - issues
+      - anomalies
+      - aiinsights
+      - postmortems
+      - auditevents
+      - servicelevelobjectives
+      - incidentslas
+      - remediationplans
+      - runbooks
+      - approvalrequests
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chatcli-role-operator
+  labels:
+    {{- include "chatcli-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+rules:
+  - apiGroups: ["platform.chatcli.io"]
+    resources:
+      - issues
+      - anomalies
+      - aiinsights
+      - postmortems
+      - auditevents
+      - servicelevelobjectives
+      - incidentslas
+      - remediationplans
+      - runbooks
+      - approvalrequests
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["platform.chatcli.io"]
+    resources: ["issues", "approvalrequests", "postmortems"]
+    verbs: ["update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chatcli-role-admin
+  labels:
+    {{- include "chatcli-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+rules:
+  - apiGroups: ["platform.chatcli.io"]
+    resources:
+      - issues
+      - anomalies
+      - aiinsights
+      - postmortems
+      - auditevents
+      - servicelevelobjectives
+      - incidentslas
+      - remediationplans
+      - approvalrequests
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["platform.chatcli.io"]
+    resources:
+      - runbooks
+      - notificationpolicies
+      - servicelevelobjectives
+      - incidentslas
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chatcli-role-superadmin
+  labels:
+    {{- include "chatcli-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+rules:
+  - apiGroups: ["platform.chatcli.io"]
+    resources:
+      - instances
+      - issues
+      - anomalies
+      - aiinsights
+      - remediationplans
+      - runbooks
+      - postmortems
+      - sourcerepositories
+      - notificationpolicies
+      - escalationpolicies
+      - approvalpolicies
+      - approvalrequests
+      - servicelevelobjectives
+      - incidentslas
+      - auditevents
+      - chaosexperiments
+      - clusterregistrations
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["platform.chatcli.io"]
+    resources:
+      - instances/status
+      - issues/status
+      - anomalies/status
+      - aiinsights/status
+      - remediationplans/status
+      - postmortems/status
+      - sourcerepositories/status
+      - notificationpolicies/status
+      - escalationpolicies/status
+      - approvalpolicies/status
+      - approvalrequests/status
+      - servicelevelobjectives/status
+      - incidentslas/status
+      - auditevents/status
+      - chaosexperiments/status
+      - clusterregistrations/status
+    verbs: ["get", "update", "patch"]
 {{- end }}

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -388,9 +388,10 @@ rules:
       - create
       - update
       - patch
-  # Security (H5): RBAC resources — read-only for monitoring.
-  # Removed patch/delete/create on ClusterRoles and ClusterRoleBindings
-  # to prevent privilege escalation if operator is compromised.
+  # Security (H5): RBAC resources — namespaced Role/RoleBinding writable (used by
+  # reconcileNamespacedRBAC), ClusterRole read-only to prevent privilege escalation.
+  # Shared ClusterRoles (chatcli-watcher, chatcli-role-*) are pre-provisioned below and
+  # referenced by per-Instance ClusterRoleBindings via the "bind" verb.
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
@@ -400,15 +401,44 @@ rules:
       - get
       - list
       - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
       - clusterroles
+    verbs:
+      - get
+      - list
+      - watch
+  # "bind" is restricted to the whitelisted shared ClusterRoles. A compromised operator
+  # cannot reference a more-privileged ClusterRole in a new ClusterRoleBinding.
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+    resourceNames:
+      - chatcli-watcher
+      - chatcli-role-viewer
+      - chatcli-role-operator
+      - chatcli-role-admin
+      - chatcli-role-superadmin
+    verbs:
+      - bind
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
       - clusterrolebindings
     verbs:
       - get
       - list
       - watch
+      - create
+      - update
+      - patch
+      - delete
   # Events (emit + read for watcher)
   - apiGroups:
       - ""
@@ -475,3 +505,158 @@ subjects:
   - kind: ServiceAccount
     name: chatcli-operator
     namespace: chatcli-system
+---
+# Shared ClusterRole referenced by per-Instance ClusterRoleBindings when a Watcher spans
+# multiple namespaces. Pre-provisioned so the operator never needs escalate/create rights
+# on ClusterRoles (Security H5).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chatcli-watcher
+  labels:
+    app.kubernetes.io/name: chatcli-operator
+    app.kubernetes.io/component: watcher
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "events", "services", "endpoints"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+---
+# Platform role ClusterRoles (viewer / operator / admin / superadmin). Referenced by
+# RoleBindings the operator creates when granting a user a platform role.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chatcli-role-viewer
+  labels:
+    app.kubernetes.io/name: chatcli-operator
+    app.kubernetes.io/component: rbac
+rules:
+  - apiGroups: ["platform.chatcli.io"]
+    resources:
+      - issues
+      - anomalies
+      - aiinsights
+      - postmortems
+      - auditevents
+      - servicelevelobjectives
+      - incidentslas
+      - remediationplans
+      - runbooks
+      - approvalrequests
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chatcli-role-operator
+  labels:
+    app.kubernetes.io/name: chatcli-operator
+    app.kubernetes.io/component: rbac
+rules:
+  - apiGroups: ["platform.chatcli.io"]
+    resources:
+      - issues
+      - anomalies
+      - aiinsights
+      - postmortems
+      - auditevents
+      - servicelevelobjectives
+      - incidentslas
+      - remediationplans
+      - runbooks
+      - approvalrequests
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["platform.chatcli.io"]
+    resources: ["issues", "approvalrequests", "postmortems"]
+    verbs: ["update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chatcli-role-admin
+  labels:
+    app.kubernetes.io/name: chatcli-operator
+    app.kubernetes.io/component: rbac
+rules:
+  - apiGroups: ["platform.chatcli.io"]
+    resources:
+      - issues
+      - anomalies
+      - aiinsights
+      - postmortems
+      - auditevents
+      - servicelevelobjectives
+      - incidentslas
+      - remediationplans
+      - approvalrequests
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["platform.chatcli.io"]
+    resources:
+      - runbooks
+      - notificationpolicies
+      - servicelevelobjectives
+      - incidentslas
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chatcli-role-superadmin
+  labels:
+    app.kubernetes.io/name: chatcli-operator
+    app.kubernetes.io/component: rbac
+rules:
+  - apiGroups: ["platform.chatcli.io"]
+    resources:
+      - instances
+      - issues
+      - anomalies
+      - aiinsights
+      - remediationplans
+      - runbooks
+      - postmortems
+      - sourcerepositories
+      - notificationpolicies
+      - escalationpolicies
+      - approvalpolicies
+      - approvalrequests
+      - servicelevelobjectives
+      - incidentslas
+      - auditevents
+      - chaosexperiments
+      - clusterregistrations
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["platform.chatcli.io"]
+    resources:
+      - instances/status
+      - issues/status
+      - anomalies/status
+      - aiinsights/status
+      - remediationplans/status
+      - postmortems/status
+      - sourcerepositories/status
+      - notificationpolicies/status
+      - escalationpolicies/status
+      - approvalpolicies/status
+      - approvalrequests/status
+      - servicelevelobjectives/status
+      - incidentslas/status
+      - auditevents/status
+      - chaosexperiments/status
+      - clusterregistrations/status
+    verbs: ["get", "update", "patch"]

--- a/operator/controllers/instance_controller.go
+++ b/operator/controllers/instance_controller.go
@@ -270,22 +270,17 @@ func (r *InstanceReconciler) updateStatus(ctx context.Context, instance *platfor
 
 func (r *InstanceReconciler) cleanupResources(ctx context.Context, instance *platformv1alpha1.Instance) error {
 	// Owned namespaced resources are garbage-collected via OwnerReferences.
-	// Cluster-scoped resources (ClusterRole/ClusterRoleBinding) need manual cleanup.
+	// The per-Instance ClusterRoleBinding is cluster-scoped so has no owner ref — delete
+	// it manually. The referenced ClusterRole (chatcli-watcher) is shared and owned by
+	// the Helm/kustomize release, so it must NOT be deleted here.
 	log := log.FromContext(ctx)
 	log.Info("Cleaning up resources for Instance", "name", instance.Name)
 
-	clusterRoleName := instance.Namespace + "-" + instance.Name + "-watcher"
+	crbName := instance.Namespace + "-" + instance.Name + "-watcher"
 
 	crb := &rbacv1.ClusterRoleBinding{}
-	if err := r.Get(ctx, types.NamespacedName{Name: clusterRoleName}, crb); err == nil {
+	if err := r.Get(ctx, types.NamespacedName{Name: crbName}, crb); err == nil {
 		if err := r.Delete(ctx, crb); err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-	}
-
-	cr := &rbacv1.ClusterRole{}
-	if err := r.Get(ctx, types.NamespacedName{Name: clusterRoleName}, cr); err == nil {
-		if err := r.Delete(ctx, cr); err != nil && !errors.IsNotFound(err) {
 			return err
 		}
 	}

--- a/operator/controllers/rbac_manager.go
+++ b/operator/controllers/rbac_manager.go
@@ -11,6 +11,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// Platform role ClusterRole names. Pre-provisioned by the Helm chart / kustomize
+// overlay (deploy/helm/chatcli-operator/templates/rbac.yaml). The operator only creates
+// RoleBindings that reference these — it never creates or mutates the ClusterRoles
+// themselves at runtime (Security H5).
 const (
 	RoleViewer     = "chatcli-role-viewer"
 	RoleOperator   = "chatcli-role-operator"
@@ -24,74 +28,6 @@ type RBACManager struct {
 
 func NewRBACManager(c client.Client) *RBACManager {
 	return &RBACManager{client: c}
-}
-
-// EnsureRoles creates or updates all ChatCLI ClusterRoles.
-func (rm *RBACManager) EnsureRoles(ctx context.Context) error {
-	roles := map[string][]rbacv1.PolicyRule{
-		RoleViewer: {
-			{APIGroups: []string{"platform.chatcli.io"}, Resources: []string{"issues", "anomalies", "aiinsights", "postmortems", "auditevents", "servicelevelobjectives", "incidentslas"}, Verbs: []string{"get", "list", "watch"}},
-			{APIGroups: []string{"platform.chatcli.io"}, Resources: []string{"remediationplans", "runbooks", "approvalrequests"}, Verbs: []string{"get", "list", "watch"}},
-		},
-		RoleOperator: {
-			{APIGroups: []string{"platform.chatcli.io"}, Resources: []string{"issues", "anomalies", "aiinsights", "postmortems", "auditevents", "servicelevelobjectives", "incidentslas"}, Verbs: []string{"get", "list", "watch"}},
-			{APIGroups: []string{"platform.chatcli.io"}, Resources: []string{"remediationplans", "runbooks", "approvalrequests"}, Verbs: []string{"get", "list", "watch"}},
-			{APIGroups: []string{"platform.chatcli.io"}, Resources: []string{"issues"}, Verbs: []string{"update", "patch"}},
-			{APIGroups: []string{"platform.chatcli.io"}, Resources: []string{"approvalrequests"}, Verbs: []string{"update", "patch"}},
-			{APIGroups: []string{"platform.chatcli.io"}, Resources: []string{"postmortems"}, Verbs: []string{"update", "patch"}},
-		},
-		RoleAdmin: {
-			{APIGroups: []string{"platform.chatcli.io"}, Resources: []string{"issues", "anomalies", "aiinsights", "postmortems", "auditevents", "servicelevelobjectives", "incidentslas", "remediationplans", "approvalrequests"}, Verbs: []string{"get", "list", "watch", "update", "patch"}},
-			{APIGroups: []string{"platform.chatcli.io"}, Resources: []string{"runbooks", "notificationpolicies", "servicelevelobjectives", "incidentslas"}, Verbs: []string{"get", "list", "watch", "create", "update", "patch", "delete"}},
-		},
-		RoleSuperAdmin: {
-			{APIGroups: []string{"platform.chatcli.io"}, Resources: []string{
-				"instances", "issues", "anomalies", "aiinsights", "remediationplans",
-				"runbooks", "postmortems", "sourcerepositories",
-				"notificationpolicies", "escalationpolicies",
-				"approvalpolicies", "approvalrequests",
-				"servicelevelobjectives", "incidentslas",
-				"auditevents", "chaosexperiments", "clusterregistrations",
-			}, Verbs: []string{"get", "list", "watch", "create", "update", "patch", "delete"}},
-			{APIGroups: []string{"platform.chatcli.io"}, Resources: []string{
-				"instances/status", "issues/status", "anomalies/status",
-				"aiinsights/status", "remediationplans/status", "postmortems/status",
-				"sourcerepositories/status", "notificationpolicies/status",
-				"escalationpolicies/status", "approvalpolicies/status",
-				"approvalrequests/status", "servicelevelobjectives/status",
-				"incidentslas/status", "auditevents/status",
-				"chaosexperiments/status", "clusterregistrations/status",
-			}, Verbs: []string{"get", "update", "patch"}},
-		},
-	}
-
-	for name, rules := range roles {
-		cr := &rbacv1.ClusterRole{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   name,
-				Labels: map[string]string{"app.kubernetes.io/managed-by": "chatcli-operator", "app.kubernetes.io/component": "rbac"},
-			},
-			Rules: rules,
-		}
-
-		existing := &rbacv1.ClusterRole{}
-		err := rm.client.Get(ctx, types.NamespacedName{Name: name}, existing)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				if err := rm.client.Create(ctx, cr); err != nil {
-					return fmt.Errorf("creating ClusterRole %s: %w", name, err)
-				}
-				continue
-			}
-			return err
-		}
-		existing.Rules = rules
-		existing.Labels = cr.Labels
-		if err := rm.client.Update(ctx, existing); err != nil {
-			return fmt.Errorf("updating ClusterRole %s: %w", name, err)
-		}
-	}
-	return nil
 }
 
 // GrantRole creates a RoleBinding for a user in a namespace.

--- a/operator/controllers/resources.go
+++ b/operator/controllers/resources.go
@@ -933,35 +933,27 @@ func (r *InstanceReconciler) reconcileNamespacedRBAC(ctx context.Context, instan
 	return err
 }
 
-// reconcileClusterRBAC creates ClusterRole + ClusterRoleBinding for multi-namespace watcher access.
+// SharedWatcherClusterRole is the name of the pre-provisioned ClusterRole used for
+// multi-namespace watcher access. It is deployed by the Helm chart / kustomize overlay
+// (see deploy/helm/chatcli-operator/templates/rbac.yaml) so the operator never needs
+// create/update/delete permissions on ClusterRoles (Security H5).
+const SharedWatcherClusterRole = "chatcli-watcher"
+
+// reconcileClusterRBAC creates a per-Instance ClusterRoleBinding that references the
+// pre-provisioned SharedWatcherClusterRole. The ClusterRole itself is NOT created here.
 func (r *InstanceReconciler) reconcileClusterRBAC(ctx context.Context, instance *platformv1alpha1.Instance) error {
-	clusterRole := &rbacv1.ClusterRole{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: instance.Namespace + "-" + instance.Name + "-watcher",
-		},
-	}
-
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, clusterRole, func() error {
-		clusterRole.Labels = labels(instance)
-		clusterRole.Rules = watcherPolicyRules()
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-
 	crb := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: instance.Namespace + "-" + instance.Name + "-watcher",
 		},
 	}
 
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, crb, func() error {
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, crb, func() error {
 		crb.Labels = labels(instance)
 		crb.RoleRef = rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "ClusterRole",
-			Name:     clusterRole.Name,
+			Name:     SharedWatcherClusterRole,
 		}
 		crb.Subjects = []rbacv1.Subject{
 			{

--- a/operator/main.go
+++ b/operator/main.go
@@ -254,15 +254,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	// RBAC Manager — ensure default roles exist
-	rbacMgr := controllers.NewRBACManager(mgr.GetClient())
-	go func() {
-		// Wait for cache sync then ensure roles
-		<-mgr.Elected()
-		if err := rbacMgr.EnsureRoles(context.Background()); err != nil {
-			setupLog.Error(err, "failed to ensure RBAC roles")
-		}
-	}()
+	// Platform role ClusterRoles (chatcli-role-viewer / -operator / -admin / -superadmin)
+	// and the shared chatcli-watcher ClusterRole are pre-provisioned by the Helm chart /
+	// kustomize overlay. The operator only creates RoleBindings/ClusterRoleBindings that
+	// reference them — it never creates or modifies ClusterRoles at runtime (Security H5).
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")


### PR DESCRIPTION
## Summary

- Operator tried to create `ClusterRole`/`ClusterRoleBinding` at runtime (per-Instance in `reconcileClusterRBAC`, plus 4 platform roles in `EnsureRoles`), but its own ClusterRole explicitly strips those verbs for H5 hardening — producing a permanent `clusterroles.rbac.authorization.k8s.io is forbidden` reconcile loop.
- Move the 5 shared ClusterRoles (`chatcli-watcher` + `chatcli-role-{viewer,operator,admin,superadmin}`) to the Helm chart + kustomize overlay as pre-provisioned, release-owned resources. Operator now only creates the per-Instance `ClusterRoleBinding`, using the restricted `bind` verb whitelisted via `resourceNames`. H5 is preserved.
- Fixed a side bug in `operator/config/rbac/role.yaml` where `roles`/`rolebindings` had only read verbs — mismatched with `reconcileNamespacedRBAC` (and with the Helm chart, which already had full CRUD).

## What changed

- `deploy/helm/chatcli-operator/templates/rbac.yaml` — add 5 shared ClusterRoles; add `bind` verb restricted by `resourceNames`; grant CRUD on `clusterrolebindings`.
- `operator/config/rbac/role.yaml` — mirror the Helm chart; add Role/RoleBinding CRUD.
- `operator/controllers/resources.go` — `reconcileClusterRBAC` now creates only the ClusterRoleBinding, referencing the new `SharedWatcherClusterRole` constant (`chatcli-watcher`).
- `operator/controllers/instance_controller.go` — `cleanupResources` only deletes the per-Instance CRB; the shared ClusterRole is owned by the release.
- `operator/controllers/rbac_manager.go` — remove `EnsureRoles` (dead after the move to Helm); keep `GrantRole`/`RevokeRole`/`CheckPermission`.
- `operator/main.go` — drop the `EnsureRoles` startup goroutine.

## Post-deploy notes

- Existing clusters with the `cluster-admin` workaround ClusterRoleBinding should remove it and `helm upgrade` the operator chart.
- Any orphan per-Instance CRB from before this change (e.g. `chatcli-system-chatcli-prod-watcher`) can be deleted manually — the reconciler will recreate it referencing `chatcli-watcher`.

## Test plan

- [x] `go build ./...` — root and `operator/` modules
- [x] `go test ./...` — root and `operator/` modules, all green
- [x] `helm template test deploy/helm/chatcli-operator` renders (508 lines, 5 new ClusterRoles present)
- [x] `kubectl apply --dry-run=client -f operator/config/rbac/role.yaml` accepts the new manifests
- [x] Grep for other cluster-scoped writes in the operator — none besides the 3 points fixed
- [x] Deploy in lab cluster: verify operator creates the per-Instance CRB and the Instance reconciles without the `cluster-admin` workaround