### PR TITLE
fix(claudeai): coalesce cache_control markers to fit Anthropic 4-block cap

### DIFF
--- a/llm/claudeai/cache_planner.go
+++ b/llm/claudeai/cache_planner.go
@@ -1,0 +1,57 @@
+/*
+ * ChatCLI - Anthropic cache_control breakpoint planner
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package claudeai
+
+import "sync/atomic"
+
+// anthropicMaxCacheBreakpoints is Anthropic's hard cap on the number of
+// content blocks that may carry cache_control in a single request.
+const anthropicMaxCacheBreakpoints = 4
+
+var cacheBlocksCoalesced atomic.Uint64
+
+// CacheBlocksCoalescedTotal returns the cumulative count of cache_control
+// markers that were coalesced (had their marker removed) to keep requests
+// under Anthropic's per-request breakpoint cap.
+func CacheBlocksCoalescedTotal() uint64 {
+	return cacheBlocksCoalesced.Load()
+}
+
+// coalesceCacheControl removes cache_control markers from the earliest
+// blocks until at most maxMarkers remain. The block content itself is
+// untouched — only the marker is dropped.
+//
+// Why this is safe: Anthropic's prompt cache is prefix-based. A marker
+// creates a cache breakpoint and everything BEFORE it (plus the marked
+// block) becomes a cacheable layer. Dropping an earlier marker only
+// removes that specific layer; the same content is still cached as part
+// of any later marker's prefix. So we never lose cached tokens — we only
+// lose the ability to invalidate at finer granularity, which is rarely
+// useful in practice (the prefix typically changes together).
+//
+// We keep the LATEST markers because each later marker covers strictly
+// more content than earlier ones, maximizing cache coverage with the
+// markers we are allowed to use.
+func coalesceCacheControl(blocks []map[string]interface{}, maxMarkers int) []map[string]interface{} {
+	if maxMarkers < 0 {
+		maxMarkers = 0
+	}
+	var positions []int
+	for i, b := range blocks {
+		if _, ok := b["cache_control"]; ok {
+			positions = append(positions, i)
+		}
+	}
+	if len(positions) <= maxMarkers {
+		return blocks
+	}
+	dropCount := len(positions) - maxMarkers
+	for _, pos := range positions[:dropCount] {
+		delete(blocks[pos], "cache_control")
+	}
+	cacheBlocksCoalesced.Add(uint64(dropCount))
+	return blocks
+}

--- a/llm/claudeai/cache_planner_test.go
+++ b/llm/claudeai/cache_planner_test.go
@@ -1,0 +1,107 @@
+/*
+ * ChatCLI - Tests for the Anthropic cache breakpoint planner
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package claudeai
+
+import "testing"
+
+func block(text string, marked bool) map[string]interface{} {
+	b := map[string]interface{}{"type": "text", "text": text}
+	if marked {
+		b["cache_control"] = map[string]string{"type": "ephemeral"}
+	}
+	return b
+}
+
+func countMarkers(blocks []map[string]interface{}) int {
+	n := 0
+	for _, b := range blocks {
+		if _, ok := b["cache_control"]; ok {
+			n++
+		}
+	}
+	return n
+}
+
+func TestCoalesceUnderLimitIsNoop(t *testing.T) {
+	in := []map[string]interface{}{
+		block("a", true),
+		block("b", true),
+		block("c", false),
+		block("d", true),
+	}
+	before := CacheBlocksCoalescedTotal()
+	out := coalesceCacheControl(in, 4)
+	if countMarkers(out) != 3 {
+		t.Fatalf("expected 3 markers preserved, got %d", countMarkers(out))
+	}
+	if got := CacheBlocksCoalescedTotal() - before; got != 0 {
+		t.Fatalf("expected 0 coalesced, got %d", got)
+	}
+}
+
+func TestCoalesceDropsEarliestMarkers(t *testing.T) {
+	in := []map[string]interface{}{
+		block("p0", true), // earliest — should be dropped
+		block("p1", true), // earliest — should be dropped
+		block("p2", true),
+		block("p3", true),
+		block("p4", true),
+		block("p5", true), // latest — kept
+	}
+	before := CacheBlocksCoalescedTotal()
+	out := coalesceCacheControl(in, 4)
+	if countMarkers(out) != 4 {
+		t.Fatalf("expected 4 markers after coalesce, got %d", countMarkers(out))
+	}
+	if _, ok := out[0]["cache_control"]; ok {
+		t.Fatal("expected earliest marker (p0) to be dropped")
+	}
+	if _, ok := out[1]["cache_control"]; ok {
+		t.Fatal("expected second-earliest marker (p1) to be dropped")
+	}
+	if _, ok := out[5]["cache_control"]; !ok {
+		t.Fatal("expected latest marker (p5) to be kept")
+	}
+	if got := CacheBlocksCoalescedTotal() - before; got != 2 {
+		t.Fatalf("expected counter to advance by 2, got %d", got)
+	}
+}
+
+func TestCoalesceRespectsBudgetForToolReserve(t *testing.T) {
+	in := []map[string]interface{}{
+		block("a", true),
+		block("b", true),
+		block("c", true),
+		block("d", true),
+	}
+	out := coalesceCacheControl(in, 3) // tool path reserves 1 marker for tools
+	if countMarkers(out) != 3 {
+		t.Fatalf("expected 3 markers (budget=3), got %d", countMarkers(out))
+	}
+	if _, ok := out[0]["cache_control"]; ok {
+		t.Fatal("expected earliest marker to be dropped first")
+	}
+}
+
+func TestCoalescePreservesBlockContent(t *testing.T) {
+	in := []map[string]interface{}{
+		block("alpha", true),
+		block("beta", true),
+		block("gamma", true),
+		block("delta", true),
+		block("epsilon", true),
+	}
+	out := coalesceCacheControl(in, 4)
+	if len(out) != 5 {
+		t.Fatalf("expected 5 blocks preserved, got %d", len(out))
+	}
+	expected := []string{"alpha", "beta", "gamma", "delta", "epsilon"}
+	for i, want := range expected {
+		if out[i]["text"] != want {
+			t.Fatalf("block %d: expected text %q, got %v", i, want, out[i]["text"])
+		}
+	}
+}

--- a/llm/claudeai/claude_client.go
+++ b/llm/claudeai/claude_client.go
@@ -435,7 +435,7 @@ func (c *ClaudeClient) buildMessagesAndSystem(prompt string, history []models.Me
 				"text": part,
 			})
 		}
-		return messages, systemBlocks
+		return messages, coalesceCacheControl(systemBlocks, anthropicMaxCacheBreakpoints)
 	}
 
 	if len(plainSystemParts) > 0 {
@@ -448,7 +448,7 @@ func (c *ClaudeClient) buildMessagesAndSystem(prompt string, history []models.Me
 func (c *ClaudeClient) buildOAuthMessagesAndSystem(prompt string, history []models.Message) ([]map[string]interface{}, []interface{}) {
 	var messages []map[string]interface{}
 	var systemParts []string
-	var structuredParts []interface{}
+	var structuredParts []map[string]interface{}
 
 	for _, msg := range history {
 		switch strings.ToLower(strings.TrimSpace(msg.Role)) {
@@ -497,7 +497,10 @@ func (c *ClaudeClient) buildOAuthMessagesAndSystem(prompt string, history []mode
 	}
 	// Prefer structured blocks with cache_control
 	if len(structuredParts) > 0 {
-		systemObjs = append(systemObjs, structuredParts...)
+		structuredParts = coalesceCacheControl(structuredParts, anthropicMaxCacheBreakpoints)
+		for _, p := range structuredParts {
+			systemObjs = append(systemObjs, p)
+		}
 	}
 	if len(systemParts) > 0 {
 		joined := strings.Join(systemParts, "\n\n")

--- a/llm/claudeai/tool_use.go
+++ b/llm/claudeai/tool_use.go
@@ -43,8 +43,10 @@ func (c *ClaudeClient) SendPromptWithTools(ctx context.Context, prompt string, h
 	// Sort tools for KV cache stability
 	sortedTools := client.SortToolDefinitions(tools)
 
-	// Build system prompt with cache control
-	systemBlocks := buildSystemBlocks(history)
+	// Build system prompt with cache control. The tool path reserves 1
+	// breakpoint for the tool definitions block below, so system markers
+	// are capped at anthropicMaxCacheBreakpoints-1.
+	systemBlocks := coalesceCacheControl(buildSystemBlocks(history), anthropicMaxCacheBreakpoints-1)
 
 	// Build messages (excluding system messages)
 	messages := buildClaudeToolMessages(prompt, history)


### PR DESCRIPTION
## Summary

- Resolves HTTP 400 from Anthropic when more than 4 system blocks carry `cache_control` (e.g. mode hint + workspace + several `/context attach` entries can easily emit 5–6 markers).
- Adds a planner local to `llm/claudeai/` that drops the earliest markers until at most 4 remain, keeping the latest because Anthropic's cache is prefix-based — later markers cover strictly more content.
- Block content is never discarded; only the marker label is removed. The same content stays cached as part of any later marker's prefix, so no cached tokens are lost — only the (rarely used) finer-grained invalidation.

## Why local to the adapter

The 4-marker cap is specific to Anthropic. The remaining 12 providers either use automatic prefix caching or do not honor `cache_control` at all, so the right place to enforce this limit is inside the Anthropic adapter — not in a cross-provider abstraction. Existing call sites in `cli/cli_llm.go` and `cli/agent_system_prompt.go` keep emitting hints freely.

## Changes

- `llm/claudeai/cache_planner.go` — new file with `coalesceCacheControl(blocks, maxMarkers)` and `CacheBlocksCoalescedTotal()` counter for observability.
- `llm/claudeai/cache_planner_test.go` — covers no-op under cap, drop-earliest behavior, reduced budget for the tool path, and content preservation.
- `llm/claudeai/tool_use.go` — wraps `buildSystemBlocks` with the planner, budget set to `anthropicMaxCacheBreakpoints-1` to reserve one breakpoint for the tool definitions block.
- `llm/claudeai/claude_client.go` — wraps both `buildMessagesAndSystem` and `buildOAuthMessagesAndSystem` with budget 4. OAuth path's `structuredParts` was changed from a generic interface slice to a typed map slice so the planner can operate on it.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./llm/claudeai/...`
- [x] `go test ./llm/claudeai/...`
- [x] `go test ./...` — full suite green
- [ ] Manual: reproduce the original `/context attach` flow that previously emitted 6 markers and confirm the request now succeeds