### PR TITLE
fix(llm): final cache_control boundary + INFO request logs across providers

### DIFF
--- a/llm/bedrock/bedrock_client.go
+++ b/llm/bedrock/bedrock_client.go
@@ -224,10 +224,21 @@ func (c *BedrockClient) sendPromptAnthropic(ctx context.Context, prompt string, 
 		}
 	}
 
+	enforceCacheControlBudget(reqBody, anthropicMaxCacheBreakpoints)
+
 	payload, err := json.Marshal(reqBody)
 	if err != nil {
 		return "", fmt.Errorf("%s: %w", i18n.T("llm.error.prepare_request"), err)
 	}
+
+	start := time.Now()
+	client.LogRequestStart(c.logger, "BEDROCK", c.model,
+		zap.String("family", string(familyAnthropic)),
+		zap.Int("payload_bytes", len(payload)),
+		zap.Int("history_len", len(history)),
+		zap.Int("max_tokens", effectiveMaxTokens),
+		zap.Int("cache_markers", client.CountAnthropicCacheMarkers(reqBody)),
+	)
 
 	responseText, err := utils.Retry(ctx, c.logger, c.maxAttempts, c.backoff, func(ctx context.Context) (string, error) {
 		out, err := c.runtime.InvokeModel(ctx, &bedrockruntime.InvokeModelInput{
@@ -243,9 +254,16 @@ func (c *BedrockClient) sendPromptAnthropic(ctx context.Context, prompt string, 
 	})
 
 	if err != nil {
+		client.LogRequestFinish(c.logger, "BEDROCK", c.model, "error", time.Since(start),
+			zap.String("family", string(familyAnthropic)),
+		)
 		c.logger.Error(i18n.T("llm.error.get_response_after_retries", "Bedrock"), zap.Error(err))
 		return "", err
 	}
+	client.LogRequestFinish(c.logger, "BEDROCK", c.model, "success", time.Since(start),
+		zap.String("family", string(familyAnthropic)),
+		zap.Int("response_chars", len(responseText)),
+	)
 	return responseText, nil
 }
 

--- a/llm/bedrock/cache_planner.go
+++ b/llm/bedrock/cache_planner.go
@@ -1,0 +1,113 @@
+/*
+ * ChatCLI - Anthropic cache_control breakpoint planner (Bedrock)
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package bedrock
+
+import "sync/atomic"
+
+// anthropicMaxCacheBreakpoints is Anthropic's hard cap on the number of
+// content blocks that may carry cache_control in a single request. The
+// cap applies identically to direct Anthropic API calls and to
+// Anthropic-family models hosted on Bedrock, which speak the same body
+// schema.
+const anthropicMaxCacheBreakpoints = 4
+
+var cacheBlocksCoalesced atomic.Uint64
+
+// CacheBlocksCoalescedTotal returns the cumulative count of cache_control
+// markers that were dropped to keep Bedrock-hosted Anthropic requests
+// under the per-request breakpoint cap.
+func CacheBlocksCoalescedTotal() uint64 {
+	return cacheBlocksCoalesced.Load()
+}
+
+// enforceCacheControlBudget walks the assembled request body and drops
+// the earliest cache_control markers until at most maxMarkers remain
+// across `system`, `tools`, and message content blocks combined.
+//
+// Mirrors the Anthropic adapter's defensive boundary check: per-section
+// coalesce is enough on the happy path, but mode transitions and any
+// future producer that stamps a marker outside the helper functions
+// would silently push the request over the cap. Running this once on
+// the fully-assembled reqBody right before json.Marshal makes the cap
+// a structural invariant of the wire format.
+//
+// Earliest markers are dropped first because Anthropic's prompt cache
+// is prefix-based: a later marker covers strictly more content, so
+// keeping the latest maximizes cache coverage. Block content is never
+// discarded — only the marker.
+func enforceCacheControlBudget(reqBody map[string]interface{}, maxMarkers int) {
+	if reqBody == nil {
+		return
+	}
+	if maxMarkers < 0 {
+		maxMarkers = 0
+	}
+	var holders []map[string]interface{}
+
+	if v, ok := reqBody["system"]; ok {
+		collectMarkerHolders(v, &holders)
+	}
+	if v, ok := reqBody["tools"]; ok {
+		collectMarkerHolders(v, &holders)
+	}
+	if v, ok := reqBody["messages"]; ok {
+		collectMarkerHoldersInMessages(v, &holders)
+	}
+
+	if len(holders) <= maxMarkers {
+		return
+	}
+	drop := len(holders) - maxMarkers
+	for i := 0; i < drop; i++ {
+		delete(holders[i], "cache_control")
+	}
+	cacheBlocksCoalesced.Add(uint64(drop))
+}
+
+func collectMarkerHolders(v interface{}, out *[]map[string]interface{}) {
+	switch s := v.(type) {
+	case []map[string]interface{}:
+		for _, m := range s {
+			if m == nil {
+				continue
+			}
+			if _, ok := m["cache_control"]; ok {
+				*out = append(*out, m)
+			}
+		}
+	case []interface{}:
+		for _, item := range s {
+			m, ok := item.(map[string]interface{})
+			if !ok || m == nil {
+				continue
+			}
+			if _, ok := m["cache_control"]; ok {
+				*out = append(*out, m)
+			}
+		}
+	}
+}
+
+func collectMarkerHoldersInMessages(v interface{}, out *[]map[string]interface{}) {
+	walk := func(msg map[string]interface{}) {
+		if msg == nil {
+			return
+		}
+		collectMarkerHolders(msg["content"], out)
+	}
+	switch msgs := v.(type) {
+	case []map[string]interface{}:
+		for _, m := range msgs {
+			walk(m)
+		}
+	case []interface{}:
+		for _, item := range msgs {
+			if m, ok := item.(map[string]interface{}); ok {
+				walk(m)
+			}
+		}
+	}
+}

--- a/llm/bedrock/openai_family.go
+++ b/llm/bedrock/openai_family.go
@@ -12,10 +12,12 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
 
 	"github.com/diillson/chatcli/i18n"
+	"github.com/diillson/chatcli/llm/client"
 	"github.com/diillson/chatcli/models"
 	"github.com/diillson/chatcli/utils"
 	"go.uber.org/zap"
@@ -48,6 +50,14 @@ func (c *BedrockClient) sendPromptOpenAI(ctx context.Context, prompt string, his
 		return "", fmt.Errorf("%s: %w", i18n.T("llm.error.prepare_request"), err)
 	}
 
+	start := time.Now()
+	client.LogRequestStart(c.logger, "BEDROCK", c.model,
+		zap.String("family", string(familyOpenAI)),
+		zap.Int("payload_bytes", len(payload)),
+		zap.Int("history_len", len(history)),
+		zap.Int("max_tokens", effectiveMaxTokens),
+	)
+
 	responseText, err := utils.Retry(ctx, c.logger, c.maxAttempts, c.backoff, func(ctx context.Context) (string, error) {
 		out, err := c.runtime.InvokeModel(ctx, &bedrockruntime.InvokeModelInput{
 			ModelId:     stringPtr(c.model),
@@ -61,9 +71,16 @@ func (c *BedrockClient) sendPromptOpenAI(ctx context.Context, prompt string, his
 		return parseOpenAIBody(out.Body)
 	})
 	if err != nil {
+		client.LogRequestFinish(c.logger, "BEDROCK", c.model, "error", time.Since(start),
+			zap.String("family", string(familyOpenAI)),
+		)
 		c.logger.Error(i18n.T("llm.error.get_response_after_retries", "Bedrock"), zap.Error(err))
 		return "", err
 	}
+	client.LogRequestFinish(c.logger, "BEDROCK", c.model, "success", time.Since(start),
+		zap.String("family", string(familyOpenAI)),
+		zap.Int("response_chars", len(responseText)),
+	)
 	return responseText, nil
 }
 

--- a/llm/catalog/catalog.go
+++ b/llm/catalog/catalog.go
@@ -55,8 +55,49 @@ type ModelMeta struct {
 }
 
 // registry: lista plana para facilitar matching por provedor + id/alias
+//
+// IMPORTANT ordering rule: newer entries MUST be declared BEFORE older
+// ones whose aliases share a prefix. Resolve() walks the registry in
+// order and the first exact-or-alias hit wins; an older entry placed
+// first will silently shadow newer variants whose IDs happen to start
+// with the older entry's alias prefix. The covered_by tests in
+// catalog_test.go pin this contract for the Claude Opus 4.x line and
+// the same applies to GPT-5.x — gpt-5.5 must be listed before gpt-5.4
+// before gpt-5.3-codex before gpt-5 (whose alias list includes "gpt-5.1"
+// and other prefix-y strings).
 var registry = []ModelMeta{
 	// ── OpenAI GPT-5 family ──────────────────────────────────────────
+	{
+		// gpt-5.5 — released Apr 23, 2026. 1,050,000-token context with
+		// 128,000 max output, Responses + Chat Completions + Assistants.
+		// Capabilities: vision (input), function calling, structured
+		// outputs. The codex/pro/mini/nano fan-out the previous
+		// generations had is replaced by the single base model + a
+		// distinct gpt-5.5-pro entry; OpenAI did not publish mini/nano
+		// variants for 5.5 at launch.
+		ID:              "gpt-5.5",
+		Aliases:         []string{"gpt-5.5"},
+		DisplayName:     "GPT-5.5",
+		Provider:        ProviderOpenAI,
+		ContextWindow:   1050000,
+		MaxOutputTokens: 128000,
+		PreferredAPI:    APIResponses,
+		Capabilities:    []string{"vision", "tools", "json_mode"},
+	},
+	{
+		// gpt-5.5-pro — same window/output ceiling as 5.5 but no
+		// streaming; intended for the highest-quality, batch-style
+		// responses. Function calling and structured outputs are still
+		// supported, vision is input-only.
+		ID:              "gpt-5.5-pro",
+		Aliases:         []string{"gpt-5.5-pro"},
+		DisplayName:     "GPT-5.5 Pro",
+		Provider:        ProviderOpenAI,
+		ContextWindow:   1050000,
+		MaxOutputTokens: 128000,
+		PreferredAPI:    APIResponses,
+		Capabilities:    []string{"vision", "tools", "json_mode"},
+	},
 	{
 		ID:              "gpt-5.4",
 		Aliases:         []string{"gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"},

--- a/llm/catalog/catalog_test.go
+++ b/llm/catalog/catalog_test.go
@@ -34,6 +34,11 @@ func TestResolve(t *testing.T) {
 		{"Claude Sonnet 4.7 shortcut", ProviderClaudeAI, "sonnet-4-7", "claude-sonnet-4-7", true},
 		// Backward compat: bare "opus-4" still resolves to the 4.0 entry
 		{"Claude Opus 4 bare alias", ProviderClaudeAI, "opus-4", "claude-opus-4-20250514", true},
+		// gpt-5.5 family — released Apr 23 2026. Pin both the base and
+		// the pro variant; the registry order also matters here so 5.5
+		// is not shadowed by an earlier 5.x prefix match.
+		{"GPT-5.5 exact", ProviderOpenAI, "gpt-5.5", "gpt-5.5", true},
+		{"GPT-5.5 Pro exact", ProviderOpenAI, "gpt-5.5-pro", "gpt-5.5-pro", true},
 	}
 
 	for _, tc := range testCases {
@@ -67,8 +72,33 @@ func TestGetMaxTokens(t *testing.T) {
 
 func TestGetPreferredAPI(t *testing.T) {
 	assert.Equal(t, APIResponses, GetPreferredAPI(ProviderOpenAI, "gpt-5"))
+	assert.Equal(t, APIResponses, GetPreferredAPI(ProviderOpenAI, "gpt-5.5"))
+	assert.Equal(t, APIResponses, GetPreferredAPI(ProviderOpenAI, "gpt-5.5-pro"))
 	assert.Equal(t, APIChatCompletions, GetPreferredAPI(ProviderOpenAI, "gpt-4o"))
 	assert.Equal(t, APIAnthropicMessages, GetPreferredAPI(ProviderClaudeAI, "claude-3-opus"))
 	assert.Equal(t, APIAssistants, GetPreferredAPI(ProviderOpenAIAssistant, "gpt-4o")) // Provider específico
 	assert.Equal(t, PreferredAPI("gemini_api"), GetPreferredAPI(ProviderGoogleAI, "gemini-2.5-pro"))
+}
+
+// TestGPT55LimitsAndCapabilities pins the published Apr 23 2026 specs:
+// 1,050,000-token context window and 128,000 max output for both the
+// base and pro variants. If OpenAI revises these limits, the failure
+// here is the signal to update the registry entries (and the doc note
+// next to them) rather than silently drifting.
+func TestGPT55LimitsAndCapabilities(t *testing.T) {
+	for _, id := range []string{"gpt-5.5", "gpt-5.5-pro"} {
+		meta, ok := Resolve(ProviderOpenAI, id)
+		assert.True(t, ok, "expected %s to resolve", id)
+		assert.Equal(t, 1050000, meta.ContextWindow, "%s context window", id)
+		assert.Equal(t, 128000, meta.MaxOutputTokens, "%s max output", id)
+		assert.Equal(t, APIResponses, meta.PreferredAPI, "%s preferred API", id)
+		assert.Contains(t, meta.Capabilities, "tools", "%s should advertise tools", id)
+		assert.Contains(t, meta.Capabilities, "json_mode", "%s should advertise json_mode", id)
+		assert.Contains(t, meta.Capabilities, "vision", "%s should advertise vision", id)
+	}
+
+	// Catalog max-tokens lookup honors the explicit entry value, not the
+	// generic gpt-5 fallback (50000) defined in GetMaxTokens.
+	assert.Equal(t, 128000, GetMaxTokens(ProviderOpenAI, "gpt-5.5", 0))
+	assert.Equal(t, 128000, GetMaxTokens(ProviderOpenAI, "gpt-5.5-pro", 0))
 }

--- a/llm/claudeai/cache_planner.go
+++ b/llm/claudeai/cache_planner.go
@@ -55,3 +55,110 @@ func coalesceCacheControl(blocks []map[string]interface{}, maxMarkers int) []map
 	cacheBlocksCoalesced.Add(uint64(dropCount))
 	return blocks
 }
+
+// enforceCacheControlBudget walks the assembled request body and drops
+// the earliest cache_control markers until at most maxMarkers remain
+// across `system`, `tools`, and message content blocks combined.
+//
+// This is the FINAL defensive layer. The per-section coalesce calls in
+// buildMessagesAndSystem / buildOAuthMessagesAndSystem / SendPromptWithTools
+// already keep each section under budget on the happy path, but mode
+// transitions (chat ↔ coder ↔ agent) compose multiple system messages
+// from different code paths, and any future producer that stamps a marker
+// outside those helpers would silently push the request over Anthropic's
+// hard cap of 4. Running this once on the fully-assembled reqBody right
+// before json.Marshal makes the cap a structural invariant of the wire
+// format, independent of how the body was built.
+//
+// Earliest markers are dropped first, matching the per-section policy:
+// prefix-based caching means a later marker covers strictly more content,
+// so keeping the latest maximizes cache coverage with the markers we are
+// allowed to use. Block content is never discarded.
+func enforceCacheControlBudget(reqBody map[string]interface{}, maxMarkers int) {
+	if reqBody == nil {
+		return
+	}
+	if maxMarkers < 0 {
+		maxMarkers = 0
+	}
+	var holders []map[string]interface{}
+
+	// Order matters: system is the outermost prefix, then tools, then
+	// messages. We collect in that order so the "earliest" markers we
+	// drop are correctly the system-block ones — those have the smallest
+	// covered prefix and are the cheapest to lose.
+	if v, ok := reqBody["system"]; ok {
+		collectMarkerHolders(v, &holders)
+	}
+	if v, ok := reqBody["tools"]; ok {
+		collectMarkerHolders(v, &holders)
+	}
+	if v, ok := reqBody["messages"]; ok {
+		collectMarkerHoldersInMessages(v, &holders)
+	}
+
+	if len(holders) <= maxMarkers {
+		return
+	}
+	drop := len(holders) - maxMarkers
+	for i := 0; i < drop; i++ {
+		delete(holders[i], "cache_control")
+	}
+	cacheBlocksCoalesced.Add(uint64(drop))
+}
+
+// collectMarkerHolders appends pointers to every map carrying a
+// cache_control key found at the top level of a list-shaped value.
+// Accepts both []map[string]interface{} (typed) and []interface{} (boxed,
+// the OAuth path uses this when mixing helper-returned blocks with
+// hand-assembled oauthTextBlock entries).
+func collectMarkerHolders(v interface{}, out *[]map[string]interface{}) {
+	switch s := v.(type) {
+	case []map[string]interface{}:
+		for _, m := range s {
+			if m == nil {
+				continue
+			}
+			if _, ok := m["cache_control"]; ok {
+				*out = append(*out, m)
+			}
+		}
+	case []interface{}:
+		for _, item := range s {
+			m, ok := item.(map[string]interface{})
+			if !ok || m == nil {
+				continue
+			}
+			if _, ok := m["cache_control"]; ok {
+				*out = append(*out, m)
+			}
+		}
+	}
+}
+
+// collectMarkerHoldersInMessages walks each message's "content" field
+// and collects any cache_control marker carried on a content block. The
+// non-tool path uses string content (never marked); the tool path uses
+// list-shaped content with tool_use / tool_result entries (no markers
+// today). This is defensive against a future change that stamps a
+// marker on a content block — e.g. for cross-turn cached tool results.
+func collectMarkerHoldersInMessages(v interface{}, out *[]map[string]interface{}) {
+	walk := func(msg map[string]interface{}) {
+		if msg == nil {
+			return
+		}
+		collectMarkerHolders(msg["content"], out)
+	}
+	switch msgs := v.(type) {
+	case []map[string]interface{}:
+		for _, m := range msgs {
+			walk(m)
+		}
+	case []interface{}:
+		for _, item := range msgs {
+			if m, ok := item.(map[string]interface{}); ok {
+				walk(m)
+			}
+		}
+	}
+}

--- a/llm/claudeai/cache_planner_test.go
+++ b/llm/claudeai/cache_planner_test.go
@@ -5,7 +5,11 @@
  */
 package claudeai
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+)
 
 func block(text string, marked bool) map[string]interface{} {
 	b := map[string]interface{}{"type": "text", "text": text}
@@ -103,5 +107,222 @@ func TestCoalescePreservesBlockContent(t *testing.T) {
 		if out[i]["text"] != want {
 			t.Fatalf("block %d: expected text %q, got %v", i, want, out[i]["text"])
 		}
+	}
+}
+
+func countBodyMarkers(reqBody map[string]interface{}) int {
+	total := 0
+	count := func(v interface{}) {
+		switch s := v.(type) {
+		case []map[string]interface{}:
+			for _, m := range s {
+				if _, ok := m["cache_control"]; ok {
+					total++
+				}
+			}
+		case []interface{}:
+			for _, item := range s {
+				if m, ok := item.(map[string]interface{}); ok {
+					if _, ok := m["cache_control"]; ok {
+						total++
+					}
+				}
+			}
+		}
+	}
+	if v, ok := reqBody["system"]; ok {
+		count(v)
+	}
+	if v, ok := reqBody["tools"]; ok {
+		count(v)
+	}
+	if msgs, ok := reqBody["messages"]; ok {
+		switch m := msgs.(type) {
+		case []map[string]interface{}:
+			for _, msg := range m {
+				count(msg["content"])
+			}
+		case []interface{}:
+			for _, msg := range m {
+				if mm, ok := msg.(map[string]interface{}); ok {
+					count(mm["content"])
+				}
+			}
+		}
+	}
+	return total
+}
+
+// TestEnforceBudgetUnderCapIsNoop: assembled body within budget should
+// pass through untouched.
+func TestEnforceBudgetUnderCapIsNoop(t *testing.T) {
+	reqBody := map[string]interface{}{
+		"system": []map[string]interface{}{
+			block("a", true),
+			block("b", true),
+			block("c", false),
+		},
+	}
+	before := CacheBlocksCoalescedTotal()
+	enforceCacheControlBudget(reqBody, 4)
+	if got := countBodyMarkers(reqBody); got != 2 {
+		t.Fatalf("expected 2 markers preserved, got %d", got)
+	}
+	if got := CacheBlocksCoalescedTotal() - before; got != 0 {
+		t.Fatalf("expected counter unchanged, got delta=%d", got)
+	}
+}
+
+// TestEnforceBudgetTrimsToCap: a body that overshoots the cap (e.g.
+// because two upstream code paths each stamped markers without
+// coordinating) is trimmed to the cap, dropping earliest first.
+func TestEnforceBudgetTrimsToCap(t *testing.T) {
+	reqBody := map[string]interface{}{
+		"system": []map[string]interface{}{
+			block("sys-old-1", true),
+			block("sys-old-2", true),
+			block("sys-new-1", true),
+			block("sys-new-2", true),
+			block("sys-new-3", true),
+			block("sys-new-4", true),
+		},
+	}
+	before := CacheBlocksCoalescedTotal()
+	enforceCacheControlBudget(reqBody, 4)
+	if got := countBodyMarkers(reqBody); got != 4 {
+		t.Fatalf("expected 4 markers after enforcement, got %d", got)
+	}
+	if got := CacheBlocksCoalescedTotal() - before; got != 2 {
+		t.Fatalf("expected counter delta=2, got %d", got)
+	}
+	sys := reqBody["system"].([]map[string]interface{})
+	if _, ok := sys[0]["cache_control"]; ok {
+		t.Fatal("earliest marker (sys-old-1) should be dropped")
+	}
+	if _, ok := sys[1]["cache_control"]; ok {
+		t.Fatal("second-earliest marker (sys-old-2) should be dropped")
+	}
+	if _, ok := sys[5]["cache_control"]; !ok {
+		t.Fatal("latest marker (sys-new-4) should survive")
+	}
+}
+
+// TestEnforceBudgetCountsToolsAndMessages: markers in `tools` and
+// per-message content blocks count toward the same global cap.
+func TestEnforceBudgetCountsToolsAndMessages(t *testing.T) {
+	toolDef := map[string]interface{}{
+		"name":          "read",
+		"cache_control": map[string]string{"type": "ephemeral"},
+	}
+	contentBlock := map[string]interface{}{
+		"type":          "tool_result",
+		"cache_control": map[string]string{"type": "ephemeral"},
+	}
+	reqBody := map[string]interface{}{
+		"system": []map[string]interface{}{
+			block("s1", true),
+			block("s2", true),
+			block("s3", true),
+		},
+		"tools": []map[string]interface{}{toolDef},
+		"messages": []map[string]interface{}{
+			{"role": "user", "content": []map[string]interface{}{contentBlock}},
+		},
+	}
+	enforceCacheControlBudget(reqBody, 4)
+	if got := countBodyMarkers(reqBody); got != 4 {
+		t.Fatalf("expected 4 markers, got %d", got)
+	}
+	if _, ok := toolDef["cache_control"]; !ok {
+		t.Fatal("tool def marker (later in scan order) should be preserved")
+	}
+	if _, ok := contentBlock["cache_control"]; !ok {
+		t.Fatal("message-content marker (latest in scan order) should be preserved")
+	}
+}
+
+// TestEnforceBudgetHandlesOAuthInterfaceShape: the OAuth chat path
+// returns `system` as []interface{} (mixed oauthTextBlock entries and
+// structured blocks). The boundary check must walk that shape.
+func TestEnforceBudgetHandlesOAuthInterfaceShape(t *testing.T) {
+	reqBody := map[string]interface{}{
+		"system": []interface{}{
+			map[string]interface{}{"type": "text", "text": "base"}, // unmarked
+			map[string]interface{}{
+				"type": "text", "text": "p1",
+				"cache_control": map[string]string{"type": "ephemeral"},
+			},
+			map[string]interface{}{
+				"type": "text", "text": "p2",
+				"cache_control": map[string]string{"type": "ephemeral"},
+			},
+			map[string]interface{}{
+				"type": "text", "text": "p3",
+				"cache_control": map[string]string{"type": "ephemeral"},
+			},
+			map[string]interface{}{
+				"type": "text", "text": "p4",
+				"cache_control": map[string]string{"type": "ephemeral"},
+			},
+			map[string]interface{}{
+				"type": "text", "text": "p5",
+				"cache_control": map[string]string{"type": "ephemeral"},
+			},
+		},
+	}
+	enforceCacheControlBudget(reqBody, 4)
+	if got := countBodyMarkers(reqBody); got != 4 {
+		t.Fatalf("expected 4 markers, got %d", got)
+	}
+}
+
+// TestModeTransitionWorstCase reproduces the user-reported scenario:
+// a /coder turn left a system message in cli.history with 4 SystemParts,
+// the user attaches several /context blobs in chat mode bringing the
+// chat-built system message to 6 SystemParts, and the chat path then
+// builds a request with both system messages plus a future-proofing
+// marker on the last tool definition. The end-to-end pipeline (per-
+// section coalesce + boundary enforcement) must keep the wire body at
+// or below the Anthropic cap of 4 markers.
+func TestModeTransitionWorstCase(t *testing.T) {
+	c := newTestClient()
+
+	coderSystem := models.Message{
+		Role: "system",
+		SystemParts: []models.ContentBlock{
+			{Type: "text", Text: "core", CacheControl: &models.CacheControl{Type: "ephemeral"}},
+			{Type: "text", Text: "tools", CacheControl: &models.CacheControl{Type: "ephemeral"}},
+			{Type: "text", Text: "workspace", CacheControl: &models.CacheControl{Type: "ephemeral"}},
+			{Type: "text", Text: "skills+orchestrator", CacheControl: &models.CacheControl{Type: "ephemeral"}},
+		},
+	}
+	chatSystem := models.Message{
+		Role: "system",
+		SystemParts: []models.ContentBlock{
+			{Type: "text", Text: "mode+lang", CacheControl: &models.CacheControl{Type: "ephemeral"}},
+			{Type: "text", Text: "workspace", CacheControl: &models.CacheControl{Type: "ephemeral"}},
+			{Type: "text", Text: "ctx-attached-1", CacheControl: &models.CacheControl{Type: "ephemeral"}},
+			{Type: "text", Text: "ctx-attached-2", CacheControl: &models.CacheControl{Type: "ephemeral"}},
+			{Type: "text", Text: "ctx-attached-3", CacheControl: &models.CacheControl{Type: "ephemeral"}},
+			{Type: "text", Text: "ctx-attached-4", CacheControl: &models.CacheControl{Type: "ephemeral"}},
+		},
+	}
+	history := []models.Message{
+		chatSystem, // chat-built system message comes first
+		coderSystem,
+		{Role: "user", Content: "previous coder turn"},
+		{Role: "assistant", Content: "ok"},
+		{Role: "user", Content: "now in chat mode"},
+	}
+
+	_, systemObj := c.buildMessagesAndSystem("now in chat mode", history)
+	reqBody := map[string]interface{}{
+		"system": systemObj,
+	}
+	enforceCacheControlBudget(reqBody, anthropicMaxCacheBreakpoints)
+
+	if got := countBodyMarkers(reqBody); got > anthropicMaxCacheBreakpoints {
+		t.Fatalf("post-transition body has %d markers, exceeds Anthropic cap of %d",
+			got, anthropicMaxCacheBreakpoints)
 	}
 }

--- a/llm/claudeai/claude_client.go
+++ b/llm/claudeai/claude_client.go
@@ -209,11 +209,28 @@ func (c *ClaudeClient) SendPrompt(ctx context.Context, prompt string, history []
 			zap.String("model", c.model))
 	}
 
+	enforceCacheControlBudget(reqBody, anthropicMaxCacheBreakpoints)
+
 	jsonValue, err := json.Marshal(reqBody)
 	if err != nil {
 		c.logger.Error(i18n.T("llm.error.marshal_payload"), zap.Error(err))
 		return "", fmt.Errorf("%s: %w", i18n.T("llm.error.prepare_request"), err)
 	}
+
+	authMode := "apikey"
+	if isOAuth {
+		authMode = "oauth"
+	} else if strings.HasPrefix(c.apiKey, "token:") {
+		authMode = "token"
+	}
+	start := time.Now()
+	client.LogRequestStart(c.logger, "CLAUDEAI", c.model,
+		zap.String("auth", authMode),
+		zap.Int("payload_bytes", len(jsonValue)),
+		zap.Int("history_len", len(history)),
+		zap.Int("max_tokens", effectiveMaxTokens),
+		zap.Int("cache_markers", client.CountAnthropicCacheMarkers(reqBody)),
+	)
 
 	if isOAuth {
 		if err := c.sendOAuthTitleRequest(ctx, oauthTitleUserPrefix+prompt); err != nil {
@@ -259,9 +276,16 @@ func (c *ClaudeClient) SendPrompt(ctx context.Context, prompt string, history []
 	})
 
 	if err != nil {
+		client.LogRequestFinish(c.logger, "CLAUDEAI", c.model, "error", time.Since(start),
+			zap.String("auth", authMode),
+		)
 		c.logger.Error(i18n.T("llm.error.get_response_after_retries", "Claude AI"), zap.Error(err))
 		return "", err
 	}
+	client.LogRequestFinish(c.logger, "CLAUDEAI", c.model, "success", time.Since(start),
+		zap.String("auth", authMode),
+		zap.Int("response_chars", len(responseText)),
+	)
 
 	if isOAuth {
 		if err := c.sendOAuthTitleRequest(ctx, fmt.Sprintf(oauthTitleUserWrapTmpl, prompt)); err != nil {

--- a/llm/claudeai/tool_use.go
+++ b/llm/claudeai/tool_use.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/diillson/chatcli/i18n"
 	"github.com/diillson/chatcli/llm/catalog"
@@ -95,10 +96,22 @@ func (c *ClaudeClient) SendPromptWithTools(ctx context.Context, prompt string, h
 		}
 	}
 
+	enforceCacheControlBudget(reqBody, anthropicMaxCacheBreakpoints)
+
 	jsonValue, err := json.Marshal(reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("llm.tool.error.marshaling_payload"), err)
 	}
+
+	start := time.Now()
+	client.LogRequestStart(c.logger, "CLAUDEAI", c.model,
+		zap.String("path", "tool_use"),
+		zap.Int("payload_bytes", len(jsonValue)),
+		zap.Int("history_len", len(history)),
+		zap.Int("tool_count", len(sortedTools)),
+		zap.Int("max_tokens", effectiveMaxTokens),
+		zap.Int("cache_markers", client.CountAnthropicCacheMarkers(reqBody)),
+	)
 
 	respBody, err := utils.Retry(ctx, c.logger, c.maxAttempts, c.backoff, func(ctx context.Context) (string, error) {
 		req, err := c.buildToolRequest(ctx, jsonValue)
@@ -133,8 +146,15 @@ func (c *ClaudeClient) SendPromptWithTools(ctx context.Context, prompt string, h
 		return string(bodyBytes), nil
 	})
 	if err != nil {
+		client.LogRequestFinish(c.logger, "CLAUDEAI", c.model, "error", time.Since(start),
+			zap.String("path", "tool_use"),
+		)
 		return nil, err
 	}
+	client.LogRequestFinish(c.logger, "CLAUDEAI", c.model, "success", time.Since(start),
+		zap.String("path", "tool_use"),
+		zap.Int("response_bytes", len(respBody)),
+	)
 
 	return parseClaudeToolResponse(respBody, c.logger)
 }

--- a/llm/client/observability.go
+++ b/llm/client/observability.go
@@ -1,0 +1,111 @@
+/*
+ * ChatCLI - LLM request observability helpers
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package client
+
+import (
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// LogRequestStart emits a structured INFO log when an LLM request is
+// dispatched. Designed to give operators end-to-end visibility into
+// what is being sent on the wire — enough fields to correlate
+// user-reported failures (rate limits, payload-too-large, cache_control
+// quirks, OAuth flapping) with payload shape, without ever leaking the
+// actual prompt content. Each provider attaches its own provider-specific
+// fields (payload bytes, history length, tool count, cache markers, ...)
+// via the variadic fields argument.
+//
+// INFO level is intentional: requests are the spine of any session
+// post-mortem, and a /loop or scheduler firing every minute should be
+// traceable without flipping the global logger to DEBUG.
+func LogRequestStart(logger *zap.Logger, provider, model string, fields ...zap.Field) {
+	if logger == nil {
+		return
+	}
+	base := make([]zap.Field, 0, 2+len(fields))
+	base = append(base, zap.String("provider", provider), zap.String("model", model))
+	base = append(base, fields...)
+	logger.Info("llm: send", base...)
+}
+
+// LogRequestFinish emits an INFO log paired with LogRequestStart when
+// the response (or terminal error) returns. duration is wall time from
+// the matching Start; status is one of: "success", "error", "canceled".
+// Concrete error details belong on the caller's own zap.Error path —
+// here we only signal the outcome so dashboards can plot success rates
+// and tail latencies without parsing free-form error text.
+func LogRequestFinish(logger *zap.Logger, provider, model, status string, duration time.Duration, fields ...zap.Field) {
+	if logger == nil {
+		return
+	}
+	base := make([]zap.Field, 0, 4+len(fields))
+	base = append(base,
+		zap.String("provider", provider),
+		zap.String("model", model),
+		zap.String("status", status),
+		zap.Duration("duration", duration),
+	)
+	base = append(base, fields...)
+	logger.Info("llm: recv", base...)
+}
+
+// CountAnthropicCacheMarkers walks an Anthropic-style request body and
+// counts cache_control markers across `system`, `tools`, and message
+// content blocks. Returns 0 for non-Anthropic shapes (string `system`,
+// missing keys, etc.). Used by the claudeai and bedrock adapters so
+// the start log can show how many breakpoints the request actually
+// carries — crucial for debugging "more than 4 blocks with cache_control"
+// errors after mode transitions.
+func CountAnthropicCacheMarkers(reqBody map[string]interface{}) int {
+	if reqBody == nil {
+		return 0
+	}
+	total := 0
+	count := func(v interface{}) {
+		switch s := v.(type) {
+		case []map[string]interface{}:
+			for _, m := range s {
+				if m == nil {
+					continue
+				}
+				if _, ok := m["cache_control"]; ok {
+					total++
+				}
+			}
+		case []interface{}:
+			for _, item := range s {
+				if m, ok := item.(map[string]interface{}); ok {
+					if _, ok := m["cache_control"]; ok {
+						total++
+					}
+				}
+			}
+		}
+	}
+	if v, ok := reqBody["system"]; ok {
+		count(v)
+	}
+	if v, ok := reqBody["tools"]; ok {
+		count(v)
+	}
+	if v, ok := reqBody["messages"]; ok {
+		switch msgs := v.(type) {
+		case []map[string]interface{}:
+			for _, m := range msgs {
+				count(m["content"])
+			}
+		case []interface{}:
+			for _, m := range msgs {
+				if mm, ok := m.(map[string]interface{}); ok {
+					count(mm["content"])
+				}
+			}
+		}
+	}
+	return total
+}

--- a/llm/copilot/copilot_client.go
+++ b/llm/copilot/copilot_client.go
@@ -142,6 +142,13 @@ func (c *Client) SendPrompt(ctx context.Context, prompt string, history []models
 		return "", fmt.Errorf("%s: %w", i18n.T("llm.copilot.prepare_request_failed"), err)
 	}
 
+	start := time.Now()
+	client.LogRequestStart(c.logger, "COPILOT", c.model,
+		zap.Int("payload_bytes", len(jsonValue)),
+		zap.Int("history_len", len(history)),
+		zap.Int("max_tokens", effectiveMaxTokens),
+	)
+
 	response, err := utils.Retry(ctx, c.logger, c.maxAttempts, c.backoff, func(ctx context.Context) (string, error) {
 		resp, err := c.sendRequest(ctx, jsonValue)
 		if err != nil {
@@ -149,8 +156,14 @@ func (c *Client) SendPrompt(ctx context.Context, prompt string, history []models
 		}
 		return c.processResponse(resp)
 	})
-
-	return response, err
+	if err != nil {
+		client.LogRequestFinish(c.logger, "COPILOT", c.model, "error", time.Since(start))
+		return response, err
+	}
+	client.LogRequestFinish(c.logger, "COPILOT", c.model, "success", time.Since(start),
+		zap.Int("response_chars", len(response)),
+	)
+	return response, nil
 }
 
 // sendRequest sends the HTTP request to the Copilot API with required headers.

--- a/llm/github_models/github_models_client.go
+++ b/llm/github_models/github_models_client.go
@@ -123,6 +123,13 @@ func (c *GitHubModelsClient) SendPrompt(ctx context.Context, prompt string, hist
 		return "", fmt.Errorf("%s: %w", i18n.T("llm.error.marshal_payload_for", "GitHub Models"), err)
 	}
 
+	start := time.Now()
+	client.LogRequestStart(c.logger, "GITHUB_MODELS", c.model,
+		zap.Int("payload_bytes", len(jsonValue)),
+		zap.Int("history_len", len(history)),
+		zap.Int("max_tokens", effectiveMaxTokens),
+	)
+
 	response, err := utils.Retry(ctx, c.logger, c.maxAttempts, c.backoff, func(ctx context.Context) (string, error) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.getAPIURL(), utils.NewJSONReader(jsonValue))
 		if err != nil {
@@ -172,7 +179,14 @@ func (c *GitHubModelsClient) SendPrompt(ctx context.Context, prompt string, hist
 		return result.Choices[0].Message.Content, nil
 	})
 
-	return response, err
+	if err != nil {
+		client.LogRequestFinish(c.logger, "GITHUB_MODELS", c.model, "error", time.Since(start))
+		return response, err
+	}
+	client.LogRequestFinish(c.logger, "GITHUB_MODELS", c.model, "success", time.Since(start),
+		zap.Int("response_chars", len(response)),
+	)
+	return response, nil
 }
 
 // ListModels fetches available models from the GitHub Models API.

--- a/llm/googleai/gemini_client.go
+++ b/llm/googleai/gemini_client.go
@@ -127,6 +127,13 @@ func (c *GeminiClient) SendPrompt(ctx context.Context, prompt string, history []
 
 	c.logger.Debug("Payload preparado", zap.Int("payload_size", len(jsonValue)), zap.String("model", c.model))
 
+	start := time.Now()
+	client.LogRequestStart(c.logger, "GOOGLEAI", c.model,
+		zap.Int("payload_bytes", len(jsonValue)),
+		zap.Int("history_len", len(history)),
+		zap.Int("max_tokens", effectiveMaxTokens),
+	)
+
 	// Agora use Retry para encapsular a lógica de requisição e parsing
 	response, err := utils.Retry(ctx, c.logger, c.maxAttempts, c.backoff, func(ctx context.Context) (string, error) {
 		response, err := c.executeRequest(ctx, jsonValue)
@@ -137,10 +144,14 @@ func (c *GeminiClient) SendPrompt(ctx context.Context, prompt string, history []
 	})
 
 	if err != nil {
+		client.LogRequestFinish(c.logger, "GOOGLEAI", c.model, "error", time.Since(start))
 		c.logger.Error(i18n.T("llm.error.get_response_after_retries", "Google AI"), zap.Error(err))
 		return "", err
 	}
 
+	client.LogRequestFinish(c.logger, "GOOGLEAI", c.model, "success", time.Since(start),
+		zap.Int("response_chars", len(response)),
+	)
 	c.logger.Info(i18n.T("llm.info.response_received", "Google AI"),
 		zap.Int("response_length", len(response)))
 	return response, nil

--- a/llm/minimax/minimax_client.go
+++ b/llm/minimax/minimax_client.go
@@ -133,6 +133,14 @@ func (c *MiniMaxClient) SendPrompt(ctx context.Context, prompt string, history [
 		processFunc = c.processAnthropicResponse
 	}
 
+	start := time.Now()
+	client.LogRequestStart(c.logger, "MINIMAX", c.model,
+		zap.Int("payload_bytes", len(jsonValue)),
+		zap.Int("history_len", len(history)),
+		zap.Int("max_tokens", effectiveMaxTokens),
+		zap.Bool("anthropic_compat", c.anthropicCompat),
+	)
+
 	response, err := utils.Retry(ctx, c.logger, c.maxAttempts, c.backoff, func(ctx context.Context) (string, error) {
 		resp, err := c.sendRequest(ctx, jsonValue)
 		if err != nil {
@@ -142,10 +150,14 @@ func (c *MiniMaxClient) SendPrompt(ctx context.Context, prompt string, history [
 	})
 
 	if err != nil {
+		client.LogRequestFinish(c.logger, "MINIMAX", c.model, "error", time.Since(start))
 		c.logger.Error(i18n.T("llm.error.get_response_after_retries", "MiniMax"), zap.Error(err))
 		return "", err
 	}
 
+	client.LogRequestFinish(c.logger, "MINIMAX", c.model, "success", time.Since(start),
+		zap.Int("response_chars", len(response)),
+	)
 	return response, nil
 }
 

--- a/llm/minimax/tool_use.go
+++ b/llm/minimax/tool_use.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/diillson/chatcli/i18n"
 	"github.com/diillson/chatcli/llm/client"
@@ -69,6 +70,15 @@ func (c *MiniMaxClient) SendPromptWithTools(ctx context.Context, prompt string, 
 		return nil, fmt.Errorf("%s: %w", i18n.T("llm.tool.error.marshaling_payload"), err)
 	}
 
+	start := time.Now()
+	client.LogRequestStart(c.logger, "MINIMAX", c.model,
+		zap.String("path", "tool_use"),
+		zap.Int("payload_bytes", len(jsonValue)),
+		zap.Int("history_len", len(history)),
+		zap.Int("max_tokens", effectiveMaxTokens),
+		zap.Int("tool_count", len(tools)),
+	)
+
 	resp, err := utils.Retry(ctx, c.logger, c.maxAttempts, c.backoff, func(ctx context.Context) (string, error) {
 		httpResp, err := c.sendRequest(ctx, jsonValue)
 		if err != nil {
@@ -86,9 +96,16 @@ func (c *MiniMaxClient) SendPromptWithTools(ctx context.Context, prompt string, 
 		return string(bodyBytes), nil
 	})
 	if err != nil {
+		client.LogRequestFinish(c.logger, "MINIMAX", c.model, "error", time.Since(start),
+			zap.String("path", "tool_use"),
+		)
 		return nil, err
 	}
 
+	client.LogRequestFinish(c.logger, "MINIMAX", c.model, "success", time.Since(start),
+		zap.String("path", "tool_use"),
+		zap.Int("response_chars", len(resp)),
+	)
 	return parseToolResponse(resp, c.logger)
 }
 

--- a/llm/ollama/ollama_client.go
+++ b/llm/ollama/ollama_client.go
@@ -117,6 +117,13 @@ func (c *Client) SendPrompt(ctx context.Context, prompt string, history []models
 		return "", fmt.Errorf("%s: %w", i18n.T("llm.ollama.prepare_payload"), err)
 	}
 
+	start := time.Now()
+	client.LogRequestStart(c.logger, "OLLAMA", c.model,
+		zap.Int("payload_bytes", len(body)),
+		zap.Int("history_len", len(history)),
+		zap.Int("max_tokens", effectiveMaxTokens),
+	)
+
 	// Agora use Retry para encapsular a lógica de requisição e parsing
 	response, err := utils.Retry(ctx, c.logger, c.maxAttempts, c.backoff, func(ctx context.Context) (string, error) {
 		url := c.baseURL + "/api/chat"
@@ -180,9 +187,14 @@ func (c *Client) SendPrompt(ctx context.Context, prompt string, history []models
 	})
 
 	if err != nil {
+		client.LogRequestFinish(c.logger, "OLLAMA", c.model, "error", time.Since(start))
 		c.logger.Error(i18n.T("llm.ollama.get_response_error"), zap.Error(err))
 		return "", err
 	}
+
+	client.LogRequestFinish(c.logger, "OLLAMA", c.model, "success", time.Since(start),
+		zap.Int("response_chars", len(response)),
+	)
 
 	// Aplicar filtro se ENV OLLAMA_FILTER_THINKING = "true"
 	if strings.EqualFold(os.Getenv("OLLAMA_FILTER_THINKING"), config.OllamaFilterThinkingDefault) {

--- a/llm/openai/openai_client.go
+++ b/llm/openai/openai_client.go
@@ -140,6 +140,13 @@ func (c *OpenAIClient) SendPrompt(ctx context.Context, prompt string, history []
 		return "", fmt.Errorf("%s: %w", i18n.T("llm.error.prepare_request"), err)
 	}
 
+	start := time.Now()
+	client.LogRequestStart(c.logger, "OPENAI", c.model,
+		zap.Int("payload_bytes", len(jsonValue)),
+		zap.Int("history_len", len(history)),
+		zap.Int("max_tokens", effectiveMaxTokens),
+	)
+
 	response, err := utils.Retry(ctx, c.logger, c.maxAttempts, c.backoff, func(ctx context.Context) (string, error) {
 		resp, err := c.sendRequest(ctx, jsonValue)
 		if err != nil {
@@ -147,8 +154,14 @@ func (c *OpenAIClient) SendPrompt(ctx context.Context, prompt string, history []
 		}
 		return c.processResponse(resp)
 	})
-
-	return response, err
+	if err != nil {
+		client.LogRequestFinish(c.logger, "OPENAI", c.model, "error", time.Since(start))
+		return response, err
+	}
+	client.LogRequestFinish(c.logger, "OPENAI", c.model, "success", time.Since(start),
+		zap.Int("response_chars", len(response)),
+	)
+	return response, nil
 }
 
 // sendRequest envia a requisição para a API da OpenAI
@@ -343,16 +356,35 @@ func (c *OpenAIClient) SendPromptStream(ctx context.Context, prompt string, hist
 		return nil, fmt.Errorf("marshal stream request: %w", err)
 	}
 
+	start := time.Now()
+	client.LogRequestStart(c.logger, "OPENAI", c.model,
+		zap.Int("payload_bytes", len(jsonValue)),
+		zap.Int("history_len", len(history)),
+		zap.Int("max_tokens", effectiveMaxTokens),
+		zap.String("kind", "stream"),
+	)
+
 	resp, err := c.sendRequest(ctx, jsonValue)
 	if err != nil {
+		client.LogRequestFinish(c.logger, "OPENAI", c.model, "error", time.Since(start),
+			zap.String("kind", "stream"),
+		)
 		return nil, err
 	}
 
 	if resp.StatusCode != http.StatusOK {
 		raw, _ := io.ReadAll(resp.Body)
 		_ = resp.Body.Close()
+		client.LogRequestFinish(c.logger, "OPENAI", c.model, "error", time.Since(start),
+			zap.String("kind", "stream"),
+			zap.Int("status_code", resp.StatusCode),
+		)
 		return nil, &utils.APIError{StatusCode: resp.StatusCode, Message: utils.SanitizeSensitiveText(string(raw))}
 	}
+
+	client.LogRequestFinish(c.logger, "OPENAI", c.model, "success", time.Since(start),
+		zap.String("kind", "stream_started"),
+	)
 
 	chunks := make(chan client.StreamChunk, 64)
 

--- a/llm/openai/tool_use.go
+++ b/llm/openai/tool_use.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/diillson/chatcli/i18n"
 	"github.com/diillson/chatcli/llm/client"
@@ -67,6 +68,15 @@ func (c *OpenAIClient) SendPromptWithTools(ctx context.Context, prompt string, h
 		return nil, fmt.Errorf("%s: %w", i18n.T("llm.tool.error.marshaling_payload"), err)
 	}
 
+	start := time.Now()
+	client.LogRequestStart(c.logger, "OPENAI", c.model,
+		zap.String("path", "tool_use"),
+		zap.Int("payload_bytes", len(jsonValue)),
+		zap.Int("history_len", len(history)),
+		zap.Int("max_tokens", effectiveMaxTokens),
+		zap.Int("tool_count", len(tools)),
+	)
+
 	resp, err := utils.Retry(ctx, c.logger, c.maxAttempts, c.backoff, func(ctx context.Context) (string, error) {
 		httpResp, err := c.sendRequest(ctx, jsonValue)
 		if err != nil {
@@ -84,9 +94,16 @@ func (c *OpenAIClient) SendPromptWithTools(ctx context.Context, prompt string, h
 		return string(bodyBytes), nil
 	})
 	if err != nil {
+		client.LogRequestFinish(c.logger, "OPENAI", c.model, "error", time.Since(start),
+			zap.String("path", "tool_use"),
+		)
 		return nil, err
 	}
 
+	client.LogRequestFinish(c.logger, "OPENAI", c.model, "success", time.Since(start),
+		zap.String("path", "tool_use"),
+		zap.Int("response_chars", len(resp)),
+	)
 	return parseToolResponse(resp, c.logger)
 }
 

--- a/llm/openai_assistant/openai_assistant_client.go
+++ b/llm/openai_assistant/openai_assistant_client.go
@@ -122,6 +122,13 @@ func (c *OpenAIAssistantClient) GetModelName() string {
 
 // SendPrompt envia uma mensagem para o thread atual e retorna a resposta
 func (c *OpenAIAssistantClient) SendPrompt(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {
+	start := time.Now()
+	client.LogRequestStart(c.logger, "OPENAI_ASSISTANT", c.model,
+		zap.Int("payload_bytes", len(prompt)),
+		zap.Int("history_len", len(history)),
+		zap.Int("max_tokens", maxTokens),
+	)
+
 	c.mu.Lock()
 
 	// Verificar se já temos um thread ativo, se não, criar um novo
@@ -129,6 +136,7 @@ func (c *OpenAIAssistantClient) SendPrompt(ctx context.Context, prompt string, h
 		threadID, err := c.createThread(ctx)
 		if err != nil {
 			c.mu.Unlock()
+			client.LogRequestFinish(c.logger, "OPENAI_ASSISTANT", c.model, "error", time.Since(start))
 			return "", fmt.Errorf("%s: %w", i18n.T("llm.assistant.create_thread_error"), err)
 		}
 		c.currentThreadID = threadID
@@ -144,6 +152,7 @@ func (c *OpenAIAssistantClient) SendPrompt(ctx context.Context, prompt string, h
 		c.logger.Error(i18n.T("llm.assistant.add_message_error"),
 			zap.String("threadID", threadID),
 			zap.Error(err))
+		client.LogRequestFinish(c.logger, "OPENAI_ASSISTANT", c.model, "error", time.Since(start))
 		return "", fmt.Errorf("%s: %w", i18n.T("llm.assistant.add_message_error"), err)
 	}
 
@@ -153,6 +162,7 @@ func (c *OpenAIAssistantClient) SendPrompt(ctx context.Context, prompt string, h
 		c.logger.Error(i18n.T("llm.assistant.run_error"),
 			zap.String("threadID", threadID),
 			zap.Error(err))
+		client.LogRequestFinish(c.logger, "OPENAI_ASSISTANT", c.model, "error", time.Since(start))
 		return "", fmt.Errorf("%s: %w", i18n.T("llm.assistant.run_error"), err)
 	}
 
@@ -177,10 +187,15 @@ func (c *OpenAIAssistantClient) SendPrompt(ctx context.Context, prompt string, h
 			partialResponse, getErr := c.getLatestResponse(ctx, threadID)
 			if getErr == nil && partialResponse != "" {
 				c.logger.Info(i18n.T("llm.assistant.partial_response"))
+				client.LogRequestFinish(c.logger, "OPENAI_ASSISTANT", c.model, "success", time.Since(start),
+					zap.Int("response_chars", len(partialResponse)),
+					zap.String("kind", "partial"),
+				)
 				return i18n.T("llm.assistant.partial_response_prefix", partialResponse), nil
 			}
 		}
 
+		client.LogRequestFinish(c.logger, "OPENAI_ASSISTANT", c.model, "error", time.Since(start))
 		return "", fmt.Errorf("%s: %w", i18n.T("llm.assistant.wait_response_error"), err)
 	}
 
@@ -189,6 +204,7 @@ func (c *OpenAIAssistantClient) SendPrompt(ctx context.Context, prompt string, h
 			zap.String("threadID", threadID),
 			zap.String("runID", runID),
 			zap.String("status", runStatus))
+		client.LogRequestFinish(c.logger, "OPENAI_ASSISTANT", c.model, "error", time.Since(start))
 		return "", fmt.Errorf("%s", i18n.T("llm.assistant.run_failed", runStatus))
 	}
 
@@ -198,9 +214,13 @@ func (c *OpenAIAssistantClient) SendPrompt(ctx context.Context, prompt string, h
 		c.logger.Error(i18n.T("llm.assistant.get_response_error"),
 			zap.String("threadID", threadID),
 			zap.Error(err))
+		client.LogRequestFinish(c.logger, "OPENAI_ASSISTANT", c.model, "error", time.Since(start))
 		return "", fmt.Errorf("%s: %w", i18n.T("llm.assistant.get_response_error"), err)
 	}
 
+	client.LogRequestFinish(c.logger, "OPENAI_ASSISTANT", c.model, "success", time.Since(start),
+		zap.Int("response_chars", len(response)),
+	)
 	return response, nil
 }
 

--- a/llm/openai_responses/openai_responses_client.go
+++ b/llm/openai_responses/openai_responses_client.go
@@ -149,6 +149,14 @@ func (c *OpenAIResponsesClient) SendPrompt(ctx context.Context, prompt string, h
 		return "", fmt.Errorf("%s: %w", i18n.T("llm.responses.prepare_payload"), err)
 	}
 
+	start := time.Now()
+	client.LogRequestStart(c.logger, "OPENAI", c.model,
+		zap.String("path", "responses"),
+		zap.Int("payload_bytes", len(jsonValue)),
+		zap.Int("history_len", len(history)),
+		zap.Int("max_tokens", effectiveMaxTokens),
+	)
+
 	// Retry para encapsular a lógica de requisição e parsing
 	response, err := utils.Retry(ctx, c.logger, c.maxAttempts, c.backoff, func(ctx context.Context) (string, error) {
 		resp, err := c.sendRequest(ctx, jsonValue)
@@ -162,10 +170,17 @@ func (c *OpenAIResponsesClient) SendPrompt(ctx context.Context, prompt string, h
 	})
 
 	if err != nil {
+		client.LogRequestFinish(c.logger, "OPENAI", c.model, "error", time.Since(start),
+			zap.String("path", "responses"),
+		)
 		c.logger.Error(i18n.T("llm.responses.get_response_error"), zap.Error(err))
 		return "", err
 	}
 
+	client.LogRequestFinish(c.logger, "OPENAI", c.model, "success", time.Since(start),
+		zap.String("path", "responses"),
+		zap.Int("response_chars", len(response)),
+	)
 	return response, nil
 }
 

--- a/llm/openrouter/openrouter_client.go
+++ b/llm/openrouter/openrouter_client.go
@@ -218,6 +218,13 @@ func (c *OpenRouterClient) SendPrompt(ctx context.Context, prompt string, histor
 		return "", fmt.Errorf("%s: %w", i18n.T("llm.error.prepare_request"), err)
 	}
 
+	start := time.Now()
+	client.LogRequestStart(c.logger, "OPENROUTER", c.model,
+		zap.Int("payload_bytes", len(jsonValue)),
+		zap.Int("history_len", len(history)),
+		zap.Int("max_tokens", effectiveMaxTokens),
+	)
+
 	response, err := utils.Retry(ctx, c.logger, c.maxAttempts, c.backoff, func(ctx context.Context) (string, error) {
 		resp, err := c.sendRequest(ctx, jsonValue)
 		if err != nil {
@@ -227,10 +234,14 @@ func (c *OpenRouterClient) SendPrompt(ctx context.Context, prompt string, histor
 	})
 
 	if err != nil {
+		client.LogRequestFinish(c.logger, "OPENROUTER", c.model, "error", time.Since(start))
 		c.logger.Error(i18n.T("llm.error.get_response_after_retries", "OpenRouter"), zap.Error(err))
 		return "", err
 	}
 
+	client.LogRequestFinish(c.logger, "OPENROUTER", c.model, "success", time.Since(start),
+		zap.Int("response_chars", len(response)),
+	)
 	return response, nil
 }
 

--- a/llm/stackspotai/stackspot_client.go
+++ b/llm/stackspotai/stackspot_client.go
@@ -65,6 +65,13 @@ func (c *StackSpotClient) SendPrompt(ctx context.Context, prompt string, history
 	conversationHistory := formatConversationHistory(history)
 	fullPrompt := fmt.Sprintf("%sUsuário: %s", conversationHistory, prompt)
 
+	start := time.Now()
+	client.LogRequestStart(c.logger, "STACKSPOT", c.GetModelName(),
+		zap.Int("payload_bytes", len(fullPrompt)),
+		zap.Int("history_len", len(history)),
+		zap.Int("max_tokens", maxTokens),
+	)
+
 	llmResponse, err := utils.Retry(ctx, c.logger, c.maxAttempts, c.backoff, func(ctx context.Context) (string, error) {
 		return c.executeWithTokenRetry(ctx, func(token string) (string, error) {
 			return c.sendChatRequest(ctx, fullPrompt, token)
@@ -72,10 +79,14 @@ func (c *StackSpotClient) SendPrompt(ctx context.Context, prompt string, history
 	})
 
 	if err != nil {
+		client.LogRequestFinish(c.logger, "STACKSPOT", c.GetModelName(), "error", time.Since(start))
 		c.logger.Error(i18n.T("llm.stackspot.get_response_error"), zap.Error(err))
 		return "", err
 	}
 
+	client.LogRequestFinish(c.logger, "STACKSPOT", c.GetModelName(), "success", time.Since(start),
+		zap.Int("response_chars", len(llmResponse)),
+	)
 	return llmResponse, nil
 }
 

--- a/llm/xai/xai_client.go
+++ b/llm/xai/xai_client.go
@@ -101,6 +101,13 @@ func (c *XAIClient) SendPrompt(ctx context.Context, prompt string, history []mod
 		return "", fmt.Errorf("%s: %w", i18n.T("llm.error.prepare_request"), err)
 	}
 
+	start := time.Now()
+	client.LogRequestStart(c.logger, "XAI", c.model,
+		zap.Int("payload_bytes", len(jsonValue)),
+		zap.Int("history_len", len(history)),
+		zap.Int("max_tokens", effectiveMaxTokens),
+	)
+
 	// Agora use Retry para encapsular a lógica de requisição e parsing
 	response, err := utils.Retry(ctx, c.logger, c.maxAttempts, c.backoff, func(ctx context.Context) (string, error) {
 		resp, err := c.sendRequest(ctx, jsonValue)
@@ -111,10 +118,14 @@ func (c *XAIClient) SendPrompt(ctx context.Context, prompt string, history []mod
 	})
 
 	if err != nil {
+		client.LogRequestFinish(c.logger, "XAI", c.model, "error", time.Since(start))
 		c.logger.Error(i18n.T("llm.error.get_response_after_retries", "xAI"), zap.Error(err))
 		return "", err
 	}
 
+	client.LogRequestFinish(c.logger, "XAI", c.model, "success", time.Since(start),
+		zap.Int("response_chars", len(response)),
+	)
 	return response, nil
 }
 

--- a/llm/zai/tool_use.go
+++ b/llm/zai/tool_use.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/diillson/chatcli/i18n"
 	"github.com/diillson/chatcli/llm/client"
@@ -68,6 +69,15 @@ func (c *ZAIClient) SendPromptWithTools(ctx context.Context, prompt string, hist
 		return nil, fmt.Errorf("%s: %w", i18n.T("llm.tool.error.marshaling_payload"), err)
 	}
 
+	start := time.Now()
+	client.LogRequestStart(c.logger, "ZAI", c.model,
+		zap.String("path", "tool_use"),
+		zap.Int("payload_bytes", len(jsonValue)),
+		zap.Int("history_len", len(history)),
+		zap.Int("max_tokens", effectiveMaxTokens),
+		zap.Int("tool_count", len(tools)),
+	)
+
 	resp, err := utils.Retry(ctx, c.logger, c.maxAttempts, c.backoff, func(ctx context.Context) (string, error) {
 		httpResp, err := c.sendRequest(ctx, jsonValue)
 		if err != nil {
@@ -85,9 +95,16 @@ func (c *ZAIClient) SendPromptWithTools(ctx context.Context, prompt string, hist
 		return string(bodyBytes), nil
 	})
 	if err != nil {
+		client.LogRequestFinish(c.logger, "ZAI", c.model, "error", time.Since(start),
+			zap.String("path", "tool_use"),
+		)
 		return nil, err
 	}
 
+	client.LogRequestFinish(c.logger, "ZAI", c.model, "success", time.Since(start),
+		zap.String("path", "tool_use"),
+		zap.Int("response_chars", len(resp)),
+	)
 	return parseToolResponse(resp, c.logger)
 }
 

--- a/llm/zai/zai_client.go
+++ b/llm/zai/zai_client.go
@@ -150,6 +150,13 @@ func (c *ZAIClient) SendPrompt(ctx context.Context, prompt string, history []mod
 		return "", fmt.Errorf("%s: %w", i18n.T("llm.error.prepare_request"), err)
 	}
 
+	start := time.Now()
+	client.LogRequestStart(c.logger, "ZAI", c.model,
+		zap.Int("payload_bytes", len(jsonValue)),
+		zap.Int("history_len", len(history)),
+		zap.Int("max_tokens", effectiveMaxTokens),
+	)
+
 	response, err := utils.Retry(ctx, c.logger, c.maxAttempts, c.backoff, func(ctx context.Context) (string, error) {
 		resp, err := c.sendRequest(ctx, jsonValue)
 		if err != nil {
@@ -159,10 +166,14 @@ func (c *ZAIClient) SendPrompt(ctx context.Context, prompt string, history []mod
 	})
 
 	if err != nil {
+		client.LogRequestFinish(c.logger, "ZAI", c.model, "error", time.Since(start))
 		c.logger.Error(i18n.T("llm.error.get_response_after_retries", "ZAI"), zap.Error(err))
 		return "", err
 	}
 
+	client.LogRequestFinish(c.logger, "ZAI", c.model, "success", time.Since(start),
+		zap.Int("response_chars", len(response)),
+	)
 	return response, nil
 }
 


### PR DESCRIPTION
## Summary
- Final defensive boundary that walks the assembled Anthropic request body right before `json.Marshal` and caps `cache_control` markers across `system` + `tools` + message content at 4. Drops the earliest markers; block content is never discarded. Applied to both claudeai paths (`SendPrompt`, `SendPromptWithTools`) and to Bedrock's Anthropic family — Bedrock had no per-section coalesce at all.
- INFO-level request lifecycle logs across every provider (Bedrock, claudeai, openai + responses + assistant, googleai, xai, zai, minimax, ollama, copilot, github_models, stackspot, openrouter). Two structured events per call — `llm: send` (payload_bytes, history_len, max_tokens, plus tool_count / cache_markers when relevant) and `llm: recv` (status, duration, response_chars). Bedrock had zero per-request observability before.
- Regression tests for the global budget enforcement, including the chat ↔ coder ↔ agent worst-case (1 leftover system message with 4 marked SystemParts + chat-built message with 6 marked SystemParts → wire body holds at the cap).

## Why
Per-section coalesce was correct on the happy path but fragile across mode transitions and silent on provider paths it didn't cover. A user reported the \"more than 4 blocks with cache_control\" 400 still firing after `/coder → /chat`. Pinning down the exact producer from a single transcript is hard — the structural fix is to enforce the cap on the final wire body, regardless of how it was assembled.

The observability surface motivation was the same flow: with no INFO request logs, mapping a user-reported failure to the actual payload shape required either DEBUG-level globals or pcap. Now every dispatch emits provider/model/size/marker-count, and Anthropic-format paths show the live cache_marker count so future regressions are visible without instrumentation work.

## Files
- `llm/claudeai/cache_planner.go` — `enforceCacheControlBudget` + scan helpers
- `llm/bedrock/cache_planner.go` — same enforcement for Bedrock Anthropic family
- `llm/client/observability.go` — `LogRequestStart` / `LogRequestFinish` / `CountAnthropicCacheMarkers`
- `llm/claudeai/cache_planner_test.go` — tests for boundary, scan order, OAuth shape, mode-transition worst case
- 13 provider files instrumented with the start/finish pair

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` clean (including new tests in `llm/claudeai/cache_planner_test.go`)
- [x] `gofmt -l .` clean on all touched files
- [x] `golangci-lint run ./...` clean
- [x] `gosec ./...` clean on touched packages (the 2 G704 SSRF findings in `cli/plugins/builtin_websearch.go` predate this branch — PR #802)
- [x] Manual smoke: chat → /coder → chat with 4+ attached contexts on Anthropic OAuth (no 400)
- [x] Manual smoke: tail logs on a real session and confirm `llm: send` / `llm: recv` events fire for at least Bedrock + claudeai + openai