### PR TITLE
ci(workflows): pula gates pesados em PRs do release-please

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -36,6 +36,7 @@ jobs:
     outputs:
       skip: ${{ steps.decide.outputs.skip }}
       docs_only: ${{ steps.decide.outputs.docs_only }}
+      release_please: ${{ steps.decide.outputs.release_please }}
       labels: ${{ steps.decide.outputs.labels }}
       base_ref: ${{ steps.decide.outputs.base_ref }}
     steps:
@@ -81,11 +82,22 @@ jobs:
           docs_only="false"
           if qg_is_docs_only; then docs_only="true"; fi
 
+          # release-please PR detection: branch is deterministic
+          # ("release-please--branches--<base>"). The PR only bumps versions
+          # and CHANGELOG, so the heavy floors are noise — we keep
+          # commit-lint running as a sanity check and skip the rest.
+          release_please="false"
+          head_ref='${{ github.head_ref }}'
+          if [[ "$head_ref" == release-please--* ]]; then
+            release_please="true"
+          fi
+
           labels=$(qg_pr_labels | xargs)
 
           {
             echo "skip=$skip"
             echo "docs_only=$docs_only"
+            echo "release_please=$release_please"
             echo "labels=$labels"
             echo "base_ref=$base_ref"
           } >> "$GITHUB_OUTPUT"
@@ -96,7 +108,7 @@ jobs:
   build-static:
     name: Floor 1 · Build & Static
     needs: meta
-    if: needs.meta.outputs.skip != 'true'
+    if: needs.meta.outputs.skip != 'true' && needs.meta.outputs.release_please != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -134,7 +146,7 @@ jobs:
   test-coverage:
     name: Floor 2 · Coverage ratchet
     needs: meta
-    if: needs.meta.outputs.skip != 'true'
+    if: needs.meta.outputs.skip != 'true' && needs.meta.outputs.release_please != 'true'
     runs-on: ubuntu-latest
     outputs:
       passed: ${{ steps.ratchet.outputs.passed }}
@@ -181,7 +193,7 @@ jobs:
   patch-coverage:
     name: Floor 3 · Patch coverage
     needs: [meta, test-coverage]
-    if: needs.meta.outputs.skip != 'true'
+    if: needs.meta.outputs.skip != 'true' && needs.meta.outputs.release_please != 'true'
     runs-on: ubuntu-latest
     outputs:
       passed: ${{ steps.patch.outputs.passed }}
@@ -223,7 +235,7 @@ jobs:
   ai-smells:
     name: Floor 4 · AI smells
     needs: meta
-    if: needs.meta.outputs.skip != 'true' && needs.meta.outputs.docs_only != 'true'
+    if: needs.meta.outputs.skip != 'true' && needs.meta.outputs.docs_only != 'true' && needs.meta.outputs.release_please != 'true'
     runs-on: ubuntu-latest
     outputs:
       passed: ${{ steps.scan.outputs.passed }}
@@ -249,7 +261,7 @@ jobs:
   scope-budget:
     name: Floor 5 · Scope budget
     needs: meta
-    if: needs.meta.outputs.skip != 'true'
+    if: needs.meta.outputs.skip != 'true' && needs.meta.outputs.release_please != 'true'
     runs-on: ubuntu-latest
     outputs:
       passed: ${{ steps.scope.outputs.passed }}
@@ -279,7 +291,7 @@ jobs:
   e2e:
     name: Floor 6 · E2E
     needs: meta
-    if: needs.meta.outputs.skip != 'true' && needs.meta.outputs.docs_only != 'true'
+    if: needs.meta.outputs.skip != 'true' && needs.meta.outputs.docs_only != 'true' && needs.meta.outputs.release_please != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -323,7 +335,7 @@ jobs:
   cyclo-new:
     name: Floor 8 · Cyclo (new code)
     needs: meta
-    if: needs.meta.outputs.skip != 'true' && needs.meta.outputs.docs_only != 'true'
+    if: needs.meta.outputs.skip != 'true' && needs.meta.outputs.docs_only != 'true' && needs.meta.outputs.release_please != 'true'
     runs-on: ubuntu-latest
     outputs:
       passed: ${{ steps.cyclo.outputs.passed }}
@@ -354,7 +366,7 @@ jobs:
   secrets-scan:
     name: Floor 9 · Secrets scan
     needs: meta
-    if: needs.meta.outputs.skip != 'true'
+    if: needs.meta.outputs.skip != 'true' && needs.meta.outputs.release_please != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -402,6 +414,7 @@ jobs:
           R_CYCLO: ${{ needs.cyclo-new.result }}
           R_SEC: ${{ needs.secrets-scan.result }}
           DOCS_ONLY: ${{ needs.meta.outputs.docs_only }}
+          RELEASE_PLEASE: ${{ needs.meta.outputs.release_please }}
           SKIP: ${{ needs.meta.outputs.skip }}
           COV_CURRENT: ${{ needs.test-coverage.outputs.current }}
           COV_BASELINE: ${{ needs.test-coverage.outputs.baseline }}
@@ -430,6 +443,17 @@ jobs:
           if [[ "$SKIP" == "true" ]]; then
             verdict="bypassed"
             body="### Quality Gate · Bypassed%0AThis PR was skipped (bot actor or \`quality-gate-skip\` label)."
+          elif [[ "$RELEASE_PLEASE" == "true" ]]; then
+            # release-please PRs run only commit-lint; the heavy floors
+            # are intentionally skipped and reported as ⏭️ in the body.
+            failed=()
+            if [[ "$R_LINT" != "success" && "$R_LINT" != "skipped" && -n "$R_LINT" ]]; then
+              failed+=("commit-lint")
+            fi
+            verdict="pass"
+            if [[ ${#failed[@]} -gt 0 ]]; then
+              verdict="fail"
+            fi
           else
             # Treat skipped as success (e.g. ai-smells skipped on docs-only PRs).
             failed=()

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -17,6 +17,11 @@ jobs:
   govulncheck:
     name: Go Vulnerability Check
     runs-on: ubuntu-latest
+    # Skip on release-please PRs (deterministic version bumps don't need
+    # a fresh vuln scan — the underlying go.mod was already gated on the
+    # PR that introduced the change). Schedule + workflow_dispatch keep
+    # running for drift detection.
+    if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please--')
     steps:
       - uses: actions/checkout@v6
 
@@ -33,6 +38,7 @@ jobs:
   gosec:
     name: Go Security Analysis
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please--')
     steps:
       - uses: actions/checkout@v6
 
@@ -67,6 +73,7 @@ jobs:
   trivy-image-chatcli:
     name: Trivy — ChatCLI Image
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please--')
     steps:
       - uses: actions/checkout@v6
 
@@ -113,6 +120,7 @@ jobs:
   trivy-image-operator:
     name: Trivy — Operator Image
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please--')
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary

Os PRs do release-please bumpam apenas `CHANGELOG.md`, `.release-please-manifest.json` e versões nos `Chart.yaml` — não introduzem código novo. Rodar Quality Gate completo (E2E, coverage ratchet, patch coverage, AI smells, scope budget, cyclo, secrets) e Security Scan completo (govulncheck, gosec, Trivy x2) neles é puro custo de CI sem retorno.

Atualmente o `meta` job filtra por `skip_actors` (`release-please[bot]`), mas o filtro só pega quando o actor do evento é o bot — em sync/edição manual o actor vira humano e os gates voltam a rodar. A solução desse PR é determinística: olha o `head_ref`.

## Changes

**`quality-gate.yml`**
- `meta` exporta novo output `release_please` quando `github.head_ref` começa com `release-please--`.
- Floors 1, 2, 3, 4, 5, 6, 8, 9 ganham guard adicional `needs.meta.outputs.release_please != 'true'`.
- **Floor 7 (Commit lint)** mantido — é o sanity check mínimo de que o commit gerado segue convencional.
- Aggregator interpreta o cenário release-please isoladamente: passa quando commit-lint passa, ignora os demais (que aparecem como ⏭️ skipped).

**`security-scan.yml`**
- `govulncheck`, `gosec`, `trivy-image-chatcli`, `trivy-image-operator` ganham `if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please--')`.
- `schedule` (segunda 06:00 UTC) e `workflow_dispatch` continuam rodando — drift detection preservado.
- **`dependency-review`** mantido — custo desprezível, signal alto contra deps maliciosas.

## Net effect

| Workflow             | release-please PR rodava | release-please PR roda agora |
|----------------------|--------------------------|------------------------------|
| Quality Gate         | 9 floors (~5 min)        | meta + commit-lint (~30s)    |
| Security Scan        | 4 jobs (~5 min)          | dependency-review (~10s)     |
| 1-ci.yml             | já filtrado por actor    | inalterado                   |

## Test plan

- [x] YAML válido (`yq '. | type'` em ambos os workflows)
- [x] Próximo PR do release-please confirma que apenas Floor 7 + Dependency Review rodam
- [x] Schedule mensal continua disparando govulncheck/gosec/trivy normalmente