### PR TITLE
fix(bedrock): list and dispatch every model the AWS account has access to

### DIFF
--- a/cli/config_env_defaults.go
+++ b/cli/config_env_defaults.go
@@ -129,6 +129,15 @@ var envDefaults = map[string]envDefault{
 	"CHATCLI_BEDROCK_INSECURE_SKIP_VERIFY": {Value: "false", IsBool: true, Source: "bedrock client"},
 	"CHATCLI_BEDROCK_ENABLE_IMDS":          {Value: "false", IsBool: true, Source: "bedrock client"},
 
+	// ─── Embeddings (HyDE / RAG) ─────────────────────────────────
+	// Defaults are described in llm/embedding/factory.go. CHATCLI_EMBED_PROVIDER
+	// is purely opt-in (empty == null provider, no embeddings); we register
+	// the model/dimensions defaults so /config can show what each provider
+	// would use if selected.
+	"CHATCLI_EMBED_PROVIDER":   {Value: "(off)", Source: "llm/embedding/factory.go (empty == null)"},
+	"CHATCLI_EMBED_MODEL":      {Value: "(provider-specific)", Source: "voyage-3 / text-embedding-3-small / amazon.titan-embed-text-v2:0"},
+	"CHATCLI_EMBED_DIMENSIONS": {Value: "(provider-default)", Source: "openai 1536, titan-v2 1024 (256/512/1024), titan-v1 1536, cohere-v3 1024"},
+
 	// ─── Cost / budget ───────────────────────────────────────────
 	"CHATCLI_SESSION_BUDGET_USD": {Value: "(no budget)", Source: "cost_tracker.go"},
 	"CHATCLI_BUDGET_WARNING_PCT": {Value: "0.80", Source: "cost_tracker.go"},

--- a/cli/config_quality.go
+++ b/cli/config_quality.go
@@ -104,6 +104,7 @@ func (cli *ChatCLI) showConfigQuality() {
 	kv(p, "CHATCLI_QUALITY_HYDE_USE_VECTORS", boolLabel(cfg.HyDE.UseVectors))
 	kv(p, "CHATCLI_EMBED_PROVIDER", envOr("CHATCLI_EMBED_PROVIDER"))
 	kv(p, "CHATCLI_EMBED_MODEL", envOr("CHATCLI_EMBED_MODEL"))
+	kv(p, "CHATCLI_EMBED_DIMENSIONS", envOr("CHATCLI_EMBED_DIMENSIONS"))
 	kv(p, "CHATCLI_QUALITY_HYDE_NUM_KEYWORDS", fmt.Sprintf("%d", cfg.HyDE.NumKeywords))
 	if cli.memoryStore != nil {
 		if vi := cli.memoryStore.VectorIndex(); vi != nil {

--- a/cli/config_sections.go
+++ b/cli/config_sections.go
@@ -454,6 +454,7 @@ func (cli *ChatCLI) showConfigProviders() {
 	kv(p, "BEDROCK_PROVIDER", envOr("BEDROCK_PROVIDER"))
 	kv(p, "BEDROCK_MAX_TOKENS", envOr("BEDROCK_MAX_TOKENS"))
 	kv(p, "BEDROCK_TEMPERATURE", envOr("BEDROCK_TEMPERATURE"))
+	kv(p, "BEDROCK_TOP_P", envOr("BEDROCK_TOP_P"))
 
 	fmt.Println(p)
 	subheader(p, "cfg.sub.prov.copilot")

--- a/llm/bedrock/awsclient.go
+++ b/llm/bedrock/awsclient.go
@@ -1,0 +1,59 @@
+/*
+ * ChatCLI - Shared AWS runtime client construction.
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package bedrock
+
+import (
+	"context"
+	"fmt"
+
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+	"go.uber.org/zap"
+)
+
+// LoadBedrockRuntime builds a bedrockruntime.Client using the same
+// credential chain, region resolution, IMDS gating and corporate-CA
+// support that the chat client (BedrockClient) uses. Exported so other
+// callers — notably the embedding provider in llm/embedding/bedrock.go —
+// can consume Bedrock without duplicating the AWS config plumbing.
+//
+// The returned region is the one effectively in use after the SDK
+// finishes resolving env vars / shared config / SSO profile defaults.
+// Callers that previously stored the input region should overwrite
+// their cached value with this resolved one (the chat client does).
+//
+// A nil logger is rejected — callers should pass zap.NewNop() if they
+// don't care about Bedrock-side observability.
+func LoadBedrockRuntime(ctx context.Context, region, profile string, logger *zap.Logger) (*bedrockruntime.Client, string, error) {
+	if logger == nil {
+		return nil, "", fmt.Errorf("bedrock: logger is required (pass zap.NewNop() if you don't need logs)")
+	}
+	opts := []func(*awsconfig.LoadOptions) error{}
+	if region != "" {
+		opts = append(opts, awsconfig.WithRegion(region))
+	}
+	if profile != "" {
+		opts = append(opts, awsconfig.WithSharedConfigProfile(profile))
+	}
+	if httpClient, note := buildCorporateHTTPClient(logger); httpClient != nil {
+		opts = append(opts, awsconfig.WithHTTPClient(httpClient))
+		if note != "" {
+			logger.Warn(note)
+		}
+	}
+	if shouldDisableIMDS() {
+		opts = append(opts, awsconfig.WithEC2IMDSClientEnableState(imds.ClientDisabled))
+	}
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		return nil, "", fmt.Errorf("bedrock: failed to load AWS config: %w", err)
+	}
+	if cfg.Region == "" {
+		return nil, "", fmt.Errorf("bedrock: AWS region not configured (set AWS_REGION, BEDROCK_REGION, or configure ~/.aws/config)")
+	}
+	return bedrockruntime.NewFromConfig(cfg), cfg.Region, nil
+}

--- a/llm/bedrock/awsclient.go
+++ b/llm/bedrock/awsclient.go
@@ -15,6 +15,21 @@ import (
 	"go.uber.org/zap"
 )
 
+// RuntimeEndpointURL returns the standard AWS Bedrock runtime endpoint
+// for a given region. The SDK resolves this internally through the
+// service-default endpoint resolver, but we expose it explicitly so it
+// can land in structured logs — every other LLM client in the project
+// logs the URL it talks to, and Bedrock used to be the odd one out.
+//
+// Returns an empty string for an empty region so callers can decide
+// whether to log the field at all.
+func RuntimeEndpointURL(region string) string {
+	if region == "" {
+		return ""
+	}
+	return "https://bedrock-runtime." + region + ".amazonaws.com"
+}
+
 // LoadBedrockRuntime builds a bedrockruntime.Client using the same
 // credential chain, region resolution, IMDS gating and corporate-CA
 // support that the chat client (BedrockClient) uses. Exported so other

--- a/llm/bedrock/bedrock_client.go
+++ b/llm/bedrock/bedrock_client.go
@@ -160,36 +160,42 @@ func (c *BedrockClient) ensureRuntime(ctx context.Context) error {
 	if c.runtime != nil {
 		return nil
 	}
-	opts := []func(*awsconfig.LoadOptions) error{}
-	if c.region != "" {
-		opts = append(opts, awsconfig.WithRegion(c.region))
-	}
-	if c.profile != "" {
-		opts = append(opts, awsconfig.WithSharedConfigProfile(c.profile))
-	}
-	if httpClient, note := buildCorporateHTTPClient(c.logger); httpClient != nil {
-		opts = append(opts, awsconfig.WithHTTPClient(httpClient))
-		if note != "" {
-			c.logger.Warn(note)
-		}
-	}
-	if shouldDisableIMDS() {
-		opts = append(opts, awsconfig.WithEC2IMDSClientEnableState(imds.ClientDisabled))
-	}
-	cfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
+	runtime, resolvedRegion, err := LoadBedrockRuntime(ctx, c.region, c.profile, c.logger)
 	if err != nil {
-		return fmt.Errorf("bedrock: failed to load AWS config: %w", err)
+		return err
 	}
-	if cfg.Region == "" {
-		return fmt.Errorf("bedrock: AWS region not configured (set AWS_REGION, BEDROCK_REGION, or configure ~/.aws/config)")
+	// The control-plane client is only used by the chat client (ListModels);
+	// the embedding provider doesn't need it, which is why LoadBedrockRuntime
+	// returns just the runtime. We rebuild the AWS config locally here only
+	// to construct the bedrock control client with the same credential chain.
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, controlPlaneConfigOptions(c.region, c.profile)...)
+	if err != nil {
+		return fmt.Errorf("bedrock: failed to load control-plane AWS config: %w", err)
 	}
-	c.region = cfg.Region
-	c.runtime = bedrockruntime.NewFromConfig(cfg)
+	c.region = resolvedRegion
+	c.runtime = runtime
 	c.control = bedrocksvc.NewFromConfig(cfg)
 	c.logger.Info(i18n.T("llm.info.configuring_provider", "Bedrock"),
 		zap.String("region", c.region),
 		zap.String("model", c.model))
 	return nil
+}
+
+// controlPlaneConfigOptions mirrors the LoadOptions used by the runtime
+// helper so the bedrock control-plane client (used for ListModels) sees
+// the same region/profile/IMDS settings as the runtime client.
+func controlPlaneConfigOptions(region, profile string) []func(*awsconfig.LoadOptions) error {
+	opts := []func(*awsconfig.LoadOptions) error{}
+	if region != "" {
+		opts = append(opts, awsconfig.WithRegion(region))
+	}
+	if profile != "" {
+		opts = append(opts, awsconfig.WithSharedConfigProfile(profile))
+	}
+	if shouldDisableIMDS() {
+		opts = append(opts, awsconfig.WithEC2IMDSClientEnableState(imds.ClientDisabled))
+	}
+	return opts
 }
 
 // SendPrompt dispatches to the correct body schema based on the resolved

--- a/llm/bedrock/bedrock_client.go
+++ b/llm/bedrock/bedrock_client.go
@@ -177,6 +177,7 @@ func (c *BedrockClient) ensureRuntime(ctx context.Context) error {
 	c.control = bedrocksvc.NewFromConfig(cfg)
 	c.logger.Info(i18n.T("llm.info.configuring_provider", "Bedrock"),
 		zap.String("region", c.region),
+		zap.String("endpoint", RuntimeEndpointURL(c.region)),
 		zap.String("model", c.model))
 	return nil
 }
@@ -258,6 +259,8 @@ func (c *BedrockClient) sendPromptAnthropic(ctx context.Context, prompt string, 
 	start := time.Now()
 	client.LogRequestStart(c.logger, "BEDROCK", c.model,
 		zap.String("family", string(familyAnthropic)),
+		zap.String("region", c.region),
+		zap.String("endpoint", RuntimeEndpointURL(c.region)),
 		zap.Int("payload_bytes", len(payload)),
 		zap.Int("history_len", len(history)),
 		zap.Int("max_tokens", effectiveMaxTokens),

--- a/llm/bedrock/bedrock_client.go
+++ b/llm/bedrock/bedrock_client.go
@@ -34,39 +34,55 @@ import (
 	"go.uber.org/zap"
 )
 
-// modelFamily identifies the request/response body schema a Bedrock model
-// expects. Each family has a distinct InvokeModel payload.
+// modelFamily identifies which dispatch path a Bedrock model uses.
+// Anthropic and OpenAI keep dedicated InvokeModel paths (preserving cache
+// markers, extended thinking and the existing wire formats). Everything
+// else routes through the unified Converse API, which supports Llama,
+// Amazon Nova, Mistral, Cohere, AI21 Jamba, DeepSeek, Stability and any
+// future provider Bedrock onboards without a per-provider body schema.
 type modelFamily string
 
 const (
 	familyAnthropic modelFamily = "anthropic"
 	familyOpenAI    modelFamily = "openai"
+	familyConverse  modelFamily = "converse"
 )
 
-// resolveFamily picks the body schema to use. Precedence:
-//  1. BEDROCK_PROVIDER env var (explicit override: "anthropic" | "openai")
-//  2. Model ID prefix: "openai.*" → OpenAI; "anthropic.*", "global.anthropic.*",
-//     "us.anthropic.*", "eu.anthropic.*", "apac.anthropic.*" → Anthropic.
-//  3. Default: Anthropic (preserves existing behavior).
+// resolveFamily picks the dispatch path. Precedence:
+//  1. BEDROCK_PROVIDER env var ("anthropic"/"claude", "openai"/"gpt",
+//     "converse"/"auto").
+//  2. Model ID prefix: "openai.*" → OpenAI; any "anthropic" segment
+//     (bare or behind a global./us./eu./apac. profile prefix) → Anthropic.
+//  3. Default: Converse — covers Llama, Nova, Mistral, Cohere, AI21,
+//     DeepSeek, Stability and any unknown provider through the unified
+//     Bedrock Converse API.
 func resolveFamily(model string) modelFamily {
 	switch strings.ToLower(strings.TrimSpace(os.Getenv("BEDROCK_PROVIDER"))) {
 	case "openai", "gpt":
 		return familyOpenAI
 	case "anthropic", "claude":
 		return familyAnthropic
+	case "converse", "auto":
+		return familyConverse
 	}
 	m := strings.ToLower(model)
 	if strings.HasPrefix(m, "openai.") || strings.Contains(m, ".openai.") {
 		return familyOpenAI
 	}
-	return familyAnthropic
+	if strings.HasPrefix(m, "anthropic.") || strings.Contains(m, ".anthropic.") {
+		return familyAnthropic
+	}
+	return familyConverse
 }
 
 // BedrockClient invokes foundation models hosted on AWS Bedrock.
-// Currently supports two body schemas via auto-dispatch (model-id prefix)
-// or explicit selection through BEDROCK_PROVIDER:
-//   - Anthropic Messages schema (Claude 3/3.5/3.7/4/4.5/4.6) — default
-//   - OpenAI Chat Completions schema (openai.gpt-oss-*)
+// Three dispatch paths via auto-detection (model-id prefix) or explicit
+// selection through BEDROCK_PROVIDER:
+//   - Anthropic Messages schema (Claude 3/3.5/3.7/4/4.5/4.6/4.7) — preserves
+//     cache_control markers and extended-thinking knobs.
+//   - OpenAI Chat Completions schema (openai.gpt-oss-*).
+//   - Converse API (default for everything else: Llama, Nova, Mistral,
+//     Cohere, AI21 Jamba, DeepSeek, Stability) — one schema for all.
 //
 // Authentication uses the default AWS credentials chain:
 //   - Environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN)
@@ -190,6 +206,8 @@ func (c *BedrockClient) SendPrompt(ctx context.Context, prompt string, history [
 	switch family {
 	case familyOpenAI:
 		return c.sendPromptOpenAI(ctx, prompt, history, maxTokens)
+	case familyConverse:
+		return c.sendPromptConverse(ctx, prompt, history, maxTokens)
 	default:
 		return c.sendPromptAnthropic(ctx, prompt, history, maxTokens)
 	}
@@ -248,7 +266,7 @@ func (c *BedrockClient) sendPromptAnthropic(ctx context.Context, prompt string, 
 			Body:        payload,
 		})
 		if err != nil {
-			return "", err
+			return "", wrapBedrockInferenceProfileError(c.model, err)
 		}
 		return parseAnthropicBody(out.Body)
 	})
@@ -437,8 +455,25 @@ func (c *BedrockClient) ListModels(ctx context.Context) ([]client.ModelInfo, err
 	seen := make(map[string]bool)
 	var result []client.ModelInfo
 
-	// 1) Foundation models (on-demand capable) — all providers whose
-	//    body schema we currently support (Anthropic + OpenAI).
+	// 1) Foundation models — text-output, on-demand-invokable.
+	//
+	// We deliberately do NOT maintain a hardcoded provider allowlist here.
+	// AWS continuously onboards new providers (Moonshot, MiniMax, Qwen,
+	// Z.AI, Google Gemma, NVIDIA Nemotron, TwelveLabs, …) and any
+	// provider-name allowlist would silently hide them until we ship a
+	// release. Two AWS-side signals do the gating instead:
+	//
+	//   - ByOutputModality: ModelModalityText excludes embedding-only and
+	//     image-only models server-side.
+	//   - supportsOnDemand(InferenceTypesSupported) drops models whose
+	//     bare ID isn't invokable directly — those are exposed via the
+	//     matching inference profile in the next loop, which avoids the
+	//     "user picks anthropic.claude-3-7-... and gets ValidationException"
+	//     trap.
+	//
+	// If a listed ID happens to be incompatible with our dispatch (rare),
+	// wrapBedrockInferenceProfileError surfaces a helpful message instead
+	// of a cryptic AWS error.
 	fm, err := c.control.ListFoundationModels(ctx, &bedrocksvc.ListFoundationModelsInput{
 		ByOutputModality: bedrocktypes.ModelModalityText,
 	})
@@ -446,8 +481,14 @@ func (c *BedrockClient) ListModels(ctx context.Context) ([]client.ModelInfo, err
 		c.logger.Warn("bedrock: ListFoundationModels failed", zap.Error(err))
 	} else {
 		for _, s := range fm.ModelSummaries {
-			id, displayName := derefModelSummary(s.ModelId, s.ModelName)
-			if id == "" || seen[id] || !isSupportedBedrockFamily(id) {
+			id, displayName := derefModelSummary(s.ModelId, s.ModelName, s.ProviderName)
+			if id == "" || seen[id] {
+				continue
+			}
+			if !supportsOnDemand(s.InferenceTypesSupported) {
+				c.logger.Debug("bedrock: skipping foundation model without ON_DEMAND inference",
+					zap.String("model_id", id),
+					zap.Any("inference_types", s.InferenceTypesSupported))
 				continue
 			}
 			seen[id] = true
@@ -460,8 +501,8 @@ func (c *BedrockClient) ListModels(ctx context.Context) ([]client.ModelInfo, err
 		}
 	}
 
-	// 2) Inference profiles (required for Claude 3.7, 4.x, 4.5, 4.6
-	//    and also used by some newer cross-region OpenAI profiles).
+	// 2) Inference profiles — needed for Claude 3.7, 4.x, 4.5, 4.6, 4.7
+	//    and any cross-region-only profile across other providers.
 	paginator := bedrocksvc.NewListInferenceProfilesPaginator(c.control, &bedrocksvc.ListInferenceProfilesInput{})
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
@@ -474,7 +515,7 @@ func (c *BedrockClient) ListModels(ctx context.Context) ([]client.ModelInfo, err
 			if p.InferenceProfileId != nil {
 				id = *p.InferenceProfileId
 			}
-			if id == "" || seen[id] || !isSupportedBedrockFamily(id) {
+			if id == "" || seen[id] {
 				continue
 			}
 			displayName := id
@@ -495,21 +536,29 @@ func (c *BedrockClient) ListModels(ctx context.Context) ([]client.ModelInfo, err
 	return result, nil
 }
 
-// isSupportedBedrockFamily filters ListFoundation/InferenceProfile output to
-// families whose body schema the client knows how to encode. Expand this when
-// new families (Llama, Nova, Mistral, etc.) get first-class support.
-func isSupportedBedrockFamily(id string) bool {
-	m := strings.ToLower(id)
-	return strings.Contains(m, "anthropic") || strings.Contains(m, "openai")
+// supportsOnDemand returns true when ON_DEMAND is one of the inference
+// types declared by the foundation model. Models without ON_DEMAND require
+// an inference profile to be invoked and would fail with ValidationException
+// if selected by the bare model ID.
+func supportsOnDemand(types []bedrocktypes.InferenceType) bool {
+	for _, t := range types {
+		if t == bedrocktypes.InferenceTypeOnDemand {
+			return true
+		}
+	}
+	return false
 }
 
-func derefModelSummary(id, name *string) (string, string) {
+func derefModelSummary(id, name, provider *string) (string, string) {
 	idStr := ""
 	if id != nil {
 		idStr = *id
 	}
 	display := idStr
-	if name != nil && *name != "" {
+	switch {
+	case name != nil && *name != "" && provider != nil && *provider != "":
+		display = *provider + " " + *name + " (Bedrock)"
+	case name != nil && *name != "":
 		display = *name + " (Bedrock)"
 	}
 	return idStr, display
@@ -524,8 +573,22 @@ func registerBedrockModel(id, displayName string) {
 		Aliases:      []string{id},
 		DisplayName:  displayName,
 		Provider:     catalog.ProviderBedrock,
-		PreferredAPI: catalog.APIAnthropicMessages,
+		PreferredAPI: preferredAPIFor(id),
 	})
+}
+
+// preferredAPIFor matches the dispatch family to a catalog PreferredAPI so
+// downstream code (token sizing, capability lookups) does the right thing
+// for the provider we just discovered. Anthropic keeps its messages API
+// hint; OpenAI gets chat-completions; everything else marks itself as
+// chat-completions-compatible too — Converse normalizes onto that shape.
+func preferredAPIFor(id string) catalog.PreferredAPI {
+	switch resolveFamily(id) {
+	case familyAnthropic:
+		return catalog.APIAnthropicMessages
+	default:
+		return catalog.APIChatCompletions
+	}
 }
 
 // Ensure BedrockClient satisfies the LLMClient and ModelLister interfaces.

--- a/llm/bedrock/converse_family.go
+++ b/llm/bedrock/converse_family.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -53,7 +54,7 @@ func (c *BedrockClient) sendPromptConverse(ctx context.Context, prompt string, h
 		Messages: messages,
 		System:   system,
 		InferenceConfig: &bedrockruntimetypes.InferenceConfiguration{
-			MaxTokens: aws.Int32(int32(effectiveMaxTokens)),
+			MaxTokens: aws.Int32(clampInt32(effectiveMaxTokens)),
 		},
 	}
 	if t := os.Getenv("BEDROCK_TEMPERATURE"); t != "" {
@@ -70,6 +71,8 @@ func (c *BedrockClient) sendPromptConverse(ctx context.Context, prompt string, h
 	start := time.Now()
 	client.LogRequestStart(c.logger, "BEDROCK", c.model,
 		zap.String("family", string(familyConverse)),
+		zap.String("region", c.region),
+		zap.String("endpoint", RuntimeEndpointURL(c.region)),
 		zap.Int("history_len", len(history)),
 		zap.Int("max_tokens", effectiveMaxTokens),
 	)
@@ -93,6 +96,21 @@ func (c *BedrockClient) sendPromptConverse(ctx context.Context, prompt string, h
 		zap.Int("response_chars", len(responseText)),
 	)
 	return responseText, nil
+}
+
+// clampInt32 narrows an int into the int32 range Bedrock's Converse API
+// expects for MaxTokens. Practical maxima for any model are well under
+// the int32 ceiling, but the explicit clamp silences gosec G115 and
+// keeps the conversion safe even if a misconfigured caller passes a
+// truly huge value.
+func clampInt32(v int) int32 {
+	if v < 0 {
+		return 0
+	}
+	if v > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	return int32(v)
 }
 
 func (c *BedrockClient) getMaxTokensConverse() int {

--- a/llm/bedrock/converse_family.go
+++ b/llm/bedrock/converse_family.go
@@ -1,0 +1,239 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package bedrock
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+	bedrockruntimetypes "github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+	smithy "github.com/aws/smithy-go"
+
+	"github.com/diillson/chatcli/i18n"
+	"github.com/diillson/chatcli/llm/client"
+	"github.com/diillson/chatcli/models"
+	"github.com/diillson/chatcli/utils"
+	"go.uber.org/zap"
+)
+
+// sendPromptConverse routes the request through Bedrock's unified Converse
+// API. A single body schema works for Llama, Amazon Nova, Mistral, Cohere,
+// AI21 Jamba, DeepSeek, Stability and any future provider Bedrock onboards
+// — no per-provider InvokeModel encoder needed.
+//
+// Anthropic and OpenAI keep their dedicated InvokeModel paths because:
+//   - Anthropic: cache_control breakpoints + extended-thinking knobs map
+//     onto Converse with a different shape, and we don't want to disturb
+//     the working cache planner during this rollout.
+//   - OpenAI gpt-oss: stable on InvokeModel today and Converse coverage
+//     for these IDs has been uneven across regions.
+func (c *BedrockClient) sendPromptConverse(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {
+	effectiveMaxTokens := maxTokens
+	if effectiveMaxTokens <= 0 {
+		effectiveMaxTokens = c.getMaxTokensConverse()
+	}
+
+	messages, system := buildConverseMessages(prompt, history)
+	if len(messages) == 0 {
+		return "", fmt.Errorf("%s", i18n.T("llm.error.no_response", "Bedrock"))
+	}
+
+	input := &bedrockruntime.ConverseInput{
+		ModelId:  stringPtr(c.model),
+		Messages: messages,
+		System:   system,
+		InferenceConfig: &bedrockruntimetypes.InferenceConfiguration{
+			MaxTokens: aws.Int32(int32(effectiveMaxTokens)),
+		},
+	}
+	if t := os.Getenv("BEDROCK_TEMPERATURE"); t != "" {
+		if f, err := strconv.ParseFloat(t, 32); err == nil {
+			input.InferenceConfig.Temperature = aws.Float32(float32(f))
+		}
+	}
+	if t := os.Getenv("BEDROCK_TOP_P"); t != "" {
+		if f, err := strconv.ParseFloat(t, 32); err == nil {
+			input.InferenceConfig.TopP = aws.Float32(float32(f))
+		}
+	}
+
+	start := time.Now()
+	client.LogRequestStart(c.logger, "BEDROCK", c.model,
+		zap.String("family", string(familyConverse)),
+		zap.Int("history_len", len(history)),
+		zap.Int("max_tokens", effectiveMaxTokens),
+	)
+
+	responseText, err := utils.Retry(ctx, c.logger, c.maxAttempts, c.backoff, func(ctx context.Context) (string, error) {
+		out, err := c.runtime.Converse(ctx, input)
+		if err != nil {
+			return "", wrapBedrockInferenceProfileError(c.model, err)
+		}
+		return parseConverseOutput(out)
+	})
+	if err != nil {
+		client.LogRequestFinish(c.logger, "BEDROCK", c.model, "error", time.Since(start),
+			zap.String("family", string(familyConverse)),
+		)
+		c.logger.Error(i18n.T("llm.error.get_response_after_retries", "Bedrock"), zap.Error(err))
+		return "", err
+	}
+	client.LogRequestFinish(c.logger, "BEDROCK", c.model, "success", time.Since(start),
+		zap.String("family", string(familyConverse)),
+		zap.Int("response_chars", len(responseText)),
+	)
+	return responseText, nil
+}
+
+func (c *BedrockClient) getMaxTokensConverse() int {
+	if tokenStr := os.Getenv("BEDROCK_MAX_TOKENS"); tokenStr != "" {
+		if parsed, err := strconv.Atoi(tokenStr); err == nil && parsed > 0 {
+			return parsed
+		}
+	}
+	return 4096
+}
+
+// buildConverseMessages projects the internal history onto Converse's
+// strict alternating user/assistant shape. System messages are pulled out
+// into a separate slice (Converse requires this — they cannot live inside
+// the messages array). Cache markers from SystemParts are intentionally
+// dropped here: Converse's cachePoint block has a different placement
+// model and we deliberately keep the Anthropic cache planner scoped to
+// the dedicated familyAnthropic path.
+func buildConverseMessages(prompt string, history []models.Message) ([]bedrockruntimetypes.Message, []bedrockruntimetypes.SystemContentBlock) {
+	var messages []bedrockruntimetypes.Message
+	var systemBlocks []bedrockruntimetypes.SystemContentBlock
+
+	flushSystem := func(text string) {
+		if strings.TrimSpace(text) == "" {
+			return
+		}
+		systemBlocks = append(systemBlocks, &bedrockruntimetypes.SystemContentBlockMemberText{Value: text})
+	}
+
+	appendMessage := func(role bedrockruntimetypes.ConversationRole, text string) {
+		if strings.TrimSpace(text) == "" {
+			return
+		}
+		// Coalesce consecutive same-role messages — Bedrock Converse
+		// rejects two user (or two assistant) messages in a row.
+		if n := len(messages); n > 0 && messages[n-1].Role == role {
+			messages[n-1].Content = append(messages[n-1].Content,
+				&bedrockruntimetypes.ContentBlockMemberText{Value: text})
+			return
+		}
+		messages = append(messages, bedrockruntimetypes.Message{
+			Role: role,
+			Content: []bedrockruntimetypes.ContentBlock{
+				&bedrockruntimetypes.ContentBlockMemberText{Value: text},
+			},
+		})
+	}
+
+	for _, msg := range history {
+		switch strings.ToLower(strings.TrimSpace(msg.Role)) {
+		case "system":
+			if len(msg.SystemParts) > 0 {
+				for _, part := range msg.SystemParts {
+					flushSystem(part.Text)
+				}
+			} else {
+				flushSystem(msg.Content)
+			}
+		case "assistant":
+			appendMessage(bedrockruntimetypes.ConversationRoleAssistant, msg.Content)
+		default:
+			appendMessage(bedrockruntimetypes.ConversationRoleUser, msg.Content)
+		}
+	}
+
+	if len(history) == 0 || history[len(history)-1].Role != "user" || history[len(history)-1].Content != prompt {
+		appendMessage(bedrockruntimetypes.ConversationRoleUser, prompt)
+	}
+
+	// Converse rejects requests that start with an assistant message.
+	// Drop the leading assistant turn(s) so we always start with user —
+	// this matches what Anthropic's path tolerates implicitly.
+	for len(messages) > 0 && messages[0].Role != bedrockruntimetypes.ConversationRoleUser {
+		messages = messages[1:]
+	}
+	return messages, systemBlocks
+}
+
+func parseConverseOutput(out *bedrockruntime.ConverseOutput) (string, error) {
+	if out == nil || out.Output == nil {
+		return "", fmt.Errorf("%s", i18n.T("llm.error.no_response", "Bedrock"))
+	}
+	msg, ok := out.Output.(*bedrockruntimetypes.ConverseOutputMemberMessage)
+	if !ok {
+		return "", fmt.Errorf("bedrock-converse: unexpected output type %T", out.Output)
+	}
+	var b strings.Builder
+	for _, block := range msg.Value.Content {
+		if text, ok := block.(*bedrockruntimetypes.ContentBlockMemberText); ok {
+			b.WriteString(text.Value)
+		}
+	}
+	if b.Len() == 0 {
+		return "", fmt.Errorf("%s", i18n.T("llm.error.no_response", "Bedrock"))
+	}
+	return b.String(), nil
+}
+
+// wrapBedrockInferenceProfileError annotates the common ValidationException
+// users hit when they pick a foundation ID that requires an inference
+// profile. The raw AWS message tells you the model isn't on-demand
+// invokable but doesn't suggest the fix; this wrapper points at the
+// correct prefix family ("global." / "us." / "eu." / "apac.") so /switch
+// users have a path forward without reading AWS docs.
+func wrapBedrockInferenceProfileError(model string, err error) error {
+	if err == nil {
+		return nil
+	}
+	msg := err.Error()
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		msg = apiErr.ErrorMessage()
+	}
+	low := strings.ToLower(msg)
+	if !strings.Contains(low, "inference profile") &&
+		!strings.Contains(low, "on-demand throughput isn't supported") &&
+		!strings.Contains(low, "on-demand throughput is not supported") {
+		return err
+	}
+	hint := suggestInferenceProfilePrefix(model)
+	return fmt.Errorf(
+		"bedrock: model %q requires an inference profile (the bare foundation ID is not invokable on-demand). "+
+			"Try selecting %s instead, or run `/switch --model` to see profiles your account has access to. Original: %w",
+		model, hint, err)
+}
+
+// suggestInferenceProfilePrefix builds a short, copy-pasteable hint based
+// on the bare model ID the user picked. We stay deliberately vague on
+// region — the right profile depends on the account's region and the
+// model's availability — and just nudge them toward the prefix family.
+func suggestInferenceProfilePrefix(model string) string {
+	m := strings.TrimSpace(model)
+	if m == "" {
+		return "an inference profile (e.g. \"global.<provider>.<model>\")"
+	}
+	// Already prefixed — nothing useful to suggest.
+	if strings.HasPrefix(m, "global.") ||
+		strings.HasPrefix(m, "us.") ||
+		strings.HasPrefix(m, "eu.") ||
+		strings.HasPrefix(m, "apac.") {
+		return fmt.Sprintf("a different inference profile for %q", m)
+	}
+	return fmt.Sprintf("\"global.%s\", \"us.%s\", \"eu.%s\", or \"apac.%s\"", m, m, m, m)
+}

--- a/llm/bedrock/family_test.go
+++ b/llm/bedrock/family_test.go
@@ -2,7 +2,10 @@ package bedrock
 
 import (
 	"os"
+	"strings"
 	"testing"
+
+	bedrocktypes "github.com/aws/aws-sdk-go-v2/service/bedrock/types"
 )
 
 func TestResolveFamily(t *testing.T) {
@@ -20,8 +23,15 @@ func TestResolveFamily(t *testing.T) {
 		{"openai gpt-oss 20b", "", "openai.gpt-oss-20b-1:0", familyOpenAI},
 		{"openai via regional profile", "", "us.openai.gpt-oss-120b-1:0", familyOpenAI},
 
-		// Unknown prefix falls back to default (anthropic)
-		{"unknown prefix defaults to anthropic", "", "meta.llama3-70b-instruct-v1:0", familyAnthropic},
+		// Unknown / non-Anthropic / non-OpenAI prefixes route to Converse —
+		// one schema covers Llama, Nova, Mistral, Cohere, AI21, DeepSeek,
+		// Stability, and any future provider.
+		{"meta llama defaults to converse", "", "meta.llama3-70b-instruct-v1:0", familyConverse},
+		{"amazon nova defaults to converse", "", "amazon.nova-pro-v1:0", familyConverse},
+		{"mistral defaults to converse", "", "mistral.mistral-large-2407-v1:0", familyConverse},
+		{"cohere defaults to converse", "", "cohere.command-r-plus-v1:0", familyConverse},
+		{"ai21 defaults to converse", "", "ai21.jamba-1-5-large-v1:0", familyConverse},
+		{"deepseek defaults to converse", "", "us.deepseek.r1-v1:0", familyConverse},
 
 		// Env override takes precedence
 		{"env override openai", "openai", "anthropic.claude-3-5-sonnet-20241022-v2:0", familyOpenAI},
@@ -29,6 +39,8 @@ func TestResolveFamily(t *testing.T) {
 		{"env override anthropic", "anthropic", "openai.gpt-oss-120b-1:0", familyAnthropic},
 		{"env override claude alias", "claude", "openai.gpt-oss-120b-1:0", familyAnthropic},
 		{"env override case insensitive", "OpenAI", "anthropic.claude-3-5-sonnet-20241022-v2:0", familyOpenAI},
+		{"env override converse", "converse", "anthropic.claude-3-5-sonnet-20241022-v2:0", familyConverse},
+		{"env override auto alias", "auto", "openai.gpt-oss-120b-1:0", familyConverse},
 		{"env invalid value ignored", "bogus", "openai.gpt-oss-120b-1:0", familyOpenAI},
 	}
 	for _, tc := range tests {
@@ -54,20 +66,57 @@ func TestResolveFamily(t *testing.T) {
 	}
 }
 
-func TestIsSupportedBedrockFamily(t *testing.T) {
-	cases := map[string]bool{
-		"anthropic.claude-3-5-sonnet-20241022-v2:0":        true,
-		"global.anthropic.claude-sonnet-4-5-20250929-v1:0": true,
-		"openai.gpt-oss-120b-1:0":                          true,
-		"us.openai.gpt-oss-120b-1:0":                       true,
-		"meta.llama3-70b-instruct-v1:0":                    false,
-		"amazon.nova-pro-v1:0":                             false,
-		"mistral.mistral-large-2407-v1:0":                  false,
-		"":                                                 false,
+// TestSupportsOnDemand pins the only listing-side gate we keep:
+// foundation models that don't expose ON_DEMAND aren't directly invokable
+// by their bare ID and would fail with ValidationException at first call.
+// We rely on the matching ListInferenceProfiles entry to surface them.
+func TestSupportsOnDemand(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []bedrocktypes.InferenceType
+		want bool
+	}{
+		{"empty list", nil, false},
+		{"only provisioned", []bedrocktypes.InferenceType{bedrocktypes.InferenceTypeProvisioned}, false},
+		{"on-demand only", []bedrocktypes.InferenceType{bedrocktypes.InferenceTypeOnDemand}, true},
+		{"both", []bedrocktypes.InferenceType{
+			bedrocktypes.InferenceTypeOnDemand,
+			bedrocktypes.InferenceTypeProvisioned,
+		}, true},
 	}
-	for id, want := range cases {
-		if got := isSupportedBedrockFamily(id); got != want {
-			t.Errorf("isSupportedBedrockFamily(%q) = %v, want %v", id, got, want)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := supportsOnDemand(tc.in); got != tc.want {
+				t.Errorf("supportsOnDemand(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSuggestInferenceProfilePrefix(t *testing.T) {
+	cases := []struct {
+		model string
+		// substrings every suggestion must contain so users see a copy-paste
+		// hint regardless of the exact format.
+		mustContain []string
+	}{
+		{"anthropic.claude-3-7-sonnet-20250219-v1:0",
+			[]string{"global.anthropic.claude-3-7-sonnet-20250219-v1:0",
+				"us.anthropic.claude-3-7-sonnet-20250219-v1:0"}},
+		{"meta.llama3-70b-instruct-v1:0",
+			[]string{"global.meta.llama3-70b-instruct-v1:0"}},
+		// Already-prefixed IDs should not get a re-suggestion that wraps
+		// them again.
+		{"global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+			[]string{"different inference profile"}},
+		{"", []string{"inference profile"}},
+	}
+	for _, tc := range cases {
+		got := suggestInferenceProfilePrefix(tc.model)
+		for _, want := range tc.mustContain {
+			if !strings.Contains(got, want) {
+				t.Errorf("suggestInferenceProfilePrefix(%q) = %q, missing %q", tc.model, got, want)
+			}
 		}
 	}
 }

--- a/llm/bedrock/openai_family.go
+++ b/llm/bedrock/openai_family.go
@@ -66,7 +66,7 @@ func (c *BedrockClient) sendPromptOpenAI(ctx context.Context, prompt string, his
 			Body:        payload,
 		})
 		if err != nil {
-			return "", err
+			return "", wrapBedrockInferenceProfileError(c.model, err)
 		}
 		return parseOpenAIBody(out.Body)
 	})

--- a/llm/bedrock/openai_family.go
+++ b/llm/bedrock/openai_family.go
@@ -53,6 +53,8 @@ func (c *BedrockClient) sendPromptOpenAI(ctx context.Context, prompt string, his
 	start := time.Now()
 	client.LogRequestStart(c.logger, "BEDROCK", c.model,
 		zap.String("family", string(familyOpenAI)),
+		zap.String("region", c.region),
+		zap.String("endpoint", RuntimeEndpointURL(c.region)),
 		zap.Int("payload_bytes", len(payload)),
 		zap.Int("history_len", len(history)),
 		zap.Int("max_tokens", effectiveMaxTokens),

--- a/llm/bedrock/register.go
+++ b/llm/bedrock/register.go
@@ -16,7 +16,7 @@ import (
 func init() {
 	registry.Register(registry.ProviderInfo{
 		Name:         "BEDROCK",
-		DisplayName:  "AWS Bedrock (Anthropic Claude)",
+		DisplayName:  "AWS Bedrock (all text models available to your account)",
 		RequiresAuth: false, // Auth comes from AWS credential chain, not a string APIKey
 		EnvKeys:      []string{"BEDROCK_REGION", "AWS_REGION", "AWS_PROFILE"},
 		Factory: func(cfg registry.ProviderConfig) (client.LLMClient, error) {

--- a/llm/embedding/bedrock.go
+++ b/llm/embedding/bedrock.go
@@ -70,9 +70,10 @@ type Bedrock struct {
 	family  embedFamily
 	logger  *zap.Logger
 
-	once    sync.Once
-	runtime *bedrockruntime.Client
-	initErr error
+	once     sync.Once
+	runtime  *bedrockruntime.Client
+	endpoint string
+	initErr  error
 }
 
 // NewBedrock constructs the provider. region/profile follow the same
@@ -119,6 +120,13 @@ func (b *Bedrock) Embed(ctx context.Context, texts []string) ([][]float32, error
 	if err := b.ensureRuntime(ctx); err != nil {
 		return nil, err
 	}
+	b.logger.Debug("bedrock embeddings: request",
+		zap.String("model", b.model),
+		zap.String("family", string(b.family)),
+		zap.String("region", b.region),
+		zap.String("endpoint", b.endpoint),
+		zap.Int("batch_size", len(texts)),
+	)
 	switch b.family {
 	case embedFamilyCohere:
 		return b.embedCohere(ctx, texts)
@@ -136,6 +144,14 @@ func (b *Bedrock) ensureRuntime(ctx context.Context) error {
 		}
 		b.runtime = runtime
 		b.region = resolvedRegion
+		b.endpoint = bedrock.RuntimeEndpointURL(resolvedRegion)
+		b.logger.Info("bedrock embeddings: configured",
+			zap.String("region", b.region),
+			zap.String("endpoint", b.endpoint),
+			zap.String("model", b.model),
+			zap.String("family", string(b.family)),
+			zap.Int("dim", b.dim),
+		)
 	})
 	return b.initErr
 }

--- a/llm/embedding/bedrock.go
+++ b/llm/embedding/bedrock.go
@@ -1,0 +1,297 @@
+/*
+ * ChatCLI - AWS Bedrock embeddings provider.
+ *
+ * Reuses the credential chain, region resolution, IMDS gating and
+ * corporate-CA support that the Bedrock chat client already has via
+ * the shared bedrock.LoadBedrockRuntime helper. The embedding API
+ * lives on the same `bedrock-runtime` endpoint as InvokeModel — there
+ * is NO Converse equivalent for embeddings, so each provider family
+ * keeps its own body schema:
+ *
+ *   - Titan v1 / v2 (amazon.titan-embed-text-*): single text per call,
+ *     dimension knob on v2 (256 / 512 / 1024).
+ *   - Cohere v3 (cohere.embed-*): batch-native, 1024-dim fixed.
+ *
+ * For Titan, batches are parallelized with a small worker pool to
+ * stay within Bedrock's per-account InvokeModel concurrency budget
+ * without serializing IO.
+ */
+package embedding
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+	"go.uber.org/zap"
+
+	"github.com/diillson/chatcli/llm/bedrock"
+)
+
+const (
+	bedrockDefaultModel = "amazon.titan-embed-text-v2:0"
+	// titanV2DefaultDim is the recommended dim for Titan v2 — 1024 is
+	// the highest fidelity tier and matches what Anthropic recommends
+	// for retrieval. Users who want cheaper storage can drop to 512 or
+	// 256 via CHATCLI_EMBED_DIMENSIONS.
+	titanV2DefaultDim = 1024
+	titanV1Dim        = 1536
+	cohereV3Dim       = 1024
+	// bedrockTitanBatchConcurrency caps how many parallel InvokeModel
+	// calls the provider issues for Titan when the caller hands in a
+	// batch. 8 is a defensive default that lands well under typical
+	// Bedrock account quotas while still hiding most of the per-call
+	// latency behind concurrency.
+	bedrockTitanBatchConcurrency = 8
+)
+
+// embedFamily identifies the body schema for a Bedrock embedding model.
+type embedFamily string
+
+const (
+	embedFamilyTitan  embedFamily = "titan"
+	embedFamilyCohere embedFamily = "cohere"
+)
+
+// Bedrock is the AWS Bedrock embeddings provider.
+//
+// The runtime client is built lazily on the first Embed call so that
+// missing AWS credentials don't break /config dispatch — the provider
+// surfaces the error only when the caller actually wants vectors.
+type Bedrock struct {
+	model   string
+	region  string
+	profile string
+	dim     int
+	family  embedFamily
+	logger  *zap.Logger
+
+	once    sync.Once
+	runtime *bedrockruntime.Client
+	initErr error
+}
+
+// NewBedrock constructs the provider. region/profile follow the same
+// precedence as the chat client (caller resolves env vars). When dim
+// is 0, the family default is used (Titan v2: 1024, Titan v1: 1536,
+// Cohere v3: 1024). A nil logger is replaced with zap.NewNop().
+func NewBedrock(model, region, profile string, dim int, logger *zap.Logger) (*Bedrock, error) {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	if strings.TrimSpace(model) == "" {
+		model = bedrockDefaultModel
+	}
+	family := resolveEmbedFamily(model)
+	if dim <= 0 {
+		dim = defaultDim(model, family)
+	}
+	if family == embedFamilyTitan && !isValidTitanDim(model, dim) {
+		return nil, fmt.Errorf("bedrock embeddings: invalid dimension %d for %s (Titan v2 supports 256/512/1024; v1 fixed at 1536)", dim, model)
+	}
+	return &Bedrock{
+		model:   model,
+		region:  region,
+		profile: profile,
+		dim:     dim,
+		family:  family,
+		logger:  logger,
+	}, nil
+}
+
+// Name identifies the provider in /config quality output.
+func (b *Bedrock) Name() string { return "bedrock:" + b.model }
+
+// Dimension returns the vector dimensionality.
+func (b *Bedrock) Dimension() int { return b.dim }
+
+// Embed converts the batch to vectors. Titan models loop with bounded
+// parallelism (one InvokeModel per text); Cohere ships the whole batch
+// in a single call.
+func (b *Bedrock) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+	if err := b.ensureRuntime(ctx); err != nil {
+		return nil, err
+	}
+	switch b.family {
+	case embedFamilyCohere:
+		return b.embedCohere(ctx, texts)
+	default:
+		return b.embedTitan(ctx, texts)
+	}
+}
+
+func (b *Bedrock) ensureRuntime(ctx context.Context) error {
+	b.once.Do(func() {
+		runtime, resolvedRegion, err := bedrock.LoadBedrockRuntime(ctx, b.region, b.profile, b.logger)
+		if err != nil {
+			b.initErr = err
+			return
+		}
+		b.runtime = runtime
+		b.region = resolvedRegion
+	})
+	return b.initErr
+}
+
+// ── Titan family ────────────────────────────────────────────────────
+
+type titanRequest struct {
+	InputText  string `json:"inputText"`
+	Dimensions int    `json:"dimensions,omitempty"`
+	Normalize  bool   `json:"normalize,omitempty"`
+}
+
+type titanResponse struct {
+	Embedding           []float32 `json:"embedding"`
+	InputTextTokenCount int       `json:"inputTextTokenCount"`
+}
+
+func (b *Bedrock) embedTitan(ctx context.Context, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	errs := make([]error, len(texts))
+
+	concurrency := bedrockTitanBatchConcurrency
+	if concurrency > len(texts) {
+		concurrency = len(texts)
+	}
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+	for i, text := range texts {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(idx int, in string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			vec, err := b.invokeTitan(ctx, in)
+			if err != nil {
+				errs[idx] = err
+				return
+			}
+			out[idx] = vec
+		}(i, text)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			return nil, fmt.Errorf("bedrock titan: index %d: %w", i, err)
+		}
+	}
+	return out, nil
+}
+
+func (b *Bedrock) invokeTitan(ctx context.Context, text string) ([]float32, error) {
+	body := titanRequest{InputText: text, Normalize: true}
+	if b.isTitanV2() {
+		body.Dimensions = b.dim
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("titan marshal: %w", err)
+	}
+	out, err := b.runtime.InvokeModel(ctx, &bedrockruntime.InvokeModelInput{
+		ModelId:     aws.String(b.model),
+		ContentType: aws.String("application/json"),
+		Accept:      aws.String("application/json"),
+		Body:        payload,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var parsed titanResponse
+	if err := json.Unmarshal(out.Body, &parsed); err != nil {
+		return nil, fmt.Errorf("titan decode: %w", err)
+	}
+	if len(parsed.Embedding) == 0 {
+		return nil, fmt.Errorf("titan: empty embedding in response")
+	}
+	return parsed.Embedding, nil
+}
+
+// ── Cohere family ───────────────────────────────────────────────────
+
+type cohereRequest struct {
+	Texts     []string `json:"texts"`
+	InputType string   `json:"input_type"`
+	Truncate  string   `json:"truncate,omitempty"`
+}
+
+type cohereResponse struct {
+	Embeddings [][]float32 `json:"embeddings"`
+}
+
+func (b *Bedrock) embedCohere(ctx context.Context, texts []string) ([][]float32, error) {
+	body := cohereRequest{
+		Texts:     texts,
+		InputType: "search_document",
+		Truncate:  "END",
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("cohere marshal: %w", err)
+	}
+	out, err := b.runtime.InvokeModel(ctx, &bedrockruntime.InvokeModelInput{
+		ModelId:     aws.String(b.model),
+		ContentType: aws.String("application/json"),
+		Accept:      aws.String("application/json"),
+		Body:        payload,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cohere invoke: %w", err)
+	}
+	var parsed cohereResponse
+	if err := json.Unmarshal(out.Body, &parsed); err != nil {
+		return nil, fmt.Errorf("cohere decode: %w", err)
+	}
+	if len(parsed.Embeddings) != len(texts) {
+		return nil, fmt.Errorf("cohere returned %d vectors for %d inputs", len(parsed.Embeddings), len(texts))
+	}
+	return parsed.Embeddings, nil
+}
+
+// ── Family + dim helpers ────────────────────────────────────────────
+
+func resolveEmbedFamily(model string) embedFamily {
+	m := strings.ToLower(strings.TrimSpace(model))
+	if strings.Contains(m, "cohere.embed") || strings.Contains(m, "cohere-embed") {
+		return embedFamilyCohere
+	}
+	return embedFamilyTitan
+}
+
+func defaultDim(model string, family embedFamily) int {
+	switch family {
+	case embedFamilyCohere:
+		return cohereV3Dim
+	}
+	if isTitanV1ID(model) {
+		return titanV1Dim
+	}
+	return titanV2DefaultDim
+}
+
+func (b *Bedrock) isTitanV2() bool {
+	return b.family == embedFamilyTitan && !isTitanV1ID(b.model)
+}
+
+func isTitanV1ID(model string) bool {
+	m := strings.ToLower(model)
+	return strings.Contains(m, "titan-embed-text-v1")
+}
+
+func isValidTitanDim(model string, dim int) bool {
+	if isTitanV1ID(model) {
+		return dim == titanV1Dim
+	}
+	switch dim {
+	case 256, 512, 1024:
+		return true
+	}
+	return false
+}

--- a/llm/embedding/bedrock_test.go
+++ b/llm/embedding/bedrock_test.go
@@ -1,0 +1,213 @@
+/*
+ * ChatCLI - Bedrock embeddings tests.
+ *
+ * Network-free: every test exercises pure helpers (family resolution,
+ * dim validation, body schema). The runtime client is built lazily
+ * on first Embed, so NewBedrock returning a valid provider does not
+ * touch AWS — exactly the behavior we want for /config dispatch.
+ */
+package embedding
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestResolveEmbedFamily(t *testing.T) {
+	cases := map[string]embedFamily{
+		"amazon.titan-embed-text-v2:0":  embedFamilyTitan,
+		"amazon.titan-embed-text-v1":    embedFamilyTitan,
+		"amazon.titan-embed-image-v1":   embedFamilyTitan,
+		"cohere.embed-english-v3":       embedFamilyCohere,
+		"cohere.embed-multilingual-v3":  embedFamilyCohere,
+		"us.amazon.titan-embed-text-v2": embedFamilyTitan,
+		"":                              embedFamilyTitan, // default safety
+	}
+	for id, want := range cases {
+		if got := resolveEmbedFamily(id); got != want {
+			t.Errorf("resolveEmbedFamily(%q) = %q, want %q", id, got, want)
+		}
+	}
+}
+
+func TestDefaultDim(t *testing.T) {
+	cases := []struct {
+		model string
+		want  int
+	}{
+		{"amazon.titan-embed-text-v2:0", titanV2DefaultDim},
+		{"amazon.titan-embed-text-v1", titanV1Dim},
+		{"cohere.embed-english-v3", cohereV3Dim},
+	}
+	for _, tc := range cases {
+		family := resolveEmbedFamily(tc.model)
+		if got := defaultDim(tc.model, family); got != tc.want {
+			t.Errorf("defaultDim(%q) = %d, want %d", tc.model, got, tc.want)
+		}
+	}
+}
+
+func TestIsValidTitanDim(t *testing.T) {
+	cases := []struct {
+		model string
+		dim   int
+		want  bool
+	}{
+		// Titan v2 — only 256/512/1024 are valid.
+		{"amazon.titan-embed-text-v2:0", 256, true},
+		{"amazon.titan-embed-text-v2:0", 512, true},
+		{"amazon.titan-embed-text-v2:0", 1024, true},
+		{"amazon.titan-embed-text-v2:0", 768, false},
+		{"amazon.titan-embed-text-v2:0", 1536, false},
+		{"amazon.titan-embed-text-v2:0", 0, false},
+		// Titan v1 — fixed at 1536.
+		{"amazon.titan-embed-text-v1", 1536, true},
+		{"amazon.titan-embed-text-v1", 1024, false},
+	}
+	for _, tc := range cases {
+		if got := isValidTitanDim(tc.model, tc.dim); got != tc.want {
+			t.Errorf("isValidTitanDim(%q, %d) = %v, want %v", tc.model, tc.dim, got, tc.want)
+		}
+	}
+}
+
+func TestNewBedrock_DefaultsAndOverrides(t *testing.T) {
+	p, err := NewBedrock("", "us-east-1", "", 0, nil)
+	if err != nil {
+		t.Fatalf("default constructor must not error: %v", err)
+	}
+	if p.model != bedrockDefaultModel {
+		t.Errorf("default model = %q, want %q", p.model, bedrockDefaultModel)
+	}
+	if p.Dimension() != titanV2DefaultDim {
+		t.Errorf("default dim = %d, want %d", p.Dimension(), titanV2DefaultDim)
+	}
+	if p.Name() != "bedrock:"+bedrockDefaultModel {
+		t.Errorf("name = %q", p.Name())
+	}
+}
+
+func TestNewBedrock_RejectsInvalidTitanDim(t *testing.T) {
+	if _, err := NewBedrock("amazon.titan-embed-text-v2:0", "us-east-1", "", 999, nil); err == nil {
+		t.Fatal("expected error for invalid Titan v2 dimension")
+	}
+}
+
+func TestNewBedrock_AcceptsCohereDim(t *testing.T) {
+	p, err := NewBedrock("cohere.embed-english-v3", "us-east-1", "", 0, nil)
+	if err != nil {
+		t.Fatalf("cohere constructor: %v", err)
+	}
+	if p.family != embedFamilyCohere {
+		t.Errorf("expected cohere family; got %q", p.family)
+	}
+	if p.Dimension() != cohereV3Dim {
+		t.Errorf("cohere dim = %d, want %d", p.Dimension(), cohereV3Dim)
+	}
+}
+
+// TestTitanRequestShape pins the JSON body Bedrock expects for Titan v2:
+// inputText + dimensions + normalize. AWS rejects unknown fields here,
+// so silent shape drift would break embeddings without us noticing.
+func TestTitanRequestShape(t *testing.T) {
+	body := titanRequest{InputText: "hello", Dimensions: 1024, Normalize: true}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["inputText"] != "hello" {
+		t.Errorf("inputText missing or wrong: %v", got)
+	}
+	if got["dimensions"].(float64) != 1024 {
+		t.Errorf("dimensions missing or wrong: %v", got["dimensions"])
+	}
+	if got["normalize"] != true {
+		t.Errorf("normalize missing or wrong: %v", got["normalize"])
+	}
+}
+
+func TestCohereRequestShape(t *testing.T) {
+	body := cohereRequest{
+		Texts:     []string{"a", "b"},
+		InputType: "search_document",
+		Truncate:  "END",
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if texts, ok := got["texts"].([]interface{}); !ok || len(texts) != 2 {
+		t.Errorf("texts missing or wrong: %v", got["texts"])
+	}
+	if got["input_type"] != "search_document" {
+		t.Errorf("input_type missing or wrong: %v", got["input_type"])
+	}
+}
+
+// TestTitanResponseDecode pins the parser against the canonical Titan v2
+// response shape. Drift here yields zero-length embeddings silently.
+func TestTitanResponseDecode(t *testing.T) {
+	raw := []byte(`{"embedding":[0.1,0.2,0.3],"inputTextTokenCount":3}`)
+	var parsed titanResponse
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(parsed.Embedding) != 3 {
+		t.Errorf("expected 3-dim embedding; got %d", len(parsed.Embedding))
+	}
+	if parsed.InputTextTokenCount != 3 {
+		t.Errorf("token count = %d", parsed.InputTextTokenCount)
+	}
+}
+
+func TestCohereResponseDecode(t *testing.T) {
+	raw := []byte(`{"embeddings":[[0.1,0.2],[0.3,0.4]]}`)
+	var parsed cohereResponse
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(parsed.Embeddings) != 2 {
+		t.Errorf("expected 2 vectors; got %d", len(parsed.Embeddings))
+	}
+}
+
+func TestNewByName_Bedrock(t *testing.T) {
+	t.Setenv("BEDROCK_REGION", "us-east-1")
+	t.Setenv("CHATCLI_EMBED_MODEL", "")
+	t.Setenv("CHATCLI_EMBED_DIMENSIONS", "")
+	p, err := NewByName("bedrock")
+	if err != nil {
+		t.Fatalf("bedrock factory: %v", err)
+	}
+	if IsNull(p) {
+		t.Fatal("bedrock provider must not be null")
+	}
+	bp, ok := p.(*Bedrock)
+	if !ok {
+		t.Fatalf("expected *Bedrock; got %T", p)
+	}
+	if bp.model != bedrockDefaultModel {
+		t.Errorf("default model = %q, want %q", bp.model, bedrockDefaultModel)
+	}
+}
+
+func TestNewByName_BedrockWithCustomDim(t *testing.T) {
+	t.Setenv("BEDROCK_REGION", "us-east-1")
+	t.Setenv("CHATCLI_EMBED_MODEL", "amazon.titan-embed-text-v2:0")
+	t.Setenv("CHATCLI_EMBED_DIMENSIONS", "512")
+	p, err := NewByName("bedrock")
+	if err != nil {
+		t.Fatalf("bedrock factory: %v", err)
+	}
+	if got := p.Dimension(); got != 512 {
+		t.Errorf("dim = %d, want 512", got)
+	}
+}

--- a/llm/embedding/embedding.go
+++ b/llm/embedding/embedding.go
@@ -9,6 +9,8 @@
  * Providers wired in this package:
  *   - voyage  : Voyage AI (Anthropic-recommended, best quality/$)
  *   - openai  : OpenAI text-embedding-3-small (256/512/1024/1536 dim)
+ *   - bedrock : AWS Bedrock — Titan v1/v2 (single-text) and Cohere v3
+ *               (batch); reuses the chat client's AWS credential chain.
  *   - null    : default no-op (returned when no provider is configured)
  */
 package embedding

--- a/llm/embedding/factory.go
+++ b/llm/embedding/factory.go
@@ -16,12 +16,17 @@ import (
 )
 
 // NewByName returns a provider by short name. Supported names: "voyage",
-// "openai", "null", "" (== "null"). Unknown names return ErrUnknownProvider.
+// "openai", "bedrock", "null", "" (== "null"). Unknown names return
+// ErrUnknownProvider.
 //
 // Required env vars per provider:
 //   - voyage: VOYAGE_API_KEY (model: CHATCLI_EMBED_MODEL or "voyage-3")
 //   - openai: OPENAI_API_KEY (model: CHATCLI_EMBED_MODEL or
 //     "text-embedding-3-small"; dim: CHATCLI_EMBED_DIMENSIONS)
+//   - bedrock: AWS credential chain (AWS_PROFILE / AWS_ACCESS_KEY_ID /
+//     IAM role); model: CHATCLI_EMBED_MODEL or "amazon.titan-embed-text-v2:0";
+//     dim: CHATCLI_EMBED_DIMENSIONS (Titan v2: 256/512/1024); region:
+//     BEDROCK_REGION or AWS_REGION; profile: AWS_PROFILE.
 func NewByName(name string) (Provider, error) {
 	switch NormalizeName(name) {
 	case "", "null", "off":
@@ -36,9 +41,28 @@ func NewByName(name string) (Provider, error) {
 			}
 		}
 		return NewOpenAI(os.Getenv("OPENAI_API_KEY"), os.Getenv("CHATCLI_EMBED_MODEL"), dim)
+	case "bedrock":
+		dim := 0
+		if v := os.Getenv("CHATCLI_EMBED_DIMENSIONS"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil {
+				dim = n
+			}
+		}
+		region := firstNonEmpty(os.Getenv("BEDROCK_REGION"), os.Getenv("AWS_REGION"))
+		profile := os.Getenv("AWS_PROFILE")
+		return NewBedrock(os.Getenv("CHATCLI_EMBED_MODEL"), region, profile, dim, nil)
 	default:
 		return nil, fmt.Errorf("%w: %q", ErrUnknownProvider, name)
 	}
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 // NewFromEnv reads CHATCLI_EMBED_PROVIDER and dispatches via NewByName.


### PR DESCRIPTION
## Summary
- List models now trusts the AWS-side signals (`ByOutputModality: TEXT` + `ON_DEMAND` inference type) instead of a hardcoded provider allowlist — Kimi, GLM, Qwen, MiniMax, Gemma, Nemotron and any future provider show up automatically without a release.
- Dispatch grew a `familyConverse` path that routes everything non-Anthropic / non-OpenAI through the unified Bedrock Converse API. Anthropic and OpenAI keep their existing InvokeModel paths intact — same body schema, same cache planner, same extended-thinking knobs, zero behavior change for what already works.
- `ON_DEMAND` filter doubles as a UX fix: bare Claude 3.7+ / 4.x foundation IDs that require an inference profile no longer leak into the `/switch` suggestion list, so users stop picking IDs that fail at first call. ValidationException about inference profiles now surfaces a copy-pasteable hint with the right `global./us./eu./apac.` prefix.
- New `BEDROCK_PROVIDER` aliases: `converse` / `auto`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./llm/bedrock/...`
- [x] `go test ./...`
- [x] Manual: with valid AWS creds, run `/switch BEDROCK` then `/switch --model` and confirm Moonshot / Z.AI / Qwen / MiniMax show up when the account has access.
- [x] Manual: prompt against a Converse-routed model (e.g. `moonshotai.kimi-k2.5`) and verify the response.
- [x] Manual: prompt against an Anthropic profile (e.g. `global.anthropic.claude-sonnet-4-5-20250929-v1:0`) and verify cache markers / behavior unchanged.
- [x] Manual: try selecting a bare Claude 3.7 ID and confirm the friendly error message points at the profile prefix.