### PR TITLE
fix(operator): pin nghttp2-libs >=1.68.1-r0 (CVE-2026-27135)

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -32,10 +32,15 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -o manager main.go
 # needs git to clone and sync application repositories.
 # Pinned to exact patch version; Dependabot keeps this updated.
 FROM alpine:3.23.4 AS runtime
+# nghttp2-libs is pulled in transitively by git but the constraint
+# pins it to 1.68.0-r0 in alpine:3.23.4, which has CVE-2026-27135
+# (HTTP/2 frame parsing DoS). The apk upgrade above doesn't widen
+# the constraint, so we pin the patched version (1.68.1+) explicitly.
 RUN apk update && apk upgrade --no-cache && \
     apk add --no-cache \
         "libcrypto3>=3.5.6-r0" \
         "libssl3>=3.5.6-r0" \
+        "nghttp2-libs>=1.68.1-r0" \
         git ca-certificates tzdata && \
     adduser -D -u 65532 -g 65532 nonroot
 WORKDIR /


### PR DESCRIPTION
## Summary
Trivy flagged **HIGH CVE-2026-27135** on the operator image after the v1.112.0 release: \`nghttp2-libs 1.68.0-r0\` in alpine 3.23.4 is vulnerable to a DoS via malformed HTTP/2 frames after session termination. Fixed in 1.68.1.

The existing \`apk upgrade --no-cache\` doesn't lift the package because nghttp2-libs is pulled transitively by git with a 1.68.0-r0 constraint baked into the alpine:3.23.4 baseline. Adding an explicit \`"nghttp2-libs>=1.68.1-r0"\` to the apk add list forces the resolver to pick the patched 1.69.0-r0 from the alpine 3.23 community repo.

## Verification
\`\`\`
$ docker run --rm alpine:3.23 sh -c 'apk update -q && apk info nghttp2-libs'
nghttp2-libs-1.69.0-r0 description:
\`\`\`
1.69.0 satisfies \`>=1.68.1-r0\`, so the constraint is satisfiable today.

## Test plan
- [ ] CI Trivy — Operator Image step turns green
- [ ] No regression: image still builds, operator still starts (no CGO ↔ libssl3/libcrypto3 mismatch)

## Notes
The chatcli image (root Dockerfile) uses distroless and is not affected by this CVE.