### PR TITLE
fix(rag-hyde): correct openai dim, raise backfill cap, drop dead var

### DIFF
--- a/cli/agent/quality/config.go
+++ b/cli/agent/quality/config.go
@@ -135,11 +135,16 @@ type PlanFirstConfig struct {
 }
 
 // HyDEConfig controls Hypothetical Document Embeddings retrieval (#4).
+//
+// Provider selection lives in CHATCLI_EMBED_PROVIDER (read by the
+// embedding factory, not this struct) — there is intentionally no
+// EmbedProvider field here. An older CHATCLI_QUALITY_HYDE_PROVIDER var
+// was removed because it only annotated the display and never wired
+// the actual provider, which made it a silent footgun.
 type HyDEConfig struct {
-	Enabled       bool
-	UseVectors    bool   // if true, use embedding provider for cosine search
-	EmbedProvider string // "voyage" | "openai" | ""
-	NumKeywords   int    // top-N keywords extracted from hypothesis
+	Enabled     bool
+	UseVectors  bool // if true, use embedding provider for cosine search
+	NumKeywords int  // top-N keywords extracted from hypothesis
 }
 
 // ReasoningConfig controls cross-provider reasoning backbone wiring (#7).
@@ -202,10 +207,9 @@ func Defaults() Config {
 			ComplexityThreshold: 6,
 		},
 		HyDE: HyDEConfig{
-			Enabled:       false,
-			UseVectors:    false,
-			EmbedProvider: "",
-			NumKeywords:   5,
+			Enabled:     false,
+			UseVectors:  false,
+			NumKeywords: 5,
 		},
 		Reasoning: ReasoningConfig{
 			Mode:       "auto",
@@ -375,9 +379,6 @@ func loadHyDEEnv(c *HyDEConfig) {
 	}
 	if v := os.Getenv("CHATCLI_QUALITY_HYDE_USE_VECTORS"); v != "" {
 		c.UseVectors = parseBool(v, c.UseVectors)
-	}
-	if v := os.Getenv("CHATCLI_QUALITY_HYDE_PROVIDER"); v != "" {
-		c.EmbedProvider = strings.ToLower(strings.TrimSpace(v))
 	}
 	if v := os.Getenv("CHATCLI_QUALITY_HYDE_NUM_KEYWORDS"); v != "" {
 		c.NumKeywords = parseInt(v, c.NumKeywords)

--- a/cli/config_quality.go
+++ b/cli/config_quality.go
@@ -102,11 +102,6 @@ func (cli *ChatCLI) showConfigQuality() {
 	subheader(p, "cfg.sub.quality.hyde")
 	kv(p, "CHATCLI_QUALITY_HYDE_ENABLED", boolLabel(cfg.HyDE.Enabled))
 	kv(p, "CHATCLI_QUALITY_HYDE_USE_VECTORS", boolLabel(cfg.HyDE.UseVectors))
-	provider := cfg.HyDE.EmbedProvider
-	if provider == "" {
-		provider = i18n.T("cfg.val.none")
-	}
-	kv(p, "CHATCLI_QUALITY_HYDE_PROVIDER", provider)
 	kv(p, "CHATCLI_EMBED_PROVIDER", envOr("CHATCLI_EMBED_PROVIDER"))
 	kv(p, "CHATCLI_EMBED_MODEL", envOr("CHATCLI_EMBED_MODEL"))
 	kv(p, "CHATCLI_QUALITY_HYDE_NUM_KEYWORDS", fmt.Sprintf("%d", cfg.HyDE.NumKeywords))

--- a/cli/workspace/memory/store.go
+++ b/cli/workspace/memory/store.go
@@ -97,12 +97,13 @@ func (m *Manager) GetRelevantContextWithHyDE(ctx context.Context, query string, 
 	out := m.retriever.RetrieveWithHyDE(ctx, query, hints, augmenter, m.vectors)
 
 	// Lazy backfill: fire-and-forget embedding of any facts visible to
-	// the current scorer that lack a vector. Bounded to a reasonable
-	// number (top 25) so a cold cache doesn't bill the user $0.50.
+	// the current scorer that lack a vector. Bounded so a cold cache
+	// doesn't bill more than a few cents — at Voyage's $0.05/M tokens
+	// and ~50 tokens/fact average, 500 facts ≈ $0.001.
 	if m.vectors != nil && m.vectors.Enabled() {
 		all := m.Facts.GetAll()
-		if len(all) > 25 {
-			all = all[:25]
+		if len(all) > 500 {
+			all = all[:500]
 		}
 		ids := make([]string, 0, len(all))
 		for _, f := range all {

--- a/docs/SEVEN_PATTERNS_PLAN.md
+++ b/docs/SEVEN_PATTERNS_PLAN.md
@@ -149,7 +149,7 @@ Levar o chatcli de "ReAct + multi-agente" para **suite completa de 7 padrões de
        Verify        VerifyConfig   // {Enabled bool, NumQuestions int, RewriteOnDiscrepancy bool}
        Reflexion     ReflexionConfig // {Enabled bool, OnError bool, OnHallucination bool, Persist bool}
        PlanFirst     PlanFirstConfig // {Mode "off"|"auto"|"always", ComplexityThreshold int}
-       HyDE          HyDEConfig      // {Enabled bool, UseVectors bool, EmbedProvider string, NumKeywords int}
+       HyDE          HyDEConfig      // {Enabled bool, UseVectors bool, NumKeywords int} — provider via CHATCLI_EMBED_PROVIDER
        Reasoning     ReasoningConfig // {Mode "off"|"on"|"auto", Budget int, AutoAgents []string}
    }
    ```

--- a/llm/embedding/openai.go
+++ b/llm/embedding/openai.go
@@ -21,9 +21,23 @@ import (
 
 const (
 	openaiDefaultModel = "text-embedding-3-small"
-	openaiDefaultDim   = 1536
 	openaiEndpoint     = "https://api.openai.com/v1/embeddings"
 )
+
+// openaiNativeDim returns the dimension OpenAI emits when the request
+// omits the `dimensions` field. text-embedding-3-large defaults to 3072,
+// not 1536 — relying on a single constant silently breaks the store
+// when users switch models without setting CHATCLI_EMBED_DIMENSIONS.
+func openaiNativeDim(model string) int {
+	switch model {
+	case "text-embedding-3-large":
+		return 3072
+	case "text-embedding-3-small", "text-embedding-ada-002":
+		return 1536
+	default:
+		return 1536
+	}
+}
 
 // OpenAI is the OpenAI embeddings provider.
 type OpenAI struct {
@@ -45,7 +59,7 @@ func NewOpenAI(apiKey, model string, dim int) (*OpenAI, error) {
 		model = openaiDefaultModel
 	}
 	if dim <= 0 {
-		dim = openaiDefaultDim
+		dim = openaiNativeDim(model)
 	}
 	return &OpenAI{
 		apiKey:   apiKey,
@@ -89,7 +103,7 @@ func (o *OpenAI) Embed(ctx context.Context, texts []string) ([][]float32, error)
 		Model:          o.model,
 		EncodingFormat: "float",
 	}
-	if o.dim != openaiDefaultDim {
+	if o.dim != openaiNativeDim(o.model) {
 		body.Dimensions = o.dim
 	}
 	payload, err := json.Marshal(body)


### PR DESCRIPTION
## Summary

Three independent fixes scoped to the HyDE/RAG pipeline, all uncovered while debugging a real session.

- **OpenAI native dimension by model.** `llm/embedding/openai.go` no longer uses a single hardcoded 1536 default. New helper `openaiNativeDim(model)` resolves to 1536 for `text-embedding-3-small` and `text-embedding-ada-002`, 3072 for `text-embedding-3-large`. The `Embed` gate on the request `dimensions` field also compares against this per-model native, so Matryoshka truncation via `CHATCLI_EMBED_DIMENSIONS` keeps working unchanged.
- **Lazy backfill cap raised from 25 to 500** in `cli/workspace/memory/store.go`. Comment refreshed with the actual cost estimate at Voyage pricing — about US\$0.001 for a fully cold cache of 500 facts. Users with hundreds of facts now get cosine coverage on the first interaction instead of being stuck at 25 forever.
- **Removed dead `CHATCLI_QUALITY_HYDE_PROVIDER` env var** and the `EmbedProvider` field on `HyDEConfig`. It only annotated the `/config quality` display and never wired the embedding factory — a silent footgun where users would see the chosen backend in the UI while the actual provider fell back to null. `CHATCLI_EMBED_PROVIDER` is now the single source of truth, and the doc-comment on `HyDEConfig` records why the field was removed.

## Bug it fixes (with timeline)

A user setting `CHATCLI_EMBED_MODEL=text-embedding-3-large` without `CHATCLI_EMBED_DIMENSIONS` would hit:

```
HyDE vector index attached  provider=openai:text-embedding-3-large  dimension=1536
vector backfill failed: provider openai:text-embedding-3-large emitted dim=3072
                       but store dim=1536 (clear ... to migrate)
```

The provider declared 1536 from the global constant, the API returned the model's native 3072, and the store rejected every single backfill. After this PR the same env yields a 3072-dim store and clean backfills.

## Files

- `llm/embedding/openai.go` — added `openaiNativeDim`, removed `openaiDefaultDim`, updated `NewOpenAI` and `Embed`
- `cli/workspace/memory/store.go` — backfill cap 25 → 500 with refreshed comment
- `cli/agent/quality/config.go` — removed `EmbedProvider` field, removed env loader for `CHATCLI_QUALITY_HYDE_PROVIDER`, doc-comment on `HyDEConfig` explains the removal
- `cli/config_quality.go` — removed display row for the dead var
- `docs/SEVEN_PATTERNS_PLAN.md` — struct doc updated to match

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — full suite green, including \`llm/embedding\`, \`cli/agent/quality\`, \`cli/workspace/memory\`
- [x] Manual: set \`CHATCLI_EMBED_MODEL=text-embedding-3-large\` without \`CHATCLI_EMBED_DIMENSIONS\`, confirm vector index attaches at dim=3072 and backfill succeeds
- [x] Manual: confirm \`/config quality\` no longer shows the \`CHATCLI_QUALITY_HYDE_PROVIDER\` line
- [x] Manual: with hundreds of facts, confirm \`vector_count\` in \`/config quality\` rises beyond 25 after a single retrieve

## Doc companion

Documentation in \`~/chatcli.ai\` (separate repo) was updated and pushed in commit \`2b86d3f\` to keep \`features/quality/rag-hyde.mdx\`, \`features/quality/configuration.mdx\` and \`reference/environment-variables.mdx\` (PT + EN) consistent with this change.