### PR TITLE
fix(mcp): inherit parent env, expand ${VAR}, and hot-reload from empty state

### DIFF
--- a/cli/agent_mode_test.go
+++ b/cli/agent_mode_test.go
@@ -388,3 +388,49 @@ func TestMCPConfigWatcherFiresOnFileWrite(t *testing.T) {
 	}
 	t.Fatalf("watcher did not propagate edit; got %d servers, want 2", len(mgr.GetServerStatus()))
 }
+
+// TestMCPConfigWatcherFiresOnFileCreation pins the hot-reload
+// behavior for the "empty start" case: chatcli boots with the config
+// directory present but the mcp_servers.json file missing, the user
+// then creates the file. The watcher must trigger Reload so the new
+// server set is picked up without a restart.
+func TestMCPConfigWatcherFiresOnFileCreation(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "mcp_servers.json")
+	// File deliberately absent at watcher start time.
+	mgr := mcp.NewManager(zap.NewNop())
+	// LoadConfig on a missing file is a no-op (returns nil with zero
+	// servers) — we mirror what cli.go does on a fresh setup.
+	if err := mgr.LoadConfig(cfgPath); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cli := &ChatCLI{
+		logger:        zap.NewNop(),
+		mcpManager:    mgr,
+		mcpCtx:        ctx,
+		mcpConfigPath: cfgPath,
+	}
+	cli.startMCPConfigWatcher()
+	defer cli.stopMCPConfigWatcher()
+	if cli.mcpWatcher == nil {
+		t.Fatal("watcher did not start with missing config file")
+	}
+
+	// Now create the file — the Create event must trigger Reload.
+	if err := os.WriteFile(cfgPath, []byte(`{"mcpServers":[
+		{"name":"late","transport":"x","enabled":true}
+	]}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(mgr.GetServerStatus()) == 1 {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("watcher did not pick up newly-created config; got %d servers, want 1", len(mgr.GetServerStatus()))
+}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -476,65 +476,7 @@ func NewChatCLI(manager manager.LLMManager, logger *zap.Logger) (*ChatCLI, error
 	// Initialize cost tracker
 	cli.costTracker = NewCostTracker()
 
-	// Initialize MCP servers for client mode.
-	//
-	// Auto-enable rules (any one is enough):
-	//   1. CHATCLI_MCP_ENABLED=true (explicit opt-in).
-	//   2. The config file already exists.
-	//   3. The config file's parent directory exists.
-	//
-	// Rule 3 is what keeps hot-reload working when the user starts
-	// chatcli with ~/.chatcli/mcp_servers.json missing or empty and
-	// later creates/edits it: we still spin up the manager and the
-	// fsnotify watcher on ~/.chatcli/, so the Create event for the
-	// new file fires Reload as expected. Without it, the whole MCP
-	// subsystem would be skipped at startup and no watcher would
-	// ever see the file appear.
-	mcpEnabled := os.Getenv("CHATCLI_MCP_ENABLED") == "true"
-	mcpConfigPath := os.Getenv("CHATCLI_MCP_CONFIG")
-	if mcpConfigPath == "" {
-		mcpConfigPath = mcp.DefaultConfigPath()
-	}
-	if !mcpEnabled {
-		if _, err := os.Stat(mcpConfigPath); err == nil { //#nosec G703 -- path validated by engine.validatePath / SensitiveReadPaths.IsReadAllowed
-			mcpEnabled = true
-		} else if info, err := os.Stat(filepath.Dir(mcpConfigPath)); err == nil && info.IsDir() {
-			mcpEnabled = true
-		}
-	}
-	if mcpEnabled {
-		mcpMgr := mcp.NewManager(logger)
-		// LoadConfig is tolerant of a missing file (returns nil with
-		// zero servers). A 0-byte or malformed file errors here — we
-		// log it but still register the manager and start the watcher
-		// so the user can fix the file in place and have it picked up
-		// on save without restarting chatcli.
-		if err := mcpMgr.LoadConfig(mcpConfigPath); err != nil {
-			logger.Warn("Failed to load MCP config (will retry on file change)",
-				zap.String("path", mcpConfigPath), zap.Error(err))
-		}
-		// Register the manager up front so /mcp status, the agent
-		// system prompt and the tool dispatcher all see the configured
-		// servers immediately. Servers start in Status.Starting=true
-		// (set by LoadConfig) and transition to Connected/LastError as
-		// the background StartAll progresses — which keeps shell
-		// startup fast even when stdio servers need npx to fetch a
-		// package on first run.
-		mcpCtx, mcpCancelFn := context.WithCancel(context.Background())
-		cli.mcpManager = mcpMgr
-		cli.mcpCancel = mcpCancelFn
-		cli.mcpConfigPath = mcpConfigPath
-		cli.mcpCtx = mcpCtx
-		go func() {
-			_ = mcpMgr.StartAll(mcpCtx)
-			statuses := mcpMgr.GetServerStatus()
-			tools := mcpMgr.GetTools()
-			logger.Info("MCP manager initialized (client mode)",
-				zap.Int("servers", len(statuses)),
-				zap.Int("tools", len(tools)))
-		}()
-		cli.startMCPConfigWatcher()
-	}
+	cli.bootstrapMCP(logger)
 
 	// Initialize persona handler
 	cli.personaHandler = NewPersonaHandler(logger)
@@ -1266,6 +1208,76 @@ func (cli *ChatCLI) schedulerStatusLine() string {
 	}
 	summaries := cli.schedulerList(scheduler.ListFilter{})
 	return scheduler.StatusLine(summaries)
+}
+
+// resolveMCPConfigPath returns the path chatcli should consult for
+// MCP server configuration: the explicit `CHATCLI_MCP_CONFIG`
+// override when set, otherwise the conventional `~/.chatcli/mcp_servers.json`.
+// Extracted so tests can drive the auto-enable decision without
+// stomping on the real user environment.
+func resolveMCPConfigPath() string {
+	if p := os.Getenv("CHATCLI_MCP_CONFIG"); p != "" {
+		return p
+	}
+	return mcp.DefaultConfigPath()
+}
+
+// shouldAutoEnableMCP returns true when MCP should be initialized
+// automatically (i.e., without `CHATCLI_MCP_ENABLED=true`). It says
+// yes when either the config file already exists OR its parent
+// directory exists — the latter is what keeps hot-reload alive when
+// the user opens chatcli with no `mcp_servers.json` and creates one
+// later: we still need the fsnotify watcher running on the parent
+// directory so the Create event can fire Reload.
+func shouldAutoEnableMCP(mcpConfigPath string) bool {
+	if _, err := os.Stat(mcpConfigPath); err == nil { //#nosec G304 -- env-supplied path; only Stat, no read
+		return true
+	}
+	if info, err := os.Stat(filepath.Dir(mcpConfigPath)); err == nil && info.IsDir() { //#nosec G304 -- env-supplied path; only Stat of parent directory
+		return true
+	}
+	return false
+}
+
+// bootstrapMCP wires up the MCP manager + config watcher during
+// chatcli startup. Pulled out of NewChatCLI so the auto-enable rule,
+// the LoadConfig-tolerates-failure path, and the watcher handoff
+// are testable in isolation. Safe no-op when MCP is not enabled by
+// the env var and neither the config file nor its parent directory
+// exists.
+//
+// LoadConfig errors (0-byte file, malformed JSON, …) are logged but
+// don't abort initialization — we still register the manager and
+// start the watcher so the user can fix the file in place and have
+// it picked up on save instead of having to restart chatcli.
+func (cli *ChatCLI) bootstrapMCP(logger *zap.Logger) {
+	mcpEnabled := os.Getenv("CHATCLI_MCP_ENABLED") == "true"
+	mcpConfigPath := resolveMCPConfigPath()
+	if !mcpEnabled && shouldAutoEnableMCP(mcpConfigPath) {
+		mcpEnabled = true
+	}
+	if !mcpEnabled {
+		return
+	}
+	mcpMgr := mcp.NewManager(logger)
+	if err := mcpMgr.LoadConfig(mcpConfigPath); err != nil {
+		logger.Warn("Failed to load MCP config (will retry on file change)",
+			zap.String("path", mcpConfigPath), zap.Error(err))
+	}
+	mcpCtx, mcpCancelFn := context.WithCancel(context.Background())
+	cli.mcpManager = mcpMgr
+	cli.mcpCancel = mcpCancelFn
+	cli.mcpConfigPath = mcpConfigPath
+	cli.mcpCtx = mcpCtx
+	go func() {
+		_ = mcpMgr.StartAll(mcpCtx)
+		statuses := mcpMgr.GetServerStatus()
+		tools := mcpMgr.GetTools()
+		logger.Info("MCP manager initialized (client mode)",
+			zap.Int("servers", len(statuses)),
+			zap.Int("tools", len(tools)))
+	}()
+	cli.startMCPConfigWatcher()
 }
 
 // startMCPConfigWatcher boots an fsnotify watcher on the MCP config

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -476,45 +476,64 @@ func NewChatCLI(manager manager.LLMManager, logger *zap.Logger) (*ChatCLI, error
 	// Initialize cost tracker
 	cli.costTracker = NewCostTracker()
 
-	// Initialize MCP servers for client mode
+	// Initialize MCP servers for client mode.
+	//
+	// Auto-enable rules (any one is enough):
+	//   1. CHATCLI_MCP_ENABLED=true (explicit opt-in).
+	//   2. The config file already exists.
+	//   3. The config file's parent directory exists.
+	//
+	// Rule 3 is what keeps hot-reload working when the user starts
+	// chatcli with ~/.chatcli/mcp_servers.json missing or empty and
+	// later creates/edits it: we still spin up the manager and the
+	// fsnotify watcher on ~/.chatcli/, so the Create event for the
+	// new file fires Reload as expected. Without it, the whole MCP
+	// subsystem would be skipped at startup and no watcher would
+	// ever see the file appear.
 	mcpEnabled := os.Getenv("CHATCLI_MCP_ENABLED") == "true"
 	mcpConfigPath := os.Getenv("CHATCLI_MCP_CONFIG")
 	if mcpConfigPath == "" {
 		mcpConfigPath = mcp.DefaultConfigPath()
 	}
-	// Auto-enable if config file exists (even without env var)
 	if !mcpEnabled {
 		if _, err := os.Stat(mcpConfigPath); err == nil { //#nosec G703 -- path validated by engine.validatePath / SensitiveReadPaths.IsReadAllowed
+			mcpEnabled = true
+		} else if info, err := os.Stat(filepath.Dir(mcpConfigPath)); err == nil && info.IsDir() {
 			mcpEnabled = true
 		}
 	}
 	if mcpEnabled {
 		mcpMgr := mcp.NewManager(logger)
+		// LoadConfig is tolerant of a missing file (returns nil with
+		// zero servers). A 0-byte or malformed file errors here — we
+		// log it but still register the manager and start the watcher
+		// so the user can fix the file in place and have it picked up
+		// on save without restarting chatcli.
 		if err := mcpMgr.LoadConfig(mcpConfigPath); err != nil {
-			logger.Warn("Failed to load MCP config", zap.String("path", mcpConfigPath), zap.Error(err))
-		} else {
-			// Register the manager up front so /mcp status, the agent
-			// system prompt and the tool dispatcher all see the configured
-			// servers immediately. Servers start in Status.Starting=true
-			// (set by LoadConfig) and transition to Connected/LastError as
-			// the background StartAll progresses — which keeps shell
-			// startup fast even when stdio servers need npx to fetch a
-			// package on first run.
-			mcpCtx, mcpCancelFn := context.WithCancel(context.Background())
-			cli.mcpManager = mcpMgr
-			cli.mcpCancel = mcpCancelFn
-			cli.mcpConfigPath = mcpConfigPath
-			cli.mcpCtx = mcpCtx
-			go func() {
-				_ = mcpMgr.StartAll(mcpCtx)
-				statuses := mcpMgr.GetServerStatus()
-				tools := mcpMgr.GetTools()
-				logger.Info("MCP manager initialized (client mode)",
-					zap.Int("servers", len(statuses)),
-					zap.Int("tools", len(tools)))
-			}()
-			cli.startMCPConfigWatcher()
+			logger.Warn("Failed to load MCP config (will retry on file change)",
+				zap.String("path", mcpConfigPath), zap.Error(err))
 		}
+		// Register the manager up front so /mcp status, the agent
+		// system prompt and the tool dispatcher all see the configured
+		// servers immediately. Servers start in Status.Starting=true
+		// (set by LoadConfig) and transition to Connected/LastError as
+		// the background StartAll progresses — which keeps shell
+		// startup fast even when stdio servers need npx to fetch a
+		// package on first run.
+		mcpCtx, mcpCancelFn := context.WithCancel(context.Background())
+		cli.mcpManager = mcpMgr
+		cli.mcpCancel = mcpCancelFn
+		cli.mcpConfigPath = mcpConfigPath
+		cli.mcpCtx = mcpCtx
+		go func() {
+			_ = mcpMgr.StartAll(mcpCtx)
+			statuses := mcpMgr.GetServerStatus()
+			tools := mcpMgr.GetTools()
+			logger.Info("MCP manager initialized (client mode)",
+				zap.Int("servers", len(statuses)),
+				zap.Int("tools", len(tools)))
+		}()
+		cli.startMCPConfigWatcher()
 	}
 
 	// Initialize persona handler

--- a/cli/mcp/mcp_test.go
+++ b/cli/mcp/mcp_test.go
@@ -1319,6 +1319,108 @@ func TestReloadAddsRemovesAndUpdatesServers(t *testing.T) {
 	}
 }
 
+// --- buildProcessEnv tests -------------------------------------------------
+// MCP stdio servers (npx, uvx, docker, ...) need PATH/HOME/etc. to
+// find their binaries, and users want to keep secrets in shell env
+// instead of plaintext in mcp_servers.json. These tests pin both
+// behaviors.
+
+func TestBuildProcessEnvInheritsParentWhenNoOverrides(t *testing.T) {
+	parent := []string{"PATH=/usr/bin", "HOME=/home/me"}
+	got := buildProcessEnv(parent, nil)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 entries, got %d (%v)", len(got), got)
+	}
+	if got[0] != "PATH=/usr/bin" || got[1] != "HOME=/home/me" {
+		t.Errorf("parent entries not preserved: %v", got)
+	}
+}
+
+func TestBuildProcessEnvAppendsOverrides(t *testing.T) {
+	parent := []string{"PATH=/usr/bin"}
+	got := buildProcessEnv(parent, map[string]string{"API_KEY": "secret"})
+	hasPath, hasKey := false, false
+	for _, e := range got {
+		if e == "PATH=/usr/bin" {
+			hasPath = true
+		}
+		if e == "API_KEY=secret" {
+			hasKey = true
+		}
+	}
+	if !hasPath {
+		t.Error("PATH from parent missing")
+	}
+	if !hasKey {
+		t.Errorf("API_KEY override missing: %v", got)
+	}
+}
+
+func TestBuildProcessEnvOverrideWinsOverParent(t *testing.T) {
+	parent := []string{"FOO=parent-value"}
+	got := buildProcessEnv(parent, map[string]string{"FOO": "override"})
+	// Last assignment wins on both Unix and Windows: ensure the
+	// override entry sits after the parent's so it takes effect.
+	parentIdx, overrideIdx := -1, -1
+	for i, e := range got {
+		if e == "FOO=parent-value" {
+			parentIdx = i
+		}
+		if e == "FOO=override" {
+			overrideIdx = i
+		}
+	}
+	if parentIdx < 0 {
+		t.Fatal("parent FOO entry missing")
+	}
+	if overrideIdx < 0 {
+		t.Fatal("override FOO entry missing")
+	}
+	if overrideIdx <= parentIdx {
+		t.Errorf("override must come after parent; got parentIdx=%d overrideIdx=%d (%v)", parentIdx, overrideIdx, got)
+	}
+}
+
+func TestBuildProcessEnvExpandsVariables(t *testing.T) {
+	parent := []string{"GH_TOKEN=ghp_abc123", "DB_HOST=localhost"}
+	got := buildProcessEnv(parent, map[string]string{
+		"GITHUB_TOKEN": "${GH_TOKEN}",
+		"DSN":          "postgres://user:pass@$DB_HOST:5432/db",
+	})
+
+	want := map[string]string{
+		"GITHUB_TOKEN": "ghp_abc123",
+		"DSN":          "postgres://user:pass@localhost:5432/db",
+	}
+	for k, v := range want {
+		needle := k + "=" + v
+		found := false
+		for _, e := range got {
+			if e == needle {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected %q in env, got %v", needle, got)
+		}
+	}
+}
+
+func TestBuildProcessEnvUnresolvedExpandsToEmpty(t *testing.T) {
+	// os.Expand resolves unknown vars to empty string, matching
+	// shell behavior. Document it explicitly so a typo doesn't
+	// silently leak the literal "${TYPO}" into the child.
+	parent := []string{"PATH=/usr/bin"}
+	got := buildProcessEnv(parent, map[string]string{"TOKEN": "${MISSING_VAR}"})
+	for _, e := range got {
+		if e == "TOKEN=" {
+			return
+		}
+	}
+	t.Errorf("expected TOKEN= (empty) in env, got %v", got)
+}
+
 func TestMarkDisconnectedFlipsStatusAndDropsTools(t *testing.T) {
 	m := NewManager(testLogger())
 	conn := &ServerConnection{

--- a/cli/mcp/transport_stdio.go
+++ b/cli/mcp/transport_stdio.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -49,10 +50,13 @@ func newStdioTransport(ctx context.Context, cfg ServerConfig, logger *zap.Logger
 	args := cfg.Args
 	cmd := exec.CommandContext(ctx, cfg.Command, args...) //#nosec G204 -- agent/CLI tool execution; commands validated by command_validator + policy_manager upstream
 
-	// Set environment variables
-	for k, v := range cfg.Env {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
-	}
+	// Inherit the parent environment (PATH, HOME, npm cache, etc.) so
+	// launchers like `npx`, `uvx` and `docker` can find their binaries
+	// and caches, then layer the user-configured Env on top. Values
+	// support ${VAR}/$VAR expansion against the parent environment so
+	// users can keep secrets in shell env (or a sourced .env) instead
+	// of plaintext in mcp_servers.json.
+	cmd.Env = buildProcessEnv(os.Environ(), cfg.Env)
 
 	stdinPipe, err := cmd.StdinPipe()
 	if err != nil {
@@ -236,6 +240,41 @@ func (t *stdioTransport) drainStderr(name string, r io.ReadCloser) {
 			zap.String("server", name),
 			zap.String("line", scanner.Text()))
 	}
+}
+
+// buildProcessEnv merges the parent process environment with the
+// user-configured overrides. Override values are expanded against the
+// parent environment so a config like {"GITHUB_TOKEN": "${GH_TOKEN}"}
+// resolves at spawn time. If the same key appears in both, the
+// override wins (last assignment in cmd.Env takes precedence on Unix
+// and Windows).
+func buildProcessEnv(parent []string, overrides map[string]string) []string {
+	if len(overrides) == 0 {
+		// Return the parent slice as-is — exec.Cmd treats nil as
+		// "inherit", but we want explicit inheritance regardless of
+		// whether overrides exist.
+		out := make([]string, len(parent))
+		copy(out, parent)
+		return out
+	}
+
+	lookup := func(key string) string {
+		needle := key + "="
+		for i := len(parent) - 1; i >= 0; i-- {
+			if strings.HasPrefix(parent[i], needle) {
+				return parent[i][len(needle):]
+			}
+		}
+		return ""
+	}
+
+	out := make([]string, 0, len(parent)+len(overrides))
+	out = append(out, parent...)
+	for k, v := range overrides {
+		expanded := os.Expand(v, lookup)
+		out = append(out, fmt.Sprintf("%s=%s", k, expanded))
+	}
+	return out
 }
 
 // Close kills the MCP server process and cleans up.

--- a/cli/mcp_bootstrap_test.go
+++ b/cli/mcp_bootstrap_test.go
@@ -1,0 +1,125 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// TestResolveMCPConfigPathHonorsEnvOverride pins the env override
+// rule so a deployment that points at a custom location continues
+// to work without code changes.
+func TestResolveMCPConfigPathHonorsEnvOverride(t *testing.T) {
+	t.Setenv("CHATCLI_MCP_CONFIG", "/custom/path/servers.json")
+	if got := resolveMCPConfigPath(); got != "/custom/path/servers.json" {
+		t.Errorf("got %q, want /custom/path/servers.json", got)
+	}
+}
+
+func TestResolveMCPConfigPathFallsBackToDefault(t *testing.T) {
+	t.Setenv("CHATCLI_MCP_CONFIG", "")
+	got := resolveMCPConfigPath()
+	if got == "" {
+		t.Fatal("default path was empty")
+	}
+	if filepath.Base(got) != "mcp_servers.json" {
+		t.Errorf("default path basename = %q, want mcp_servers.json", filepath.Base(got))
+	}
+}
+
+func TestShouldAutoEnableMCPFileExists(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "mcp_servers.json")
+	if err := os.WriteFile(cfg, []byte(`{"mcpServers":[]}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !shouldAutoEnableMCP(cfg) {
+		t.Error("expected auto-enable when file exists")
+	}
+}
+
+func TestShouldAutoEnableMCPDirExistsFileMissing(t *testing.T) {
+	// This is the case the hot-reload fix unlocks: directory present
+	// but no file yet. Without auto-enable, the user can never get
+	// hot-reload after creating mcp_servers.json mid-session.
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "mcp_servers.json") // file deliberately absent
+	if !shouldAutoEnableMCP(cfg) {
+		t.Error("expected auto-enable when only the parent dir exists")
+	}
+}
+
+func TestShouldAutoEnableMCPNothingExists(t *testing.T) {
+	cfg := filepath.Join(t.TempDir(), "missing-subdir", "mcp_servers.json")
+	if shouldAutoEnableMCP(cfg) {
+		t.Error("expected no auto-enable when neither file nor parent dir exist")
+	}
+}
+
+func TestBootstrapMCPSkipsWhenDisabled(t *testing.T) {
+	// CHATCLI_MCP_ENABLED unset + a fully-bogus config path means
+	// bootstrap should skip the entire subsystem. Important so users
+	// who don't use MCP don't pay the cost of a manager + watcher.
+	t.Setenv("CHATCLI_MCP_ENABLED", "")
+	t.Setenv("CHATCLI_MCP_CONFIG", filepath.Join(t.TempDir(), "missing-subdir", "mcp_servers.json"))
+	cli := &ChatCLI{}
+	cli.bootstrapMCP(zap.NewNop())
+	if cli.mcpManager != nil {
+		t.Error("manager should not be initialized when MCP is disabled and no path exists")
+	}
+	if cli.mcpWatcher != nil {
+		t.Error("watcher should not start when MCP is disabled")
+	}
+}
+
+func TestBootstrapMCPInitsManagerWhenDirExists(t *testing.T) {
+	// Mirrors the chatcli first-run experience: ~/.chatcli/ exists
+	// but mcp_servers.json doesn't. bootstrapMCP must still set up
+	// the manager + watcher so a later file creation triggers Reload.
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "mcp_servers.json")
+	t.Setenv("CHATCLI_MCP_ENABLED", "")
+	t.Setenv("CHATCLI_MCP_CONFIG", cfgPath)
+	cli := &ChatCLI{}
+	cli.bootstrapMCP(zap.NewNop())
+	defer cli.stopMCPConfigWatcher()
+	if cli.mcpManager == nil {
+		t.Fatal("manager should be initialized when parent dir exists")
+	}
+	if cli.mcpConfigPath != cfgPath {
+		t.Errorf("mcpConfigPath = %q, want %q", cli.mcpConfigPath, cfgPath)
+	}
+	if cli.mcpWatcher == nil {
+		t.Fatal("watcher should start so hot-reload works once the file appears")
+	}
+	// Allow the goroutine started by bootstrapMCP (StartAll on an
+	// empty server set) to finish so the test doesn't race against it.
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestBootstrapMCPSurvivesMalformedConfig(t *testing.T) {
+	// 0-byte / malformed mcp_servers.json must not abort init.
+	// Without this, a typo in the JSON file would force the user
+	// to restart chatcli to recover — exactly the scenario the
+	// hot-reload fix is supposed to handle.
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "mcp_servers.json")
+	if err := os.WriteFile(cfgPath, []byte("{not json"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CHATCLI_MCP_ENABLED", "true")
+	t.Setenv("CHATCLI_MCP_CONFIG", cfgPath)
+	cli := &ChatCLI{}
+	cli.bootstrapMCP(zap.NewNop())
+	defer cli.stopMCPConfigWatcher()
+	if cli.mcpManager == nil {
+		t.Error("manager must still be set up despite LoadConfig failure")
+	}
+	if cli.mcpWatcher == nil {
+		t.Error("watcher must still start so the user can save the fix")
+	}
+	time.Sleep(50 * time.Millisecond)
+}


### PR DESCRIPTION
## Summary

Two MCP fixes that became visible together:

- **stdio transport now inherits `os.Environ()`** before layering `cfg.Env` on top, so launchers like `npx`, `uvx`, and `docker` find their binaries and per-user caches. Override values pass through `os.Expand`, so a config like `\"GITHUB_TOKEN\": \"${GH_TOKEN}\"` resolves at spawn time against the parent env — secrets stay in shell env / sourced .env instead of plaintext JSON. Parity with Claude Desktop / OpenCode behavior.
- **Hot-reload now triggers when starting from empty/missing config.** Previously, `mcpEnabled` only auto-flipped on if `mcp_servers.json` already existed AND `LoadConfig` succeeded — so creating the file later or fixing a 0-byte/malformed file required a chatcli restart. Now MCP is enabled when the config **directory** exists, and the watcher always starts when MCP is enabled, even if the initial `LoadConfig` errors. The Create event for the new file fires `Reload` as expected.

## Test plan

- [x] `go build ./...`
- [x] `go test ./cli/mcp/... -count=1` — 5 new tests for `buildProcessEnv` (inheritance, override-wins, `${VAR}` expansion, missing-var → empty)
- [x] `go test ./cli/ -run 'TestMCPConfigWatcher' -count=1` — new `TestMCPConfigWatcherFiresOnFileCreation` boots the watcher with no config file and asserts a later write triggers Reload
- [x] Full `go test ./...` green
- [x] Manual smoke: start chatcli with empty `~/.chatcli/`, create `mcp_servers.json` with one stdio server, confirm it comes up without restart
- [x] Manual smoke: configure an MCP server with `\"GITHUB_TOKEN\": \"${GH_TOKEN}\"` against a shell that exports `GH_TOKEN`, confirm the child sees the resolved value