### PR TITLE
fix(quality): /plan dispatch, UX, Claude models compat, subcommands

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -626,6 +626,14 @@ func (a *AgentMode) Run(ctx context.Context, query string, additionalContext str
 	// system message so the ReAct loop can finalize with full context.
 	a.runPlanFirstIfApplicable(ctx, currentQuery)
 
+	// Dry-run / preview: runPlanFirstIfApplicable rendered the plan and
+	// asked us to stop. Don't enter the ReAct loop — the user wanted to
+	// inspect the plan before committing to execution.
+	if a.cli.planDryRunHandled {
+		a.cli.planDryRunHandled = false
+		return nil
+	}
+
 	// --- 2. O LOOP DE RACIOCÍNIO-AÇÃO (ReAct) ---
 	return a.processAIResponseAndAct(ctx, maxTurns)
 }

--- a/cli/agent_plan_first.go
+++ b/cli/agent_plan_first.go
@@ -36,17 +36,28 @@ import (
 // because Plan-First is meant to be a behind-the-scenes accelerator,
 // not a UI feature. /config quality + the deterministic report in
 // history are the visible artifacts.
+//
+// Dry-run mode: when pendingPlanDryRun is set, only the planner runs.
+// The plan is rendered for the user and the ReAct loop is skipped (see
+// planDryRunHandled).
 func (a *AgentMode) runPlanFirstIfApplicable(ctx context.Context, userQuery string) {
 	if a.agentDispatcher == nil || a.agentRegistry == nil {
 		return
 	}
 
-	// One-shot trigger from /plan beats the config; clear it after read
+	// Safety: any return path below must leave the spinner off, otherwise
+	// the /r/033[K repaint can overlap a downstream security approval
+	// prompt and swallow the user's response.
+	defer a.cli.animation.StopThinkingAnimation()
+
+	// One-shot triggers from /plan beat the config; clear them after read
 	// so a subsequent /agent invocation behaves normally.
 	forced := a.cli.pendingPlanFirst
+	dryRun := a.cli.pendingPlanDryRun
 	a.cli.pendingPlanFirst = false
+	a.cli.pendingPlanDryRun = false
 
-	if !forced && !quality.ShouldPlanFirst(a.qualityConfig.PlanFirst, userQuery) {
+	if !forced && !dryRun && !quality.ShouldPlanFirst(a.qualityConfig.PlanFirst, userQuery) {
 		return
 	}
 
@@ -59,6 +70,7 @@ func (a *AgentMode) runPlanFirstIfApplicable(ctx context.Context, userQuery stri
 
 	a.logger.Info("Plan-First triggered",
 		zap.Bool("forced", forced),
+		zap.Bool("dry_run", dryRun),
 		zap.String("mode", a.qualityConfig.PlanFirst.Mode),
 		zap.Int("complexity", quality.ComplexityScore(userQuery)))
 
@@ -70,7 +82,9 @@ func (a *AgentMode) runPlanFirstIfApplicable(ctx context.Context, userQuery stri
 		Task:  workers.PlannerStructuredOutputDirective + "\n" + userQuery,
 		ID:    "plan-first",
 	}
+	a.cli.animation.ShowThinkingAnimation(i18n.T("plan_first.spinner_planning"))
 	planResults := a.agentDispatcher.Dispatch(ctx, []workers.AgentCall{plannerCall})
+	a.cli.animation.StopThinkingAnimation()
 	if len(planResults) == 0 || planResults[0].Error != nil {
 		var errMsg string
 		if len(planResults) > 0 {
@@ -81,9 +95,23 @@ func (a *AgentMode) runPlanFirstIfApplicable(ctx context.Context, userQuery stri
 		return
 	}
 
+	// Dry-run branch: render the plan to the user and stop. No execution,
+	// no orchestrator hand-off. The caller (Run) will skip the ReAct loop
+	// when planDryRunHandled is set.
+	if dryRun {
+		a.renderPlanPreview(planResults[0].Output)
+		a.cli.planDryRunHandled = true
+		return
+	}
+
 	// Step 2: parse + execute via PlanRunner. The runner reuses the
 	// same dispatcher, so quality hooks (Refine, Verify, …) keep
 	// firing per step.
+	//
+	// NOTE: do NOT wrap this in a spinner. Per-step tools may pop security
+	// approval prompts; the spinner's \r\033[K repaint would overwrite the
+	// prompt and make it impossible to answer.
+	fmt.Println(colorize("  "+i18n.T("plan_first.spinner_executing"), ColorCyan))
 	runner := quality.NewPlanRunner(a.agentDispatcher, a.logger)
 	runRes, parseErr := runner.RunFromPlannerOutput(ctx, planResults[0].Output)
 	if parseErr != nil {
@@ -113,8 +141,12 @@ func (a *AgentMode) runPlanFirstIfApplicable(ctx context.Context, userQuery stri
 			Content: i18n.T("plan_first.synth_plan_header") + "\n\n" + planJSON,
 		})
 	}
+	// Final turn MUST be user: Claude Sonnet 4.6 (and other prefill-disabled
+	// models) refuse completion when the conversation ends on assistant.
+	// Emitting the report + handoff as a user turn closes the loop and gives
+	// the orchestrator an explicit "please finalize" anchor.
 	a.cli.history = append(a.cli.history, models.Message{
-		Role:    "system",
+		Role:    "user",
 		Content: runRes.FinalReport + "\n\n" + i18n.T("plan_first.orchestrator_handoff"),
 	})
 }
@@ -127,4 +159,39 @@ func truncatePlannerOutput(s string, n int) string {
 		return s
 	}
 	return string(r[:n]) + "..."
+}
+
+// renderPlanPreview pretty-prints the planner's JSON output for the
+// /plan preview (dry-run) mode. Falls back to the raw JSON when
+// parsing fails so the user still sees *something* actionable.
+func (a *AgentMode) renderPlanPreview(plannerOutput string) {
+	fmt.Println(colorize("\n  "+i18n.T("plan_first.preview_header"), ColorCyan+ColorBold))
+
+	plan, err := quality.ParsePlan(plannerOutput)
+	if err != nil || plan == nil {
+		fmt.Println(colorize("  "+i18n.T("plan_first.preview_parse_failed"), ColorYellow))
+		fmt.Println(strings.TrimSpace(plannerOutput))
+		return
+	}
+
+	if plan.TaskSummary != "" {
+		fmt.Println(colorize("  "+i18n.T("plan_first.preview_task")+": ", ColorGray) + plan.TaskSummary)
+	}
+	fmt.Println()
+	for i, step := range plan.Steps {
+		fmt.Printf("  %s [%s] agent=%s\n", colorize(fmt.Sprintf("%d.", i+1), ColorGreen), step.ID, step.Agent)
+		fmt.Printf("     %s\n", step.Task)
+		if len(step.Deps) > 0 {
+			fmt.Println(colorize("     deps: "+strings.Join(step.Deps, ", "), ColorGray))
+		}
+	}
+	if len(plan.ParallelGroups) > 0 {
+		fmt.Println()
+		fmt.Println(colorize("  "+i18n.T("plan_first.preview_parallel")+":", ColorGray))
+		for _, g := range plan.ParallelGroups {
+			fmt.Printf("     [%s]\n", strings.Join(g, ", "))
+		}
+	}
+	fmt.Println()
+	fmt.Println(colorize("  "+i18n.T("plan_first.preview_footer"), ColorYellow))
 }

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -259,6 +259,17 @@ type ChatCLI struct {
 	// by AgentMode.runPlanFirstIfApplicable after the plan executes.
 	pendingPlanFirst bool
 
+	// /plan preview (or /plan dry): when true, only the planner runs and
+	// its output is rendered — no execution, no orchestrator. Consumed
+	// together with pendingPlanFirst in runPlanFirstIfApplicable.
+	pendingPlanDryRun bool
+
+	// planDryRunHandled is set by runPlanFirstIfApplicable after rendering
+	// the dry-run preview. AgentMode.Run checks this to skip the ReAct
+	// loop so we don't burn a SendPrompt call on a request the user only
+	// wanted to preview.
+	planDryRunHandled bool
+
 	// /refine and /verify session toggles. nil pointers mean "no
 	// override — defer to /config quality"; *bool=true forces the
 	// hook on, *bool=false forces it off. Consumed by AgentMode
@@ -823,9 +834,11 @@ func (cli *ChatCLI) Start(ctx context.Context) {
 				lastCmd = cli.commandHistory[len(cli.commandHistory)-1]
 			}
 
-			if strings.HasPrefix(lastCmd, "/coder") {
+			// /plan coder <task> routes to coder; /plan [agent] <task> routes to agent.
+			planCoder := strings.HasPrefix(lastCmd, "/plan coder ") || lastCmd == "/plan coder"
+			if strings.HasPrefix(lastCmd, "/coder") || planCoder {
 				cli.runCoderLogic()
-			} else if strings.HasPrefix(lastCmd, "/run") || strings.HasPrefix(lastCmd, "/agent") {
+			} else if strings.HasPrefix(lastCmd, "/run") || strings.HasPrefix(lastCmd, "/agent") || strings.HasPrefix(lastCmd, "/plan") {
 				cli.runAgentLogic()
 			}
 		}
@@ -911,6 +924,15 @@ func (cli *ChatCLI) runAgentLogic() {
 		query = strings.TrimSpace(strings.TrimPrefix(lastCommand, "/agent"))
 	} else if strings.HasPrefix(lastCommand, "/run") {
 		query = strings.TrimSpace(strings.TrimPrefix(lastCommand, "/run"))
+	} else if strings.HasPrefix(lastCommand, "/plan") {
+		query = strings.TrimSpace(strings.TrimPrefix(lastCommand, "/plan"))
+		// Optional subcommands after /plan
+		for _, sub := range []string{"preview", "dry", "agent"} {
+			if strings.HasPrefix(query, sub+" ") || query == sub {
+				query = strings.TrimSpace(strings.TrimPrefix(query, sub))
+				break
+			}
+		}
 	} else {
 		fmt.Println(i18n.T("error.agent_query_extraction"))
 		return
@@ -954,7 +976,12 @@ func (cli *ChatCLI) runCoderLogic() {
 	}
 	lastCommand := cli.commandHistory[len(cli.commandHistory)-1]
 
-	query := strings.TrimSpace(strings.TrimPrefix(lastCommand, "/coder"))
+	var query string
+	if strings.HasPrefix(lastCommand, "/plan coder") {
+		query = strings.TrimSpace(strings.TrimPrefix(lastCommand, "/plan coder"))
+	} else {
+		query = strings.TrimSpace(strings.TrimPrefix(lastCommand, "/coder"))
+	}
 	if query == "" {
 		fmt.Println(i18n.T("error.agent_query_extraction"))
 		return

--- a/cli/cli_completer_quality.go
+++ b/cli/cli_completer_quality.go
@@ -119,18 +119,20 @@ func qualityToggleCompleter(d prompt.Document, slash, rootKey, prefix string) []
 
 // ─── /plan ─────────────────────────────────────────────────────────────────
 
-// getPlanSuggestions returns a usage-hint suggestion for /plan.
+// getPlanSuggestions returns suggestions for /plan (Plan-and-Solve #2).
 //
-// /plan accepts either:
+// Accepted forms (see cli.handlePlanCommand):
 //
-//	/plan                  arm plan-first flag; consumed by next /agent or /coder
-//	/plan <free task>      arm + enter agent mode with that task inline
-//
-// Since there are no enumerable subcommands, the completer shows a single
-// hint so the user understands the command form.
+//	/plan                        arm plan-first flag; consumed by next /agent or /coder
+//	/plan <free task>            arm + enter agent mode with that task inline
+//	/plan agent <task>           explicit agent mode (same as bare /plan <task>)
+//	/plan coder <task>           coder mode with plan-first armed
+//	/plan preview <task>         dry-run: generate plan and render it without executing
+//	/plan dry <task>             alias of preview
 func (cli *ChatCLI) getPlanSuggestions(d prompt.Document) []prompt.Suggest {
 	line := d.TextBeforeCursor()
 	args := strings.Fields(line)
+	word := d.GetWordBeforeCursor()
 
 	if len(args) == 1 && !strings.HasSuffix(line, " ") {
 		return []prompt.Suggest{
@@ -138,11 +140,29 @@ func (cli *ChatCLI) getPlanSuggestions(d prompt.Document) []prompt.Suggest {
 		}
 	}
 
-	// After space: show usage hint (non-selectable placeholder; the user
-	// types free-form task).
+	// First argument slot: offer named subcommands alongside the
+	// free-form <task> hint. The subcommands are filterable by prefix so
+	// typing "c" narrows to /plan coder, "pr" to /plan preview, etc.
 	if len(args) == 1 || (len(args) == 2 && !strings.HasSuffix(line, " ")) {
-		return []prompt.Suggest{
+		subs := []prompt.Suggest{
+			{Text: "agent", Description: i18n.T("complete.plan.agent")},
+			{Text: "coder", Description: i18n.T("complete.plan.coder")},
+			{Text: "preview", Description: i18n.T("complete.plan.preview")},
+			{Text: "dry", Description: i18n.T("complete.plan.dry")},
 			{Text: "<task>", Description: i18n.T("complete.plan.hint")},
+		}
+		return prompt.FilterHasPrefix(subs, word, true)
+	}
+
+	// After a known subcommand (e.g. "/plan coder "), show the task hint
+	// so the user knows free-form text is expected next.
+	if len(args) >= 2 {
+		first := args[1]
+		isSub := first == "agent" || first == "coder" || first == "preview" || first == "dry"
+		if isSub && (len(args) == 2 || (len(args) == 3 && !strings.HasSuffix(line, " "))) {
+			return []prompt.Suggest{
+				{Text: "<task>", Description: i18n.T("complete.plan.hint")},
+			}
 		}
 	}
 

--- a/cli/command_handler.go
+++ b/cli/command_handler.go
@@ -132,8 +132,11 @@ func (ch *CommandHandler) HandleCommand(userInput string) bool {
 		ch.cli.handleThinkingCommand(userInput)
 		return false
 	case userInput == "/plan" || strings.HasPrefix(userInput, "/plan "):
-		if ch.cli.handlePlanCommand(userInput) {
+		switch ch.cli.handlePlanCommand(userInput) {
+		case planRouteAgent:
 			panic(errAgentModeRequest)
+		case planRouteCoder:
+			panic(errCoderModeRequest)
 		}
 		return false
 	case userInput == "/refine" || strings.HasPrefix(userInput, "/refine "):

--- a/cli/plan_command.go
+++ b/cli/plan_command.go
@@ -5,14 +5,18 @@
  *
  * /plan — force Plan-First (Plan-and-Solve / ReWOO) for the next agent run.
  *
- * Two shapes:
- *   /plan                → arms the one-shot flag; user then runs /agent <task>
- *                          or /coder <task> to consume it
- *   /plan <task...>      → equivalent to "arm + run /agent <task>" so the
- *                          user gets a single-line workflow
+ * Shapes:
+ *   /plan                            → arms the one-shot flag; user then runs /agent <task>
+ *                                      or /coder <task> to consume it
+ *   /plan <task...>                  → arm + run /agent <task>  (default, matches doc)
+ *   /plan agent <task...>            → explicit agent mode
+ *   /plan coder <task...>            → arm + run /coder <task>  (coder with plan-first)
+ *   /plan preview <task...>          → dry-run: generate and display the plan only
+ *   /plan dry <task...>              → alias of preview
  *
  * The actual planning + execution happens inside AgentMode.Run via
- * runPlanFirstIfApplicable; this command only flips the trigger.
+ * runPlanFirstIfApplicable; this command only flips the trigger and
+ * picks the consuming mode.
  */
 package cli
 
@@ -23,20 +27,64 @@ import (
 	"github.com/diillson/chatcli/i18n"
 )
 
-// handleThinkingCommand's sibling for Plan-First. Returns true when the
-// caller should immediately enter agent mode (because /plan was given a
-// task) so command_handler can panic with errAgentModeRequest.
-func (cli *ChatCLI) handlePlanCommand(userInput string) bool {
+// planCommandRoute is what handlePlanCommand signals back to the caller.
+type planCommandRoute int
+
+const (
+	planRouteNone  planCommandRoute = iota // no mode entry (bare /plan)
+	planRouteAgent                         // enter agent mode
+	planRouteCoder                         // enter coder mode
+)
+
+// handlePlanCommand parses /plan, arms pendingPlanFirst (+ optionally
+// pendingPlanDryRun), and tells the caller which mode to enter (if any).
+// Returning planRouteAgent or planRouteCoder means command_handler
+// should panic with the matching sentinel error after this returns.
+func (cli *ChatCLI) handlePlanCommand(userInput string) planCommandRoute {
 	cli.pendingPlanFirst = true
+	cli.pendingPlanDryRun = false
 
 	rest := strings.TrimSpace(strings.TrimPrefix(userInput, "/plan"))
 	if rest == "" {
 		fmt.Println(colorize("  "+i18n.T("plan.armed"), ColorGreen))
-		return false
+		return planRouteNone
 	}
-	// Inline form: /plan <task> → arm and immediately ask the agent
-	// loop to consume it. We mirror /agent's behavior: pendingAction
-	// is set and the caller panics with errAgentModeRequest.
+
+	// /plan preview|dry <task> → generate plan, show it, don't execute.
+	// Runs under agent mode so the dispatcher/registry are available, but
+	// AgentMode.Run returns before the ReAct loop (see planDryRunHandled).
+	if strings.HasPrefix(rest, "preview ") || rest == "preview" ||
+		strings.HasPrefix(rest, "dry ") || rest == "dry" {
+		var task string
+		switch {
+		case strings.HasPrefix(rest, "preview"):
+			task = strings.TrimSpace(strings.TrimPrefix(rest, "preview"))
+		default:
+			task = strings.TrimSpace(strings.TrimPrefix(rest, "dry"))
+		}
+		if task == "" {
+			// Without a task there's nothing to plan; keep the arm + hint.
+			fmt.Println(colorize("  "+i18n.T("plan.preview_usage"), ColorYellow))
+			cli.pendingPlanFirst = false
+			return planRouteNone
+		}
+		cli.pendingPlanDryRun = true
+		cli.pendingAction = "agent"
+		return planRouteAgent
+	}
+
+	// /plan coder <task> → coder mode with plan-first armed
+	if strings.HasPrefix(rest, "coder ") || rest == "coder" {
+		task := strings.TrimSpace(strings.TrimPrefix(rest, "coder"))
+		if task == "" {
+			fmt.Println(colorize("  "+i18n.T("plan.armed"), ColorGreen))
+			return planRouteNone
+		}
+		cli.pendingAction = "coder"
+		return planRouteCoder
+	}
+
+	// /plan <task> (or /plan agent <task>) → default: agent mode
 	cli.pendingAction = "agent"
-	return true
+	return planRouteAgent
 }

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -1444,6 +1444,14 @@
   "plan_first.with_errors": "(some steps had errors — orchestrator will see them in the report)",
   "plan_first.synth_plan_header": "Auto-generated structured plan (Plan-and-Solve / ReWOO):",
   "plan_first.orchestrator_handoff": "Use the report above as ground truth for the user-facing answer; do not re-run completed steps.",
+  "plan_first.spinner_planning": "planning structured steps (Plan-and-Solve)...",
+  "plan_first.spinner_executing": "executing structured plan...",
+  "plan_first.preview_header": "Generated plan (dry-run — nothing will be executed)",
+  "plan_first.preview_task": "Summary",
+  "plan_first.preview_parallel": "Parallel groups",
+  "plan_first.preview_parse_failed": "Could not parse the plan JSON — showing raw output:",
+  "plan_first.preview_footer": "To execute this plan: /plan <same task> (or /plan coder <task>)",
+  "plan.preview_usage": "usage: /plan preview <task description>",
   "thinking.cleared": "thinking override cleared — using skill hints + quality auto-agents",
   "thinking.disabled": "thinking disabled for next turn (override active)",
   "thinking.set": "thinking override set to %s for next turn",
@@ -1649,6 +1657,10 @@
   "complete.verify.clear": "Alias for auto — clear session override",
 
   "complete.plan.hint": "Free-text task. Without args, arms plan-first flag for the next /agent or /coder run.",
+  "complete.plan.agent": "Explicit: plan-first + agent mode (same as /plan <task>)",
+  "complete.plan.coder": "Plan-first + coder mode (software engineer with tools)",
+  "complete.plan.preview": "Dry-run: generate and render the plan without executing anything",
+  "complete.plan.dry": "Alias of preview — dry-run without execution",
 
   "complete.reflect.hint": "Free-text lesson. Persists directly to memory.Fact (category=lesson, trigger=manual) without LLM call.",
 

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1444,6 +1444,14 @@
   "plan_first.with_errors": "(some steps had errors — orchestrator will see them in the report)",
   "plan_first.synth_plan_header": "Auto-generated structured plan (Plan-and-Solve / ReWOO):",
   "plan_first.orchestrator_handoff": "Use the report above as ground truth for the user-facing answer; do not re-run completed steps.",
+  "plan_first.spinner_planning": "planning structured steps (Plan-and-Solve)...",
+  "plan_first.spinner_executing": "executing structured plan...",
+  "plan_first.preview_header": "Generated plan (dry-run — nothing will be executed)",
+  "plan_first.preview_task": "Summary",
+  "plan_first.preview_parallel": "Parallel groups",
+  "plan_first.preview_parse_failed": "Could not parse the plan JSON — showing raw output:",
+  "plan_first.preview_footer": "To execute this plan: /plan <same task> (or /plan coder <task>)",
+  "plan.preview_usage": "usage: /plan preview <task description>",
   "thinking.cleared": "thinking override cleared — using skill hints + quality auto-agents",
   "thinking.disabled": "thinking disabled for next turn (override active)",
   "thinking.set": "thinking override set to %s for next turn",
@@ -1649,6 +1657,10 @@
   "complete.verify.clear": "Alias for auto — clear session override",
 
   "complete.plan.hint": "Free-text task. Without args, arms plan-first flag for the next /agent or /coder run.",
+  "complete.plan.agent": "Explicit: plan-first + agent mode (same as /plan <task>)",
+  "complete.plan.coder": "Plan-first + coder mode (software engineer with tools)",
+  "complete.plan.preview": "Dry-run: generate and render the plan without executing anything",
+  "complete.plan.dry": "Alias of preview — dry-run without execution",
 
   "complete.reflect.hint": "Free-text lesson. Persists directly to memory.Fact (category=lesson, trigger=manual) without LLM call.",
 

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -1444,6 +1444,14 @@
   "plan_first.with_errors": "(alguns passos tiveram erros — o orquestrador verá isso no relatório)",
   "plan_first.synth_plan_header": "Plano estruturado auto-gerado (Plan-and-Solve / ReWOO):",
   "plan_first.orchestrator_handoff": "Use o relatório acima como verdade absoluta para a resposta final; não re-execute passos já concluídos.",
+  "plan_first.spinner_planning": "planejando estrutura (Plan-and-Solve)...",
+  "plan_first.spinner_executing": "executando plano estruturado...",
+  "plan_first.preview_header": "Plano gerado (dry-run — nada será executado)",
+  "plan_first.preview_task": "Resumo",
+  "plan_first.preview_parallel": "Grupos paralelizáveis",
+  "plan_first.preview_parse_failed": "Não foi possível interpretar o JSON do plano — exibindo bruto:",
+  "plan_first.preview_footer": "Para executar este plano: /plan <mesma tarefa> (ou /plan coder <tarefa>)",
+  "plan.preview_usage": "uso: /plan preview <descrição da tarefa>",
   "thinking.cleared": "override de thinking limpo — usando skill hints + auto-agents da config quality",
   "thinking.disabled": "thinking desligado para o próximo turno (override ativo)",
   "thinking.set": "override de thinking definido para %s no próximo turno",
@@ -1649,6 +1657,10 @@
   "complete.verify.clear": "Alias de auto — limpa override de sessão",
 
   "complete.plan.hint": "Task livre. Sem args, arma plan-first flag para o próximo /agent ou /coder.",
+  "complete.plan.agent": "Explícito: plan-first + modo agent (igual a /plan <task>)",
+  "complete.plan.coder": "Plan-first + modo coder (engenheiro de software com tools)",
+  "complete.plan.preview": "Dry-run: gera e mostra o plano sem executar nada",
+  "complete.plan.dry": "Alias de preview — dry-run sem execução",
 
   "complete.reflect.hint": "Lição livre. Persiste direto em memory.Fact (category=lesson, trigger=manual) sem chamada LLM.",
 


### PR DESCRIPTION
## Summary

Five related fixes to the `/plan` (Plan-and-Solve / ReWOO) command:

- **Dispatch bug**: `/plan <task>` used to just clear the terminal. `runAgentLogic` and the `Start` loop dispatch now recognize the `/plan` prefix and extract the query correctly.
- **Routing**: `/plan coder <task>` now routes to coder mode with plan-first armed (was hardcoded to agent only). `/plan agent <task>` accepted for symmetry.
- **Preview / dry-run**: `/plan preview <task>` (alias `/plan dry <task>`) runs the planner only and renders the plan without executing any step. `AgentMode.Run` skips the ReAct loop via `planDryRunHandled`.
- **Security-approval overlay**: Dropped the spinner wrapper around `runner.RunFromPlannerOutput`. Its `\r\033[K` repaint was overwriting security-approval prompts, making it impossible to answer them. Spinner stays only on the pure planner LLM call; the execution phase prints a static status line.
- **Claude Sonnet 4.6 compat**: Final Plan-First message is now `role=user` (was `assistant`). Claude 4.6 rejects completion when the conversation ends on `assistant` with "This model does not support assistant message prefill".

**Autocomplete**: `/plan` now suggests `agent`, `coder`, `preview`, `dry` alongside the free-form `<task>` hint. i18n keys added for pt-BR, en-US, and en.

## Test plan

- [x] `/plan` alone → shows "plan-first armed" hint
- [x] `/plan <task>` → agent mode with plan-first (executes)
- [x] `/plan coder <task>` → coder mode with plan-first (executes)
- [x] `/plan preview <task>` → renders plan, does NOT execute, does NOT burn an orchestrator call
- [x] `/plan` autocomplete shows `agent`, `coder`, `preview`, `dry`, `<task>`
- [x] Plan-First task that triggers a security check — approval prompt is NOT overwritten by spinner
- [x] Ctrl+C during Plan-First execution — terminal remains usable afterward
- [x] `/plan coder como dizer ola em 3 idiomas` on Claude Sonnet 4.6 — completes without 400 `assistant message prefill`