### PR TITLE
fix(scheduler): /schedule quote parser + recurring re-arm with cycle tracking

### DIFF
--- a/cli/scheduler/dispatcher.go
+++ b/cli/scheduler/dispatcher.go
@@ -35,6 +35,18 @@ import (
 )
 
 // handleJob drives one fire of the given job ID.
+//
+// For recurring schedules the dispatcher reuses ONE Job record across
+// every cycle (Running→Pending re-arm in runAction's success branch).
+// This keeps Job count and WAL footprint bounded even for short-
+// interval schedules (e.g. every 30s would otherwise create thousands
+// of records/day) and gives the queue a natural anti-overlap property
+// — a JobID can only sit in the queue once, so if the action takes
+// longer than the interval the next fire window is skipped via
+// Schedule.Next instead of stacking concurrent runs.
+//
+// Each cycle gets its own CycleNum on the resulting ExecutionResult so
+// /jobs logs can render them as distinct entries.
 func (s *Scheduler) handleJob(id JobID, workerID int) {
 	s.mu.RLock()
 	j, ok := s.jobs[id]
@@ -54,6 +66,20 @@ func (s *Scheduler) handleJob(id JobID, workerID int) {
 		zap.Int("worker_id", workerID),
 	)
 
+	// Recurring schedules: a fresh fire window means a new cycle.
+	// Bump CycleCount only on the first attempt of the cycle so that
+	// retries (which re-enter handleJob via scheduleRetryOrFail) don't
+	// inflate the counter. A cycle = one logical run; retries within
+	// it share a CycleNum.
+	if j.Schedule.IsRecurring() {
+		j.lock()
+		if j.Attempts == 0 {
+			j.CycleCount++
+			_ = s.wal.Write(j)
+		}
+		j.unlock()
+	}
+
 	// Emit "fired" and run the wait + action pipeline.
 	s.emit(NewEvent(EventJobFired).WithJob(j).WithMessage("job fire window reached"))
 
@@ -64,12 +90,54 @@ func (s *Scheduler) handleJob(id JobID, workerID int) {
 		}
 	}
 
-	// Action phase.
+	// Action phase. runAction handles recurring re-arm inline on the
+	// success path so a Running→Pending transition is taken before the
+	// (terminal) Completed state is reached.
 	s.runAction(j)
+}
 
-	// Recurring re-enqueue (outside the action section so a terminal
-	// transition by the action doesn't double-schedule).
-	s.maybeReschedule(j)
+// rearmRecurring closes one cycle of a recurring schedule and queues
+// the next fire on the same Job record. Called from runAction's success
+// branch when j.Schedule.IsRecurring() — the dispatcher takes the
+// Running→Pending edge so the JobID, WAL record, name index, and DAG
+// edges all keep flowing across cycles.
+//
+// Resets Attempts to 0 so retry budget applies per cycle, not across
+// the lifetime of the job. CycleCount is NOT reset; the next cycle
+// will increment it in handleJob.
+//
+// If Schedule.Next returns the zero time (cron/interval somehow
+// exhausted), we fall through to markCompleted so the job terminates
+// cleanly instead of dangling forever in Running.
+func (s *Scheduler) rearmRecurring(j *Job, r ExecutionResult) {
+	j.lock()
+	if j.Status.IsTerminal() {
+		j.unlock()
+		return
+	}
+	next := j.Schedule.Next(time.Now(), j.CreatedAt)
+	if next.IsZero() {
+		j.unlock()
+		s.markCompleted(j, r)
+		return
+	}
+	if err := j.transition(StatusPending, "recurring re-arm", s.logger); err != nil {
+		j.unlock()
+		s.logger.Warn("scheduler: recurring re-arm transition failed",
+			zap.String("job_id", string(j.ID)),
+			zap.String("name", j.Name),
+			zap.Error(err))
+		return
+	}
+	j.NextFireAt = next
+	j.Attempts = 0
+	_ = s.wal.Write(j)
+	j.unlock()
+
+	s.emit(NewEvent(EventJobCompleted).WithJob(j).WithExecution(r).
+		WithMessage(fmt.Sprintf("cycle %d completed; re-armed", r.CycleNum)))
+	s.queue.Enqueue(j.ID, next)
+	s.version.Add(1)
 }
 
 // ─── Wait phase ───────────────────────────────────────────────
@@ -262,6 +330,7 @@ func (s *Scheduler) runAction(j *Job) {
 	}
 	j.Attempts++
 	attempt := j.Attempts
+	cycleNum := j.CycleCount
 	action := j.Action
 	budget := j.Budget
 	_ = s.wal.Write(j)
@@ -320,6 +389,7 @@ func (s *Scheduler) runAction(j *Job) {
 	s.metrics.ActionDuration.WithLabelValues(string(action.Type), string(outcome)).Observe(duration.Seconds())
 
 	exec := ExecutionResult{
+		CycleNum:   cycleNum,
 		AttemptNum: attempt,
 		StartedAt:  startedAt,
 		FinishedAt: startedAt.Add(duration),
@@ -333,6 +403,13 @@ func (s *Scheduler) runAction(j *Job) {
 	s.recordActionResult(j, attempt, exec)
 
 	if res.Err == nil {
+		// Recurring schedules re-arm here, BEFORE the (terminal)
+		// Completed transition. Non-recurring jobs go straight to
+		// Completed and run unblockDependents / fireTriggers.
+		if j.Schedule.IsRecurring() {
+			s.rearmRecurring(j, exec)
+			return
+		}
 		s.markCompleted(j, exec)
 		return
 	}
@@ -435,41 +512,6 @@ func (s *Scheduler) scheduleRetryOrFail(j *Job, err error) {
 		WithMessage(errString(err)))
 }
 
-// maybeReschedule handles recurring schedules and DAG fan-out on the
-// non-terminal path. Terminal jobs are left alone — completion
-// handling already runs unblockDependents / fireTriggers.
-func (s *Scheduler) maybeReschedule(j *Job) {
-	j.lock()
-	if j.Status.IsTerminal() {
-		j.unlock()
-		return
-	}
-	if j.Status != StatusCompleted {
-		// Non-completion paths (retry, fail) manage their own re-enqueue.
-		j.unlock()
-		return
-	}
-	sched := j.Schedule
-	createdAt := j.CreatedAt
-	j.unlock()
-	if !sched.IsRecurring() {
-		return
-	}
-	next := sched.Next(time.Now(), createdAt)
-	if next.IsZero() {
-		return
-	}
-	j.lock()
-	// Reset state for a fresh occurrence, but we stay on the same Job
-	// record — the JobID + WAL record are reused. History carries the
-	// prior executions.
-	_ = j.transition(StatusPending, "recurring re-arm", s.logger)
-	j.NextFireAt = next
-	j.Attempts = 0
-	_ = s.wal.Write(j)
-	j.unlock()
-	s.queue.Enqueue(j.ID, next)
-}
 
 // unblockDependents scans for any Blocked jobs that had this one in
 // their DependsOn list; if all their deps are now terminal-successful,

--- a/cli/scheduler/dispatcher.go
+++ b/cli/scheduler/dispatcher.go
@@ -512,7 +512,6 @@ func (s *Scheduler) scheduleRetryOrFail(j *Job, err error) {
 		WithMessage(errString(err)))
 }
 
-
 // unblockDependents scans for any Blocked jobs that had this one in
 // their DependsOn list; if all their deps are now terminal-successful,
 // they become Pending. Event emission and queue enqueue happen after

--- a/cli/scheduler/job.go
+++ b/cli/scheduler/job.go
@@ -73,6 +73,11 @@ type Job struct {
 	History      []ExecutionResult `json:"history,omitempty"`
 	HistoryLimit int               `json:"history_limit,omitempty"`
 	Attempts     int               `json:"attempts,omitempty"`
+	// CycleCount is incremented on a recurring template every time it
+	// spawns a child cycle. Always zero on a non-recurring or one-shot
+	// (cycle) Job — it identifies templates and gives /jobs show a
+	// cheap count of how many fires have happened so far.
+	CycleCount int `json:"cycle_count,omitempty"`
 
 	// ─── Flags ─────────────────────────────────────────────
 	// DangerousConfirmed marks a job whose action is otherwise filtered
@@ -138,6 +143,7 @@ func (j *Job) cloneLocked() *Job {
 		CancelReason:       j.CancelReason,
 		HistoryLimit:       j.HistoryLimit,
 		Attempts:           j.Attempts,
+		CycleCount:         j.CycleCount,
 		DangerousConfirmed: j.DangerousConfirmed,
 		Description:        j.Description,
 	}

--- a/cli/scheduler/render.go
+++ b/cli/scheduler/render.go
@@ -195,10 +195,21 @@ func RenderShow(j *Job) string {
 		fmt.Fprintf(&b, "  Tags     : %s\n", strings.Join(tags, ", "))
 	}
 	if n := len(j.History); n > 0 {
-		fmt.Fprintf(&b, "  History (%d):\n", n)
+		header := fmt.Sprintf("  History (%d", n)
+		if j.CycleCount > 0 {
+			header += fmt.Sprintf(", %d cycles", j.CycleCount)
+		}
+		header += "):\n"
+		fmt.Fprint(&b, header)
 		for i := len(j.History) - 1; i >= 0 && i >= len(j.History)-10; i-- {
 			r := j.History[i]
-			fmt.Fprintf(&b, "    #%d %s %s (%s)", r.AttemptNum, r.StartedAt.Format(time.RFC3339), r.Outcome, compactDuration(r.Duration))
+			// For recurring jobs, render "#cycle.attempt"; for one-shot
+			// jobs keep the existing "#attempt" form unchanged.
+			tag := fmt.Sprintf("#%d", r.AttemptNum)
+			if r.CycleNum > 0 {
+				tag = fmt.Sprintf("#%d.%d", r.CycleNum, r.AttemptNum)
+			}
+			fmt.Fprintf(&b, "    %s %s %s (%s)", tag, r.StartedAt.Format(time.RFC3339), r.Outcome, compactDuration(r.Duration))
 			if r.Error != "" {
 				fmt.Fprintf(&b, "  err=%s", truncRender(r.Error, 80))
 			}

--- a/cli/scheduler/scheduler_test.go
+++ b/cli/scheduler/scheduler_test.go
@@ -353,4 +353,3 @@ func TestScheduler_RecurringInterval_CancelStopsRearm(t *testing.T) {
 		t.Errorf("cycles kept firing after cancel: before=%d after=%d", stableCount, got)
 	}
 }
-

--- a/cli/scheduler/scheduler_test.go
+++ b/cli/scheduler/scheduler_test.go
@@ -187,3 +187,170 @@ func TestScheduler_DAG_DependsOn(t *testing.T) {
 	}
 	t.Fatalf("dag did not finish — calls=%d", fa.calls.Load())
 }
+
+// TestScheduler_RecurringInterval_RearmsInPlace guards the bug where
+// ScheduleInterval/Cron jobs ran exactly once. After a successful
+// action the dispatcher used to call markCompleted (terminal) and the
+// recurrence path bailed at IsTerminal(). Now runAction takes the
+// Running→Pending edge for recurring schedules, the same JobID keeps
+// cycling, and CycleCount/CycleNum identify each execution distinctly.
+//
+// The single-Job model is intentional: the queue is keyed by JobID so
+// a still-Running job can't be re-fired, which gives natural anti-
+// overlap (long actions skip a window via Schedule.Next instead of
+// stacking concurrent runs), and Job count / WAL footprint stay
+// bounded even on short intervals.
+func TestScheduler_RecurringInterval_RearmsInPlace(t *testing.T) {
+	dir := t.TempDir()
+	cfg := DefaultConfig()
+	cfg.DataDir = dir
+	cfg.AuditEnabled = false
+	cfg.SnapshotInterval = 0
+	cfg.WALGCInterval = 0
+	cfg.DaemonAutoConnect = false
+
+	s, err := New(cfg, NewNoopBridge(), SchedulerDeps{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fa := &fakeAct{}
+	_ = s.Actions().Register(fa)
+	cfg.ActionAllowlist[ActionType("fake_act")] = true
+	s.cfg = cfg
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := s.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	defer s.DrainAndShutdown(2 * time.Second)
+
+	job := NewJob("ticker",
+		Owner{Kind: OwnerUser, ID: "u"},
+		Schedule{Kind: ScheduleInterval, Interval: 80 * time.Millisecond},
+		Action{Type: ActionType("fake_act")})
+	created, err := s.Enqueue(ctx, job)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const wantFires = 3
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if fa.calls.Load() >= wantFires {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if got := fa.calls.Load(); got < wantFires {
+		t.Fatalf("recurring job fired only %d times in %s, want >=%d", got, 3*time.Second, wantFires)
+	}
+
+	q, err := s.Query(created.ID)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+
+	// Same JobID, alive (not terminal), and re-armed for another cycle.
+	if q.ID != created.ID {
+		t.Errorf("JobID changed: %s → %s", created.ID, q.ID)
+	}
+	if q.Status.IsTerminal() {
+		t.Errorf("recurring job ended in terminal state %s after %d fires", q.Status, fa.calls.Load())
+	}
+	if q.NextFireAt.Before(time.Now().Add(-200 * time.Millisecond)) {
+		t.Errorf("NextFireAt did not advance: %v (now=%v)", q.NextFireAt, time.Now())
+	}
+	if q.CycleCount < wantFires {
+		t.Errorf("CycleCount=%d, want >=%d", q.CycleCount, wantFires)
+	}
+
+	// History accumulates per cycle, capped by HistoryLimit. Each entry
+	// must carry a distinct CycleNum so /jobs logs can separate them.
+	if len(q.History) < wantFires {
+		t.Errorf("history entries=%d, want >=%d (one per cycle)", len(q.History), wantFires)
+	}
+	seenCycles := map[int]bool{}
+	for _, h := range q.History {
+		if h.CycleNum == 0 {
+			t.Errorf("history entry missing CycleNum: %+v", h)
+		}
+		seenCycles[h.CycleNum] = true
+	}
+	if len(seenCycles) < wantFires {
+		t.Errorf("only %d distinct CycleNums in history, want >=%d", len(seenCycles), wantFires)
+	}
+
+	// Name index still resolves — recurring re-arm doesn't cleanup name.
+	if found, ok := s.FindByName("ticker"); !ok || found.ID != created.ID {
+		t.Errorf("FindByName(ticker) lost the job: ok=%v found=%v", ok, found)
+	}
+
+	// No phantom child jobs were spawned — the whole point of in-place
+	// re-arm. Only the original Job should exist.
+	allJobs := s.List(ListFilter{IncludeTerminal: true})
+	if len(allJobs) != 1 {
+		t.Errorf("recurring should reuse one Job; got %d total entries", len(allJobs))
+	}
+}
+
+// TestScheduler_RecurringInterval_CancelStopsRearm ensures cancelling
+// a recurring job prevents future cycles. A cycle that was already
+// running may still complete (cancel is checked at fire boundaries).
+func TestScheduler_RecurringInterval_CancelStopsRearm(t *testing.T) {
+	dir := t.TempDir()
+	cfg := DefaultConfig()
+	cfg.DataDir = dir
+	cfg.AuditEnabled = false
+	cfg.SnapshotInterval = 0
+	cfg.WALGCInterval = 0
+	cfg.DaemonAutoConnect = false
+
+	s, err := New(cfg, NewNoopBridge(), SchedulerDeps{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fa := &fakeAct{}
+	_ = s.Actions().Register(fa)
+	cfg.ActionAllowlist[ActionType("fake_act")] = true
+	s.cfg = cfg
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := s.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	defer s.DrainAndShutdown(2 * time.Second)
+
+	job := NewJob("stoppable",
+		Owner{Kind: OwnerUser, ID: "u"},
+		Schedule{Kind: ScheduleInterval, Interval: 60 * time.Millisecond},
+		Action{Type: ActionType("fake_act")})
+	created, err := s.Enqueue(ctx, job)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && fa.calls.Load() < 1 {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if fa.calls.Load() < 1 {
+		t.Fatal("no cycles fired before cancel")
+	}
+
+	if err := s.Cancel(created.ID, "test", Owner{Kind: OwnerUser, ID: "u"}); err != nil {
+		t.Fatalf("cancel: %v", err)
+	}
+	q, _ := s.Query(created.ID)
+	if q.Status != StatusCancelled {
+		t.Fatalf("status after cancel = %s, want cancelled", q.Status)
+	}
+
+	stableCount := fa.calls.Load()
+	time.Sleep(300 * time.Millisecond)
+	if got := fa.calls.Load(); got > stableCount+1 {
+		t.Errorf("cycles kept firing after cancel: before=%d after=%d", stableCount, got)
+	}
+}
+

--- a/cli/scheduler/state_machine.go
+++ b/cli/scheduler/state_machine.go
@@ -19,13 +19,20 @@
  *   Pending   → Blocked, Waiting, Running, Paused, Cancelled, Skipped
  *   Blocked   → Pending, Cancelled
  *   Waiting   → Running, TimedOut, Cancelled, Failed
- *   Running   → Completed, Failed, TimedOut, Cancelled
+ *   Running   → Completed, Failed, TimedOut, Cancelled, Pending (recurring re-arm)
  *   Paused    → Pending, Cancelled
  *   (terminal) Completed / Failed / Cancelled / TimedOut / Skipped
  *
- * The scheduler never resurrects terminal jobs. A recurring cron job
- * doesn't "go back to pending" on the same Job record — it spawns a
- * fresh occurrence (sibling Job) with a new ID.
+ * The scheduler never resurrects terminal jobs. A recurring cron or
+ * interval schedule re-arms BEFORE the Running→Completed transition:
+ * after a successful action the dispatcher takes the Running→Pending
+ * edge so the same Job record (and JobID) keeps cycling. This keeps
+ * Job count, WAL footprint, and queue depth bounded — a critical
+ * property when intervals are short (e.g. health-check every 30s
+ * would otherwise grow 2880 records/day). History entries carry a
+ * CycleNum so /jobs logs separates cycles cleanly even though they
+ * share one Job. Terminal statuses remain a one-way door for non-
+ * recurring work.
  */
 package scheduler
 
@@ -63,6 +70,9 @@ var transitionTable = map[JobStatus]map[JobStatus]struct{}{
 		StatusFailed:    {},
 		StatusTimedOut:  {},
 		StatusCancelled: {},
+		// Recurring schedules re-arm via Running→Pending after a
+		// successful action so the same JobID keeps cycling.
+		StatusPending: {},
 	},
 	StatusPaused: {
 		StatusPending:   {},

--- a/cli/scheduler/state_machine_test.go
+++ b/cli/scheduler/state_machine_test.go
@@ -35,8 +35,9 @@ func TestJob_Transition_RecordsReason(t *testing.T) {
 	if len(j.Transitions) != 1 || j.Transitions[0].Message != "start" {
 		t.Errorf("transitions not recorded: %+v", j.Transitions)
 	}
-	// Illegal: pending → pending (already left pending).
-	if err := j.transition(StatusPending, "should fail", zap.NewNop()); err == nil {
+	// Illegal: running → waiting (no edge — recurring re-arm uses
+	// running → pending, but waiting always reaches via pending).
+	if err := j.transition(StatusWaiting, "should fail", zap.NewNop()); err == nil {
 		t.Error("expected error on illegal transition")
 	}
 }

--- a/cli/scheduler/types.go
+++ b/cli/scheduler/types.go
@@ -143,6 +143,10 @@ const (
 // result (from an on_condition schedule) or an action execution.
 // Stored in Job.History as a ring buffer.
 type ExecutionResult struct {
+	// CycleNum is the recurring-schedule cycle this execution belongs
+	// to (1 = first cycle). Always 0 for one-shot jobs. Lets /jobs logs
+	// group attempts within a cycle and separate cycles visually.
+	CycleNum   int           `json:"cycle,omitempty"`
 	AttemptNum int           `json:"attempt"`
 	StartedAt  time.Time     `json:"started_at"`
 	FinishedAt time.Time     `json:"finished_at"`

--- a/cli/scheduler_command.go
+++ b/cli/scheduler_command.go
@@ -25,7 +25,11 @@ func (cli *ChatCLI) handleScheduleCommand(input string) {
 		fmt.Println(colorize("  "+i18n.T("scheduler.disabled"), ColorYellow))
 		return
 	}
-	args := strings.Fields(strings.TrimPrefix(input, "/schedule"))
+	args, err := tokenizeSchedulerInput(strings.TrimPrefix(input, "/schedule"))
+	if err != nil {
+		fmt.Println(colorize("  ❌ "+err.Error(), ColorRed))
+		return
+	}
 	if len(args) == 0 {
 		cli.printScheduleUsage()
 		return
@@ -76,7 +80,11 @@ func (cli *ChatCLI) handleWaitCommand(input string) {
 		fmt.Println(colorize("  "+i18n.T("scheduler.disabled"), ColorYellow))
 		return
 	}
-	args := strings.Fields(strings.TrimPrefix(input, "/wait"))
+	args, err := tokenizeSchedulerInput(strings.TrimPrefix(input, "/wait"))
+	if err != nil {
+		fmt.Println(colorize("  ❌ "+err.Error(), ColorRed))
+		return
+	}
 	if len(args) == 0 || args[0] == "help" {
 		cli.printWaitUsage()
 		return
@@ -134,7 +142,11 @@ func (cli *ChatCLI) handleJobsCommand(input string) {
 		fmt.Println(colorize("  "+i18n.T("scheduler.disabled"), ColorYellow))
 		return
 	}
-	args := strings.Fields(strings.TrimPrefix(input, "/jobs"))
+	args, err := tokenizeSchedulerInput(strings.TrimPrefix(input, "/jobs"))
+	if err != nil {
+		fmt.Println(colorize("  ❌ "+err.Error(), ColorRed))
+		return
+	}
 	if len(args) == 0 {
 		args = []string{"list"}
 	}
@@ -319,16 +331,34 @@ func (cli *ChatCLI) jobsLogs(args []string) {
 		fmt.Println(colorize("  "+i18n.T("scheduler.jobs.logs_empty"), ColorGray))
 		return
 	}
+	// Render history with a cycle separator so recurring jobs don't
+	// look like one big blur. Cycle 0 = non-recurring (no separator).
+	// Within a cycle, attempts (retries) print indented under the
+	// cycle header so the relation is obvious.
+	prevCycle := -1
 	for _, h := range j.History {
-		fmt.Printf("  #%d %s %s (%s)\n", h.AttemptNum, h.StartedAt.Format(time.RFC3339), h.Outcome, h.Duration)
+		if h.CycleNum > 0 && h.CycleNum != prevCycle {
+			fmt.Println(colorize(fmt.Sprintf("  ── cycle #%d ──", h.CycleNum), ColorCyan))
+			prevCycle = h.CycleNum
+		}
+		header := fmt.Sprintf("  #%d %s %s (%s)", h.AttemptNum, h.StartedAt.Format(time.RFC3339), h.Outcome, h.Duration)
+		if h.CycleNum > 0 {
+			// Indent attempts under their cycle header.
+			header = "    #" + strconv.Itoa(h.AttemptNum) + " " + h.StartedAt.Format(time.RFC3339) + " " + string(h.Outcome) + " (" + h.Duration.String() + ")"
+		}
+		fmt.Println(header)
+		pref := "      "
+		if h.CycleNum == 0 {
+			pref = "    "
+		}
 		if h.Output != "" {
-			fmt.Println(colorize(indent("    ", h.Output), ColorGray))
+			fmt.Println(colorize(indent(pref, h.Output), ColorGray))
 		}
 		if h.Error != "" {
-			fmt.Println(colorize(indent("    ", "err: "+h.Error), ColorRed))
+			fmt.Println(colorize(indent(pref, "err: "+h.Error), ColorRed))
 		}
 		if h.ConditionDetails != "" {
-			fmt.Println(colorize(indent("    ", "cond: "+h.ConditionDetails), ColorGray))
+			fmt.Println(colorize(indent(pref, "cond: "+h.ConditionDetails), ColorGray))
 		}
 	}
 }
@@ -705,6 +735,12 @@ func parseScheduleArgs(args []string) (scheduler.ToolInput, error) {
 			if strings.HasPrefix(args[i], "--") {
 				return in, fmt.Errorf("schedule: unknown flag %s", args[i])
 			}
+			// Bare positional after the name is almost always a quoting
+			// mistake (e.g. --do /run X Y instead of --do "/run X Y").
+			// Surfacing the offending token lets the user fix it instead
+			// of silently dropping it and getting a downstream parse
+			// error like "action: cannot parse".
+			return in, fmt.Errorf("schedule: unexpected positional %q (did you forget to quote a multi-word value?)", args[i])
 		}
 	}
 	if in.When == "" {
@@ -740,6 +776,11 @@ func parseWaitArgs(args []string) (scheduler.ToolInput, error) {
 			in.OnTimeout, i = takeString(args, i)
 		case "--name":
 			in.Name, i = takeString(args, i)
+		default:
+			if strings.HasPrefix(args[i], "--") {
+				return in, fmt.Errorf("wait: unknown flag %s", args[i])
+			}
+			return in, fmt.Errorf("wait: unexpected positional %q (did you forget to quote a multi-word value?)", args[i])
 		}
 	}
 	if in.Until == "" {
@@ -763,6 +804,81 @@ func takeString(args []string, i int) (string, int) {
 		return "", i
 	}
 	return args[i+1], i + 1
+}
+
+// tokenizeSchedulerInput splits a /schedule, /wait, or /jobs argument
+// string into tokens while respecting single- and double-quoted spans
+// so that flag values like --do "/run X Y" or --tag 'k=v with space'
+// arrive as a single token. Backslash escapes the next character inside
+// a quoted span; outside quotes it is taken literally.
+//
+// strings.Fields cannot do this because it splits on every whitespace
+// run, which truncates --do "/run X Y" to --do "/run and leaks the
+// rest as bare positionals — silently dropping them and producing a
+// confusing "action: cannot parse" error downstream.
+//
+// Returns an error only when a quote is left unterminated, so callers
+// can surface a precise message to the user.
+func tokenizeSchedulerInput(input string) ([]string, error) {
+	var (
+		out     []string
+		buf     strings.Builder
+		inQuote rune // 0 = none, '"' or '\''
+		escaped bool
+		hasTok  bool
+	)
+	flush := func() {
+		if hasTok {
+			out = append(out, buf.String())
+			buf.Reset()
+			hasTok = false
+		}
+	}
+	for _, r := range input {
+		if escaped {
+			buf.WriteRune(r)
+			hasTok = true
+			escaped = false
+			continue
+		}
+		if inQuote != 0 {
+			if r == '\\' && inQuote == '"' {
+				// Backslash only escapes within double quotes; inside
+				// single quotes it is literal (POSIX-ish).
+				escaped = true
+				continue
+			}
+			if r == inQuote {
+				inQuote = 0
+				// An empty "" or '' still counts as a token.
+				hasTok = true
+				continue
+			}
+			buf.WriteRune(r)
+			hasTok = true
+			continue
+		}
+		switch r {
+		case '"', '\'':
+			inQuote = r
+			hasTok = true
+		case '\\':
+			escaped = true
+		case ' ', '\t', '\n', '\r':
+			flush()
+		default:
+			buf.WriteRune(r)
+			hasTok = true
+		}
+	}
+	if inQuote != 0 {
+		return nil, fmt.Errorf("unterminated %c-quoted argument", inQuote)
+	}
+	if escaped {
+		return nil, fmt.Errorf("trailing backslash with nothing to escape")
+	}
+	flush()
+	return out, nil
 }
 
 func indent(pref, s string) string {

--- a/cli/scheduler_command_parse_test.go
+++ b/cli/scheduler_command_parse_test.go
@@ -1,0 +1,130 @@
+/*
+ * ChatCLI - scheduler_command parsing tests.
+ *
+ * Covers the regressions we fixed in April 2026:
+ *
+ *   1. tokenizeSchedulerInput must respect single- and double-quoted
+ *      spans so /schedule --do "/run X Y" survives intact. The previous
+ *      implementation used strings.Fields which truncated the value to
+ *      "/run and silently leaked X Y as bare positionals.
+ *
+ *   2. parseScheduleArgs must surface unknown bare positionals instead
+ *      of swallowing them. Silent drops mask quoting mistakes and
+ *      produce confusing downstream errors like "action: cannot parse".
+ */
+package cli
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestTokenizeSchedulerInput_RespectsDoubleQuotes(t *testing.T) {
+	got, err := tokenizeSchedulerInput(` health-check --every 30s --do "/run healthcheck prod" --tag env=prod`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"health-check", "--every", "30s", "--do", "/run healthcheck prod", "--tag", "env=prod"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("tokens mismatch:\n got=%q\nwant=%q", got, want)
+	}
+}
+
+func TestTokenizeSchedulerInput_RespectsSingleQuotes(t *testing.T) {
+	got, err := tokenizeSchedulerInput(` deploy --when +0s --do 'shell: terraform apply -auto-approve'`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"deploy", "--when", "+0s", "--do", "shell: terraform apply -auto-approve"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("tokens mismatch:\n got=%q\nwant=%q", got, want)
+	}
+}
+
+func TestTokenizeSchedulerInput_BackslashEscapeInDoubleQuotes(t *testing.T) {
+	got, err := tokenizeSchedulerInput(` foo --do "say \"hi\" twice"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"foo", "--do", `say "hi" twice`}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("tokens mismatch:\n got=%q\nwant=%q", got, want)
+	}
+}
+
+func TestTokenizeSchedulerInput_UnterminatedQuoteIsErr(t *testing.T) {
+	_, err := tokenizeSchedulerInput(` foo --do "/run X`)
+	if err == nil || !strings.Contains(err.Error(), "unterminated") {
+		t.Fatalf("expected unterminated-quote error, got %v", err)
+	}
+}
+
+func TestTokenizeSchedulerInput_EmptyAndOnlySpaces(t *testing.T) {
+	for _, in := range []string{"", "   ", "\t\n "} {
+		got, err := tokenizeSchedulerInput(in)
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", in, err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("expected zero tokens for %q, got %q", in, got)
+		}
+	}
+}
+
+// Doc example from features/scheduler.mdx — must round-trip cleanly
+// through both the tokenizer and parseScheduleArgs.
+func TestParseScheduleArgs_DocExample_HealthCheck(t *testing.T) {
+	tokens, err := tokenizeSchedulerInput(` health-check --every 30s --do "/run healthcheck prod" --tag env=prod`)
+	if err != nil {
+		t.Fatalf("tokenize: %v", err)
+	}
+	in, err := parseScheduleArgs(tokens)
+	if err != nil {
+		t.Fatalf("parseScheduleArgs: %v", err)
+	}
+	if in.Name != "health-check" {
+		t.Errorf("Name = %q, want health-check", in.Name)
+	}
+	if in.When != "every 30s" {
+		t.Errorf("When = %q, want %q", in.When, "every 30s")
+	}
+	if in.Do != "/run healthcheck prod" {
+		t.Errorf("Do = %q, want %q", in.Do, "/run healthcheck prod")
+	}
+	if in.Tags["env"] != "prod" {
+		t.Errorf("Tags[env] = %q, want prod", in.Tags["env"])
+	}
+}
+
+func TestParseScheduleArgs_DocExample_BackupCron(t *testing.T) {
+	tokens, err := tokenizeSchedulerInput(` backup --cron "0 2 * * *" --do "/run backup --full"`)
+	if err != nil {
+		t.Fatalf("tokenize: %v", err)
+	}
+	in, err := parseScheduleArgs(tokens)
+	if err != nil {
+		t.Fatalf("parseScheduleArgs: %v", err)
+	}
+	if in.When != "cron:0 2 * * *" {
+		t.Errorf("When = %q, want %q", in.When, "cron:0 2 * * *")
+	}
+	if in.Do != "/run backup --full" {
+		t.Errorf("Do = %q, want %q", in.Do, "/run backup --full")
+	}
+}
+
+func TestParseScheduleArgs_BarePositionalAfterNameErrors(t *testing.T) {
+	// User forgot to quote the multi-word --do value. The old parser
+	// silently dropped "healthcheck" and "prod" and left Do = "/run",
+	// which then failed at a deeper layer. We want the error here.
+	tokens, err := tokenizeSchedulerInput(` health-check --every 30s --do /run healthcheck prod`)
+	if err != nil {
+		t.Fatalf("tokenize: %v", err)
+	}
+	if _, err := parseScheduleArgs(tokens); err == nil {
+		t.Fatal("expected error for unquoted multi-word --do value")
+	} else if !strings.Contains(err.Error(), "positional") {
+		t.Errorf("error message should mention positional, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Two related bugs from the same user report on /schedule.

- The CLI argument parser used strings.Fields, which ignores shell quoting. Documented syntax like `/schedule X --do "/run healthcheck prod"` was silently truncated and produced a confusing downstream parse error. Replaced with a quote-aware tokenizer; bare positionals after the job name now error instead of being swallowed.
- Recurring schedules (cron, interval) ran exactly once and went dormant. The dispatcher marked them Completed (terminal) and the recurrence path bailed at IsTerminal. Re-arm in place via a Running to Pending edge; recompute NextFireAt and reset Attempts so the retry budget applies per cycle. Same JobID keeps cycling — single Job per recurring schedule keeps WAL footprint bounded and the queue's JobID dedupe gives natural anti-overlap (a long action skips the missed window via Schedule.Next instead of stacking concurrent runs).

To keep individual executions distinguishable, Job gains CycleCount and ExecutionResult gains CycleNum; /jobs logs separates cycles with a header and /jobs show tags attempts as cycle.attempt for recurring jobs.

## Test plan

- [x] go build ./...
- [x] go test ./... (47 packages green)
- [x] New unit tests for the quote tokenizer cover the doc examples, backslash escape, unterminated quote, empty input, and the silently-dropped-positional regression
- [x] New unit tests for recurring re-arm assert same JobID across cycles, only one Job in the index, CycleCount growth, distinct CycleNums in history, and that cancel stops re-arm
- [x] Manual smoke: `/schedule health-check --every 30s --do "/run healthcheck prod" --tag env=prod` then `/jobs logs <id>` shows separate cycle headers