### PR TITLE
feat(catalog,config): real model windows + env defaults registry for /config

### DIFF
--- a/cli/config_env_defaults.go
+++ b/cli/config_env_defaults.go
@@ -1,0 +1,190 @@
+/*
+ * ChatCLI - Environment Variable Default Registry
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Single source of truth for the default value of every CHATCLI_* /
+ * provider env var that /config surfaces. The registry powers two things:
+ *
+ *  1. /config rendering — when an env is unset, we no longer print a
+ *     bare "[NOT SET]". We print the actual fallback value the runtime
+ *     uses so the operator can see what the system is actually doing
+ *     without spelunking through the source.
+ *
+ *  2. Self-documentation — every entry carries a `Source` pointing to
+ *     the file:line where the default lives in code. If the runtime
+ *     ever drifts from this registry the audit trail makes it cheap to
+ *     reconcile.
+ *
+ * Adding a default
+ * ----------------
+ * Find where the env var is read with os.Getenv (or a wrapper) in code,
+ * look up the literal that's used when the var is empty, and add an
+ * entry below using the same literal. Do NOT invent values: if the code
+ * has no static fallback (e.g. the var is purely opt-in and the runtime
+ * skips the feature when absent), leave it OUT of the registry. The
+ * UI will fall back to the "[NOT SET]" placeholder for those, which is
+ * the truthful answer.
+ */
+
+package cli
+
+import (
+	"strings"
+
+	"github.com/diillson/chatcli/config"
+)
+
+// envDefault describes the runtime fallback for one env var.
+//
+//	Value    — what the runtime uses when the env is empty/unset, formatted
+//	           the same way the user would set it (e.g. "10m" for durations,
+//	           "0.80" for ratios, "100MB" for byte sizes). Booleans use
+//	           "true"/"false" (lowercase) regardless of the var's accepted
+//	           parsing form, so the display is uniform.
+//	Source   — file:line or constant name where the default is defined,
+//	           kept short and human-greppable.
+//	IsBool   — true when the var is parsed as a boolean. Lets envBool()
+//	           render the default with the same on/off labels it uses for
+//	           explicitly-set values.
+type envDefault struct {
+	Value  string
+	Source string
+	IsBool bool
+}
+
+// envDefaults is the static registry. Keys are the exact env var names
+// as users would `export` them. The map is intentionally an unsorted
+// literal — lookup is O(1) and order does not matter.
+var envDefaults = map[string]envDefault{
+	// ─── General / process ───────────────────────────────────────
+	"CHATCLI_DEBUG":                 {Value: "false", IsBool: true, Source: "logger.SetupLogger"},
+	"CHATCLI_DISABLE_VERSION_CHECK": {Value: "false", IsBool: true, Source: "version_checker.go"},
+	"CHATCLI_LOG_COMPRESS":          {Value: "false", IsBool: true, Source: "logger.go"},
+	"CHATCLI_LANG":                  {Value: "(system locale)", Source: "i18n.LoadLocale"},
+	"LOG_LEVEL":                     {Value: "info", Source: "logger.SetupLogger"},
+	"LOG_MAX_SIZE":                  {Value: "100", Source: "config.DefaultMaxLogSize"},
+	"CHATCLI_LOG_FILE":              {Value: config.DefaultLogFile, Source: "config.DefaultLogFile"},
+	"CHATCLI_LOG_MAX_SIZE_MB":       {Value: "100", Source: "config.DefaultMaxLogSize"},
+	"HISTORY_MAX_SIZE":              {Value: "100MB", Source: "config.DefaultMaxHistorySize"},
+
+	// ─── Provider model defaults ─────────────────────────────────
+	"OPENAI_MODEL":               {Value: config.DefaultOpenAIModel, Source: "config.DefaultOpenAIModel"},
+	"OPENAI_ASSISTANT_MODEL":     {Value: config.DefaultOpenAiAssistModel, Source: "config.DefaultOpenAiAssistModel"},
+	"OPENAI_USE_RESPONSES":       {Value: "(auto, per model)", Source: "catalog.GetPreferredAPI"},
+	"ANTHROPIC_MODEL":            {Value: config.DefaultClaudeAIModel, Source: "config.DefaultClaudeAIModel"},
+	"ANTHROPIC_BASE_URL":         {Value: config.ClaudeAIAPIURL, Source: "config.ClaudeAIAPIURL"},
+	"ANTHROPIC_API_VERSION":      {Value: config.ClaudeAIAPIVersionDefault, Source: "config.ClaudeAIAPIVersionDefault"},
+	"GOOGLEAI_MODEL":             {Value: config.DefaultGoogleAIModel, Source: "config.DefaultGoogleAIModel"},
+	"XAI_MODEL":                  {Value: config.DefaultXAIModel, Source: "config.DefaultXAIModel"},
+	"OLLAMA_MODEL":               {Value: config.DefaultOllamaModel, Source: "config.DefaultOllamaModel"},
+	"OLLAMA_BASE_URL":            {Value: config.OllamaDefaultBaseURL, Source: "config.OllamaDefaultBaseURL"},
+	"BEDROCK_REGION":             {Value: config.DefaultBedrockRegion, Source: "config.DefaultBedrockRegion"},
+	"COPILOT_MODEL":              {Value: config.DefaultCopilotModel, Source: "config.DefaultCopilotModel"},
+	"COPILOT_API_BASE_URL":       {Value: config.CopilotAPIURL, Source: "config.CopilotAPIURL"},
+	"GITHUB_MODELS_MODEL":        {Value: config.DefaultGitHubModelsModel, Source: "config.DefaultGitHubModelsModel"},
+	"ZAI_MODEL":                  {Value: config.DefaultZAIModel, Source: "config.DefaultZAIModel"},
+	"MINIMAX_MODEL":              {Value: config.DefaultMiniMaxModel, Source: "config.DefaultMiniMaxModel"},
+	"OPENROUTER_FALLBACK_MODELS": {Value: "(none)", Source: "openrouter client"},
+	"OPENROUTER_PROVIDER_ORDER":  {Value: "(none)", Source: "openrouter client"},
+
+	// ─── Agent: parallelism / orchestration ──────────────────────
+	"CHATCLI_AGENT_PARALLEL_MODE":      {Value: "true", IsBool: true, Source: "agent_mode.go:initMultiAgent"},
+	"CHATCLI_AGENT_MAX_WORKERS":        {Value: "4", Source: "workers.DefaultMaxWorkers"},
+	"CHATCLI_AGENT_WORKER_TIMEOUT":     {Value: "10m", Source: "workers.DefaultWorkerTimeout"},
+	"CHATCLI_AGENT_WORKER_MAX_TURNS":   {Value: "30", Source: "workers.DefaultWorkerMaxTurns"},
+	"CHATCLI_AGENT_SUBAGENT_MAX_DEPTH": {Value: "2", Source: "workers.DefaultSubagentMaxDepth"},
+	"CHATCLI_AGENT_SUBAGENT_MAX_TURNS": {Value: "15", Source: "workers.DefaultSubagentMaxTurns"},
+
+	// ─── Agent: token efficiency ─────────────────────────────────
+	"CHATCLI_AGENT_EARLY_EXIT":       {Value: "true", IsBool: true, Source: "agent_earlyexit.earlyExitEnabled"},
+	"CHATCLI_AGENT_EARLY_EXIT_TURNS": {Value: "3", Source: "agent_earlyexit.defaultStagnationThreshold"},
+	"CHATCLI_AGENT_SMART_ROUTE":      {Value: "hint", Source: "agent_routing.smartRouting"},
+
+	// ─── Agent: execution ────────────────────────────────────────
+	"CHATCLI_AGENT_CMD_TIMEOUT":         {Value: "10m", Source: "agent.NewContextManager"},
+	"CHATCLI_AGENT_SOURCE_SHELL_CONFIG": {Value: "false", IsBool: true, Source: "command_executor.go"},
+	"CHATCLI_AGENT_KEEP_TMPDIR":         {Value: "false", IsBool: true, Source: "session_workspace.go"},
+	"CHATCLI_MAX_COMMAND_OUTPUT":        {Value: "102400", Source: "defaultMaxCommandOutput (100KB)"},
+
+	// ─── Resilience: payload / recovery ──────────────────────────
+	"CHATCLI_MAX_PAYLOAD":             {Value: "(no cap)", Source: "history_compactor.DefaultCompactConfig"},
+	"CHATCLI_MAX_RECOVERY_ATTEMPTS":   {Value: "3", Source: "agent.DefaultContextRecoveryConfig"},
+	"CHATCLI_MAX_TOKEN_ESCALATIONS":   {Value: "2", Source: "agent.DefaultContextRecoveryConfig"},
+	"CHATCLI_EMERGENCY_KEEP_MESSAGES": {Value: "10", Source: "agent.DefaultContextRecoveryConfig"},
+
+	// ─── Resilience: streaming ───────────────────────────────────
+	"CHATCLI_STREAM_IDLE_TIMEOUT_SECONDS": {Value: "90", Source: "client.DefaultWatchdogConfig"},
+
+	// ─── Resilience: compaction ──────────────────────────────────
+	"CHATCLI_MICROCOMPACT_TRUNCATE_TURNS":  {Value: "2", Source: "agent.DefaultMicrocompactConfig"},
+	"CHATCLI_MICROCOMPACT_SUMMARIZE_TURNS": {Value: "4", Source: "agent.DefaultMicrocompactConfig"},
+	"CHATCLI_MICROCOMPACT_HEAD_CHARS":      {Value: "2000", Source: "agent.DefaultMicrocompactConfig"},
+	"CHATCLI_MICROCOMPACT_TAIL_CHARS":      {Value: "500", Source: "agent.DefaultMicrocompactConfig"},
+	"CHATCLI_MICROCOMPACT_MIN_CONTENT":     {Value: "3000", Source: "agent.DefaultMicrocompactConfig"},
+	"CHATCLI_TOOL_RESULT_BUDGET_CHARS":     {Value: "200000", Source: "agent.DefaultTurnBudgetChars"},
+	"CHATCLI_TOOL_RESULT_MAX_CHARS":        {Value: "20000", Source: "agent.DefaultPerResultMaxChars"},
+
+	// ─── Resilience: bedrock proxy ───────────────────────────────
+	"CHATCLI_BEDROCK_INSECURE_SKIP_VERIFY": {Value: "false", IsBool: true, Source: "bedrock client"},
+	"CHATCLI_BEDROCK_ENABLE_IMDS":          {Value: "false", IsBool: true, Source: "bedrock client"},
+
+	// ─── Cost / budget ───────────────────────────────────────────
+	"CHATCLI_SESSION_BUDGET_USD": {Value: "(no budget)", Source: "cost_tracker.go"},
+	"CHATCLI_BUDGET_WARNING_PCT": {Value: "0.80", Source: "cost_tracker.go"},
+	"CHATCLI_SESSION_TTL":        {Value: "90", Source: "session_manager.go (days)"},
+	"CHATCLI_DISABLE_HISTORY":    {Value: "false", IsBool: true, Source: "history_manager.go"},
+
+	// ─── Memory / bootstrap ──────────────────────────────────────
+	"CHATCLI_MEMORY_ENABLED":    {Value: "true", IsBool: true, Source: "memory.go"},
+	"CHATCLI_BOOTSTRAP_ENABLED": {Value: "true", IsBool: true, Source: "bootstrap.go"},
+
+	// ─── Integrations ────────────────────────────────────────────
+	"CHATCLI_MCP_ENABLED":            {Value: "false", IsBool: true, Source: "mcp manager"},
+	"CHATCLI_ALLOW_UNSIGNED_PLUGINS": {Value: "false", IsBool: true, Source: "plugin manager"},
+	"CHATCLI_REGISTRY_DISABLE":       {Value: "false", IsBool: true, Source: "skill registry"},
+	"CHATCLI_WEBSEARCH_PROVIDER":     {Value: "auto", Source: "websearch_command.go"},
+
+	// ─── Security ────────────────────────────────────────────────
+	"CHATCLI_AGENT_SECURITY_MODE":    {Value: "strict", Source: "agent.command_allowlist (default unless permissive)"},
+	"CHATCLI_AGENT_ALLOW_SUDO":       {Value: "false", IsBool: true, Source: "command_allowlist"},
+	"CHATCLI_AGENT_WORKSPACE_STRICT": {Value: "true", IsBool: true, Source: "session_workspace"},
+	"CHATCLI_AGENT_ALLOW_KUBECONFIG": {Value: "false", IsBool: true, Source: "session_workspace"},
+	"CHATCLI_BLOCK_TMP_WRITES":       {Value: "false", IsBool: true, Source: "session_workspace.go:150"},
+	"CHATCLI_ALLOW_HTTP_PROVIDERS":   {Value: "false", IsBool: true, Source: "TLS posture"},
+	"CHATCLI_ALLOW_INSECURE":         {Value: "false", IsBool: true, Source: "TLS posture"},
+	"CHATCLI_ENV_REDACT_MODE":        {Value: "normal", Source: "env_redactor.go (strict|normal)"},
+
+	// ─── Server mode ─────────────────────────────────────────────
+	"CHATCLI_GRPC_REFLECTION":   {Value: "false", IsBool: true, Source: "server.go"},
+	"CHATCLI_FALLBACK_ENABLED":  {Value: "false", IsBool: true, Source: "server fallback"},
+	"CHATCLI_OPERATOR_DEV_MODE": {Value: "false", IsBool: true, Source: "operator"},
+}
+
+// lookupEnvDefault returns the registered default for `name`, or
+// (zero, false) when the var is not in the registry. It's the entry
+// point used by envOr/envBool — the registry stays a closed map at
+// package level to enforce that defaults come from a single audited
+// source instead of being scattered as inline string literals across
+// the rendering code.
+func lookupEnvDefault(name string) (envDefault, bool) {
+	d, ok := envDefaults[name]
+	return d, ok
+}
+
+// formatDefaultValue normalizes the displayed form of a registered
+// default. Long URLs and paths get shortened so they don't blow past
+// the column width that the /config grid uses; everything else goes
+// through verbatim. Kept tiny on purpose — the registry stores the
+// canonical form, this helper only adapts it for terminal width.
+func formatDefaultValue(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return v
+	}
+	const maxDisplay = 60
+	if len(v) <= maxDisplay {
+		return v
+	}
+	return v[:maxDisplay-3] + "..."
+}

--- a/cli/config_sections.go
+++ b/cli/config_sections.go
@@ -101,14 +101,45 @@ func sectionEnd(color string) {
 	fmt.Println(uiBoxEnd(color))
 }
 
+// defaultMarker is a zero-width sentinel prefix that envOr/envBool use
+// to flag a value as "this is the runtime default, the env var is unset".
+// kv() detects the marker, strips it for display, and renders the line
+// in a distinct color with a "(default)" suffix so the operator sees at
+// a glance whether the value comes from their environment or from the
+// code's fallback. Using an ASCII control character (U+0001) keeps the
+// channel out-of-band from any legitimate env value the user could set.
+const defaultMarker = "\x01"
+
 // kv prints a key/value line inside a section with automatic coloring.
 // key is an i18n-translated label (the caller passes i18n.T(...)) or a
 // literal env var name when no translation applies.
+//
+// Coloring rules:
+//   - "[SET]" / enabled / on     → green (explicitly configured truthy)
+//   - "[NOT SET]" / disabled     → yellow (off OR unconfigured w/ no fallback)
+//   - defaultMarker prefix       → cyan + "(default)" suffix (the runtime
+//     fallback from the env-default registry)
+//   - everything else            → gray (user-set value)
 func kv(prefix, key, value string) {
 	valueColor := ColorGray
 	display := strings.TrimSpace(value)
 	enabledLabel := i18n.T("cfg.val.enabled")
 	disabledLabel := i18n.T("cfg.val.disabled")
+	defaultTag := i18n.T("cfg.val.default_tag")
+
+	// Default-value path: strip the sentinel, render in cyan with a
+	// trailing "(default)" tag so the line visibly distinguishes from
+	// user-set values without losing the actual value.
+	if strings.HasPrefix(display, defaultMarker) {
+		display = strings.TrimPrefix(display, defaultMarker)
+		fmt.Printf("%s%s  %s %s\n",
+			prefix,
+			colorize(fmt.Sprintf("%-32s", key+":"), ColorCyan),
+			colorize(display, ColorCyan),
+			colorize(defaultTag, ColorGray))
+		return
+	}
+
 	switch {
 	case display == "":
 		display = i18n.T("cfg.val.default")
@@ -127,16 +158,29 @@ func kv(prefix, key, value string) {
 		colorize(display, valueColor))
 }
 
-// envOr returns the env value or the localized "(not set)" placeholder.
+// envOr returns the env value, or the registered runtime default tagged
+// with defaultMarker so kv() can color it as "(default)", or the
+// localized "(not set)" placeholder when neither source has a value.
+//
+// The default registry is consulted only when the env is unset — an
+// explicitly-set empty string still goes through the not_set branch
+// (matching pre-registry behavior).
 func envOr(name string) string {
 	if v := strings.TrimSpace(os.Getenv(name)); v != "" {
 		return v
+	}
+	if d, ok := lookupEnvDefault(name); ok && !d.IsBool {
+		return defaultMarker + formatDefaultValue(d.Value)
 	}
 	return i18n.T("cfg.val.not_set")
 }
 
 // envBool renders the localized enabled/disabled/default labels for boolean
-// envs (accepts 1/true/yes).
+// envs (accepts 1/true/yes). When the var is unset and the default
+// registry has a known boolean fallback, the rendered line is the
+// localized enabled/disabled label tagged with defaultMarker so kv()
+// reports e.g. "enabled (default)" instead of a bare "(default)" with
+// no truth value attached.
 func envBool(name string) string {
 	v := strings.ToLower(strings.TrimSpace(os.Getenv(name)))
 	switch v {
@@ -145,6 +189,13 @@ func envBool(name string) string {
 	case "0", "false", "no", "off":
 		return i18n.T("cfg.val.disabled")
 	case "":
+		if d, ok := lookupEnvDefault(name); ok && d.IsBool {
+			label := i18n.T("cfg.val.disabled")
+			if strings.EqualFold(d.Value, "true") {
+				label = i18n.T("cfg.val.enabled")
+			}
+			return defaultMarker + label
+		}
 		return i18n.T("cfg.val.default")
 	default:
 		return v

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -1377,6 +1377,7 @@
   "cfg.route.hint": "Sections: all, general, providers, agent, resilience, session, integrations, auth, security, server",
 
   "cfg.val.default": "(default)",
+  "cfg.val.default_tag": "(default)",
   "cfg.val.not_set": "(not set)",
   "cfg.val.none": "(none)",
   "cfg.val.empty": "(empty)",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1377,6 +1377,7 @@
   "cfg.route.hint": "Sections: all, general, providers, agent, resilience, session, integrations, auth, security, server",
 
   "cfg.val.default": "(default)",
+  "cfg.val.default_tag": "(default)",
   "cfg.val.not_set": "(not set)",
   "cfg.val.none": "(none)",
   "cfg.val.empty": "(empty)",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -1377,6 +1377,7 @@
   "cfg.route.hint": "Seções: all, general, providers, agent, resilience, session, integrations, auth, security, server",
 
   "cfg.val.default": "(padrão)",
+  "cfg.val.default_tag": "(padrão)",
   "cfg.val.not_set": "(não definido)",
   "cfg.val.none": "(nenhum)",
   "cfg.val.empty": "(vazio)",

--- a/llm/catalog/catalog.go
+++ b/llm/catalog/catalog.go
@@ -139,14 +139,17 @@ var registry = []ModelMeta{
 		Capabilities:    []string{"json_mode", "tools"},
 	},
 	{
+		// gpt-5 (Aug 7 2025), incl. mini/nano/pro: 400K context, 128K max
+		// output. Previous catalog (128K/16K) was inherited from GPT-4o
+		// and undercounted by ~3× on context, ~8× on output.
 		ID:              "gpt-5",
-		Aliases:         []string{"gpt-5", "gpt-5.1", "gpt-5-mini", "gpt-5-nano"},
+		Aliases:         []string{"gpt-5", "gpt-5.1", "gpt-5-mini", "gpt-5-nano", "gpt-5-pro"},
 		DisplayName:     "GPT-5",
 		Provider:        ProviderOpenAI,
-		ContextWindow:   128000,
-		MaxOutputTokens: 16384,
+		ContextWindow:   400000,
+		MaxOutputTokens: 128000,
 		PreferredAPI:    APIResponses,
-		Capabilities:    []string{"json_mode", "tools"},
+		Capabilities:    []string{"json_mode", "tools", "vision"},
 	},
 	// ── OpenAI o-series reasoning models ──────────────────────────
 	{
@@ -231,19 +234,26 @@ var registry = []ModelMeta{
 		PreferredAPI:    APIChatCompletions,
 		Capabilities:    []string{"vision", "tools", "json_mode"},
 	},
-	// Claude 4 e 4.1 (sonnet/opus)
+	// Claude 4 e 4.1 (sonnet/opus). Specs grounded in Anthropic's official
+	// models page (platform.claude.com/docs/en/docs/about-claude/models/overview).
 	{
+		// Sonnet 4 (claude-sonnet-4-20250514): deprecated, retires Jun 15
+		// 2026. Real specs: 200K context, 64K max output. Previous catalog
+		// value (50K/50K) was a conservative override that masked the model's
+		// actual capacity and caused premature compaction.
 		ID:              "claude-sonnet-4",
 		Aliases:         []string{"claude-4-sonnet", "sonnet-4-20250514", "claude-4-sonnet-"},
 		DisplayName:     "Claude sonnet 4",
 		Provider:        ProviderClaudeAI,
-		ContextWindow:   50000,
-		MaxOutputTokens: 50000,
+		ContextWindow:   200000,
+		MaxOutputTokens: 64000,
 		PreferredAPI:    APIAnthropicMessages,
 		APIVersion:      config.ClaudeAIAPIVersionDefault,
 		Capabilities:    []string{"json_mode", "tools"},
 	},
 	{
+		// Sonnet 4.5: 200K context, 64K max output. 1M context available
+		// via beta header; default registry tracks the GA limit.
 		ID:              "claude-sonnet-4-5",
 		Aliases:         []string{"claude-4-5-sonnet", "sonnet-4-5", "claude-4-5-sonnet-", "claude-sonnet-4-5-"},
 		DisplayName:     "Claude sonnet 4.5",
@@ -255,12 +265,28 @@ var registry = []ModelMeta{
 		Capabilities:    []string{"json_mode", "tools"},
 	},
 	{
+		// Sonnet 4.6: 1M context, 64K max output (per Anthropic). Previous
+		// catalog (200K/128K) had output inflated and ctx undersized.
 		ID:              "claude-sonnet-4-6",
 		Aliases:         []string{"claude-4-6-sonnet", "sonnet-4-6", "claude-4-6-sonnet-", "claude-sonnet-4-6-"},
-		DisplayName:     "Claude sonnet 4.6",
+		DisplayName:     "Claude sonnet 4.6 (1M context)",
+		Provider:        ProviderClaudeAI,
+		ContextWindow:   1000000,
+		MaxOutputTokens: 64000,
+		PreferredAPI:    APIAnthropicMessages,
+		APIVersion:      config.ClaudeAIAPIVersionDefault,
+		Capabilities:    []string{"json_mode", "tools"},
+	},
+	{
+		// Haiku 4.5 (claude-haiku-4-5-20251001): 200K context, 64K max
+		// output. Newest haiku in the GA matrix; was missing from the
+		// ProviderClaudeAI side of the registry (only Bedrock had it).
+		ID:              "claude-haiku-4-5-20251001",
+		Aliases:         []string{"claude-haiku-4-5", "haiku-4-5", "claude-4-5-haiku"},
+		DisplayName:     "Claude haiku 4.5",
 		Provider:        ProviderClaudeAI,
 		ContextWindow:   200000,
-		MaxOutputTokens: 128000,
+		MaxOutputTokens: 64000,
 		PreferredAPI:    APIAnthropicMessages,
 		APIVersion:      config.ClaudeAIAPIVersionDefault,
 		Capabilities:    []string{"json_mode", "tools"},
@@ -273,9 +299,30 @@ var registry = []ModelMeta{
 	// loose prefix match fires. Reversing this order reintroduces a latent
 	// bug where "opus-4-6" silently resolves to the 4.0 entry (20K ctx).
 	{
+		// Opus 4.7: most capable GA model; 1M context, 128K max output.
+		// Previous catalog had output at 64K — corrected to match docs.
 		ID:              "claude-opus-4-7",
 		Aliases:         []string{"claude-opus-4-7", "opus-4-7"},
 		DisplayName:     "Claude opus 4.7 (1M context)",
+		Provider:        ProviderClaudeAI,
+		ContextWindow:   1000000,
+		MaxOutputTokens: 128000,
+		PreferredAPI:    APIAnthropicMessages,
+		APIVersion:      config.ClaudeAIAPIVersionDefault,
+		Capabilities:    []string{"json_mode", "tools"},
+	},
+	{
+		// Sonnet 4.7: NOT in the Anthropic GA matrix as of Apr 2026 (the
+		// current shipping line is Opus 4.7 + Sonnet 4.6 + Haiku 4.5,
+		// per https://platform.claude.com/docs/en/about-claude/models/overview).
+		// This entry is a forward-projected alias placeholder so existing
+		// tests and any caller pinning the tag don't break; the profile
+		// mirrors Sonnet 4.6 (1M / 64K). Replace with real specs the
+		// moment Anthropic publishes them — do not treat this as ground
+		// truth.
+		ID:              "claude-sonnet-4-7",
+		Aliases:         []string{"claude-4-7-sonnet", "sonnet-4-7", "claude-sonnet-4-7-"},
+		DisplayName:     "Claude sonnet 4.7",
 		Provider:        ProviderClaudeAI,
 		ContextWindow:   1000000,
 		MaxOutputTokens: 64000,
@@ -284,30 +331,22 @@ var registry = []ModelMeta{
 		Capabilities:    []string{"json_mode", "tools"},
 	},
 	{
-		ID:              "claude-sonnet-4-7",
-		Aliases:         []string{"claude-4-7-sonnet", "sonnet-4-7", "claude-sonnet-4-7-"},
-		DisplayName:     "Claude sonnet 4.7",
+		// Opus 4.6: 1M context, 128K max output (per Anthropic legacy
+		// table). Previous 400K/64K underrepresented both dimensions.
+		ID:              "claude-opus-4-6",
+		Aliases:         []string{"claude-opus-4-6", "opus-4-6"},
+		DisplayName:     "Claude opus 4.6 (1M context)",
 		Provider:        ProviderClaudeAI,
-		ContextWindow:   200000,
+		ContextWindow:   1000000,
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
 		APIVersion:      config.ClaudeAIAPIVersionDefault,
 		Capabilities:    []string{"json_mode", "tools"},
 	},
 	{
-		ID:              "claude-opus-4-6",
-		Aliases:         []string{"claude-opus-4-6", "opus-4-6"},
-		DisplayName:     "Claude opus 4.6",
-		Provider:        ProviderClaudeAI,
-		ContextWindow:   400000,
-		MaxOutputTokens: 64000,
-		PreferredAPI:    APIAnthropicMessages,
-		APIVersion:      config.ClaudeAIAPIVersionDefault,
-		Capabilities:    []string{"json_mode", "tools"},
-	},
-	{
+		// Opus 4.5 (claude-opus-4-5-20251101): 200K context, 64K max output.
 		ID:              "claude-opus-4-5",
-		Aliases:         []string{"claude-opus-4-5", "opus-4-5"},
+		Aliases:         []string{"claude-opus-4-5", "opus-4-5", "claude-opus-4-5-20251101"},
 		DisplayName:     "Claude opus 4.5",
 		Provider:        ProviderClaudeAI,
 		ContextWindow:   200000,
@@ -317,90 +356,127 @@ var registry = []ModelMeta{
 		Capabilities:    []string{"json_mode", "tools"},
 	},
 	{
+		// Opus 4.1: 200K context, 32K max output. Previous 20K/20K was a
+		// holdover from an early conservative override and made the model
+		// trip auto-compact at ~80K chars unnecessarily.
 		ID:              "claude-opus-4-1-20250805",
 		Aliases:         []string{"claude-opus-4-1", "opus-4-1", "claude-opus-4-1-20250805"},
 		DisplayName:     "Claude opus 4.1",
 		Provider:        ProviderClaudeAI,
-		ContextWindow:   20000,
-		MaxOutputTokens: 20000,
-		PreferredAPI:    APIAnthropicMessages,
-		APIVersion:      config.ClaudeAIAPIVersionDefault,
-		Capabilities:    []string{"json_mode", "tools"},
-	},
-	{
-		ID:              "claude-opus-4-20250514",
-		Aliases:         []string{"opus-4", "claude-opus-4-20250514"},
-		DisplayName:     "Claude opus 4",
-		Provider:        ProviderClaudeAI,
-		ContextWindow:   20000,
-		MaxOutputTokens: 20000,
-		PreferredAPI:    APIAnthropicMessages,
-		APIVersion:      config.ClaudeAIAPIVersionDefault,
-		Capabilities:    []string{"json_mode", "tools"},
-	},
-	// Claude 3.x já existentes no projeto
-	{
-		ID:              "claude-sonnet-3-5-20241022",
-		Aliases:         []string{"claude-3-5-sonnet", "claude-3-5-sonnet-20241022"},
-		DisplayName:     "Claude sonnet 3.5",
-		Provider:        ProviderClaudeAI,
-		ContextWindow:   50000,
-		MaxOutputTokens: 50000,
-		PreferredAPI:    APIAnthropicMessages,
-		APIVersion:      config.ClaudeAIAPIVersionDefault,
-		Capabilities:    []string{"json_mode", "tools"},
-	},
-	{
-		ID:              "claude-sonnet-3-7-20250219",
-		Aliases:         []string{"claude-3-7-sonnet", "claude-3-7-sonnet-20250219"},
-		DisplayName:     "Claude sonnet 3.7",
-		Provider:        ProviderClaudeAI,
-		ContextWindow:   50000,
-		MaxOutputTokens: 50000,
-		PreferredAPI:    APIAnthropicMessages,
-		APIVersion:      config.ClaudeAIAPIVersionDefault,
-		Capabilities:    []string{"json_mode", "tools"},
-	},
-	{
-		ID:              "claude-haiku-3",
-		Aliases:         []string{"claude-3-haiku"},
-		DisplayName:     "Claude haiku 3",
-		Provider:        ProviderClaudeAI,
-		ContextWindow:   42000,
-		MaxOutputTokens: 42000,
-		PreferredAPI:    APIAnthropicMessages,
-		APIVersion:      config.ClaudeAIAPIVersionDefault,
-		Capabilities:    []string{"json_mode"},
-	},
-	{
-		ID:              "claude-opus-3",
-		Aliases:         []string{"claude-3-opus"},
-		DisplayName:     "claude opus 3",
-		Provider:        ProviderClaudeAI,
-		ContextWindow:   32000,
+		ContextWindow:   200000,
 		MaxOutputTokens: 32000,
 		PreferredAPI:    APIAnthropicMessages,
 		APIVersion:      config.ClaudeAIAPIVersionDefault,
 		Capabilities:    []string{"json_mode", "tools"},
 	},
-	// Google Gemini Models
+	{
+		// Opus 4.0 (deprecated, retires Jun 15 2026): 200K context, 32K
+		// max output. Same correction rationale as 4.1.
+		ID:              "claude-opus-4-20250514",
+		Aliases:         []string{"opus-4", "claude-opus-4-20250514"},
+		DisplayName:     "Claude opus 4",
+		Provider:        ProviderClaudeAI,
+		ContextWindow:   200000,
+		MaxOutputTokens: 32000,
+		PreferredAPI:    APIAnthropicMessages,
+		APIVersion:      config.ClaudeAIAPIVersionDefault,
+		Capabilities:    []string{"json_mode", "tools"},
+	},
+	// Claude 3.x — specs from Anthropic's legacy/3.x docs. All 3.x models
+	// share the 200K input window; max output varies by version.
+	{
+		// Sonnet 3.5 (claude-3-5-sonnet-20241022, "v2"): 200K / 8192.
+		ID:              "claude-sonnet-3-5-20241022",
+		Aliases:         []string{"claude-3-5-sonnet", "claude-3-5-sonnet-20241022"},
+		DisplayName:     "Claude sonnet 3.5",
+		Provider:        ProviderClaudeAI,
+		ContextWindow:   200000,
+		MaxOutputTokens: 8192,
+		PreferredAPI:    APIAnthropicMessages,
+		APIVersion:      config.ClaudeAIAPIVersionDefault,
+		Capabilities:    []string{"json_mode", "tools"},
+	},
+	{
+		// Haiku 3.5 (claude-3-5-haiku-20241022): 200K / 8192. Was missing
+		// from the ProviderClaudeAI side; only Bedrock had it.
+		ID:              "claude-haiku-3-5-20241022",
+		Aliases:         []string{"claude-3-5-haiku", "claude-3-5-haiku-20241022"},
+		DisplayName:     "Claude haiku 3.5",
+		Provider:        ProviderClaudeAI,
+		ContextWindow:   200000,
+		MaxOutputTokens: 8192,
+		PreferredAPI:    APIAnthropicMessages,
+		APIVersion:      config.ClaudeAIAPIVersionDefault,
+		Capabilities:    []string{"json_mode", "tools"},
+	},
+	{
+		// Sonnet 3.7 (claude-3-7-sonnet-20250219): 200K context / 8192 max
+		// output on the synchronous Messages API (the default any client
+		// hits without opt-in headers). Extended thinking can raise
+		// output to 64K, but only when the caller explicitly sends the
+		// `output-128k-2025-02-19` beta header — pinning the catalog at
+		// 64K silently throws 400 errors for every regular call. We
+		// track the safe default; callers that opt into extended
+		// thinking can override at request time.
+		ID:              "claude-sonnet-3-7-20250219",
+		Aliases:         []string{"claude-3-7-sonnet", "claude-3-7-sonnet-20250219"},
+		DisplayName:     "Claude sonnet 3.7",
+		Provider:        ProviderClaudeAI,
+		ContextWindow:   200000,
+		MaxOutputTokens: 8192,
+		PreferredAPI:    APIAnthropicMessages,
+		APIVersion:      config.ClaudeAIAPIVersionDefault,
+		Capabilities:    []string{"json_mode", "tools"},
+	},
+	{
+		// Haiku 3 (claude-3-haiku-20240307): 200K / 4096.
+		ID:              "claude-haiku-3",
+		Aliases:         []string{"claude-3-haiku", "claude-3-haiku-20240307"},
+		DisplayName:     "Claude haiku 3",
+		Provider:        ProviderClaudeAI,
+		ContextWindow:   200000,
+		MaxOutputTokens: 4096,
+		PreferredAPI:    APIAnthropicMessages,
+		APIVersion:      config.ClaudeAIAPIVersionDefault,
+		Capabilities:    []string{"json_mode"},
+	},
+	{
+		// Opus 3 (claude-3-opus-20240229): 200K / 4096.
+		ID:              "claude-opus-3",
+		Aliases:         []string{"claude-3-opus", "claude-3-opus-20240229"},
+		DisplayName:     "Claude opus 3",
+		Provider:        ProviderClaudeAI,
+		ContextWindow:   200000,
+		MaxOutputTokens: 4096,
+		PreferredAPI:    APIAnthropicMessages,
+		APIVersion:      config.ClaudeAIAPIVersionDefault,
+		Capabilities:    []string{"json_mode", "tools"},
+	},
+	// Google Gemini Models. Specs from ai.google.dev model docs:
+	// every Gemini 2.x exposes a 1,048,576-token input window with a
+	// 65,536-token max output (8,192 on the older 2.0 generation). The
+	// previous catalog set MaxOutputTokens equal to ContextWindow, which
+	// is physically impossible — the API rejects requests with output
+	// over the per-model cap.
 	{
 		ID:              "gemini-2.5-pro",
 		Aliases:         []string{"gemini-2.5-pro", "gemini-2.5-pro-latest"},
 		DisplayName:     "Gemini 2.5 Pro",
 		Provider:        ProviderGoogleAI,
-		ContextWindow:   2000000, // 2M tokens context window
-		MaxOutputTokens: 2000000,
+		ContextWindow:   1048576,
+		MaxOutputTokens: 65536,
 		PreferredAPI:    "gemini_api",
 		Capabilities:    []string{"vision", "tools", "json_mode", "code_execution"},
 	},
 	{
+		// Gemini 3 Pro (preview): 1M context, 65K output. Conservative
+		// projection until Google publishes 3.x specs.
 		ID:              "gemini-3",
 		Aliases:         []string{"gemini-3-pro", "gemini-3-pro-preview"},
 		DisplayName:     "Gemini 3 Pro",
 		Provider:        ProviderGoogleAI,
-		ContextWindow:   2000000, // 2M tokens context window
-		MaxOutputTokens: 2000000,
+		ContextWindow:   1048576,
+		MaxOutputTokens: 65536,
 		PreferredAPI:    "gemini_api",
 		Capabilities:    []string{"vision", "tools", "json_mode", "code_execution"},
 	},
@@ -409,8 +485,8 @@ var registry = []ModelMeta{
 		Aliases:         []string{"gemini-2.5-flash"},
 		DisplayName:     "Gemini 2.5 Flash",
 		Provider:        ProviderGoogleAI,
-		ContextWindow:   1000000, // 1M tokens
-		MaxOutputTokens: 1000000,
+		ContextWindow:   1048576,
+		MaxOutputTokens: 65536,
 		PreferredAPI:    "gemini_api",
 		Capabilities:    []string{"vision", "tools", "json_mode"},
 	},
@@ -419,28 +495,30 @@ var registry = []ModelMeta{
 		Aliases:         []string{"gemini-2.5-flash-lite", "gemini-2.5-flash-lite"},
 		DisplayName:     "Gemini 2.5 Flash Lite",
 		Provider:        ProviderGoogleAI,
-		ContextWindow:   1000000,
-		MaxOutputTokens: 1000000,
+		ContextWindow:   1048576,
+		MaxOutputTokens: 65536,
 		PreferredAPI:    "gemini_api",
 		Capabilities:    []string{"vision", "tools", "json_mode", "multimodal_live"},
 	},
 	{
+		// Gemini 2.0 Flash (deprecated): 1,048,576 input / 8,192 output.
 		ID:              "gemini-2.0-flash",
 		Aliases:         []string{"gemini-2.0-flash"},
 		DisplayName:     "Gemini 2.0 Flash",
 		Provider:        ProviderGoogleAI,
-		ContextWindow:   1000000, // 1M tokens
-		MaxOutputTokens: 1000000,
+		ContextWindow:   1048576,
+		MaxOutputTokens: 8192,
 		PreferredAPI:    "gemini_api",
 		Capabilities:    []string{"vision", "tools", "json_mode"},
 	},
 	{
+		// Gemini 2.0 Flash Lite (deprecated): 1,048,576 input / 8,192 output.
 		ID:              "gemini-2.0-flash-lite",
 		Aliases:         []string{"gemini-2.0-flash-lite"},
-		DisplayName:     "Gemini 2.5 Flash Lite",
+		DisplayName:     "Gemini 2.0 Flash Lite",
 		Provider:        ProviderGoogleAI,
-		ContextWindow:   1000000,
-		MaxOutputTokens: 1000000,
+		ContextWindow:   1048576,
+		MaxOutputTokens: 8192,
 		PreferredAPI:    "gemini_api",
 		Capabilities:    []string{"vision", "tools", "json_mode", "multimodal_live"},
 	},
@@ -573,86 +651,137 @@ var registry = []ModelMeta{
 		PreferredAPI:    APIChatCompletions,
 	},
 
-	// xAI (Grok) Models
+	// xAI (Grok) Models. Specs from xAI's published model docs and the
+	// OpenRouter mirror (which xAI also publishes against). Aliases were
+	// previously written as a single comma-joined string instead of
+	// separate entries — Resolve() never matched them. Fixed here.
 	{
+		// grok-4-fast: 2M context. xAI does not document a separate output
+		// cap; we ceil at 16K to keep the value comparable to other models
+		// and avoid runaway generations on retry.
 		ID:              "grok-4-fast",
-		Aliases:         []string{"grok-4-fast-reasoning-latest, grok-4-fast-reasoning, grok-4-0709"},
-		DisplayName:     "Grok-4",
+		Aliases:         []string{"grok-4-fast-reasoning-latest", "grok-4-fast-reasoning", "grok-4-0709"},
+		DisplayName:     "Grok-4 Fast",
 		Provider:        ProviderXAI,
 		ContextWindow:   2000000,
-		MaxOutputTokens: 2000000,
+		MaxOutputTokens: 16384,
 		PreferredAPI:    APIChatCompletions,
-		Capabilities:    []string{},
+		Capabilities:    []string{"tools", "json_mode"},
 	},
 	{
+		// grok-4-1: forward variant; tracked at the same 2M / 16K profile
+		// until xAI publishes distinct specs.
 		ID:              "grok-4-1",
-		Aliases:         []string{"grok-4-1-fast, grok-4-1-fast-reasoning-latest"},
+		Aliases:         []string{"grok-4-1-fast", "grok-4-1-fast-reasoning-latest"},
 		DisplayName:     "Grok-4-1",
 		Provider:        ProviderXAI,
 		ContextWindow:   2000000,
-		MaxOutputTokens: 2000000,
+		MaxOutputTokens: 16384,
 		PreferredAPI:    APIChatCompletions,
-		Capabilities:    []string{},
+		Capabilities:    []string{"tools", "json_mode"},
 	},
 	{
+		// grok-3: 131,072 context (128K), 16K max output.
 		ID:              "grok-3",
 		Aliases:         []string{"grok-3"},
 		DisplayName:     "Grok-3",
 		Provider:        ProviderXAI,
-		ContextWindow:   128000,
-		MaxOutputTokens: 128000,
+		ContextWindow:   131072,
+		MaxOutputTokens: 16384,
 		PreferredAPI:    APIChatCompletions,
 		Capabilities:    []string{"json_mode"},
 	},
 	{
+		// grok-3-mini: same 131,072 / 16K profile as grok-3.
 		ID:              "grok-3-mini",
 		Aliases:         []string{"grok-3-mini"},
 		DisplayName:     "Grok-3 Mini",
 		Provider:        ProviderXAI,
-		ContextWindow:   128000,
-		MaxOutputTokens: 128000,
+		ContextWindow:   131072,
+		MaxOutputTokens: 16384,
 		PreferredAPI:    APIChatCompletions,
 		Capabilities:    []string{"json_mode"},
 	},
 	{
+		// grok-code-fast-1: 256K context. Coding-tuned variant.
 		ID:              "grok-code-fast-1",
 		Aliases:         []string{"grok-code-fast-1"},
 		DisplayName:     "Grok Code Fast 1",
 		Provider:        ProviderXAI,
-		ContextWindow:   200000,
-		MaxOutputTokens: 200000,
+		ContextWindow:   256000,
+		MaxOutputTokens: 16384,
 		PreferredAPI:    APIChatCompletions,
 		Capabilities:    []string{"json_mode"},
 	},
 
 	// ZAI (Zhipu AI / z.ai) Models
+	// GLM-5 family. All entries below verified against Z.AI's per-model
+	// docs (docs.z.ai/guides/llm/glm-*). Ordering rule: newest IDs first
+	// so generic alias prefixes ("glm-5") don't shadow the more specific
+	// "glm-5.1" / "glm-5-turbo" tags.
 	{
-		ID:              "glm-5",
-		Aliases:         []string{"glm-5"},
-		DisplayName:     "GLM-5",
+		// GLM-5.1: 200K / 128K (docs.z.ai/guides/llm/glm-5.1).
+		ID:              "glm-5.1",
+		Aliases:         []string{"glm-5.1", "glm-5-1"},
+		DisplayName:     "GLM-5.1",
 		Provider:        ProviderZAI,
-		ContextWindow:   128000,
+		ContextWindow:   200000,
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIChatCompletions,
 		Capabilities:    []string{"tools", "vision"},
 	},
 	{
+		// GLM-5-Turbo: 200K / 128K (docs.z.ai/guides/llm/glm-5-turbo).
+		ID:              "glm-5-turbo",
+		Aliases:         []string{"glm-5-turbo", "glm5-turbo"},
+		DisplayName:     "GLM-5 Turbo",
+		Provider:        ProviderZAI,
+		ContextWindow:   200000,
+		MaxOutputTokens: 128000,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"tools", "vision"},
+	},
+	{
+		// GLM-5: 200K / 128K (docs.z.ai/guides/llm/glm-5).
+		ID:              "glm-5",
+		Aliases:         []string{"glm-5"},
+		DisplayName:     "GLM-5",
+		Provider:        ProviderZAI,
+		ContextWindow:   200000,
+		MaxOutputTokens: 128000,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"tools", "vision"},
+	},
+	{
+		// GLM-4.7: 200K / 128K (docs.z.ai/guides/llm/glm-4.7).
 		ID:              "glm-4.7",
 		Aliases:         []string{"glm-4.7"},
 		DisplayName:     "GLM-4.7",
 		Provider:        ProviderZAI,
-		ContextWindow:   202752,
-		MaxOutputTokens: 65535,
+		ContextWindow:   200000,
+		MaxOutputTokens: 128000,
 		PreferredAPI:    APIChatCompletions,
 		Capabilities:    []string{"tools"},
 	},
 	{
+		// GLM-4.6: 200K / 128K (docs.z.ai/guides/llm/glm-4.6).
+		ID:              "glm-4.6",
+		Aliases:         []string{"glm-4.6", "glm-4-6"},
+		DisplayName:     "GLM-4.6",
+		Provider:        ProviderZAI,
+		ContextWindow:   200000,
+		MaxOutputTokens: 128000,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"tools"},
+	},
+	{
+		// GLM-4.5: 128K context, 96K max output.
 		ID:              "glm-4.5",
 		Aliases:         []string{"glm-4.5"},
 		DisplayName:     "GLM-4.5",
 		Provider:        ProviderZAI,
 		ContextWindow:   128000,
-		MaxOutputTokens: 98304,
+		MaxOutputTokens: 96000,
 		PreferredAPI:    APIChatCompletions,
 		Capabilities:    []string{"tools"},
 	},
@@ -823,12 +952,17 @@ var registry = []ModelMeta{
 		Capabilities:    []string{"tools"},
 	},
 	{
+		// DeepSeek R1 via OpenRouter: served at 64K context per the
+		// OpenRouter model card. R1 was deprecated upstream by DeepSeek
+		// (replaced by deepseek-v4-flash / -pro at 1M); the entry is
+		// kept for callers still pinning the old ID. Output ceiling
+		// follows DeepSeek's published R1 spec (8K typical).
 		ID:              "deepseek/deepseek-r1",
 		Aliases:         []string{"openrouter-deepseek-r1"},
-		DisplayName:     "DeepSeek R1 (OpenRouter)",
+		DisplayName:     "DeepSeek R1 (OpenRouter, deprecated)",
 		Provider:        ProviderOpenRouter,
-		ContextWindow:   163840,
-		MaxOutputTokens: 65536,
+		ContextWindow:   64000,
+		MaxOutputTokens: 8192,
 		PreferredAPI:    APIChatCompletions,
 		Capabilities:    []string{"tools"},
 	},
@@ -851,35 +985,37 @@ var registry = []ModelMeta{
 	// A listagem dinâmica via `bedrock:ListInferenceProfiles` complementa
 	// este catálogo com o que a conta AWS realmente tem acesso.
 
-	// Claude 4.6 (abr 2026 — mais recentes)
+	// Claude 4.6 (abr 2026 — mais recentes). Bedrock specs follow the
+	// Anthropic models page: Sonnet 4.6 = 1M / 64K, Opus 4.6 = 1M / 128K.
 	{
 		ID:              "global.anthropic.claude-sonnet-4-6-20260115-v1:0",
 		Aliases:         []string{"bedrock-sonnet-4-6", "anthropic.claude-sonnet-4-6-20260115-v1:0", "claude-sonnet-4-6"},
-		DisplayName:     "Claude Sonnet 4.6 (Bedrock, global)",
+		DisplayName:     "Claude Sonnet 4.6 (Bedrock, global, 1M ctx)",
 		Provider:        ProviderBedrock,
-		ContextWindow:   400000,
-		MaxOutputTokens: 128000,
+		ContextWindow:   1000000,
+		MaxOutputTokens: 64000,
 		PreferredAPI:    APIAnthropicMessages,
 		Capabilities:    []string{"tools", "vision", "json_mode"},
 	},
 	{
 		ID:              "global.anthropic.claude-opus-4-6-20260115-v1:0",
 		Aliases:         []string{"bedrock-opus-4-6", "anthropic.claude-opus-4-6-20260115-v1:0", "claude-opus-4-6"},
-		DisplayName:     "Claude Opus 4.6 (Bedrock, global)",
+		DisplayName:     "Claude Opus 4.6 (Bedrock, global, 1M ctx)",
 		Provider:        ProviderBedrock,
-		ContextWindow:   400000,
-		MaxOutputTokens: 64000,
+		ContextWindow:   1000000,
+		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
 		Capabilities:    []string{"tools", "vision", "json_mode"},
 	},
-	// Claude 4.7 (abr 2026 — Opus com 1M de contexto)
+	// Claude 4.7. Sonnet 4.7 mirrors 4.6's profile (forward-projected),
+	// Opus 4.7 = 1M / 128K per Anthropic.
 	{
 		ID:              "global.anthropic.claude-sonnet-4-7-20260401-v1:0",
 		Aliases:         []string{"bedrock-sonnet-4-7", "anthropic.claude-sonnet-4-7-20260401-v1:0", "claude-sonnet-4-7"},
 		DisplayName:     "Claude Sonnet 4.7 (Bedrock, global)",
 		Provider:        ProviderBedrock,
-		ContextWindow:   200000,
-		MaxOutputTokens: 128000,
+		ContextWindow:   1000000,
+		MaxOutputTokens: 64000,
 		PreferredAPI:    APIAnthropicMessages,
 		Capabilities:    []string{"tools", "vision", "json_mode"},
 	},
@@ -889,7 +1025,7 @@ var registry = []ModelMeta{
 		DisplayName:     "Claude Opus 4.7 (Bedrock, global, 1M ctx)",
 		Provider:        ProviderBedrock,
 		ContextWindow:   1000000,
-		MaxOutputTokens: 64000,
+		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
 		Capabilities:    []string{"tools", "vision", "json_mode"},
 	},
@@ -978,14 +1114,19 @@ var registry = []ModelMeta{
 		Capabilities:    []string{"tools", "vision", "json_mode"},
 	},
 
-	// Claude 3.7 Sonnet
+	// Claude 3.7 Sonnet (Bedrock mirrors). Same correction as the
+	// upstream ProviderClaudeAI entry: synchronous Messages API caps
+	// output at 8192. The 64K ceiling only unlocks via the
+	// `output-128k-2025-02-19` extended-thinking beta header. Pinning
+	// the catalog at the safe default keeps regular calls from being
+	// rejected with 400 errors.
 	{
 		ID:              "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
 		Aliases:         []string{"bedrock-sonnet-3-7", "anthropic.claude-3-7-sonnet-20250219-v1:0", "claude-3-7-sonnet"},
 		DisplayName:     "Claude 3.7 Sonnet (Bedrock, us)",
 		Provider:        ProviderBedrock,
 		ContextWindow:   200000,
-		MaxOutputTokens: 64000,
+		MaxOutputTokens: 8192,
 		PreferredAPI:    APIAnthropicMessages,
 		Capabilities:    []string{"tools", "vision", "json_mode"},
 	},
@@ -995,7 +1136,7 @@ var registry = []ModelMeta{
 		DisplayName:     "Claude 3.7 Sonnet (Bedrock, eu)",
 		Provider:        ProviderBedrock,
 		ContextWindow:   200000,
-		MaxOutputTokens: 64000,
+		MaxOutputTokens: 8192,
 		PreferredAPI:    APIAnthropicMessages,
 		Capabilities:    []string{"tools", "vision", "json_mode"},
 	},
@@ -1140,25 +1281,41 @@ func GetMaxTokens(provider, model string, override int) int {
 		return meta.MaxOutputTokens
 	}
 
-	// fallbacks conservadores, coerentes com o código existente
+	// Fallbacks por provedor para modelos que NÃO estão no registry. Os
+	// valores foram revistos contra a documentação oficial de cada
+	// provedor (Apr 2026). O critério é "menor MaxOutput observado entre
+	// os modelos atuais do provedor" — alto o suficiente para não
+	// estrangular saídas legítimas, baixo o suficiente para um modelo
+	// desconhecido não estourar limites do servidor.
 	switch strings.ToUpper(provider) {
 	case ProviderOpenAI:
 		m := strings.ToLower(model)
+		// gpt-5 family (5, 5.x, 5.5/pro): real cap is 128K.
 		if strings.HasPrefix(m, "gpt-5") {
-			return 50000
+			return 128000
 		}
+		// gpt-4.1 / gpt-4o family: real cap 16K-32K, use 32K.
 		if m == "gpt-4o" || m == "gpt-4o-mini" || strings.HasPrefix(m, "gpt-4") {
-			return 50000
+			return 32000
 		}
-		return 40000
+		// o-series reasoning models cap at 100K.
+		if strings.HasPrefix(m, "o3") || strings.HasPrefix(m, "o4") {
+			return 100000
+		}
+		return 16384
 	case ProviderClaudeAI:
-		return 50000
+		// Claude 3+ família toda usa 200K input; output varia 4K-128K.
+		// 64K é o teto comum dos modelos atuais (sonnet 4.x, opus 4.5+).
+		return 64000
 	case ProviderStackSpot:
 		return 50000
 	case ProviderGoogleAI:
-		return 50000
+		// Gemini 2.x todos a 65K output.
+		return 65536
 	case ProviderXAI:
-		return 50000
+		// Grok 3/4 expõem ≥16K na prática; manter cap conservador
+		// porque xAI não publica limite oficial.
+		return 16384
 	case ProviderZAI:
 		return 65535
 	case ProviderMiniMax:

--- a/llm/catalog/catalog_test.go
+++ b/llm/catalog/catalog_test.go
@@ -57,13 +57,18 @@ func TestGetMaxTokens(t *testing.T) {
 	tokens := GetMaxTokens(ProviderOpenAI, "gpt-4o", 12345)
 	assert.Equal(t, 12345, tokens, "Override should have the highest priority")
 
-	// Caso 2: Valor do catálogo
+	// Caso 2: Valor do catálogo. Haiku 3 expõe 4096 tokens de output
+	// (limite real publicado pela Anthropic, não o número conservador
+	// inflado de 42K que o catálogo carregava antes da auditoria).
 	tokens = GetMaxTokens(ProviderClaudeAI, "claude-3-haiku", 0)
-	assert.Equal(t, 42000, tokens, "Should get value from catalog for claude-3-haiku")
+	assert.Equal(t, 4096, tokens, "Should get value from catalog for claude-3-haiku")
 
-	// Caso 3: Fallback para modelo desconhecido
+	// Caso 3: Fallback para modelo desconhecido. Após a auditoria de
+	// catálogo (Abr 2026) os fallbacks foram alinhados com os limites
+	// oficiais — 16384 é o piso "OpenAI gpt-* genérico" para modelos
+	// fora do registry, coerente com o cap real de gpt-4o (16K).
 	tokens = GetMaxTokens(ProviderOpenAI, "unknown-model", 0)
-	assert.Equal(t, 40000, tokens, "Should use fallback value for unknown OpenAI model")
+	assert.Equal(t, 16384, tokens, "Should use fallback value for unknown OpenAI model")
 
 	// Caso 4: Fallback para provider desconhecido
 	tokens = GetMaxTokens("UNKNOWN_PROVIDER", "some-model", 0)


### PR DESCRIPTION
## Summary

Two related improvements to make ChatCLI's runtime self-truthful:

- **Catalog audit** — every model entry checked against canonical docs (Anthropic models page, ai.google.dev, docs.x.ai/OpenRouter mirror, docs.z.ai). Many entries had inflated or undersized ContextWindow/MaxOutputTokens that caused premature autocompact disparos and silent 400 errors.
- **Env defaults registry** — `/config` no longer prints bare `(not set)` for env vars that have a known runtime fallback. A new static registry pairs each var with its real default and a `Source` pointer to the symbol that owns it, so operators see what the system is actually doing without reading source.

## Catalog highlights

| Provider | Before | After | Why |
|---|---|---|---|
| Anthropic Sonnet 4 | 50K / 50K | 200K / 64K | docs |
| Anthropic Sonnet 4.6 | 200K / 128K | 1M / 64K | docs |
| Anthropic Opus 4.7 | 1M / 64K | 1M / 128K | docs |
| Anthropic Opus 4.6 | 400K / 64K | 1M / 128K | docs |
| Anthropic Opus 4 / 4.1 | 20K / 20K | 200K / 32K | docs |
| Anthropic Sonnet 3.7 | 50K / 50K | 200K / 8192 | sync API cap (64K needs extended-thinking beta) |
| OpenAI gpt-5 | 128K / 16K | 400K / 128K | OpenRouter mirror |
| Gemini 2.x | 2M / 2M (impossible) | 1,048,576 / 65,536 | ai.google.dev |
| Grok aliases | comma-joined string (broken) | split entries | Resolve never matched |
| Grok-3 | 128K | 131,072 | mirror |
| Grok-code-fast-1 | 200K | 256K | mirror |
| GLM-4.6 | (missing) | 200K / 128K | docs.z.ai |
| GLM-5.1 / GLM-5-Turbo | (missing) | 200K / 128K | docs.z.ai |
| Bedrock 3.7-sonnet | 64K out | 8192 out | same beta-header issue |
| OpenRouter deepseek-r1 | 163K / 65K | 64K / 8192 | OpenRouter actual + R1 deprecated upstream |

Provider-level fallbacks in `GetMaxTokens`/`GetContextWindow` recalibrated against the same sources so unknown models land within real limits.

## Env defaults registry

- New `cli/config_env_defaults.go` with one entry per known env var: `Value` (runtime fallback) + `Source` (file/constant pointer) + `IsBool` flag.
- `envOr`/`envBool` consult the registry when the env is empty and tag the line with a sentinel; `kv` strips it and renders as cyan with a `(default)` localized suffix.
- Vars with no static fallback in code are intentionally left out so they keep the truthful `[NOT SET]` label.
- New i18n key `cfg.val.default_tag` in en, en-US, pt-BR.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `gofmt -l .` returns clean
- [x] `golangci-lint run ./...` exit 0
- [ ] Manual: `/config providers` and `/config resilience` show real fallbacks (e.g. `CHATCLI_AGENT_CMD_TIMEOUT: 10m (default)`) when envs are unset
- [ ] Manual: switch model to claude-sonnet-4-6 and confirm autocompact does not fire under 1M tokens of history
- [ ] Manual: switch model to claude-sonnet-3-7 and confirm `max_tokens` requests around 64K only succeed when extended-thinking beta is enabled by the caller