### PR TITLE
feat(ci): image refresh pipeline for CVE drift remediation

### DIFF
--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -7,7 +7,16 @@ name: Image Refresh (drift remediation)
 # Triggers:
 #   - schedule: weekly Monday 06:00 UTC (aligned with security-scan.yml)
 #   - workflow_dispatch: manual run with optional `tags` and `force` inputs
-#   - repository_dispatch (type: image-refresh-request): external triggers (e.g. ArtifactHub webhook)
+#   - repository_dispatch (type: image-refresh-request): external triggers
+#
+# Architecture:
+#   discover -> scan (matrix image+tag) -> plan (singular)
+#                                            |
+#                                            +-> build (matrix image+tag+arch on native runners)
+#                                                  |
+#                                                  +-> merge (matrix image+tag)
+#                                                        |
+#                                                        +-> report (singular, always)
 
 on:
   schedule:
@@ -41,8 +50,7 @@ jobs:
     name: Discover target tags
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.compute.outputs.matrix }}
-      tag_list: ${{ steps.compute.outputs.tag_list }}
+      scan_matrix: ${{ steps.compute.outputs.scan_matrix }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -73,26 +81,22 @@ jobs:
               {image: "chatcli-operator", tag: $t, dockerfile: "operator/Dockerfile", context: "."}
             ]) | flatten
           ')
-          {
-            echo "matrix={\"include\":$INCLUDES}"
-            echo "tag_list<<EOF"
-            echo "$TAGS"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+          echo "scan_matrix={\"include\":$INCLUDES}" >> "$GITHUB_OUTPUT"
 
-  refresh:
-    name: "${{ matrix.image }}:${{ matrix.tag }}"
+  scan:
+    name: "Scan ${{ matrix.image }}:${{ matrix.tag }}"
     needs: discover
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.discover.outputs.scan_matrix) }}
     steps:
-      - name: Checkout source at tag
+      - name: Checkout source at tag (for .trivyignore.yaml)
         uses: actions/checkout@v6
         with:
           ref: "v${{ matrix.tag }}"
           fetch-depth: 1
+          sparse-checkout: .trivyignore.yaml
 
       - name: Login to GHCR
         uses: docker/login-action@v4
@@ -101,8 +105,8 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Scan currently-published image
-        id: scan
+      - name: Trivy scan published image
+        id: trivy
         continue-on-error: true
         uses: aquasecurity/trivy-action@master
         with:
@@ -114,55 +118,198 @@ jobs:
           scanners: vuln
           exit-code: '1'
 
-      - name: Decide whether to refresh
-        id: decide
+      - name: Record decision
         env:
+          IMAGE: ${{ matrix.image }}
+          TAG: ${{ matrix.tag }}
+          DOCKERFILE: ${{ matrix.dockerfile }}
+          CONTEXT: ${{ matrix.context }}
+          SCAN_OUTCOME: ${{ steps.trivy.outcome }}
           FORCE_INPUT: ${{ github.event.inputs.force }}
           FORCE_DISPATCH: ${{ github.event.client_payload.force }}
-          SCAN_OUTCOME: ${{ steps.scan.outcome }}
         run: |
           set -euo pipefail
           FORCE="${FORCE_INPUT:-${FORCE_DISPATCH:-false}}"
-          if [ "$FORCE" = "true" ] || [ "$SCAN_OUTCOME" = "failure" ]; then
-            REASON=$([ "$FORCE" = "true" ] && echo "forced" || echo "vulnerabilities-detected")
-            echo "refresh=true"  >> "$GITHUB_OUTPUT"
-            echo "reason=$REASON" >> "$GITHUB_OUTPUT"
-            echo "::notice::Refresh required for ${{ matrix.image }}:${{ matrix.tag }} (reason: $REASON)"
+          if [ "$FORCE" = "true" ]; then
+            REFRESH=true; REASON="forced"
+          elif [ "$SCAN_OUTCOME" = "failure" ]; then
+            REFRESH=true; REASON="vulnerabilities-detected"
           else
-            echo "refresh=false" >> "$GITHUB_OUTPUT"
-            echo "reason=clean"  >> "$GITHUB_OUTPUT"
-            echo "::notice::${{ matrix.image }}:${{ matrix.tag }} is clean — skipping refresh"
+            REFRESH=false; REASON="clean"
           fi
+          mkdir -p decisions
+          jq -nc \
+            --arg image      "$IMAGE" \
+            --arg tag        "$TAG" \
+            --arg dockerfile "$DOCKERFILE" \
+            --arg context    "$CONTEXT" \
+            --argjson refresh $REFRESH \
+            --arg reason     "$REASON" \
+            '{image:$image, tag:$tag, dockerfile:$dockerfile, context:$context, refresh:$refresh, reason:$reason}' \
+            > "decisions/${IMAGE}-${TAG}.json"
+          echo "::notice::${IMAGE}:${TAG} -> refresh=${REFRESH} (${REASON})"
 
-      - name: Set up QEMU
-        if: steps.decide.outputs.refresh == 'true'
-        uses: docker/setup-qemu-action@v4
+      - name: Upload decision
+        uses: actions/upload-artifact@v7
+        with:
+          name: decision-${{ matrix.image }}-${{ matrix.tag }}
+          path: decisions/*.json
+          retention-days: 14
+          if-no-files-found: error
+
+  plan:
+    name: Plan rebuilds
+    needs: scan
+    runs-on: ubuntu-latest
+    outputs:
+      any_refresh:  ${{ steps.compute.outputs.any_refresh }}
+      arch_matrix:  ${{ steps.compute.outputs.arch_matrix }}
+      merge_matrix: ${{ steps.compute.outputs.merge_matrix }}
+    steps:
+      - name: Download all decisions
+        uses: actions/download-artifact@v8
+        with:
+          pattern: decision-*
+          path: /tmp/decisions
+          merge-multiple: true
+
+      - name: Compute build & merge matrices
+        id: compute
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          FILES=(/tmp/decisions/*.json)
+          if [ ${#FILES[@]} -eq 0 ]; then
+            echo "::error::No decisions found"
+            exit 1
+          fi
+          ALL=$(jq -s '.' "${FILES[@]}")
+          NEEDS=$(echo "$ALL" | jq '[.[] | select(.refresh==true)]')
+          COUNT=$(echo "$NEEDS" | jq 'length')
+          if [ "$COUNT" -eq 0 ]; then
+            echo "any_refresh=false" >> "$GITHUB_OUTPUT"
+            echo "arch_matrix={\"include\":[]}"  >> "$GITHUB_OUTPUT"
+            echo "merge_matrix={\"include\":[]}" >> "$GITHUB_OUTPUT"
+            echo "::notice::No targets need refresh"
+            exit 0
+          fi
+          MERGE_MATRIX=$(echo "$NEEDS" | jq -c '{include: .}')
+          ARCH_MATRIX=$(echo "$NEEDS" | jq -c '
+            {
+              include: [
+                .[] as $t |
+                ($t + {arch:"amd64", runner:"ubuntu-latest",     platform:"linux/amd64"}),
+                ($t + {arch:"arm64", runner:"ubuntu-24.04-arm",  platform:"linux/arm64"})
+              ]
+            }
+          ')
+          {
+            echo "any_refresh=true"
+            echo "arch_matrix=$ARCH_MATRIX"
+            echo "merge_matrix=$MERGE_MATRIX"
+          } >> "$GITHUB_OUTPUT"
+          echo "::notice::$COUNT target(s) need refresh"
+
+  build:
+    name: "Build ${{ matrix.image }}:${{ matrix.tag }} (${{ matrix.arch }})"
+    needs: plan
+    if: needs.plan.outputs.any_refresh == 'true'
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.plan.outputs.arch_matrix) }}
+    steps:
+      - name: Checkout source at tag
+        uses: actions/checkout@v6
+        with:
+          ref: "v${{ matrix.tag }}"
+          fetch-depth: 1
 
       - name: Set up Docker Buildx
-        if: steps.decide.outputs.refresh == 'true'
         uses: docker/setup-buildx-action@v4
 
-      - name: Build & push refreshed multi-arch image
-        if: steps.decide.outputs.refresh == 'true'
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push by digest
         id: build
         uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
-          platforms: linux/amd64,linux/arm64
-          push: true
+          platforms: ${{ matrix.platform }}
           no-cache: true
-          tags: "ghcr.io/diillson/${{ matrix.image }}:${{ matrix.tag }}"
           provenance: true
           sbom: true
+          outputs: type=image,name=ghcr.io/diillson/${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
 
-      - name: Trivy gate on rebuilt digest
-        if: steps.decide.outputs.refresh == 'true'
+      - name: Export digest file
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v7
+        with:
+          name: digest-${{ matrix.image }}-${{ matrix.tag }}-${{ matrix.arch }}
+          path: /tmp/digests/*
+          retention-days: 1
+          if-no-files-found: error
+
+  merge:
+    name: "Merge & sign ${{ matrix.image }}:${{ matrix.tag }}"
+    needs: [plan, build]
+    if: needs.plan.outputs.any_refresh == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.plan.outputs.merge_matrix) }}
+    steps:
+      - name: Checkout source at tag (for .trivyignore.yaml)
+        uses: actions/checkout@v6
+        with:
+          ref: "v${{ matrix.tag }}"
+          fetch-depth: 1
+          sparse-checkout: .trivyignore.yaml
+
+      - name: Download digests for this target
+        uses: actions/download-artifact@v8
+        with:
+          pattern: digest-${{ matrix.image }}-${{ matrix.tag }}-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Resolve amd64 digest (for gate)
+        id: amd64
+        uses: actions/download-artifact@v8
+        with:
+          name: digest-${{ matrix.image }}-${{ matrix.tag }}-amd64
+          path: /tmp/digest-amd64
+
+      - name: Compute amd64 digest sha
+        id: digest
+        run: |
+          SHA="sha256:$(ls /tmp/digest-amd64)"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trivy gate on rebuilt amd64 digest
         id: gate
         continue-on-error: true
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: "ghcr.io/diillson/${{ matrix.image }}@${{ steps.build.outputs.digest }}"
+          image-ref: "ghcr.io/diillson/${{ matrix.image }}@${{ steps.digest.outputs.sha }}"
           format: table
           severity: CRITICAL,HIGH
           ignore-unfixed: true
@@ -170,12 +317,24 @@ jobs:
           scanners: vuln
           exit-code: '1'
 
+      - name: Set up Docker Buildx
+        if: steps.gate.outcome == 'success'
+        uses: docker/setup-buildx-action@v4
+
+      - name: Create multi-arch manifest and push tag
+        if: steps.gate.outcome == 'success'
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            -t "ghcr.io/diillson/${{ matrix.image }}:${{ matrix.tag }}" \
+            $(printf 'ghcr.io/diillson/${{ matrix.image }}@sha256:%s ' *)
+
       - name: Install Cosign
-        if: steps.decide.outputs.refresh == 'true' && steps.gate.outcome == 'success'
+        if: steps.gate.outcome == 'success'
         uses: sigstore/cosign-installer@v3
 
       - name: Sign refreshed manifest (keyless OIDC)
-        if: steps.decide.outputs.refresh == 'true' && steps.gate.outcome == 'success'
+        if: steps.gate.outcome == 'success'
         run: |
           cosign sign --yes --recursive \
             "ghcr.io/diillson/${{ matrix.image }}:${{ matrix.tag }}"
@@ -185,57 +344,51 @@ jobs:
         env:
           IMAGE: ${{ matrix.image }}
           TAG: ${{ matrix.tag }}
-          REFRESH: ${{ steps.decide.outputs.refresh }}
-          REASON: ${{ steps.decide.outputs.reason }}
+          REASON: ${{ matrix.reason }}
           GATE: ${{ steps.gate.outcome }}
-          DIGEST: ${{ steps.build.outputs.digest }}
+          DIGEST_AMD64: ${{ steps.digest.outputs.sha }}
         run: |
           set -euo pipefail
           mkdir -p results
-          if [ "$REFRESH" != "true" ]; then
-            STATUS="clean"
-          elif [ "$GATE" = "success" ]; then
-            STATUS="refreshed"
-          else
-            STATUS="gate_failed"
-          fi
+          STATUS=$([ "$GATE" = "success" ] && echo "refreshed" || echo "gate_failed")
           jq -nc \
-            --arg image   "$IMAGE" \
-            --arg tag     "$TAG" \
-            --arg status  "$STATUS" \
-            --arg reason  "${REASON:-unknown}" \
-            --arg digest  "${DIGEST:-}" \
+            --arg image  "$IMAGE" \
+            --arg tag    "$TAG" \
+            --arg status "$STATUS" \
+            --arg reason "$REASON" \
+            --arg digest "${DIGEST_AMD64:-}" \
             '{image:$image, tag:$tag, status:$status, reason:$reason, digest:$digest}' \
             > "results/${IMAGE}-${TAG}.json"
-          {
-            echo "## ${IMAGE}:${TAG}"
-            echo ""
-            echo "- Status: \`${STATUS}\`"
-            echo "- Reason: \`${REASON:-unknown}\`"
-            [ -n "${DIGEST:-}" ] && echo "- Digest: \`${DIGEST}\`"
-          } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Upload result artifact
+      - name: Upload result
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: refresh-result-${{ matrix.image }}-${{ matrix.tag }}
+          name: result-${{ matrix.image }}-${{ matrix.tag }}
           path: results/*.json
           retention-days: 14
           if-no-files-found: warn
 
   report:
-    name: Aggregate results & open issue
-    needs: refresh
-    if: always() && needs.refresh.result != 'skipped'
+    name: Aggregate & open issue
+    needs: [scan, plan, merge]
+    if: always() && needs.scan.result != 'skipped'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
-      - name: Download all results
+      - name: Download decisions
         uses: actions/download-artifact@v8
         with:
-          pattern: refresh-result-*
+          pattern: decision-*
+          path: /tmp/decisions
+          merge-multiple: true
+
+      - name: Download results (may be empty)
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: result-*
           path: /tmp/results
           merge-multiple: true
 
@@ -244,50 +397,56 @@ jobs:
         run: |
           set -euo pipefail
           shopt -s nullglob
-          FILES=(/tmp/results/*.json)
-          if [ ${#FILES[@]} -eq 0 ]; then
-            echo "::warning::No result artifacts found"
-            echo "any_action=false" >> "$GITHUB_OUTPUT"
-            echo "any_failure=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          ALL=$(jq -s '.' "${FILES[@]}")
-          REFRESHED=$(echo "$ALL" | jq '[.[] | select(.status=="refreshed")]')
-          FAILED=$(echo   "$ALL" | jq '[.[] | select(.status=="gate_failed")]')
-          CLEAN=$(echo    "$ALL" | jq '[.[] | select(.status=="clean")]')
-          ANY_ACTION=$([ "$(echo "$REFRESHED" | jq 'length')" -gt 0 ] || [ "$(echo "$FAILED" | jq 'length')" -gt 0 ] && echo true || echo false)
-          ANY_FAILURE=$([ "$(echo "$FAILED" | jq 'length')" -gt 0 ] && echo true || echo false)
+          DEC=(/tmp/decisions/*.json)
+          RES=(/tmp/results/*.json)
+          DECISIONS=$([ ${#DEC[@]} -gt 0 ] && jq -s '.' "${DEC[@]}" || echo '[]')
+          RESULTS=$(  [ ${#RES[@]} -gt 0 ] && jq -s '.' "${RES[@]}" || echo '[]')
+          # Final status per (image, tag): result wins; otherwise decision (clean) or fallback
+          MERGED=$(jq -cn --argjson dec "$DECISIONS" --argjson res "$RESULTS" '
+            $dec | map(. as $d |
+              ($res | map(select(.image==$d.image and .tag==$d.tag)) | first) as $r |
+              if $r then $r
+              elif ($d.refresh|not) then {image:$d.image, tag:$d.tag, status:"clean",        reason:$d.reason, digest:""}
+              else                       {image:$d.image, tag:$d.tag, status:"build_failed", reason:$d.reason, digest:""}
+              end
+            )
+          ')
+          REFRESHED=$(echo "$MERGED" | jq '[.[] | select(.status=="refreshed")]')
+          FAILED=$(echo    "$MERGED" | jq '[.[] | select(.status=="gate_failed" or .status=="build_failed")]')
+          CLEAN=$(echo     "$MERGED" | jq '[.[] | select(.status=="clean")]')
+          REFRESHED_N=$(echo "$REFRESHED" | jq 'length')
+          FAILED_N=$(echo    "$FAILED"    | jq 'length')
+          CLEAN_N=$(echo     "$CLEAN"     | jq 'length')
+          ANY_ACTION=$([ "$REFRESHED_N" -gt 0 ] || [ "$FAILED_N" -gt 0 ] && echo true || echo false)
+          ANY_FAILURE=$([ "$FAILED_N" -gt 0 ] && echo true || echo false)
           {
             echo "any_action=$ANY_ACTION"
             echo "any_failure=$ANY_FAILURE"
-            echo "refreshed_count=$(echo "$REFRESHED" | jq 'length')"
-            echo "failed_count=$(echo   "$FAILED"    | jq 'length')"
-            echo "clean_count=$(echo    "$CLEAN"     | jq 'length')"
           } >> "$GITHUB_OUTPUT"
-          echo "$ALL" > /tmp/all.json
-          # Render markdown body
           {
             echo "## Image refresh report — $(date -u +%Y-%m-%d)"
             echo ""
-            echo "Triggered by: \`${{ github.event_name }}\` (run [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}))"
+            echo "Triggered by \`${{ github.event_name }}\` (run [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}))"
             echo ""
-            if [ "$(echo "$FAILED" | jq 'length')" -gt 0 ]; then
-              echo "### Gate failures (manual triage required)"
+            if [ "$FAILED_N" -gt 0 ]; then
+              echo "### ❌ Failures (manual triage required)"
               echo ""
-              echo "| Image | Tag | Reason |"
-              echo "| --- | --- | --- |"
-              echo "$FAILED" | jq -r '.[] | "| `\(.image)` | `\(.tag)` | `\(.reason)` |"'
+              echo "| Image | Tag | Status | Reason |"
+              echo "| --- | --- | --- | --- |"
+              echo "$FAILED" | jq -r '.[] | "| `\(.image)` | `\(.tag)` | `\(.status)` | `\(.reason)` |"'
+              echo ""
+              echo "Old digest is preserved on these tags; no republish happened."
               echo ""
             fi
-            if [ "$(echo "$REFRESHED" | jq 'length')" -gt 0 ]; then
-              echo "### Refreshed"
+            if [ "$REFRESHED_N" -gt 0 ]; then
+              echo "### ✅ Refreshed"
               echo ""
-              echo "| Image | Tag | Reason | New digest |"
+              echo "| Image | Tag | Reason | New amd64 digest |"
               echo "| --- | --- | --- | --- |"
               echo "$REFRESHED" | jq -r '.[] | "| `\(.image)` | `\(.tag)` | `\(.reason)` | `\(.digest // "n/a")` |"'
               echo ""
             fi
-            if [ "$(echo "$CLEAN" | jq 'length')" -gt 0 ]; then
+            if [ "$CLEAN_N" -gt 0 ]; then
               echo "### Clean (no action)"
               echo ""
               echo "$CLEAN" | jq -r '.[] | "- `\(.image):\(.tag)`"'
@@ -318,7 +477,6 @@ jobs:
           if [ "$ANY_FAILURE" = "true" ]; then
             LABELS="$LABELS,priority/p1"
           fi
-          # Reuse open issue from the same UTC day if present, otherwise create
           EXISTING=$(gh issue list --label image-refresh --state open --json number,title --jq \
             ".[] | select(.title==\"$TITLE\") | .number" | head -1)
           if [ -n "$EXISTING" ]; then

--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -1,0 +1,329 @@
+name: Image Refresh (drift remediation)
+
+# Re-scans the last 3 stable image tags published to GHCR (chatcli + chatcli-operator)
+# and rebuilds them in-place when fixable HIGH/CRITICAL OS vulns are detected.
+# The semver tag is preserved; only the underlying digest changes.
+#
+# Triggers:
+#   - schedule: weekly Monday 06:00 UTC (aligned with security-scan.yml)
+#   - workflow_dispatch: manual run with optional `tags` and `force` inputs
+#   - repository_dispatch (type: image-refresh-request): external triggers (e.g. ArtifactHub webhook)
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: 'Comma-separated semver tags to refresh (e.g. "1.111.1,1.110.0"). Empty = last 3 stable.'
+        required: false
+        type: string
+      force:
+        description: 'Refresh even if scan is clean'
+        required: false
+        type: boolean
+        default: false
+  repository_dispatch:
+    types: [image-refresh-request]
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  issues: write
+
+concurrency:
+  group: image-refresh
+  cancel-in-progress: false
+
+jobs:
+  discover:
+    name: Discover target tags
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.compute.outputs.matrix }}
+      tag_list: ${{ steps.compute.outputs.tag_list }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve target matrix
+        id: compute
+        env:
+          INPUT_TAGS: ${{ github.event.inputs.tags }}
+          DISPATCH_TAGS: ${{ github.event.client_payload.tags }}
+        run: |
+          set -euo pipefail
+          INPUT="${INPUT_TAGS:-${DISPATCH_TAGS:-}}"
+          if [ -n "$INPUT" ]; then
+            TAGS=$(echo "$INPUT" | tr ',' '\n' | sed 's/^v//' | sed '/^$/d')
+          else
+            TAGS=$(git tag -l 'v*' --sort=-v:refname | head -3 | sed 's/^v//')
+          fi
+          if [ -z "$TAGS" ]; then
+            echo "::error::No semver tags resolved"
+            exit 1
+          fi
+          echo "Resolved tags:"
+          echo "$TAGS"
+          INCLUDES=$(echo "$TAGS" | jq -R -s -c '
+            split("\n") | map(select(length > 0)) | map(. as $t | [
+              {image: "chatcli",          tag: $t, dockerfile: "Dockerfile",          context: "."},
+              {image: "chatcli-operator", tag: $t, dockerfile: "operator/Dockerfile", context: "."}
+            ]) | flatten
+          ')
+          {
+            echo "matrix={\"include\":$INCLUDES}"
+            echo "tag_list<<EOF"
+            echo "$TAGS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+  refresh:
+    name: "${{ matrix.image }}:${{ matrix.tag }}"
+    needs: discover
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
+    steps:
+      - name: Checkout source at tag
+        uses: actions/checkout@v6
+        with:
+          ref: "v${{ matrix.tag }}"
+          fetch-depth: 1
+
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Scan currently-published image
+        id: scan
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: "ghcr.io/diillson/${{ matrix.image }}:${{ matrix.tag }}"
+          format: table
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          trivyignores: .trivyignore.yaml
+          scanners: vuln
+          exit-code: '1'
+
+      - name: Decide whether to refresh
+        id: decide
+        env:
+          FORCE_INPUT: ${{ github.event.inputs.force }}
+          FORCE_DISPATCH: ${{ github.event.client_payload.force }}
+          SCAN_OUTCOME: ${{ steps.scan.outcome }}
+        run: |
+          set -euo pipefail
+          FORCE="${FORCE_INPUT:-${FORCE_DISPATCH:-false}}"
+          if [ "$FORCE" = "true" ] || [ "$SCAN_OUTCOME" = "failure" ]; then
+            REASON=$([ "$FORCE" = "true" ] && echo "forced" || echo "vulnerabilities-detected")
+            echo "refresh=true"  >> "$GITHUB_OUTPUT"
+            echo "reason=$REASON" >> "$GITHUB_OUTPUT"
+            echo "::notice::Refresh required for ${{ matrix.image }}:${{ matrix.tag }} (reason: $REASON)"
+          else
+            echo "refresh=false" >> "$GITHUB_OUTPUT"
+            echo "reason=clean"  >> "$GITHUB_OUTPUT"
+            echo "::notice::${{ matrix.image }}:${{ matrix.tag }} is clean — skipping refresh"
+          fi
+
+      - name: Set up QEMU
+        if: steps.decide.outputs.refresh == 'true'
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        if: steps.decide.outputs.refresh == 'true'
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build & push refreshed multi-arch image
+        if: steps.decide.outputs.refresh == 'true'
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          no-cache: true
+          tags: "ghcr.io/diillson/${{ matrix.image }}:${{ matrix.tag }}"
+          provenance: true
+          sbom: true
+
+      - name: Trivy gate on rebuilt digest
+        if: steps.decide.outputs.refresh == 'true'
+        id: gate
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: "ghcr.io/diillson/${{ matrix.image }}@${{ steps.build.outputs.digest }}"
+          format: table
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          trivyignores: .trivyignore.yaml
+          scanners: vuln
+          exit-code: '1'
+
+      - name: Install Cosign
+        if: steps.decide.outputs.refresh == 'true' && steps.gate.outcome == 'success'
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign refreshed manifest (keyless OIDC)
+        if: steps.decide.outputs.refresh == 'true' && steps.gate.outcome == 'success'
+        run: |
+          cosign sign --yes --recursive \
+            "ghcr.io/diillson/${{ matrix.image }}:${{ matrix.tag }}"
+
+      - name: Record result
+        if: always()
+        env:
+          IMAGE: ${{ matrix.image }}
+          TAG: ${{ matrix.tag }}
+          REFRESH: ${{ steps.decide.outputs.refresh }}
+          REASON: ${{ steps.decide.outputs.reason }}
+          GATE: ${{ steps.gate.outcome }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          mkdir -p results
+          if [ "$REFRESH" != "true" ]; then
+            STATUS="clean"
+          elif [ "$GATE" = "success" ]; then
+            STATUS="refreshed"
+          else
+            STATUS="gate_failed"
+          fi
+          jq -nc \
+            --arg image   "$IMAGE" \
+            --arg tag     "$TAG" \
+            --arg status  "$STATUS" \
+            --arg reason  "${REASON:-unknown}" \
+            --arg digest  "${DIGEST:-}" \
+            '{image:$image, tag:$tag, status:$status, reason:$reason, digest:$digest}' \
+            > "results/${IMAGE}-${TAG}.json"
+          {
+            echo "## ${IMAGE}:${TAG}"
+            echo ""
+            echo "- Status: \`${STATUS}\`"
+            echo "- Reason: \`${REASON:-unknown}\`"
+            [ -n "${DIGEST:-}" ] && echo "- Digest: \`${DIGEST}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload result artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: refresh-result-${{ matrix.image }}-${{ matrix.tag }}
+          path: results/*.json
+          retention-days: 14
+          if-no-files-found: warn
+
+  report:
+    name: Aggregate results & open issue
+    needs: refresh
+    if: always() && needs.refresh.result != 'skipped'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download all results
+        uses: actions/download-artifact@v8
+        with:
+          pattern: refresh-result-*
+          path: /tmp/results
+          merge-multiple: true
+
+      - name: Aggregate
+        id: agg
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          FILES=(/tmp/results/*.json)
+          if [ ${#FILES[@]} -eq 0 ]; then
+            echo "::warning::No result artifacts found"
+            echo "any_action=false" >> "$GITHUB_OUTPUT"
+            echo "any_failure=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          ALL=$(jq -s '.' "${FILES[@]}")
+          REFRESHED=$(echo "$ALL" | jq '[.[] | select(.status=="refreshed")]')
+          FAILED=$(echo   "$ALL" | jq '[.[] | select(.status=="gate_failed")]')
+          CLEAN=$(echo    "$ALL" | jq '[.[] | select(.status=="clean")]')
+          ANY_ACTION=$([ "$(echo "$REFRESHED" | jq 'length')" -gt 0 ] || [ "$(echo "$FAILED" | jq 'length')" -gt 0 ] && echo true || echo false)
+          ANY_FAILURE=$([ "$(echo "$FAILED" | jq 'length')" -gt 0 ] && echo true || echo false)
+          {
+            echo "any_action=$ANY_ACTION"
+            echo "any_failure=$ANY_FAILURE"
+            echo "refreshed_count=$(echo "$REFRESHED" | jq 'length')"
+            echo "failed_count=$(echo   "$FAILED"    | jq 'length')"
+            echo "clean_count=$(echo    "$CLEAN"     | jq 'length')"
+          } >> "$GITHUB_OUTPUT"
+          echo "$ALL" > /tmp/all.json
+          # Render markdown body
+          {
+            echo "## Image refresh report — $(date -u +%Y-%m-%d)"
+            echo ""
+            echo "Triggered by: \`${{ github.event_name }}\` (run [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}))"
+            echo ""
+            if [ "$(echo "$FAILED" | jq 'length')" -gt 0 ]; then
+              echo "### Gate failures (manual triage required)"
+              echo ""
+              echo "| Image | Tag | Reason |"
+              echo "| --- | --- | --- |"
+              echo "$FAILED" | jq -r '.[] | "| `\(.image)` | `\(.tag)` | `\(.reason)` |"'
+              echo ""
+            fi
+            if [ "$(echo "$REFRESHED" | jq 'length')" -gt 0 ]; then
+              echo "### Refreshed"
+              echo ""
+              echo "| Image | Tag | Reason | New digest |"
+              echo "| --- | --- | --- | --- |"
+              echo "$REFRESHED" | jq -r '.[] | "| `\(.image)` | `\(.tag)` | `\(.reason)` | `\(.digest // "n/a")` |"'
+              echo ""
+            fi
+            if [ "$(echo "$CLEAN" | jq 'length')" -gt 0 ]; then
+              echo "### Clean (no action)"
+              echo ""
+              echo "$CLEAN" | jq -r '.[] | "- `\(.image):\(.tag)`"'
+              echo ""
+            fi
+          } > /tmp/body.md
+          cat /tmp/body.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Ensure tracking labels exist
+        if: steps.agg.outputs.any_action == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create image-refresh   --color 1d76db --description "Automated image refresh runs" --force
+          gh label create security        --color d93f0b --description "Security-related"             --force
+          gh label create priority/p1     --color b60205 --description "P1 — manual triage required"  --force
+
+      - name: Open or comment tracking issue
+        if: steps.agg.outputs.any_action == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANY_FAILURE: ${{ steps.agg.outputs.any_failure }}
+        run: |
+          set -euo pipefail
+          TITLE="chore(security): image refresh report — $(date -u +%Y-%m-%d)"
+          BODY=$(cat /tmp/body.md)
+          LABELS="image-refresh,security"
+          if [ "$ANY_FAILURE" = "true" ]; then
+            LABELS="$LABELS,priority/p1"
+          fi
+          # Reuse open issue from the same UTC day if present, otherwise create
+          EXISTING=$(gh issue list --label image-refresh --state open --json number,title --jq \
+            ".[] | select(.title==\"$TITLE\") | .number" | head -1)
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "$BODY"
+            echo "Commented on issue #$EXISTING"
+          else
+            gh issue create --title "$TITLE" --body "$BODY" --label "$LABELS"
+          fi


### PR DESCRIPTION
## Summary

- New workflow `.github/workflows/image-refresh.yml` that detects CVE drift on already-published GHCR images (`chatcli` + `chatcli-operator`) and rebuilds them in-place without going through release-please.
- Three triggers: weekly schedule (Mon 06:00 UTC), manual `workflow_dispatch` with optional `tags`/`force` inputs, and `repository_dispatch` (`type: image-refresh-request`) for external integrations.
- Pipeline: discover last 3 stable semver tags → scan each published image with Trivy (HIGH/CRITICAL fixable only, `ignore-unfixed: true`) → rebuild multi-arch in-place when drift is detected → gate the rebuilt digest → re-sign with cosign keyless. Semver tag is preserved; only the digest changes.
- Fallback when the rebuild Trivy gate fails (no upstream patch yet): keep the old digest, do not republish, and open a `priority/p1` issue with the aggregated report for manual triage.
- Aggregation job opens (or comments on) a daily tracking issue labeled `image-refresh,security` with a markdown summary of refreshed/clean/failed targets.

## Why

ArtifactHub flagged `CVE-2026-27135` (nghttp2-libs DoS, HIGH) on `ghcr.io/diillson/chatcli-operator:1.111.1`. Root cause: `nghttp2-libs 1.69.0-r0` reached the Alpine v3.23 repo after the `1.111.1` build ran, so the layer was frozen with the older `1.68.0-r0` and the published image cannot benefit from `apk upgrade` retroactively.

Existing Trivy gates run only at release time (`security-scan.yml` on PRs and `3-publish-release.yml` on tag push). They protect what is being released, not what is already published. This closes the loop with a low-overhead, scoped solution sized to this project (single maintainer, ~3-5 CVE-driven rebuilds per year).

## Trade-offs accepted

- The semver tag stays the same, but the underlying digest changes when a refresh happens. Consumers who pin by digest will need to re-pin (rare with Helm/K8s; typical pin is by tag).
- The Helm chart is **not** republished. `chatcli-operator` chart `1.111.1` keeps pointing at `chatcli-operator:1.111.1` (now with a clean digest).
- Multi-arch is built with QEMU rather than the native runners pattern used in the release pipeline. Acceptable for a weekly job; can be split later if runtime becomes a concern.
- Coverage window is the last 3 stable tags. Older releases are out of scope.

## Test plan

- [x] Manual dry run via `workflow_dispatch` with `force=true` against a single tag (e.g. `tags: 1.111.1`) and verify: (a) build succeeds, (b) cosign sign succeeds, (c) tracking issue opens.
- [x] Manual run with `force=false` against a known-clean tag and verify: (a) scan passes, (b) build is skipped, (c) no issue is opened.
- [x] Confirm the daily tracking issue gets a comment when the same workflow runs twice on the same UTC day.
- [x] Verify Trivy gate failure path by temporarily lowering severity threshold (or against a tag with no fix available) and confirm `priority/p1` label is applied and image is **not** republished.
- [x] After first scheduled run, validate ArtifactHub re-scan reports zero HIGH/CRITICAL on `chatcli-operator:1.111.1`.