### PR TITLE
fix(coder): use go-prompt for iteration input (paste + full width)

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -245,7 +245,19 @@ func (a *AgentMode) readLineWithEditing() (string, error) {
 		return readLinePlainFromReader(bufio.NewReader(os.Stdin)), nil
 	}
 
-	line := a.readLineFromGoPrompt()
+	return a.processInteractiveLine(a.readLineFromGoPrompt, bufio.NewReader(os.Stdin))
+}
+
+// processInteractiveLine is the TTY-side pipeline: read one line via
+// the supplied source, replay any captured bracketed-paste content,
+// and either return the trimmed line or — if the user typed a
+// multiline trigger — drain continuation lines from `multilineReader`
+// until the matching delimiter. Pulled into its own function so the
+// post-prompt logic (paste replay, multiline dispatch) is unit-
+// testable with a stub readRaw, without spinning up a real terminal
+// or go-prompt instance.
+func (a *AgentMode) processInteractiveLine(readRaw func() string, multilineReader *bufio.Reader) (string, error) {
+	line := readRaw()
 
 	// Mirror the chat-mode paste handling: when a large paste was
 	// captured behind a placeholder, swap it back in. Always clear
@@ -258,7 +270,7 @@ func (a *AgentMode) readLineWithEditing() (string, error) {
 	// Support multiline delimiter: if the user types "---", enter
 	// multiline mode and accumulate until the matching delimiter.
 	if isMultilineTrigger(trimmed) {
-		return a.runMultilineSession(trimmed, bufio.NewReader(os.Stdin))
+		return a.runMultilineSession(trimmed, multilineReader)
 	}
 
 	return trimmed, nil

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -242,63 +242,100 @@ func (a *AgentMode) readLineWithEditing() (string, error) {
 	fd := int(os.Stdin.Fd()) // #nosec G115 -- Fd() returns uintptr, safe on all supported platforms
 
 	if !term.IsTerminal(fd) {
-		reader := bufio.NewReader(os.Stdin)
-		line, _ := reader.ReadString('\n')
-		return strings.TrimSpace(line), nil
+		return readLinePlainFromReader(bufio.NewReader(os.Stdin)), nil
 	}
 
-	// BracketedPasteParser is what makes multi-line paste survive
-	// without each embedded newline being interpreted as Enter. Same
-	// parser the main chat REPL uses (cli/cli.go).
+	line := a.readLineFromGoPrompt()
+
+	// Mirror the chat-mode paste handling: when a large paste was
+	// captured behind a placeholder, swap it back in. Always clear
+	// lastPasteInfo so the next chat-mode prompt doesn't see a stale
+	// notification from this coder iteration.
+	line = a.applyPendingPasteInfo(line)
+
+	trimmed := strings.TrimSpace(line)
+
+	// Support multiline delimiter: if the user types "---", enter
+	// multiline mode and accumulate until the matching delimiter.
+	if isMultilineTrigger(trimmed) {
+		return a.runMultilineSession(trimmed, bufio.NewReader(os.Stdin))
+	}
+
+	return trimmed, nil
+}
+
+// readLinePlainFromReader is the non-TTY fallback used when stdin is
+// piped (CI, one-shot scripts). Pulled out as a top-level function so
+// tests can drive it with any io.Reader without needing to swap
+// os.Stdin.
+func readLinePlainFromReader(reader *bufio.Reader) string {
+	line, _ := reader.ReadString('\n')
+	return strings.TrimSpace(line)
+}
+
+// readLineFromGoPrompt isolates the go-prompt invocation so the
+// surrounding logic (paste replay, multiline trigger detection) can
+// be tested without spinning up a real terminal. Tests stub this by
+// not calling readLineWithEditing directly; production code uses it
+// as the one go-prompt-touching path.
+func (a *AgentMode) readLineFromGoPrompt() string {
 	pasteParser := paste.NewBracketedPasteParser(
 		prompt.NewStandardInputParser(),
 		func(info paste.Info) {
 			a.cli.lastPasteInfo = &info
 		},
 	)
-
 	noopCompleter := func(prompt.Document) []prompt.Suggest { return nil }
-
-	line := prompt.Input(
+	return prompt.Input(
 		"  > ",
 		noopCompleter,
 		prompt.OptionParser(pasteParser),
 		prompt.OptionPrefixTextColor(prompt.Green),
 		prompt.OptionInputTextColor(prompt.White),
 	)
+}
 
-	// Mirror the chat-mode paste handling: when a large paste was
-	// captured behind a placeholder, swap it back in. Always clear
-	// lastPasteInfo so the next chat-mode prompt doesn't see a stale
-	// notification from this coder iteration.
-	if a.cli.lastPasteInfo != nil {
-		info := a.cli.lastPasteInfo
-		a.cli.lastPasteInfo = nil
-		if info.Placeholder != "" && strings.Contains(line, info.Placeholder) {
-			line = strings.Replace(line, info.Placeholder, info.Content, 1)
+// applyPendingPasteInfo swaps the placeholder bracketed-paste left
+// behind in the line back for the real captured content, then clears
+// the paste-info pointer so the next chat-mode prompt doesn't see a
+// stale notification from this coder iteration. No-op when no paste
+// is pending or the placeholder isn't present in the line.
+func (a *AgentMode) applyPendingPasteInfo(line string) string {
+	if a.cli == nil || a.cli.lastPasteInfo == nil {
+		return line
+	}
+	info := a.cli.lastPasteInfo
+	a.cli.lastPasteInfo = nil
+	if info.Placeholder != "" && strings.Contains(line, info.Placeholder) {
+		return strings.Replace(line, info.Placeholder, info.Content, 1)
+	}
+	return line
+}
+
+// isMultilineTrigger reports whether the user typed one of the
+// supported multiline-mode openers. Centralized so tests pin the
+// exact set and a typo (e.g., "—" vs "---") doesn't silently work.
+func isMultilineTrigger(s string) bool {
+	return s == "---" || s == "```"
+}
+
+// runMultilineSession reads continuation lines from `reader` until
+// the multilineBuf reports the session as complete (the user typed
+// the matching delimiter). The trigger line itself is fed in first
+// so the buffer captures the opener. Returns the full assembled
+// text, trimmed.
+func (a *AgentMode) runMultilineSession(trigger string, reader *bufio.Reader) (string, error) {
+	a.multilineBuf.ProcessLine(trigger)
+	fmt.Printf("\n  \033[90m📝 %s\033[0m\n", i18n.T("multiline.hint", a.multilineBuf.Delimiter()))
+	for {
+		fmt.Printf("  \033[90m... [%d] \033[0m", a.multilineBuf.LineCount()+1)
+		nextLine, _ := reader.ReadString('\n')
+		nextLine = strings.TrimRight(nextLine, "\r\n")
+		complete, fullText := a.multilineBuf.ProcessLine(nextLine)
+		if complete {
+			return strings.TrimSpace(fullText), nil
 		}
 	}
-
-	trimmed := strings.TrimSpace(line)
-
-	// Support multiline delimiter: if the user types "---", enter multiline mode
-	// using the standard multilineBuf accumulator.
-	if trimmed == "---" || trimmed == "```" {
-		a.multilineBuf.ProcessLine(trimmed)
-		fmt.Printf("\n  \033[90m📝 %s\033[0m\n", i18n.T("multiline.hint", a.multilineBuf.Delimiter()))
-		reader := bufio.NewReader(os.Stdin)
-		for {
-			fmt.Printf("  \033[90m... [%d] \033[0m", a.multilineBuf.LineCount()+1)
-			nextLine, _ := reader.ReadString('\n')
-			nextLine = strings.TrimRight(nextLine, "\r\n")
-			complete, fullText := a.multilineBuf.ProcessLine(nextLine)
-			if complete {
-				return strings.TrimSpace(fullText), nil
-			}
-		}
-	}
-
-	return trimmed, nil
 }
 
 // drainStdinToQueue moves any pending stdin lines into the message queue.

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -21,6 +21,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/c-bata/go-prompt"
 	"github.com/diillson/chatcli/cli/agent"
 	"github.com/diillson/chatcli/cli/agent/park"
 	"github.com/diillson/chatcli/cli/agent/quality"
@@ -226,35 +227,56 @@ func (a *AgentMode) readLine() string {
 	return strings.TrimSpace(line)
 }
 
-// stdinStdout is an io.ReadWriter that reads from stdin and writes to stdout.
-// Required by term.NewTerminal which needs a single ReadWriter.
-type stdinStdout struct{}
-
-func (stdinStdout) Read(p []byte) (int, error)  { return os.Stdin.Read(p) }
-func (stdinStdout) Write(p []byte) (int, error) { return os.Stdout.Write(p) }
-
-// readLineWithEditing reads a single line with full terminal line-editing support
-// (arrow keys, Home, End, Ctrl+A/E, backspace, delete, etc.) using golang.org/x/term.
-// This is used for coder mode interactive input where the user needs to edit text.
+// readLineWithEditing reads a single line of user input for coder
+// mode iteration. It delegates to go-prompt — the same readline used
+// by chat mode — so behavior is identical: full terminal width,
+// bracketed-paste handling (multi-line paste preserved instead of
+// submitting on the first newline), arrow-key navigation, Ctrl+A/E,
+// word movement, history-free single-shot input. Reusing the chat
+// stack here is a deliberate UX choice: users should not have to
+// learn a second editing model when the agent waits for their reply.
+//
+// Falls back to plain bufio.Reader when stdin isn't a TTY (piped
+// input, CI), where go-prompt's raw-mode setup would fail.
 func (a *AgentMode) readLineWithEditing() (string, error) {
 	fd := int(os.Stdin.Fd()) // #nosec G115 -- Fd() returns uintptr, safe on all supported platforms
 
-	// Put terminal into raw mode so term.Terminal can handle escape sequences
-	oldState, err := term.MakeRaw(fd)
-	if err != nil {
-		// Fallback to simple read if raw mode fails (e.g., piped input)
+	if !term.IsTerminal(fd) {
 		reader := bufio.NewReader(os.Stdin)
 		line, _ := reader.ReadString('\n')
 		return strings.TrimSpace(line), nil
 	}
-	defer func() { _ = term.Restore(fd, oldState) }()
 
-	// term.NewTerminal provides full readline: arrow keys, Ctrl+A/E, word
-	// movement, backspace, delete — all processed correctly.
-	t := term.NewTerminal(stdinStdout{}, "  > ")
-	line, err := t.ReadLine()
-	if err != nil {
-		return "", err
+	// BracketedPasteParser is what makes multi-line paste survive
+	// without each embedded newline being interpreted as Enter. Same
+	// parser the main chat REPL uses (cli/cli.go).
+	pasteParser := paste.NewBracketedPasteParser(
+		prompt.NewStandardInputParser(),
+		func(info paste.Info) {
+			a.cli.lastPasteInfo = &info
+		},
+	)
+
+	noopCompleter := func(prompt.Document) []prompt.Suggest { return nil }
+
+	line := prompt.Input(
+		"  > ",
+		noopCompleter,
+		prompt.OptionParser(pasteParser),
+		prompt.OptionPrefixTextColor(prompt.Green),
+		prompt.OptionInputTextColor(prompt.White),
+	)
+
+	// Mirror the chat-mode paste handling: when a large paste was
+	// captured behind a placeholder, swap it back in. Always clear
+	// lastPasteInfo so the next chat-mode prompt doesn't see a stale
+	// notification from this coder iteration.
+	if a.cli.lastPasteInfo != nil {
+		info := a.cli.lastPasteInfo
+		a.cli.lastPasteInfo = nil
+		if info.Placeholder != "" && strings.Contains(line, info.Placeholder) {
+			line = strings.Replace(line, info.Placeholder, info.Content, 1)
+		}
 	}
 
 	trimmed := strings.TrimSpace(line)
@@ -262,7 +284,6 @@ func (a *AgentMode) readLineWithEditing() (string, error) {
 	// Support multiline delimiter: if the user types "---", enter multiline mode
 	// using the standard multilineBuf accumulator.
 	if trimmed == "---" || trimmed == "```" {
-		_ = term.Restore(fd, oldState) // restore terminal for multiline input
 		a.multilineBuf.ProcessLine(trimmed)
 		fmt.Printf("\n  \033[90m📝 %s\033[0m\n", i18n.T("multiline.hint", a.multilineBuf.Delimiter()))
 		reader := bufio.NewReader(os.Stdin)

--- a/cli/agent_mode_input_test.go
+++ b/cli/agent_mode_input_test.go
@@ -1,0 +1,173 @@
+package cli
+
+import (
+	"bufio"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/cli/paste"
+)
+
+// Tests for the helpers extracted from readLineWithEditing. The
+// go-prompt path needs a real TTY and isn't unit-testable, but the
+// non-TTY fallback, paste-replay, multiline-trigger detection and
+// continuation-line accumulator are pure functions over their
+// inputs and pin the contract that drove the rewrite.
+
+func TestReadLinePlainFromReaderTrimsAndStrips(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"hello\n", "hello"},
+		{"  spaced  \n", "spaced"},
+		{"crlf\r\n", "crlf"},
+		{"", ""}, // EOF before any byte → empty line
+	}
+	for _, c := range cases {
+		got := readLinePlainFromReader(bufio.NewReader(strings.NewReader(c.in)))
+		if got != c.want {
+			t.Errorf("input %q: got %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestApplyPendingPasteInfoNoPasteIsNoOp(t *testing.T) {
+	a := &AgentMode{cli: &ChatCLI{}}
+	if got := a.applyPendingPasteInfo("hello"); got != "hello" {
+		t.Errorf("expected pass-through when no paste pending, got %q", got)
+	}
+}
+
+func TestApplyPendingPasteInfoSwapsPlaceholder(t *testing.T) {
+	cli := &ChatCLI{
+		lastPasteInfo: &paste.Info{
+			Placeholder: "<<PASTE>>",
+			Content:     "actual pasted content",
+		},
+	}
+	a := &AgentMode{cli: cli}
+	got := a.applyPendingPasteInfo("user typed <<PASTE>> here")
+	if got != "user typed actual pasted content here" {
+		t.Errorf("placeholder not replaced: %q", got)
+	}
+	if cli.lastPasteInfo != nil {
+		t.Error("lastPasteInfo must be cleared so next chat-mode prompt doesn't see stale state")
+	}
+}
+
+func TestApplyPendingPasteInfoClearsEvenWhenPlaceholderAbsent(t *testing.T) {
+	// Pinned because the chat-mode REPL relies on lastPasteInfo
+	// being drained at every prompt — leaking it across a coder
+	// iteration would surface a stale "paste detected" banner.
+	cli := &ChatCLI{
+		lastPasteInfo: &paste.Info{
+			Placeholder: "<<PASTE>>",
+			Content:     "actual pasted content",
+		},
+	}
+	a := &AgentMode{cli: cli}
+	got := a.applyPendingPasteInfo("no placeholder here")
+	if got != "no placeholder here" {
+		t.Errorf("line should be untouched when placeholder absent: %q", got)
+	}
+	if cli.lastPasteInfo != nil {
+		t.Error("lastPasteInfo must still be cleared even when placeholder did not match")
+	}
+}
+
+func TestApplyPendingPasteInfoSurvivesNilCLI(t *testing.T) {
+	// Defensive: if AgentMode is constructed without a parent (only
+	// happens in narrow test paths today), don't panic.
+	a := &AgentMode{}
+	if got := a.applyPendingPasteInfo("x"); got != "x" {
+		t.Errorf("expected pass-through when cli is nil, got %q", got)
+	}
+}
+
+func TestIsMultilineTrigger(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"---", true},
+		{"```", true},
+		{"——", false}, // em-dashes, not three hyphens
+		{"--", false},
+		{"```go", false}, // language-tagged fence is NOT a multiline trigger
+		{"", false},
+		{"hello", false},
+	}
+	for _, c := range cases {
+		if got := isMultilineTrigger(c.in); got != c.want {
+			t.Errorf("isMultilineTrigger(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestRunMultilineSessionAccumulatesUntilDelimiter(t *testing.T) {
+	a := &AgentMode{}
+	// Feed three content lines and the closing delimiter through
+	// our own bufio.Reader so the test is hermetic — no os.Stdin.
+	input := "first line\nsecond line\nthird line\n---\n"
+	reader := bufio.NewReader(strings.NewReader(input))
+
+	got, err := a.runMultilineSession("---", reader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []string{"first line", "second line", "third line"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("multiline output missing %q: %q", want, got)
+		}
+	}
+}
+
+func TestReadLineWithEditingFallsBackOnNonTTYStdin(t *testing.T) {
+	// In CI / test runs stdin is a pipe, not a TTY — so this test
+	// exercises the fallback branch that was the whole reason we
+	// kept the bufio path around. Redirect stdin to a fresh pipe to
+	// guarantee non-TTY regardless of how `go test` was launched.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	orig := os.Stdin
+	os.Stdin = r
+	defer func() {
+		os.Stdin = orig
+		_ = r.Close()
+	}()
+
+	go func() {
+		_, _ = w.WriteString("piped input\n")
+		_ = w.Close()
+	}()
+
+	a := &AgentMode{cli: &ChatCLI{}}
+	got, err := a.readLineWithEditing()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "piped input" {
+		t.Errorf("got %q, want %q", got, "piped input")
+	}
+}
+
+func TestRunMultilineSessionWithBacktickFence(t *testing.T) {
+	// The "```" trigger must round-trip the same way as "---".
+	// Pinned so the parallel fence support in isMultilineTrigger
+	// stays wired to the accumulator.
+	a := &AgentMode{}
+	input := "fenced content\n```\n"
+	reader := bufio.NewReader(strings.NewReader(input))
+
+	got, err := a.runMultilineSession("```", reader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(got, "fenced content") {
+		t.Errorf("backtick fence didn't capture content: %q", got)
+	}
+}

--- a/cli/agent_mode_input_test.go
+++ b/cli/agent_mode_input_test.go
@@ -171,3 +171,69 @@ func TestRunMultilineSessionWithBacktickFence(t *testing.T) {
 		t.Errorf("backtick fence didn't capture content: %q", got)
 	}
 }
+
+// processInteractiveLine is the TTY-side pipeline that runs after
+// the go-prompt readline returns. We can't drive go-prompt itself
+// in unit tests, but we can stub the line source — that's the whole
+// point of the readRaw injection. These tests pin every post-prompt
+// behavior the function is responsible for.
+
+func TestProcessInteractiveLinePassesThroughTrimmed(t *testing.T) {
+	a := &AgentMode{cli: &ChatCLI{}}
+	got, err := a.processInteractiveLine(
+		func() string { return "  hello world  " },
+		bufio.NewReader(strings.NewReader("")),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "hello world" {
+		t.Errorf("got %q, want %q", got, "hello world")
+	}
+}
+
+func TestProcessInteractiveLineReplaysPasteContent(t *testing.T) {
+	// The chat REPL uses the same placeholder swap; if a coder
+	// iteration receives a placeholder without replay, the user
+	// would see the placeholder submitted as their actual prompt.
+	cli := &ChatCLI{
+		lastPasteInfo: &paste.Info{
+			Placeholder: "<<PASTE>>",
+			Content:     "actual pasted content",
+		},
+	}
+	a := &AgentMode{cli: cli}
+	got, err := a.processInteractiveLine(
+		func() string { return "before <<PASTE>> after" },
+		bufio.NewReader(strings.NewReader("")),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "before actual pasted content after" {
+		t.Errorf("placeholder not replayed: %q", got)
+	}
+	if cli.lastPasteInfo != nil {
+		t.Error("lastPasteInfo must be drained after processing")
+	}
+}
+
+func TestProcessInteractiveLineDispatchesMultiline(t *testing.T) {
+	// When the user types the multiline trigger, the function must
+	// hand off to runMultilineSession and feed the continuation
+	// reader. Pins the wiring between trigger detector and accumulator.
+	a := &AgentMode{cli: &ChatCLI{}}
+	cont := bufio.NewReader(strings.NewReader("line A\nline B\n---\n"))
+	got, err := a.processInteractiveLine(
+		func() string { return "---" },
+		cont,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []string{"line A", "line B"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("multiline output missing %q: %q", want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Coder mode's "waiting for input" prompt called `term.NewTerminal` from `golang.org/x/term`, which has two flaws that don't show up in chat mode:

1. **Hard-coded 80-column width** — typed input wraps to a second visual line on wider terminals because `term.Terminal` doesn't query the real size.
2. **No bracketed-paste handling** — pasted multi-line content gets submitted on the first embedded newline, and modern terminals' paste markers (`ESC [ 200 ~ … ESC [ 201 ~`) leak into the buffer as garbage characters.

Both are already solved in the main chat REPL by go-prompt + the in-tree `BracketedPasteParser`, so coder mode now delegates to the same stack via `prompt.Input`. UX is identical to chat: arrow keys, Ctrl+A/E, word movement, multi-line paste, full terminal width.

`cli.lastPasteInfo` is drained after the read so a paste captured during a coder iteration cannot leak a stale "paste detected" banner into the next chat-mode prompt.

The non-TTY fallback (piped stdin / CI) is preserved with `bufio` so agent mode still works in one-shot pipelines where go-prompt's raw-mode setup would fail.

## Test plan

- [x] `go build ./...`
- [x] `go test ./cli/ -run 'AgentMode|Coder' -count=1`
- [x] Full `go test ./...` green
- [x] Manual smoke: enter coder mode, type past 80 cols, confirm no premature wrap
- [x] Manual smoke: paste a multi-line snippet at the coder prompt, confirm it's captured intact (does not submit on first `\n`)
- [x] Manual smoke: arrow keys, Ctrl+A/E, word-jump (Alt/Ctrl+Arrow) work as in chat mode
- [x] Pipe a one-shot agent prompt (`echo "..." | chatcli ...`) to confirm the non-TTY fallback path