### PR TITLE
refactor(operator): migrate SchemeBuilder to apimachinery pattern

### DIFF
--- a/operator/api/v1alpha1/aiinsight_types.go
+++ b/operator/api/v1alpha1/aiinsight_types.go
@@ -103,7 +103,3 @@ type AIInsightList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []AIInsight `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&AIInsight{}, &AIInsightList{})
-}

--- a/operator/api/v1alpha1/anomaly_types.go
+++ b/operator/api/v1alpha1/anomaly_types.go
@@ -102,7 +102,3 @@ type AnomalyList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Anomaly `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&Anomaly{}, &AnomalyList{})
-}

--- a/operator/api/v1alpha1/approvalpolicy_types.go
+++ b/operator/api/v1alpha1/approvalpolicy_types.go
@@ -166,7 +166,3 @@ type ApprovalPolicyList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []ApprovalPolicy `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&ApprovalPolicy{}, &ApprovalPolicyList{})
-}

--- a/operator/api/v1alpha1/approvalrequest_types.go
+++ b/operator/api/v1alpha1/approvalrequest_types.go
@@ -149,7 +149,3 @@ type ApprovalRequestList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []ApprovalRequest `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&ApprovalRequest{}, &ApprovalRequestList{})
-}

--- a/operator/api/v1alpha1/auditevent_types.go
+++ b/operator/api/v1alpha1/auditevent_types.go
@@ -88,7 +88,3 @@ type AuditEventList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []AuditEvent `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&AuditEvent{}, &AuditEventList{})
-}

--- a/operator/api/v1alpha1/chaosexperiment_types.go
+++ b/operator/api/v1alpha1/chaosexperiment_types.go
@@ -185,7 +185,3 @@ type ChaosExperimentList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []ChaosExperiment `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&ChaosExperiment{}, &ChaosExperimentList{})
-}

--- a/operator/api/v1alpha1/clusterregistration_types.go
+++ b/operator/api/v1alpha1/clusterregistration_types.go
@@ -100,7 +100,3 @@ type ClusterRegistrationList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []ClusterRegistration `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&ClusterRegistration{}, &ClusterRegistrationList{})
-}

--- a/operator/api/v1alpha1/escalationpolicy_types.go
+++ b/operator/api/v1alpha1/escalationpolicy_types.go
@@ -122,7 +122,3 @@ type EscalationPolicyList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []EscalationPolicy `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&EscalationPolicy{}, &EscalationPolicyList{})
-}

--- a/operator/api/v1alpha1/groupversion_info.go
+++ b/operator/api/v1alpha1/groupversion_info.go
@@ -4,8 +4,9 @@
 package v1alpha1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -13,8 +14,32 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "platform.chatcli.io", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionResource scheme.
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
 )
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion,
+		&AIInsight{}, &AIInsightList{},
+		&Anomaly{}, &AnomalyList{},
+		&ApprovalPolicy{}, &ApprovalPolicyList{},
+		&ApprovalRequest{}, &ApprovalRequestList{},
+		&AuditEvent{}, &AuditEventList{},
+		&ChaosExperiment{}, &ChaosExperimentList{},
+		&ClusterRegistration{}, &ClusterRegistrationList{},
+		&EscalationPolicy{}, &EscalationPolicyList{},
+		&IncidentSLA{}, &IncidentSLAList{},
+		&Instance{}, &InstanceList{},
+		&Issue{}, &IssueList{},
+		&NotificationPolicy{}, &NotificationPolicyList{},
+		&PostMortem{}, &PostMortemList{},
+		&RemediationPlan{}, &RemediationPlanList{},
+		&Runbook{}, &RunbookList{},
+		&ServiceLevelObjective{}, &ServiceLevelObjectiveList{},
+		&SourceRepository{}, &SourceRepositoryList{},
+	)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}

--- a/operator/api/v1alpha1/incidentsla_types.go
+++ b/operator/api/v1alpha1/incidentsla_types.go
@@ -133,7 +133,3 @@ type IncidentSLAList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []IncidentSLA `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&IncidentSLA{}, &IncidentSLAList{})
-}

--- a/operator/api/v1alpha1/instance_types.go
+++ b/operator/api/v1alpha1/instance_types.go
@@ -553,7 +553,3 @@ type InstanceList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Instance `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&Instance{}, &InstanceList{})
-}

--- a/operator/api/v1alpha1/issue_types.go
+++ b/operator/api/v1alpha1/issue_types.go
@@ -133,7 +133,3 @@ type IssueList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Issue `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&Issue{}, &IssueList{})
-}

--- a/operator/api/v1alpha1/notificationpolicy_types.go
+++ b/operator/api/v1alpha1/notificationpolicy_types.go
@@ -171,7 +171,3 @@ type NotificationPolicyList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []NotificationPolicy `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&NotificationPolicy{}, &NotificationPolicyList{})
-}

--- a/operator/api/v1alpha1/postmortem_types.go
+++ b/operator/api/v1alpha1/postmortem_types.go
@@ -257,7 +257,3 @@ type PostMortemList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []PostMortem `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&PostMortem{}, &PostMortemList{})
-}

--- a/operator/api/v1alpha1/remediationplan_types.go
+++ b/operator/api/v1alpha1/remediationplan_types.go
@@ -381,7 +381,3 @@ type RemediationPlanList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []RemediationPlan `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&RemediationPlan{}, &RemediationPlanList{})
-}

--- a/operator/api/v1alpha1/runbook_types.go
+++ b/operator/api/v1alpha1/runbook_types.go
@@ -72,7 +72,3 @@ type RunbookList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Runbook `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&Runbook{}, &RunbookList{})
-}

--- a/operator/api/v1alpha1/slo_types.go
+++ b/operator/api/v1alpha1/slo_types.go
@@ -199,7 +199,3 @@ type ServiceLevelObjectiveList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []ServiceLevelObjective `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&ServiceLevelObjective{}, &ServiceLevelObjectiveList{})
-}

--- a/operator/api/v1alpha1/sourcerepository_types.go
+++ b/operator/api/v1alpha1/sourcerepository_types.go
@@ -139,7 +139,3 @@ type SourceRepositoryList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []SourceRepository `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&SourceRepository{}, &SourceRepositoryList{})
-}


### PR DESCRIPTION
## Summary
- controller-runtime 0.24.0 deprecou `sigs.k8s.io/controller-runtime/pkg/scheme.Builder` (PR upstream [#3461](https://github.com/kubernetes-sigs/controller-runtime/pull/3461)).
- Motivo upstream: api packages devem depender só de stdlib + `k8s.io/apimachinery` + outros api packages — não de controller-runtime.
- Migrado para o padrão recomendado:
  - `groupversion_info.go` agora usa `runtime.NewSchemeBuilder(addKnownTypes)` direto do apimachinery.
  - `addKnownTypes` registra os 17 CRDs centralmente via `scheme.AddKnownTypes(GroupVersion, ...)`.
  - Removidos 17 `init() { SchemeBuilder.Register(...) }` redundantes (1 por types file).
  - Adicionado `metav1.AddToGroupVersion(scheme, GroupVersion)` (parte do padrão).

## Impacto
- Zero mudança de comportamento — `AddToScheme` continua sendo o entrypoint, `GroupVersion` inalterado.
- Sem mais imports de `sigs.k8s.io/controller-runtime/pkg/scheme` nos types.

## Test plan
- [x] `go build ./...` em /operator — OK
- [x] `go test ./...` em /operator — OK (controllers test passou)
- [x] `go vet ./...` em /operator — OK