### PR TITLE
ci: Quality Gate workflow as single required check on PRs

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,29 @@
+# Labels managed by .github/workflows/labels-sync.yml
+#
+# These are the bypass / contextual labels honored by the Quality Gate.
+# Anything else in the repo is left untouched (the action runs in
+# non-destructive mode).
+
+- name: large-pr-approved
+  color: "fbca04"
+  description: Bypass Quality Gate LOC threshold (PR is intentionally large)
+
+- name: wide-pr-approved
+  color: "fbca04"
+  description: Bypass Quality Gate file-count threshold (PR touches many files intentionally)
+
+- name: deps:approved
+  color: "0e8a16"
+  description: New dependencies in this PR have been reviewed and approved
+
+- name: breaking-change
+  color: "b60205"
+  description: This PR removes or changes exported APIs intentionally
+
+- name: refactor-only
+  color: "5319e7"
+  description: Pure refactor — patch coverage threshold relaxed
+
+- name: quality-gate-skip
+  color: "d93f0b"
+  description: Nuclear bypass — skips the entire Quality Gate (use sparingly)

--- a/.github/quality-gate.yml
+++ b/.github/quality-gate.yml
@@ -1,0 +1,150 @@
+# Quality Gate — versioned configuration
+#
+# All thresholds the Quality Gate workflow honors live here so they can be
+# tuned without touching workflow YAML or shell scripts. Read by
+# scripts/qg/lib.sh via yq.
+#
+# Phase rollout: every floor below is enforced (blocking) by default.
+# Setting `enforcement: warn` on a floor flips it to advisory-only — useful
+# while introducing a new check without surprising contributors.
+
+version: 1
+
+# Branches the Quality Gate runs against (mirrors workflow `on.pull_request.branches`).
+target_branches:
+  - main
+  - develop
+
+# Bot actors whose PRs skip the gate entirely. Release-please reshuffles
+# changelogs and version bumps; running coverage ratchet against those is noise.
+skip_actors:
+  - release-please[bot]
+  - github-actions[bot]
+  - dependabot[bot]
+
+# Floor 1 — Build / static analysis. Already covered by 1-ci.yml; the
+# Quality Gate re-runs them so the single required check is self-contained
+# (a future cleanup of 1-ci.yml does not silently widen the gate).
+build:
+  enforcement: blocking
+  go_vet: true
+  gofmt: true
+  golangci_lint:
+    version: v1.64.8
+    timeout: 5m
+
+# Floor 2 — Total coverage ratchet vs. main. Baseline is stored as a commit
+# status `quality-gate/coverage` on every push to main by
+# quality-gate-baseline.yml. First run (no baseline) bootstraps and passes.
+coverage_total:
+  enforcement: blocking
+  # Floor below which we never go even if main regressed.
+  hard_floor_pct: 27.0
+  # Tolerance to absorb flake (line-count drift on retries, etc.).
+  tolerance_pct: 0.1
+
+# Floor 3 — Patch coverage on the diff. Computed via gocover-cobertura +
+# diff-cover comparing to origin/<base>. Excludes generated and test files.
+coverage_patch:
+  enforcement: blocking
+  threshold_pct: 60
+  # PRs labelled `refactor-only` use a relaxed threshold (move-don't-add).
+  refactor_threshold_pct: 30
+  exclude:
+    - "**/*_test.go"
+    - "**/*.pb.go"
+    - "proto/**"
+    - "tools/docgen/**"
+
+# Floor 4 — AI / hand-rolled code smells scanned in the diff (Go non-test only).
+ai_smells:
+  enforcement: blocking
+  checks:
+    todo_fixme_xxx: true
+    panic_in_new_code: true
+    interface_any_in_public_api: true
+    hardcoded_user_strings: true   # heuristic, runs on cli/ handlers only
+    obvious_secrets: true
+    new_dependency_without_label: true   # bypass: deps:approved
+    removed_exports_without_label: true  # bypass: breaking-change
+  # Paths excluded from smells scan (noise reduction).
+  exclude:
+    - "**/*_test.go"
+    - "**/*.pb.go"
+    - "proto/**"
+    - "vendor/**"
+    - "scripts/qg/**"
+
+# Floor 5 — Scope discipline. Bypassed via labels for legitimate large PRs.
+scope_budget:
+  enforcement: blocking
+  loc:
+    warn: 800
+    block: 2000
+    bypass_label: large-pr-approved
+  files:
+    warn: 25
+    block: 50
+    bypass_label: wide-pr-approved
+  # Paths counted as "tooling" — they still count toward LOC, but the warning
+  # explicitly notes the tooling share so reviewers see signal vs. noise.
+  tooling_paths:
+    - ".github/**"
+    - "scripts/**"
+    - "Makefile"
+    - "**/*.md"
+
+# Floor 6 — E2E + race. Runs the e2e/ package which builds the binary itself.
+e2e:
+  enforcement: blocking
+  timeout_minutes: 15
+
+# Floor 7 — Commit hygiene. Catches the two release-please/repo conventions
+# that have bitten this repo before (see feedback_no_coauthor.md and
+# feedback_no_code_in_commit_body.md in user memory).
+commit_lint:
+  enforcement: blocking
+  forbid_co_authored_by: true
+  forbid_nested_parens_in_body: true
+  # Conventional Commits prefix on the FIRST commit of the PR (release-please
+  # uses the merge commit subject; we still want PR-level discipline).
+  require_conventional_commits: true
+  allowed_types:
+    - feat
+    - fix
+    - refactor
+    - perf
+    - docs
+    - test
+    - build
+    - ci
+    - chore
+    - revert
+    - style
+
+# Floor 8 — Cyclomatic complexity on changed files only. Existing code is
+# grandfathered (project-wide gocyclo is 70); new code is held to 30.
+cyclo_new:
+  enforcement: blocking
+  max_complexity: 30
+  # Files whose path matches any of these are exempt (legacy hot spots that
+  # are intentionally large; splitting them is its own refactor).
+  exempt:
+    - "cli/agent_mode.go"
+    - "cli/cli.go"
+    - "cli/commands.go"
+
+# Floor 9 — Secrets scan via gitleaks on the PR diff.
+secrets_scan:
+  enforcement: blocking
+
+# Bypass labels — applied manually by maintainers when an exception is
+# legitimate. The gate logs which bypass was used so it shows up in the
+# sticky comment.
+bypass_labels:
+  - large-pr-approved
+  - wide-pr-approved
+  - deps:approved
+  - breaking-change
+  - refactor-only
+  - quality-gate-skip   # nuclear option; logs prominently in summary

--- a/.github/workflows/3-publish-release.yml
+++ b/.github/workflows/3-publish-release.yml
@@ -188,6 +188,14 @@ jobs:
         with:
           images: ghcr.io/diillson/chatcli
 
+      # no-cache + fresh apk metadata: GHA layer caching reused stale OS
+      # packages between releases (e.g. CVE-2026-27135 nghttp2-libs slipped
+      # through because the cached layer's `apk add` ran before the fix
+      # landed in the Alpine mirror). Image-Refresh already runs without
+      # cache and emits provenance/SBOM; we mirror those flags here so a
+      # release publishes the same hardened image instead of leaving it
+      # to the next drift-remediation cycle. Trade-off: ~2-5 min slower
+      # per arch, acceptable for a tag-triggered job.
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v7
@@ -196,8 +204,9 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=ghcr.io/diillson/chatcli,push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=chatcli-${{ matrix.arch }}
-          cache-to: type=gha,scope=chatcli-${{ matrix.arch }},mode=max
+          no-cache: true
+          provenance: true
+          sbom: true
 
       - name: Export digest
         run: |
@@ -349,6 +358,10 @@ jobs:
         with:
           images: ghcr.io/diillson/chatcli-operator
 
+      # See chatcli build above: no-cache+provenance+SBOM matches the
+      # Image-Refresh path so the operator image (Alpine-based, exposed
+      # to OS-package CVEs) ships fresh apk versions on every release
+      # instead of inheriting whatever the GHA cache layer captured.
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v7
@@ -358,8 +371,9 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=ghcr.io/diillson/chatcli-operator,push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=operator-${{ matrix.arch }}
-          cache-to: type=gha,scope=operator-${{ matrix.arch }},mode=max
+          no-cache: true
+          provenance: true
+          sbom: true
 
       - name: Export digest
         run: |

--- a/.github/workflows/labels-sync.yml
+++ b/.github/workflows/labels-sync.yml
@@ -1,0 +1,30 @@
+name: Sync Labels
+
+# Reconciles the labels defined in .github/labels.yml with the repository.
+# Runs on pushes to main that touch the manifest (so renames/recolors apply
+# without a manual sync) and via workflow_dispatch for ad-hoc reruns.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/labels.yml
+      - .github/workflows/labels-sync.yml
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  sync:
+    name: Sync .github/labels.yml -> repo labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Apply labels (non-destructive)
+        uses: EndBug/label-sync@v2
+        with:
+          config-file: .github/labels.yml
+          delete-other-labels: false

--- a/.github/workflows/quality-gate-baseline.yml
+++ b/.github/workflows/quality-gate-baseline.yml
@@ -1,0 +1,67 @@
+name: Quality Gate · Baseline
+
+# Publishes the total coverage % of main/develop as a GitHub commit status
+# (`quality-gate/coverage`). The Quality Gate ratchet job in
+# quality-gate.yml reads this status to compute the regression delta on a PR.
+#
+# Why a commit status? It is the cheapest authoritative store: no external
+# service, no S3, no codecov dependency. Statuses are first-class GitHub
+# objects and `gh api repos/.../commits/<sha>/statuses` is one call.
+
+on:
+  push:
+    branches: [main, develop]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  statuses: write
+
+concurrency:
+  group: quality-gate-baseline-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish-baseline:
+    name: Publish coverage baseline
+    runs-on: ubuntu-latest
+    if: github.actor != 'release-please[bot]'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run tests with coverage
+        run: |
+          go test -race -coverprofile=coverage.out ./...
+          go tool cover -func=coverage.out | tail -n 1
+
+      - name: Compute total coverage
+        id: cov
+        run: |
+          pct=$(go tool cover -func=coverage.out | awk '/^total:/ { gsub(/%/,"",$3); print $3 }')
+          echo "pct=$pct" >> "$GITHUB_OUTPUT"
+
+      - name: Publish commit status
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PCT: ${{ steps.cov.outputs.pct }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          gh api -X POST "repos/${GITHUB_REPOSITORY}/statuses/${SHA}" \
+            -f context='quality-gate/coverage' \
+            -f state='success' \
+            -f description="coverage ${PCT}%"
+
+      - name: Step summary
+        run: |
+          {
+            echo "## Coverage baseline updated"
+            echo ""
+            echo "- Branch: \`${GITHUB_REF_NAME}\`"
+            echo "- Commit: \`${GITHUB_SHA}\`"
+            echo "- Total coverage: **${{ steps.cov.outputs.pct }}%**"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -1,0 +1,538 @@
+name: Quality Gate
+
+# The Quality Gate is the single required check on the PR. Every floor lives
+# as a separate job (so failures show up granularly in the Checks UI) and the
+# aggregator job at the bottom is what branch protection should require.
+#
+# Configuration is centralised in .github/quality-gate.yml — thresholds and
+# enforcement modes are not hardcoded here.
+
+on:
+  pull_request:
+    branches: [main, develop]
+    types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review]
+
+concurrency:
+  group: quality-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: read
+  checks: read
+
+env:
+  GO_VERSION_FILE: go.mod
+
+jobs:
+  # ---------------------------------------------------------------------
+  # meta — short job that decides whether to run the gate at all and
+  # exposes shared values (PR labels, docs-only flag) to downstream jobs.
+  # ---------------------------------------------------------------------
+  meta:
+    name: Meta
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.decide.outputs.skip }}
+      docs_only: ${{ steps.decide.outputs.docs_only }}
+      labels: ${{ steps.decide.outputs.labels }}
+      base_ref: ${{ steps.decide.outputs.base_ref }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install yq + jq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - id: decide
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+        run: |
+          set -euo pipefail
+          source scripts/qg/lib.sh
+
+          # Skip release-please / bot PRs
+          actor='${{ github.actor }}'
+          mapfile -t skip_actors < <(qg_yq '.skip_actors[]?')
+          skip="false"
+          for a in "${skip_actors[@]}"; do
+            if [[ "$actor" == "$a" ]]; then
+              skip="true"; break
+            fi
+          done
+
+          # quality-gate-skip nuclear bypass
+          if qg_has_label quality-gate-skip; then
+            skip="true"
+            echo "::warning::Quality Gate bypassed via 'quality-gate-skip' label"
+          fi
+
+          base_ref="origin/${{ github.base_ref }}"
+          git fetch origin "${{ github.base_ref }}" --quiet || true
+
+          # docs-only detection
+          export QG_BASE_REF="$base_ref"
+          docs_only="false"
+          if qg_is_docs_only; then docs_only="true"; fi
+
+          labels=$(qg_pr_labels | xargs)
+
+          {
+            echo "skip=$skip"
+            echo "docs_only=$docs_only"
+            echo "labels=$labels"
+            echo "base_ref=$base_ref"
+          } >> "$GITHUB_OUTPUT"
+
+  # ---------------------------------------------------------------------
+  # Floor 1 — build, vet, gofmt, golangci-lint
+  # ---------------------------------------------------------------------
+  build-static:
+    name: Floor 1 · Build & Static
+    needs: meta
+    if: needs.meta.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: ${{ env.GO_VERSION_FILE }}
+          cache: true
+
+      - name: go build
+        run: go build ./...
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: gofmt
+        run: |
+          out=$(gofmt -l .)
+          if [[ -n "$out" ]]; then
+            echo "::error::gofmt: files not formatted:"
+            echo "$out"
+            exit 1
+          fi
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.64.8
+          install-mode: goinstall
+          args: --timeout=5m
+
+  # ---------------------------------------------------------------------
+  # Floor 2 — total coverage ratchet (unit tests with -race)
+  # Also produces coverage.out for floor 3 (patch-coverage).
+  # ---------------------------------------------------------------------
+  test-coverage:
+    name: Floor 2 · Coverage ratchet
+    needs: meta
+    if: needs.meta.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      passed: ${{ steps.ratchet.outputs.passed }}
+      current: ${{ steps.ratchet.outputs.current }}
+      baseline: ${{ steps.ratchet.outputs.baseline }}
+      delta: ${{ steps.ratchet.outputs.delta }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: ${{ env.GO_VERSION_FILE }}
+          cache: true
+
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: go test -race -coverprofile
+        run: |
+          go test -race -coverprofile=coverage.out ./...
+          go tool cover -func=coverage.out | tail -n 1
+
+      - name: Upload coverage profile
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-out
+          path: coverage.out
+          retention-days: 14
+
+      - id: ratchet
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          QG_BASE_REF: ${{ needs.meta.outputs.base_ref }}
+        run: bash scripts/qg/coverage-ratchet.sh coverage.out
+
+  # ---------------------------------------------------------------------
+  # Floor 3 — patch coverage on the diff
+  # ---------------------------------------------------------------------
+  patch-coverage:
+    name: Floor 3 · Patch coverage
+    needs: [meta, test-coverage]
+    if: needs.meta.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      passed: ${{ steps.patch.outputs.passed }}
+      percent: ${{ steps.patch.outputs.percent }}
+      threshold: ${{ steps.patch.outputs.threshold }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: ${{ env.GO_VERSION_FILE }}
+          cache: true
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - uses: actions/download-artifact@v6
+        with:
+          name: coverage-out
+
+      - id: patch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_LABELS: ${{ needs.meta.outputs.labels }}
+          QG_BASE_REF: ${{ needs.meta.outputs.base_ref }}
+        run: bash scripts/qg/patch-coverage.sh coverage.out
+
+  # ---------------------------------------------------------------------
+  # Floor 4 — AI smells scanner
+  # ---------------------------------------------------------------------
+  ai-smells:
+    name: Floor 4 · AI smells
+    needs: meta
+    if: needs.meta.outputs.skip != 'true' && needs.meta.outputs.docs_only != 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      passed: ${{ steps.scan.outputs.passed }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - id: scan
+        env:
+          PR_LABELS: ${{ needs.meta.outputs.labels }}
+          QG_BASE_REF: ${{ needs.meta.outputs.base_ref }}
+        run: bash scripts/qg/ai-smells.sh
+
+  # ---------------------------------------------------------------------
+  # Floor 5 — scope budget
+  # ---------------------------------------------------------------------
+  scope-budget:
+    name: Floor 5 · Scope budget
+    needs: meta
+    if: needs.meta.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      passed: ${{ steps.scope.outputs.passed }}
+      files: ${{ steps.scope.outputs.files }}
+      loc: ${{ steps.scope.outputs.loc }}
+      code_loc: ${{ steps.scope.outputs.code_loc }}
+      tooling_loc: ${{ steps.scope.outputs.tooling_loc }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - id: scope
+        env:
+          PR_LABELS: ${{ needs.meta.outputs.labels }}
+          QG_BASE_REF: ${{ needs.meta.outputs.base_ref }}
+        run: bash scripts/qg/scope-budget.sh
+
+  # ---------------------------------------------------------------------
+  # Floor 6 — E2E + race (the big behavioural test)
+  # ---------------------------------------------------------------------
+  e2e:
+    name: Floor 6 · E2E
+    needs: meta
+    if: needs.meta.outputs.skip != 'true' && needs.meta.outputs.docs_only != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: ${{ env.GO_VERSION_FILE }}
+          cache: true
+
+      - name: Run e2e suite
+        run: go test -race -count=1 -timeout 10m ./e2e/...
+
+  # ---------------------------------------------------------------------
+  # Floor 7 — commit hygiene
+  # ---------------------------------------------------------------------
+  commit-lint:
+    name: Floor 7 · Commit lint
+    needs: meta
+    if: needs.meta.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      passed: ${{ steps.lint.outputs.passed }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - id: lint
+        env:
+          QG_BASE_REF: ${{ needs.meta.outputs.base_ref }}
+        run: bash scripts/qg/commit-lint.sh
+
+  # ---------------------------------------------------------------------
+  # Floor 8 — cyclo on changed files
+  # ---------------------------------------------------------------------
+  cyclo-new:
+    name: Floor 8 · Cyclo (new code)
+    needs: meta
+    if: needs.meta.outputs.skip != 'true' && needs.meta.outputs.docs_only != 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      passed: ${{ steps.cyclo.outputs.passed }}
+      checked: ${{ steps.cyclo.outputs.checked }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: ${{ env.GO_VERSION_FILE }}
+          cache: true
+
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - id: cyclo
+        env:
+          QG_BASE_REF: ${{ needs.meta.outputs.base_ref }}
+        run: bash scripts/qg/cyclo-new.sh
+
+  # ---------------------------------------------------------------------
+  # Floor 9 — secrets scan (gitleaks on the diff)
+  # ---------------------------------------------------------------------
+  secrets-scan:
+    name: Floor 9 · Secrets scan
+    needs: meta
+    if: needs.meta.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: gitleaks (PR scope)
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_COMMENTS: "false"
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "true"
+
+  # ---------------------------------------------------------------------
+  # Aggregator — the single status check that branch protection requires.
+  # Posts a sticky comment with the per-floor verdict.
+  # ---------------------------------------------------------------------
+  quality-gate:
+    name: Quality Gate
+    needs:
+      - meta
+      - build-static
+      - test-coverage
+      - patch-coverage
+      - ai-smells
+      - scope-budget
+      - e2e
+      - commit-lint
+      - cyclo-new
+      - secrets-scan
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compose verdict
+        id: verdict
+        shell: bash
+        env:
+          R_BUILD: ${{ needs.build-static.result }}
+          R_COV: ${{ needs.test-coverage.result }}
+          R_PATCH: ${{ needs.patch-coverage.result }}
+          R_SMELLS: ${{ needs.ai-smells.result }}
+          R_SCOPE: ${{ needs.scope-budget.result }}
+          R_E2E: ${{ needs.e2e.result }}
+          R_LINT: ${{ needs.commit-lint.result }}
+          R_CYCLO: ${{ needs.cyclo-new.result }}
+          R_SEC: ${{ needs.secrets-scan.result }}
+          DOCS_ONLY: ${{ needs.meta.outputs.docs_only }}
+          SKIP: ${{ needs.meta.outputs.skip }}
+          COV_CURRENT: ${{ needs.test-coverage.outputs.current }}
+          COV_BASELINE: ${{ needs.test-coverage.outputs.baseline }}
+          COV_DELTA: ${{ needs.test-coverage.outputs.delta }}
+          PATCH_PCT: ${{ needs.patch-coverage.outputs.percent }}
+          PATCH_THR: ${{ needs.patch-coverage.outputs.threshold }}
+          SCOPE_FILES: ${{ needs.scope-budget.outputs.files }}
+          SCOPE_LOC: ${{ needs.scope-budget.outputs.loc }}
+          SCOPE_CODE_LOC: ${{ needs.scope-budget.outputs.code_loc }}
+          SCOPE_TOOL_LOC: ${{ needs.scope-budget.outputs.tooling_loc }}
+          CYCLO_CHECKED: ${{ needs.cyclo-new.outputs.checked }}
+          PR_LABELS: ${{ needs.meta.outputs.labels }}
+        run: |
+          set -euo pipefail
+
+          icon() {
+            case "$1" in
+              success) echo "✅";;
+              skipped) echo "⏭️";;
+              cancelled) echo "🚫";;
+              "") echo "⏭️";;
+              *) echo "❌";;
+            esac
+          }
+
+          if [[ "$SKIP" == "true" ]]; then
+            verdict="bypassed"
+            body="### Quality Gate · Bypassed%0AThis PR was skipped (bot actor or \`quality-gate-skip\` label)."
+          else
+            # Treat skipped as success (e.g. ai-smells skipped on docs-only PRs).
+            failed=()
+            for pair in \
+              "build-static:$R_BUILD" \
+              "coverage:$R_COV" \
+              "patch-coverage:$R_PATCH" \
+              "ai-smells:$R_SMELLS" \
+              "scope:$R_SCOPE" \
+              "e2e:$R_E2E" \
+              "commit-lint:$R_LINT" \
+              "cyclo:$R_CYCLO" \
+              "secrets:$R_SEC"; do
+                name=${pair%%:*}; res=${pair##*:}
+                if [[ "$res" != "success" && "$res" != "skipped" && -n "$res" ]]; then
+                  failed+=("$name")
+                fi
+            done
+
+            verdict="pass"
+            if [[ ${#failed[@]} -gt 0 ]]; then
+              verdict="fail"
+            fi
+          fi
+
+          # Build markdown body for sticky comment.
+          {
+            echo "### Quality Gate"
+            echo ""
+            if [[ "$verdict" == "pass" ]]; then
+              echo "**Result:** ✅ all floors passed"
+            elif [[ "$verdict" == "bypassed" ]]; then
+              echo "**Result:** ⏭️ bypassed"
+            else
+              echo "**Result:** ❌ ${#failed[@]} floor(s) failed: ${failed[*]}"
+            fi
+            echo ""
+            echo "| Floor | Status | Detail |"
+            echo "|---|---|---|"
+            echo "| 1 · Build & Static       | $(icon "$R_BUILD")   | go build / vet / fmt / golangci-lint |"
+
+            if [[ -n "$COV_BASELINE" ]]; then
+              echo "| 2 · Coverage ratchet     | $(icon "$R_COV")     | ${COV_CURRENT}% (baseline ${COV_BASELINE}%, Δ ${COV_DELTA}) |"
+            else
+              echo "| 2 · Coverage ratchet     | $(icon "$R_COV")     | ${COV_CURRENT}% (bootstrap) |"
+            fi
+
+            if [[ "$DOCS_ONLY" == "true" ]]; then
+              echo "| 3 · Patch coverage       | ⏭️                  | docs/CI only |"
+            else
+              echo "| 3 · Patch coverage       | $(icon "$R_PATCH")   | ${PATCH_PCT}% (≥ ${PATCH_THR}% required) |"
+            fi
+
+            if [[ "$DOCS_ONLY" == "true" ]]; then
+              echo "| 4 · AI smells            | ⏭️                  | docs/CI only |"
+            else
+              echo "| 4 · AI smells            | $(icon "$R_SMELLS")  | scanned diff |"
+            fi
+
+            echo "| 5 · Scope budget         | $(icon "$R_SCOPE")   | ${SCOPE_FILES} files, ${SCOPE_LOC} LOC (${SCOPE_CODE_LOC} code + ${SCOPE_TOOL_LOC} tooling) |"
+
+            if [[ "$DOCS_ONLY" == "true" ]]; then
+              echo "| 6 · E2E                  | ⏭️                  | docs/CI only |"
+            else
+              echo "| 6 · E2E                  | $(icon "$R_E2E")     | go test -race ./e2e/... |"
+            fi
+
+            echo "| 7 · Commit lint          | $(icon "$R_LINT")    | conventional commits + project rules |"
+
+            if [[ "$DOCS_ONLY" == "true" ]]; then
+              echo "| 8 · Cyclo (new code)     | ⏭️                  | docs/CI only |"
+            else
+              echo "| 8 · Cyclo (new code)     | $(icon "$R_CYCLO")   | ${CYCLO_CHECKED} file(s) checked |"
+            fi
+
+            echo "| 9 · Secrets scan         | $(icon "$R_SEC")     | gitleaks |"
+            echo ""
+            if [[ -n "${PR_LABELS// /}" ]]; then
+              echo "_Labels:_ \`${PR_LABELS// / }\`"
+            fi
+            echo ""
+            echo "_Config: [.github/quality-gate.yml](../blob/${{ github.head_ref }}/.github/quality-gate.yml)_"
+          } > body.md
+
+          {
+            echo "verdict=$verdict"
+            echo 'body<<__QG_EOF__'
+            cat body.md
+            echo '__QG_EOF__'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Sticky comment on PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: quality-gate
+          message: ${{ steps.verdict.outputs.body }}
+
+      - name: Final verdict
+        shell: bash
+        env:
+          V: ${{ steps.verdict.outputs.verdict }}
+        run: |
+          case "$V" in
+            pass|bypassed) echo "Quality Gate: $V"; exit 0;;
+            *) echo "Quality Gate: $V"; exit 1;;
+          esac

--- a/scripts/qg/README.md
+++ b/scripts/qg/README.md
@@ -1,0 +1,119 @@
+# Quality Gate
+
+Single required check on every PR to `main` / `develop`. Bundles 9 floors,
+each as an independent CI job, and an aggregator job that posts a sticky
+verdict comment and is the only check that needs to be marked **required**
+in branch protection.
+
+## Layout
+
+| File | Purpose |
+|------|---------|
+| `.github/workflows/quality-gate.yml`           | Orchestrator workflow — runs on `pull_request`. |
+| `.github/workflows/quality-gate-baseline.yml`  | Publishes total-coverage baseline as a commit status on `main` / `develop`. |
+| `.github/workflows/labels-sync.yml`            | Keeps bypass labels in sync with `.github/labels.yml`. |
+| `.github/quality-gate.yml`                     | All thresholds and enforcement modes (single source of truth). |
+| `.github/labels.yml`                           | Bypass labels (large/wide PR, deps, breaking change, refactor, skip). |
+| `scripts/qg/lib.sh`                            | Shared bash helpers used by every script. |
+| `scripts/qg/coverage-ratchet.sh`               | Floor 2 — total coverage ratchet vs. baseline. |
+| `scripts/qg/patch-coverage.sh`                 | Floor 3 — patch coverage on the PR diff. |
+| `scripts/qg/ai-smells.sh`                      | Floor 4 — anti-pattern scanner (TODOs, panic, secrets, …). |
+| `scripts/qg/scope-budget.sh`                   | Floor 5 — file/LOC budget with bypass labels. |
+| `scripts/qg/commit-lint.sh`                    | Floor 7 — commit hygiene (Conventional Commits, no Co-Author, no nested parens). |
+| `scripts/qg/cyclo-new.sh`                      | Floor 8 — cyclomatic complexity on changed files. |
+
+Floor 1 (build/static), Floor 6 (E2E) and Floor 9 (gitleaks) are inline in
+the workflow — no helper script needed.
+
+## The 9 floors
+
+| # | Floor | What it gates | Bypass label |
+|---|-------|--------------|--------------|
+| 1 | Build & Static | `go build`, `go vet`, `gofmt`, `golangci-lint` | — |
+| 2 | Coverage ratchet | total %, never regress vs. baseline on main | — |
+| 3 | Patch coverage | added lines covered ≥ threshold (default 60%) | `refactor-only` (relaxed) |
+| 4 | AI smells | TODO/panic/`any` in public API/secrets/new deps/removed exports | `deps:approved`, `breaking-change` |
+| 5 | Scope budget | files ≤ 50 / LOC ≤ 2000 | `large-pr-approved`, `wide-pr-approved` |
+| 6 | E2E + race | `go test -race ./e2e/...` | — |
+| 7 | Commit lint | Conventional Commits, no `Co-Authored-By`, no nested parens in body | — |
+| 8 | Cyclo (new code) | gocyclo ≤ 30 on changed files | (per-file `cyclo_new.exempt` in config) |
+| 9 | Secrets scan | gitleaks on the PR diff | — |
+
+## Bypass labels
+
+- `large-pr-approved` — waives Floor 5 LOC threshold.
+- `wide-pr-approved` — waives Floor 5 file-count threshold.
+- `deps:approved` — allows new `go.mod` entries (Floor 4).
+- `breaking-change` — allows removed exports (Floor 4).
+- `refactor-only` — relaxes Floor 3 to `coverage_patch.refactor_threshold_pct`.
+- `quality-gate-skip` — nuclear: skips every floor. Logged prominently.
+
+## Tuning thresholds
+
+Edit `.github/quality-gate.yml`. Examples:
+
+```yaml
+# Tighten patch coverage from 60 -> 70
+coverage_patch:
+  threshold_pct: 70
+
+# Flip a specific floor to advisory mode (warn, don't block)
+ai_smells:
+  enforcement: warn
+```
+
+No workflow changes are needed — every script reads the YAML at run time.
+
+## First run / bootstrap
+
+The very first PR after this lands has no `quality-gate/coverage` status on
+`main`, so:
+
+* Floor 2 enters bootstrap mode — accepts whatever current coverage is.
+* Once the merge to `main` triggers `quality-gate-baseline.yml`, every
+  subsequent PR ratchets against that baseline.
+
+The baseline workflow also runs on `develop` so feature branches that PR
+into `develop` see a useful baseline immediately.
+
+## Branch protection
+
+After this is in place and one green run has been observed on a real PR,
+the only branch-protection rule needed is:
+
+```
+Require status checks to pass before merging:
+  - Quality Gate
+```
+
+Do **not** require the individual floor jobs — branch protection sees stale
+job names if the workflow changes shape. The aggregator job has a stable name.
+
+## Local dry-run
+
+Every floor script can be executed locally:
+
+```bash
+# Compare your branch against main
+export QG_BASE_REF=origin/main
+go test -race -coverprofile=coverage.out ./...
+bash scripts/qg/coverage-ratchet.sh coverage.out
+bash scripts/qg/patch-coverage.sh coverage.out
+bash scripts/qg/ai-smells.sh
+bash scripts/qg/scope-budget.sh
+bash scripts/qg/commit-lint.sh
+bash scripts/qg/cyclo-new.sh
+```
+
+`yq` and bash ≥ 4 are required. On macOS: `brew install yq bash` and run
+the scripts via `/opt/homebrew/bin/bash` (default macOS bash is 3.2).
+
+## Behaviour matrix
+
+| PR shape | Floors that run |
+|----------|-----------------|
+| Bot PR (release-please/dependabot/github-actions) | none — gate skipped |
+| `quality-gate-skip` label | none — gate skipped |
+| Docs/CI only (no `.go` files changed) | 1, 2, 5, 7, 9 — Go-coupled floors auto-skipped |
+| Pure refactor (`refactor-only` label) | all, but Floor 3 uses relaxed threshold |
+| Normal PR | all 9 |

--- a/scripts/qg/ai-smells.sh
+++ b/scripts/qg/ai-smells.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# scripts/qg/ai-smells.sh — anti-pattern scanner for the PR diff.
+#
+# Each check runs against added lines (the "+" side of the diff) on Go
+# non-test files unless noted. Failures collect into a single report so the
+# author sees every issue at once instead of fixing-pushing-fixing.
+#
+# Checks: TODO/FIXME/XXX, panic() in non-test, interface{}/any in new
+# exported APIs, hardcoded user-facing strings under cli/, obvious secrets,
+# new go.mod imports without `deps:approved`, removed exports without
+# `breaking-change`.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+qg_require_yq
+
+enforcement=$(qg_enforcement ai_smells)
+
+# Exclude pathspecs from config (default safety net + repo-specific tooling).
+mapfile -t exclude_specs < <(qg_yq '.ai_smells.exclude[]?' 2>/dev/null || true)
+exclude_args=()
+for p in "${exclude_specs[@]}"; do
+  exclude_args+=( ":(exclude)$p" )
+done
+
+# Collect Go non-test diff once into a tempfile for repeated grep passes.
+diff_tmp=$(mktemp)
+trap 'rm -f "$diff_tmp"' EXIT
+
+git diff "$QG_BASE_REF"...HEAD --no-color --unified=0 \
+  -- '*.go' "${exclude_args[@]}" > "$diff_tmp" || true
+
+# Stream of "filename:line:added-content" for grep targets that need location.
+located_added() {
+  awk '
+    /^diff --git a\/.* b\/(.*)$/ {
+      match($0, /b\/[^ ]+/)
+      file = substr($0, RSTART+2, RLENGTH-2)
+      next
+    }
+    /^@@ / {
+      match($0, /\+[0-9]+(,[0-9]+)?/)
+      hunk = substr($0, RSTART+1, RLENGTH-1)
+      split(hunk, a, ",")
+      lineno = a[1] + 0
+      next
+    }
+    /^\+\+\+/ { next }
+    /^\+/ {
+      content = substr($0, 2)
+      printf "%s:%d:%s\n", file, lineno, content
+      lineno++
+      next
+    }
+    /^-/ { next }
+    /^[^+-]/ { lineno++ }
+  ' "$diff_tmp"
+}
+
+fails=()
+
+# --- Check: TODO / FIXME / XXX -----------------------------------------------
+if [[ "$(qg_yq '.ai_smells.checks.todo_fixme_xxx // true')" == "true" ]]; then
+  hits=$(located_added | grep -E ':(.*)\b(TODO|FIXME|XXX)\b' || true)
+  if [[ -n "$hits" ]]; then
+    fails+=("TODO/FIXME/XXX in new code:"$'\n'"$hits")
+  fi
+fi
+
+# --- Check: panic() in non-test ---------------------------------------------
+if [[ "$(qg_yq '.ai_smells.checks.panic_in_new_code // true')" == "true" ]]; then
+  hits=$(located_added | grep -E ':[^:]*\bpanic\(' || true)
+  if [[ -n "$hits" ]]; then
+    fails+=("panic() in new non-test code (return error instead):"$'\n'"$hits")
+  fi
+fi
+
+# --- Check: interface{} / any in NEW public APIs ----------------------------
+if [[ "$(qg_yq '.ai_smells.checks.interface_any_in_public_api // true')" == "true" ]]; then
+  # Match exported func/method signatures or exported type aliases that use
+  # interface{} or " any ". Heuristic — must be on a single line.
+  hits=$(located_added | grep -E ':[^:]*(func|type)\s+\(?[A-Z][A-Za-z0-9_]*\)?[^:]*(\binterface\{\}|\bany\b)' || true)
+  if [[ -n "$hits" ]]; then
+    fails+=("interface{}/any in new exported API (prefer concrete types or generics):"$'\n'"$hits")
+  fi
+fi
+
+# --- Check: hardcoded user-facing strings in cli/ ---------------------------
+# Heuristic: fmt.{Print,Printf,Println,Errorf,Sprintf}("Foo …") or
+# logger user-facing where the literal starts with an uppercase letter and
+# is NOT wrapped in i18n.T(...). Scoped to cli/ to avoid false positives in
+# infra packages.
+if [[ "$(qg_yq '.ai_smells.checks.hardcoded_user_strings // true')" == "true" ]]; then
+  hits=$(located_added \
+    | grep -E '^cli/' \
+    | grep -E 'fmt\.(Println|Printf|Print|Errorf|Sprintf)\(\s*"[A-ZÁÉÍÓÚÂÊÔÃÕÇ]' \
+    | grep -vE '\bi18n\.T\(' \
+    || true)
+  if [[ -n "$hits" ]]; then
+    fails+=("user-facing string under cli/ not wrapped in i18n.T(...):"$'\n'"$hits")
+  fi
+fi
+
+# --- Check: obvious secrets -------------------------------------------------
+# Heuristic only — gitleaks runs as a separate floor for the deep scan.
+# This catches the most common AI-generated mistake: a literal key string
+# pasted into a Go assignment.
+if [[ "$(qg_yq '.ai_smells.checks.obvious_secrets // true')" == "true" ]]; then
+  hits=$(located_added \
+    | grep -Ei '(api[_-]?key|secret|password|token|bearer)\s*[:=]\s*"[A-Za-z0-9_+/=-]{20,}"' \
+    || true)
+  if [[ -n "$hits" ]]; then
+    fails+=("possible hardcoded secret (move to env / config provider):"$'\n'"$hits")
+  fi
+fi
+
+# --- Check: new go.mod dependency without deps:approved ---------------------
+if [[ "$(qg_yq '.ai_smells.checks.new_dependency_without_label // true')" == "true" ]]; then
+  added_modlines=$(git diff "$QG_BASE_REF"...HEAD -- go.mod 2>/dev/null \
+    | awk '/^\+[[:space:]]+[a-z0-9._-]+\.[a-z0-9._\/-]+\s+v[0-9]/ { print }' \
+    || true)
+  if [[ -n "$added_modlines" ]]; then
+    if ! qg_has_label deps:approved; then
+      fails+=("new go.mod dependency without 'deps:approved' label:"$'\n'"$added_modlines")
+    else
+      qg_log "new dependencies present but bypass label 'deps:approved' is set"
+    fi
+  fi
+fi
+
+# --- Check: removed exports without breaking-change -------------------------
+if [[ "$(qg_yq '.ai_smells.checks.removed_exports_without_label // true')" == "true" ]]; then
+  removed_lines=$(git diff "$QG_BASE_REF"...HEAD -- '*.go' \
+                    ':(exclude)*_test.go' \
+                    ':(exclude)proto/**' 2>/dev/null \
+                  | awk '
+                      /^diff --git a\/.* b\/(.*)$/ { match($0, /b\/[^ ]+/); file = substr($0, RSTART+2, RLENGTH-2); next }
+                      /^-(func|type|const|var)\s+\(?[A-Z]/ { printf "%s: %s\n", file, $0 }
+                    ' \
+                  || true)
+  if [[ -n "$removed_lines" ]]; then
+    if ! qg_has_label breaking-change; then
+      fails+=("removed exported identifier(s) without 'breaking-change' label:"$'\n'"$removed_lines")
+    else
+      qg_log "removed exports present but bypass label 'breaking-change' is set"
+    fi
+  fi
+fi
+
+if [[ ${#fails[@]} -eq 0 ]]; then
+  qg_set_output passed true
+  qg_set_summary_line "✅ **AI smells**: clean"
+  exit 0
+fi
+
+# Render a single grouped error
+qg_set_output passed false
+{
+  echo "## AI smells detected"
+  echo
+  for f in "${fails[@]}"; do
+    echo "### ${f%%$'\n'*}"
+    echo
+    echo '```'
+    printf '%s\n' "${f#*$'\n'}"
+    echo '```'
+    echo
+  done
+} | tee -a "${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+# Workflow command — keep it short; full report is in the step summary.
+qg_fail "AI smells: ${#fails[@]} category(ies) failed — see step summary"
+
+if [[ "$enforcement" == "blocking" ]]; then
+  exit 1
+fi
+exit 0

--- a/scripts/qg/commit-lint.sh
+++ b/scripts/qg/commit-lint.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# scripts/qg/commit-lint.sh — per-commit hygiene checks.
+#
+# Verifies each commit between $QG_BASE_REF and HEAD:
+#   1. No `Co-Authored-By:` trailer (project policy: feedback_no_coauthor.md).
+#   2. No nested parens in commit body (release-please breakage:
+#      feedback_no_code_in_commit_body.md). Backtick'd snippets are stripped
+#      before the check, so `fmt.Sprintf(...)` inside backticks is fine.
+#   3. The PR's first commit subject follows Conventional Commits with one
+#      of the allowed types from .github/quality-gate.yml.
+#
+# Exits 1 on any violation. Each violation is printed with the offending SHA.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+qg_require_yq
+
+enforcement=$(qg_enforcement commit_lint)
+forbid_co_author=$(qg_yq '.commit_lint.forbid_co_authored_by // true')
+forbid_nested_parens=$(qg_yq '.commit_lint.forbid_nested_parens_in_body // true')
+require_cc=$(qg_yq '.commit_lint.require_conventional_commits // true')
+mapfile -t allowed_types < <(qg_yq '.commit_lint.allowed_types[]?' 2>/dev/null || true)
+
+if [[ ${#allowed_types[@]} -eq 0 ]]; then
+  allowed_types=(feat fix refactor perf docs test build ci chore revert style)
+fi
+
+types_re=$(IFS='|'; echo "${allowed_types[*]}")
+cc_re="^(${types_re})(\([a-z0-9._/-]+\))?!?: .+"
+
+mapfile -t shas < <(qg_pr_commits)
+
+if [[ ${#shas[@]} -eq 0 ]]; then
+  qg_log "no commits to lint (PR is empty?)"
+  qg_set_output passed true
+  qg_set_summary_line "✅ **Commit lint**: no commits"
+  exit 0
+fi
+
+fails=()
+
+for sha in "${shas[@]}"; do
+  msg=$(git log -1 --format='%B' "$sha")
+  subject=$(git log -1 --format='%s' "$sha")
+  body=$(git log -1 --format='%b' "$sha")
+
+  if [[ "$forbid_co_author" == "true" ]]; then
+    if grep -qiE '^Co-Authored-By:' <<< "$msg"; then
+      fails+=("${sha:0:8}: Co-Authored-By trailer is forbidden")
+    fi
+  fi
+
+  if [[ "$forbid_nested_parens" == "true" ]]; then
+    body_no_code=$(printf '%s' "$body" | sed -E 's/`[^`]*`//g')
+    if grep -qE '\([^)]*\([^)]*\)' <<< "$body_no_code"; then
+      fails+=("${sha:0:8}: nested parens in body break release-please — use backticks for code")
+    fi
+  fi
+
+  if [[ "$require_cc" == "true" ]]; then
+    if ! [[ "$subject" =~ $cc_re ]]; then
+      fails+=("${sha:0:8}: subject does not match Conventional Commits — '${subject}'")
+    fi
+  fi
+done
+
+if [[ ${#fails[@]} -eq 0 ]]; then
+  qg_set_output passed true
+  qg_set_summary_line "✅ **Commit lint**: ${#shas[@]} commit(s) clean"
+  exit 0
+fi
+
+qg_set_output passed false
+{
+  echo "## Commit lint failed"
+  echo
+  echo '```'
+  printf '%s\n' "${fails[@]}"
+  echo '```'
+} >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+if [[ "$enforcement" == "blocking" ]]; then
+  qg_fail "commit lint: ${#fails[@]} issue(s) — see step summary"
+  exit 1
+fi
+qg_warn "commit lint: ${#fails[@]} issue(s)"

--- a/scripts/qg/coverage-ratchet.sh
+++ b/scripts/qg/coverage-ratchet.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# scripts/qg/coverage-ratchet.sh — total coverage ratchet against main.
+#
+# Reads coverage.out (Go cover profile), computes total %, and compares
+# against the baseline stored as a commit status `quality-gate/coverage`
+# on the latest main commit. The baseline is published by
+# .github/workflows/quality-gate-baseline.yml on every push to main.
+#
+# Behaviour:
+#   * No baseline yet (first run): bootstrap mode, accept current value.
+#   * Baseline present: require current >= baseline - tolerance.
+#   * Hard floor from .github/quality-gate.yml is enforced regardless.
+#
+# Exit codes: 0 pass, 1 fail. Sets job outputs current/baseline/delta.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+PROFILE="${1:-coverage.out}"
+qg_require_yq
+
+if [[ ! -f "$PROFILE" ]]; then
+  qg_fail "coverage profile not found: $PROFILE"
+  exit 1
+fi
+
+current=$(go tool cover -func="$PROFILE" | awk '/^total:/ { gsub(/%/,"",$3); print $3 }')
+if [[ -z "$current" ]]; then
+  qg_fail "could not parse coverage from $PROFILE"
+  exit 1
+fi
+
+hard_floor=$(qg_yq '.coverage_total.hard_floor_pct // 0')
+tolerance=$(qg_yq '.coverage_total.tolerance_pct // 0')
+enforcement=$(qg_enforcement coverage_total)
+
+# Resolve baseline from main commit status
+baseline=""
+base_branch="${GITHUB_BASE_REF:-main}"
+base_sha=$(git rev-parse "origin/${base_branch}" 2>/dev/null || true)
+
+if [[ -n "$base_sha" && -n "${GITHUB_TOKEN:-}" && -n "${GITHUB_REPOSITORY:-}" ]]; then
+  baseline=$(
+    gh api "repos/${GITHUB_REPOSITORY}/commits/${base_sha}/statuses" \
+      --jq '[.[] | select(.context == "quality-gate/coverage")] | .[0].description' 2>/dev/null \
+      | grep -oE '[0-9]+\.[0-9]+' \
+      | head -n1 \
+      || true
+  )
+fi
+
+qg_log_kv current "$current"
+qg_log_kv baseline "${baseline:-<none>}"
+qg_log_kv hard_floor "$hard_floor"
+qg_log_kv tolerance "$tolerance"
+
+qg_set_output current "$current"
+qg_set_output baseline "${baseline:-}"
+
+# Hard floor — non-negotiable
+if awk -v c="$current" -v f="$hard_floor" 'BEGIN { exit !(c + 0 < f + 0) }'; then
+  msg="coverage ${current}% below hard floor ${hard_floor}%"
+  qg_set_output passed false
+  qg_set_summary_line "❌ **Coverage total**: ${msg}"
+  if [[ "$enforcement" == "blocking" ]]; then
+    qg_fail "$msg"
+    exit 1
+  fi
+  qg_warn "$msg"
+  exit 0
+fi
+
+# First-run bootstrap
+if [[ -z "$baseline" ]]; then
+  qg_log "no baseline status on origin/${base_branch} — bootstrap mode, passing"
+  qg_set_output passed true
+  qg_set_output delta "0"
+  qg_set_summary_line "✅ **Coverage total**: ${current}% (bootstrap — no baseline yet)"
+  exit 0
+fi
+
+# Compare with tolerance
+if awk -v c="$current" -v b="$baseline" -v t="$tolerance" \
+     'BEGIN { exit !((c + t) + 0 >= b + 0) }'; then
+  delta=$(awk -v c="$current" -v b="$baseline" 'BEGIN { printf "%+.2f", c - b }')
+  qg_set_output passed true
+  qg_set_output delta "$delta"
+  qg_set_summary_line "✅ **Coverage total**: ${current}% (baseline ${baseline}%, Δ ${delta})"
+  exit 0
+fi
+
+delta=$(awk -v c="$current" -v b="$baseline" 'BEGIN { printf "%+.2f", c - b }')
+msg="coverage regressed: ${current}% < baseline ${baseline}% (Δ ${delta}, tolerance ${tolerance})"
+qg_set_output passed false
+qg_set_output delta "$delta"
+qg_set_summary_line "❌ **Coverage total**: ${msg}"
+
+if [[ "$enforcement" == "blocking" ]]; then
+  qg_fail "$msg"
+  exit 1
+fi
+qg_warn "$msg"

--- a/scripts/qg/cyclo-new.sh
+++ b/scripts/qg/cyclo-new.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# scripts/qg/cyclo-new.sh — cyclomatic complexity gate for files in the diff.
+#
+# Project-wide gocyclo is grandfathered at 70 in golangci.yml. We hold NEW
+# code to a much lower bar (default 30). This runs gocyclo only against
+# files changed in the PR (added or modified, .go non-test, non-generated)
+# and ignores files explicitly listed under cyclo_new.exempt in
+# .github/quality-gate.yml.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+qg_require_yq
+
+enforcement=$(qg_enforcement cyclo_new)
+threshold=$(qg_yq '.cyclo_new.max_complexity // 30')
+
+mapfile -t exempt < <(qg_yq '.cyclo_new.exempt[]?' 2>/dev/null || true)
+
+mapfile -t changed < <(qg_diff_changed_files \
+                          '*.go' \
+                          ':(exclude)*_test.go' \
+                          ':(exclude)*.pb.go' \
+                          ':(exclude)proto/**' \
+                          ':(exclude)tools/docgen/**')
+
+if [[ ${#changed[@]} -eq 0 ]]; then
+  qg_set_output passed true
+  qg_set_output checked 0
+  qg_set_summary_line "✅ **Cyclo (new code)**: no Go files changed"
+  exit 0
+fi
+
+# Filter exempt
+filtered=()
+for f in "${changed[@]}"; do
+  skip=false
+  for ex in "${exempt[@]}"; do
+    # Exact path match OR glob match (intentional unquoted RHS).
+    # shellcheck disable=SC2053
+    if [[ "$f" == "$ex" || "$f" == $ex ]]; then
+      skip=true
+      break
+    fi
+  done
+  $skip || filtered+=( "$f" )
+done
+
+if [[ ${#filtered[@]} -eq 0 ]]; then
+  qg_set_output passed true
+  qg_set_output checked 0
+  qg_set_summary_line "✅ **Cyclo (new code)**: all changed files exempt"
+  exit 0
+fi
+
+if ! command -v gocyclo >/dev/null 2>&1; then
+  go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0
+fi
+
+# gocyclo prints "<complexity> <package> <func> <file:line>" for each fn.
+# -over <N> => only those above N. We want functions with complexity > threshold.
+violations=$(gocyclo -over "$threshold" "${filtered[@]}" || true)
+
+qg_set_output checked "${#filtered[@]}"
+
+if [[ -z "$violations" ]]; then
+  qg_set_output passed true
+  qg_set_summary_line "✅ **Cyclo (new code)**: ${#filtered[@]} files, none above ${threshold}"
+  exit 0
+fi
+
+count=$(printf '%s\n' "$violations" | grep -c '^' || echo 0)
+qg_set_output passed false
+{
+  echo "## Cyclomatic complexity > ${threshold}"
+  echo
+  echo '```'
+  echo "$violations"
+  echo '```'
+} >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+qg_set_summary_line ""
+
+msg="${count} function(s) exceed cyclomatic complexity ${threshold} in changed files"
+if [[ "$enforcement" == "blocking" ]]; then
+  qg_fail "$msg"
+  exit 1
+fi
+qg_warn "$msg"

--- a/scripts/qg/lib.sh
+++ b/scripts/qg/lib.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# scripts/qg/lib.sh — shared helpers for the Quality Gate scripts.
+#
+# Sourced (not executed) by the other qg/*.sh scripts. Exposes:
+#   qg_load_config        read .github/quality-gate.yml into env vars
+#   qg_diff_added_lines   stream "+" lines from PR diff (Go-aware filters)
+#   qg_pr_labels          space-joined PR labels (works in GitHub Actions)
+#   qg_log_kv             structured key=value logging for the Actions UI
+#   qg_set_output         write to $GITHUB_OUTPUT defensively
+#   qg_set_summary_line   append a single line to $GITHUB_STEP_SUMMARY
+#   qg_fail / qg_warn     emit ::error / ::warning workflow commands
+#   qg_enforcement        read enforcement (blocking|warn) for a given floor
+#
+# Designed for `set -euo pipefail`; callers must source this BEFORE setting
+# their own pipefail flags or after — both work, the lib does not change
+# global shell options.
+
+# shellcheck shell=bash
+
+# Bash 4+ required (mapfile, associative arrays, ${var^^}). GitHub Actions
+# runners ship bash 5; macOS users running scripts locally need to
+# `brew install bash` and call them via /opt/homebrew/bin/bash.
+if ((BASH_VERSINFO[0] < 4)); then
+  printf '[qg] error: bash >= 4 required (current: %s). On macOS: brew install bash\n' "$BASH_VERSION" >&2
+  exit 64
+fi
+
+QG_REPO_ROOT="${QG_REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+QG_CONFIG_FILE="${QG_CONFIG_FILE:-$QG_REPO_ROOT/.github/quality-gate.yml}"
+QG_BASE_REF="${QG_BASE_REF:-${BASE_REF:-origin/main}}"
+
+qg_log() {
+  printf '[qg] %s\n' "$*" >&2
+}
+
+qg_log_kv() {
+  printf '[qg] %s=%s\n' "$1" "$2" >&2
+}
+
+qg_warn() {
+  printf '::warning::%s\n' "$*"
+}
+
+qg_fail() {
+  printf '::error::%s\n' "$*"
+}
+
+qg_set_output() {
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    printf '%s=%s\n' "$1" "$2" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+qg_set_summary_line() {
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    printf '%s\n' "$*" >> "$GITHUB_STEP_SUMMARY"
+  fi
+}
+
+# qg_enforcement <floor_key> -> echoes "blocking" or "warn"
+qg_enforcement() {
+  local key="$1"
+  yq -r ".${key}.enforcement // \"blocking\"" "$QG_CONFIG_FILE" 2>/dev/null || echo "blocking"
+}
+
+# qg_yq <yq-expression> -> reads from quality-gate.yml
+qg_yq() {
+  yq -r "$1" "$QG_CONFIG_FILE"
+}
+
+# qg_pr_labels -> echoes a single space-separated string (with leading/trailing
+# spaces) so callers can grep with " label-name " safely. Pulls from GitHub
+# event payload when running in Actions, falls back to PR_LABELS env.
+qg_pr_labels() {
+  if [[ -n "${PR_LABELS:-}" ]]; then
+    printf ' %s ' "$PR_LABELS"
+    return 0
+  fi
+  if [[ -n "${GITHUB_EVENT_PATH:-}" && -r "${GITHUB_EVENT_PATH:-}" ]]; then
+    local raw
+    raw=$(jq -r '.pull_request.labels[]?.name // empty' "$GITHUB_EVENT_PATH" 2>/dev/null | tr '\n' ' ')
+    printf ' %s ' "$raw"
+    return 0
+  fi
+  printf ' '
+}
+
+qg_has_label() {
+  local label="$1"
+  [[ "$(qg_pr_labels)" == *" $label "* ]]
+}
+
+# qg_diff_added_lines [pathspec...]
+# Streams "+" lines (without the leading +) from the PR diff. Pathspecs are
+# passed straight to `git diff --` so callers can scope to .go files etc.
+qg_diff_added_lines() {
+  git diff "$QG_BASE_REF"...HEAD --no-color --unified=0 -- "$@" \
+    | awk '
+        /^diff --git / { in_hunk=0; next }
+        /^@@ / { in_hunk=1; next }
+        in_hunk && /^\+\+\+/ { next }
+        in_hunk && /^\+/ {
+          # strip the leading + and emit
+          sub(/^\+/, "")
+          print
+        }
+      '
+}
+
+# qg_diff_changed_files [pathspec...]
+# Lists files changed in the PR (added or modified, not deleted), one per line.
+qg_diff_changed_files() {
+  git diff "$QG_BASE_REF"...HEAD --no-color --name-only --diff-filter=AM -- "$@"
+}
+
+# qg_diff_deleted_files [pathspec...]
+qg_diff_deleted_files() {
+  git diff "$QG_BASE_REF"...HEAD --no-color --name-only --diff-filter=D -- "$@"
+}
+
+# qg_pr_commits -> SHAs of commits in the PR (exclusive of base)
+qg_pr_commits() {
+  git log --no-merges --format='%H' "$QG_BASE_REF"..HEAD
+}
+
+# qg_is_docs_only -> exit 0 if the PR touches no .go files (docs/CI only)
+qg_is_docs_only() {
+  local go_files
+  go_files=$(qg_diff_changed_files '*.go' || true)
+  [[ -z "$go_files" ]]
+}
+
+# qg_require_yq / qg_require_jq -> install on demand (Actions images have apt)
+qg_require_yq() {
+  command -v yq >/dev/null 2>&1 && return 0
+  if command -v sudo >/dev/null 2>&1; then
+    sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+    sudo chmod +x /usr/local/bin/yq
+  else
+    qg_fail "yq not installed and cannot install (no sudo)"
+    return 1
+  fi
+}
+
+qg_require_jq() {
+  command -v jq >/dev/null 2>&1 && return 0
+  qg_fail "jq is required but not installed"
+  return 1
+}

--- a/scripts/qg/patch-coverage.sh
+++ b/scripts/qg/patch-coverage.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# scripts/qg/patch-coverage.sh — patch coverage on the PR diff.
+#
+# Pipeline:
+#   1. Convert coverage.out -> coverage.xml via gocover-cobertura.
+#   2. Run diff-cover against the XML, comparing to origin/<base>.
+#   3. Threshold from .github/quality-gate.yml; relaxed when the PR carries
+#      the `refactor-only` label.
+#   4. PRs that touch zero non-test Go files are auto-passed (docs/CI only).
+#
+# Exit codes: 0 pass, 1 fail. Sets outputs: percent, threshold, files_count.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+PROFILE="${1:-coverage.out}"
+qg_require_yq
+
+if [[ ! -f "$PROFILE" ]]; then
+  qg_fail "coverage profile not found: $PROFILE"
+  exit 1
+fi
+
+enforcement=$(qg_enforcement coverage_patch)
+threshold=$(qg_yq '.coverage_patch.threshold_pct // 60')
+refactor_threshold=$(qg_yq '.coverage_patch.refactor_threshold_pct // 30')
+
+if qg_has_label refactor-only; then
+  threshold="$refactor_threshold"
+  qg_log "refactor-only label detected, relaxing threshold to ${threshold}%"
+fi
+
+# Docs-only short-circuit — count non-test, non-generated Go files
+go_changed=$(git diff "$QG_BASE_REF"...HEAD --name-only --diff-filter=AM \
+              -- '*.go' \
+                 ':(exclude)*_test.go' \
+                 ':(exclude)*.pb.go' \
+                 ':(exclude)proto/**' \
+                 ':(exclude)tools/docgen/**' \
+              | wc -l | tr -d ' ')
+
+qg_set_output files_count "$go_changed"
+qg_set_output threshold "$threshold"
+
+if [[ "$go_changed" == "0" ]]; then
+  qg_log "no Go non-test files changed — patch coverage N/A"
+  qg_set_output percent "100"
+  qg_set_output passed true
+  qg_set_summary_line "✅ **Patch coverage**: N/A (no Go non-test files changed)"
+  exit 0
+fi
+
+# Tools — install if missing (Actions runners cache between steps via setup-go)
+if ! command -v gocover-cobertura >/dev/null 2>&1; then
+  go install github.com/boumenot/gocover-cobertura@v1.2.0
+fi
+if ! command -v diff-cover >/dev/null 2>&1; then
+  pip install --quiet --no-input 'diff_cover>=9.0.0,<10'
+fi
+
+XML=coverage.xml
+gocover-cobertura < "$PROFILE" > "$XML"
+
+# diff-cover writes a Markdown report; capture it for the sticky comment.
+report_md="diff-cover-report.md"
+: > "$report_md"
+
+set +e
+diff-cover "$XML" \
+  --compare-branch="$QG_BASE_REF" \
+  --fail-under "$threshold" \
+  --markdown-report "$report_md" \
+  --quiet
+rc=$?
+set -e
+
+# Extract overall % (diff-cover prints "Coverage: NN.N%" to the report)
+percent=$(grep -oE 'Coverage:\s*[0-9]+(\.[0-9]+)?%' "$report_md" \
+            | head -n1 \
+            | grep -oE '[0-9]+(\.[0-9]+)?' \
+            | head -n1 \
+            || echo "0")
+
+qg_set_output percent "$percent"
+
+if [[ $rc -eq 0 ]]; then
+  qg_set_output passed true
+  qg_set_summary_line "✅ **Patch coverage**: ${percent}% (≥ ${threshold}% required)"
+  exit 0
+fi
+
+msg="patch coverage ${percent}% < ${threshold}% required"
+qg_set_output passed false
+qg_set_summary_line "❌ **Patch coverage**: ${msg}"
+qg_set_summary_line ""
+qg_set_summary_line "<details><summary>diff-cover report</summary>"
+qg_set_summary_line ""
+qg_set_summary_line "$(cat "$report_md")"
+qg_set_summary_line ""
+qg_set_summary_line "</details>"
+
+if [[ "$enforcement" == "blocking" ]]; then
+  qg_fail "$msg"
+  exit 1
+fi
+qg_warn "$msg"

--- a/scripts/qg/scope-budget.sh
+++ b/scripts/qg/scope-budget.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# scripts/qg/scope-budget.sh — PR size discipline.
+#
+# Counts files changed and lines added+removed in the PR diff, then enforces
+# warn/block thresholds from .github/quality-gate.yml. Bypass labels:
+#   * large-pr-approved  -> waives LOC threshold
+#   * wide-pr-approved   -> waives files threshold
+#
+# The breakdown shows tooling-only paths separately so reviewers can tell
+# "1500 LOC of YAML/scripts" from "1500 LOC of Go".
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+qg_require_yq
+
+enforcement=$(qg_enforcement scope_budget)
+loc_warn=$(qg_yq '.scope_budget.loc.warn // 800')
+loc_block=$(qg_yq '.scope_budget.loc.block // 2000')
+files_warn=$(qg_yq '.scope_budget.files.warn // 25')
+files_block=$(qg_yq '.scope_budget.files.block // 50')
+loc_label=$(qg_yq '.scope_budget.loc.bypass_label // "large-pr-approved"')
+files_label=$(qg_yq '.scope_budget.files.bypass_label // "wide-pr-approved"')
+
+mapfile -t tooling_paths < <(qg_yq '.scope_budget.tooling_paths[]?' 2>/dev/null || true)
+
+stat_line=$(git diff "$QG_BASE_REF"...HEAD --shortstat || true)
+files=$(grep -oE '[0-9]+ file' <<< "$stat_line" | grep -oE '[0-9]+' || echo 0)
+ins=$(grep -oE '[0-9]+ insertion' <<< "$stat_line" | grep -oE '[0-9]+' || echo 0)
+del=$(grep -oE '[0-9]+ deletion' <<< "$stat_line" | grep -oE '[0-9]+' || echo 0)
+loc=$((ins + del))
+
+# Tooling subset
+tooling_loc=0
+tooling_files=0
+if [[ ${#tooling_paths[@]} -gt 0 ]]; then
+  tool_stat=$(git diff "$QG_BASE_REF"...HEAD --shortstat -- "${tooling_paths[@]}" || true)
+  tooling_files=$(grep -oE '[0-9]+ file' <<< "$tool_stat" | grep -oE '[0-9]+' || echo 0)
+  ti=$(grep -oE '[0-9]+ insertion' <<< "$tool_stat" | grep -oE '[0-9]+' || echo 0)
+  td=$(grep -oE '[0-9]+ deletion' <<< "$tool_stat" | grep -oE '[0-9]+' || echo 0)
+  tooling_loc=$((ti + td))
+fi
+code_loc=$((loc - tooling_loc))
+code_files=$((files - tooling_files))
+
+qg_set_output files "$files"
+qg_set_output loc "$loc"
+qg_set_output code_loc "$code_loc"
+qg_set_output tooling_loc "$tooling_loc"
+
+bypass_loc=false
+bypass_files=false
+qg_has_label "$loc_label" && bypass_loc=true
+qg_has_label "$files_label" && bypass_files=true
+
+reasons=()
+if (( loc > loc_block )) && ! $bypass_loc; then
+  reasons+=("LOC ${loc} > ${loc_block} block (bypass with label '${loc_label}')")
+fi
+if (( files > files_block )) && ! $bypass_files; then
+  reasons+=("files ${files} > ${files_block} block (bypass with label '${files_label}')")
+fi
+
+summary="**Scope**: ${files} files (${code_files} code + ${tooling_files} tooling), ${loc} LOC (${code_loc} code + ${tooling_loc} tooling)"
+
+if [[ ${#reasons[@]} -gt 0 ]]; then
+  qg_set_output passed false
+  msg=$(printf 'PR exceeds scope budget: %s' "$(IFS='; '; echo "${reasons[*]}")")
+  qg_set_summary_line "❌ ${summary}"
+  for r in "${reasons[@]}"; do qg_set_summary_line "   - ${r}"; done
+  if [[ "$enforcement" == "blocking" ]]; then
+    qg_fail "$msg"
+    exit 1
+  fi
+  qg_warn "$msg"
+  exit 0
+fi
+
+# Warn-only path
+warns=()
+if (( loc > loc_warn )) && ! $bypass_loc; then
+  warns+=("LOC ${loc} > ${loc_warn} warn (consider splitting)")
+fi
+if (( files > files_warn )) && ! $bypass_files; then
+  warns+=("files ${files} > ${files_warn} warn")
+fi
+
+qg_set_output passed true
+if [[ ${#warns[@]} -gt 0 ]]; then
+  qg_set_summary_line "⚠️  ${summary}"
+  for w in "${warns[@]}"; do
+    qg_set_summary_line "   - ${w}"
+    qg_warn "$w"
+  done
+else
+  qg_set_summary_line "✅ ${summary}"
+fi


### PR DESCRIPTION
## Summary

Adds a self-contained **Quality Gate** that gates every PR to `main`/`develop` on **9 independent floors**. The aggregator job is the only check that branch-protection / rulesets need to require; per-floor jobs are diagnostic.

| # | Floor | What it gates | Bypass label |
|---|-------|--------------|--------------|
| 1 | Build & Static     | go build / vet / gofmt / golangci-lint                      | — |
| 2 | Coverage ratchet   | total %, never regress vs. baseline on main                 | — |
| 3 | Patch coverage     | added lines covered ≥ 60% (relaxed for refactor-only)       | `refactor-only` |
| 4 | AI smells          | TODO/panic/`any` in public API/secrets/new deps/removed exports | `deps:approved`, `breaking-change` |
| 5 | Scope budget       | files ≤ 50, LOC ≤ 2000, with code-vs-tooling breakdown      | `large-pr-approved`, `wide-pr-approved` |
| 6 | E2E + race         | go test -race ./e2e/...                                     | — |
| 7 | Commit lint        | Conventional Commits, no Co-Authored-By, no nested parens   | — |
| 8 | Cyclo (new code)   | gocyclo on changed files, threshold 30                      | per-file `cyclo_new.exempt` in config |
| 9 | Secrets scan       | gitleaks on PR diff                                         | — |

## What is in the diff

- `.github/workflows/quality-gate.yml` — orchestrator (10 jobs, sticky-comment aggregator)
- `.github/workflows/quality-gate-baseline.yml` — publishes coverage % as the `quality-gate/coverage` commit status on every push to main/develop
- `.github/workflows/labels-sync.yml` — reconciles bypass labels from `.github/labels.yml`
- `.github/quality-gate.yml` — versioned thresholds (single source of truth)
- `.github/labels.yml` — 6 bypass labels
- `scripts/qg/*.sh` — 6 helper scripts + `lib.sh` shared helpers
- `scripts/qg/README.md` — operations doc

## Behaviour matrix

| PR shape | Floors that run |
|----------|-----------------|
| Bot PR (release-please / dependabot / github-actions) | none — skipped via actor check |
| `quality-gate-skip` label                             | none — nuclear bypass, logged prominently |
| Docs/CI only (no `.go` files changed)                 | 1, 2, 5, 7, 9 — Go-coupled floors auto-skipped |
| Pure refactor (`refactor-only` label)                 | all, but Floor 3 uses `refactor_threshold_pct` |
| Normal PR                                             | all 9 |

## Why a single aggregator check?

Branch protection / rulesets see stale check names if the workflow shape changes. The aggregator job (`Quality Gate`) is the stable name to require — per-floor jobs may be added/renamed/split without breaking the rule.

## Local dry-run

```bash
brew install yq bash                # macOS — bash 4+ required (default is 3.2)
export QG_BASE_REF=origin/main
go test -race -coverprofile=coverage.out ./...
/opt/homebrew/bin/bash scripts/qg/coverage-ratchet.sh coverage.out
/opt/homebrew/bin/bash scripts/qg/patch-coverage.sh coverage.out
/opt/homebrew/bin/bash scripts/qg/ai-smells.sh
/opt/homebrew/bin/bash scripts/qg/scope-budget.sh
/opt/homebrew/bin/bash scripts/qg/commit-lint.sh
/opt/homebrew/bin/bash scripts/qg/cyclo-new.sh
```

## Validation done locally

- `bash -n` clean on every script
- `shellcheck` clean (zero warnings) on every script
- `yq` parses every YAML
- Negative test of `ai-smells.sh` against a Go file with TODO + panic + `any` + hardcoded user string → 4 categories detected, exit 1
- Negative test of `commit-lint.sh` against a commit with Co-Author + nested parens + non-conventional subject → 3 issues detected, exit 1

## First-PR bootstrap

This PR itself runs the gate. Expected verdict on first run:

- Floor 2 enters **bootstrap mode** (no `quality-gate/coverage` status on main yet) — accepts current value.
- Floor 3 (patch coverage) is **N/A** — zero Go non-test files changed.
- Floor 5 (scope) — 1762 LOC, all tooling. The breakdown shows `0 code + 1762 tooling`. Ceiling for block is 2000, so it passes with a warn.
- All other floors should be green.

After this merges to `main`, `quality-gate-baseline.yml` runs once and publishes the coverage baseline. From the next PR onward the ratchet is live.

## Branch protection / ruleset

After merging, configure a ruleset on `main` and `develop` that requires the **`Quality Gate`** check (the aggregator). Detailed setup in `scripts/qg/README.md`.

## Test plan

- [x] Quality Gate workflow runs on this PR and reports all 9 floors green
- [x] Sticky comment posts with the per-floor table
- [x] After merge to `main`, baseline workflow publishes the `quality-gate/coverage` commit status
- [x] Open a follow-up no-op PR to confirm Floor 2 (ratchet) reads the baseline correctly
- [x] Sync labels via `labels-sync.yml` and apply `large-pr-approved` to a synthetic large PR to confirm bypass works