### PR TITLE
fix(scheduler): take per-job lock in writeSnapshotNow

### DIFF
--- a/cli/scheduler/replay.go
+++ b/cli/scheduler/replay.go
@@ -154,11 +154,17 @@ func (s *Scheduler) replay() error {
 }
 
 // writeSnapshotNow captures state. Exposed for Shutdown and test helpers.
+//
+// Uses Clone (which takes each Job's mutex) rather than cloneLocked
+// because the caller only holds s.mu — not the per-Job lock. With
+// cloneLocked the race detector flagged a data race against any
+// concurrent transition (most easily triggered by a recurring job
+// re-arming during DrainAndShutdown).
 func (s *Scheduler) writeSnapshotNow() error {
 	s.mu.RLock()
 	jobs := make([]*Job, 0, len(s.jobs))
 	for _, j := range s.jobs {
-		jobs = append(jobs, j.cloneLocked())
+		jobs = append(jobs, j.Clone())
 	}
 	s.mu.RUnlock()
 	return writeSnapshot(s.cfg.DataDir, jobs, s.logger)


### PR DESCRIPTION
## Summary

writeSnapshotNow built each snapshot record via cloneLocked, which by contract requires the caller to already hold the per-Job mutex. The caller only held s.mu, so reading j.Status / j.UpdatedAt during the clone raced against any concurrent transition writer. Switch to Clone, which takes the per-Job lock itself.

## Why now

The race went undetected until the recurring re-arm path landed in #853. One-shot jobs reach a terminal state quickly so the snapshot loop rarely caught them in transition; recurring jobs keep firing for the scheduler's lifetime and are far more likely to be mid-transition when DrainAndShutdown captures the final snapshot. CI on PR #848 rebased onto post-#853 main and the race detector tripped on TestScheduler_RecurringInterval_RearmsInPlace.

## Test plan

- [x] go test -race -count=1 ./cli/scheduler/ (no race, all green)
- [x] go test -race -count=1 ./cli/... (all green)
- [x] Re-runs of the previously flaky TestScheduler_RecurringInterval_RearmsInPlace pass under -race