### PR TITLE
fix(coder): restore terminal state after go-prompt so multiline (---) works

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -245,22 +245,32 @@ func (a *AgentMode) readLineWithEditing() (string, error) {
 		return readLinePlainFromReader(bufio.NewReader(os.Stdin)), nil
 	}
 
-	// Snapshot the current cooked-mode terminal state BEFORE go-prompt
-	// runs. go-prompt switches stdin to raw mode internally and tries
-	// to restore on tearDown, but on macOS that cleanup is not
-	// 100% reliable — `icanon`/`icrnl` sometimes stay off, so the
-	// bufio reader used for multiline continuation lines below would
-	// hang forever (Enter delivers '\r' which never satisfies a
-	// `ReadString('\n')`). Force-restoring this snapshot after go-prompt
-	// returns guarantees a cooked terminal for any subsequent
-	// line-buffered read in this turn.
-	cookedState, _ := term.GetState(fd)
-	line := a.readLineFromGoPrompt()
-	if cookedState != nil {
-		_ = term.Restore(fd, cookedState)
-	}
-
+	line := runWithCookedTerminalRestore(fd, a.readLineFromGoPrompt)
 	return a.processInteractiveLine(line, bufio.NewReader(os.Stdin))
+}
+
+// runWithCookedTerminalRestore invokes fn while preserving the
+// terminal's cooked-mode state across go-prompt's raw-mode usage.
+//
+// go-prompt switches stdin to raw mode internally and tries to
+// restore on tearDown, but on macOS that cleanup is not 100%
+// reliable — `icanon`/`icrnl` sometimes stay off, which makes any
+// subsequent line-buffered read (e.g. the bufio reader used for
+// multiline continuation lines) hang forever because Enter delivers
+// '\r' instead of '\n'. Snapshotting before fn runs and forcing
+// term.Restore afterwards is the cinto-+-suspensório fix.
+//
+// On non-TTY stdin (pipes, GetState error) the snapshot fails
+// silently and fn still runs — there's nothing to restore. Extracted
+// so the snapshot/invoke/restore dance is unit-testable with a pipe
+// fd, without spinning up a real PTY.
+func runWithCookedTerminalRestore(fd int, fn func() string) string {
+	state, _ := term.GetState(fd)
+	out := fn()
+	if state != nil {
+		_ = term.Restore(fd, state)
+	}
+	return out
 }
 
 // processInteractiveLine is the TTY-side post-prompt pipeline: take

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -245,20 +245,36 @@ func (a *AgentMode) readLineWithEditing() (string, error) {
 		return readLinePlainFromReader(bufio.NewReader(os.Stdin)), nil
 	}
 
-	return a.processInteractiveLine(a.readLineFromGoPrompt, bufio.NewReader(os.Stdin))
+	// Snapshot the current cooked-mode terminal state BEFORE go-prompt
+	// runs. go-prompt switches stdin to raw mode internally and tries
+	// to restore on tearDown, but on macOS that cleanup is not
+	// 100% reliable — `icanon`/`icrnl` sometimes stay off, so the
+	// bufio reader used for multiline continuation lines below would
+	// hang forever (Enter delivers '\r' which never satisfies a
+	// `ReadString('\n')`). Force-restoring this snapshot after go-prompt
+	// returns guarantees a cooked terminal for any subsequent
+	// line-buffered read in this turn.
+	cookedState, _ := term.GetState(fd)
+	line := a.readLineFromGoPrompt()
+	if cookedState != nil {
+		_ = term.Restore(fd, cookedState)
+	}
+
+	return a.processInteractiveLine(line, bufio.NewReader(os.Stdin))
 }
 
-// processInteractiveLine is the TTY-side pipeline: read one line via
-// the supplied source, replay any captured bracketed-paste content,
-// and either return the trimmed line or — if the user typed a
-// multiline trigger — drain continuation lines from `multilineReader`
-// until the matching delimiter. Pulled into its own function so the
-// post-prompt logic (paste replay, multiline dispatch) is unit-
-// testable with a stub readRaw, without spinning up a real terminal
-// or go-prompt instance.
-func (a *AgentMode) processInteractiveLine(readRaw func() string, multilineReader *bufio.Reader) (string, error) {
-	line := readRaw()
-
+// processInteractiveLine is the TTY-side post-prompt pipeline: take
+// the line that go-prompt already returned, replay any captured
+// bracketed-paste content, and either return the trimmed line or —
+// if the user typed a multiline trigger — drain continuation lines
+// from `multilineReader` until the matching delimiter.
+//
+// Kept as a separate function so paste replay and multiline dispatch
+// are unit-testable without spinning up a real terminal. The function
+// no longer reads anything itself — readLineWithEditing is the single
+// point that touches stdin/go-prompt, which keeps the terminal-mode
+// dance contained in one place.
+func (a *AgentMode) processInteractiveLine(line string, multilineReader *bufio.Reader) (string, error) {
 	// Mirror the chat-mode paste handling: when a large paste was
 	// captured behind a placeholder, swap it back in. Always clear
 	// lastPasteInfo so the next chat-mode prompt doesn't see a stale

--- a/cli/agent_mode_input_test.go
+++ b/cli/agent_mode_input_test.go
@@ -172,16 +172,16 @@ func TestRunMultilineSessionWithBacktickFence(t *testing.T) {
 	}
 }
 
-// processInteractiveLine is the TTY-side pipeline that runs after
-// the go-prompt readline returns. We can't drive go-prompt itself
-// in unit tests, but we can stub the line source — that's the whole
-// point of the readRaw injection. These tests pin every post-prompt
-// behavior the function is responsible for.
+// processInteractiveLine is the TTY-side post-prompt pipeline. The
+// function takes the line go-prompt already returned and decides
+// what to do with it (paste replay, multiline dispatch, plain
+// pass-through). Pure post-processing — no stdin reads of its own —
+// so tests can drive every branch directly with a string input.
 
 func TestProcessInteractiveLinePassesThroughTrimmed(t *testing.T) {
 	a := &AgentMode{cli: &ChatCLI{}}
 	got, err := a.processInteractiveLine(
-		func() string { return "  hello world  " },
+		"  hello world  ",
 		bufio.NewReader(strings.NewReader("")),
 	)
 	if err != nil {
@@ -204,7 +204,7 @@ func TestProcessInteractiveLineReplaysPasteContent(t *testing.T) {
 	}
 	a := &AgentMode{cli: cli}
 	got, err := a.processInteractiveLine(
-		func() string { return "before <<PASTE>> after" },
+		"before <<PASTE>> after",
 		bufio.NewReader(strings.NewReader("")),
 	)
 	if err != nil {
@@ -224,10 +224,7 @@ func TestProcessInteractiveLineDispatchesMultiline(t *testing.T) {
 	// reader. Pins the wiring between trigger detector and accumulator.
 	a := &AgentMode{cli: &ChatCLI{}}
 	cont := bufio.NewReader(strings.NewReader("line A\nline B\n---\n"))
-	got, err := a.processInteractiveLine(
-		func() string { return "---" },
-		cont,
-	)
+	got, err := a.processInteractiveLine("---", cont)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/cli/agent_mode_input_test.go
+++ b/cli/agent_mode_input_test.go
@@ -218,6 +218,42 @@ func TestProcessInteractiveLineReplaysPasteContent(t *testing.T) {
 	}
 }
 
+func TestRunWithCookedTerminalRestoreInvokesFnAndReturnsValue(t *testing.T) {
+	// Non-TTY fd path: term.GetState returns (nil, error), so the
+	// Restore branch is skipped and fn still runs. This is the
+	// behavior we depend on in CI / piped contexts.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	defer func() { _ = r.Close(); _ = w.Close() }()
+
+	called := false
+	got := runWithCookedTerminalRestore(int(r.Fd()), func() string {
+		called = true
+		return "delivered"
+	})
+	if !called {
+		t.Error("fn was not invoked")
+	}
+	if got != "delivered" {
+		t.Errorf("got %q, want %q", got, "delivered")
+	}
+}
+
+func TestRunWithCookedTerminalRestorePropagatesEmpty(t *testing.T) {
+	// Pin that an empty return (e.g. user typed nothing and hit
+	// Enter) flows through unchanged — no nil-coalescing or "default"
+	// surprises in the helper.
+	r, w, _ := os.Pipe()
+	defer func() { _ = r.Close(); _ = w.Close() }()
+
+	got := runWithCookedTerminalRestore(int(r.Fd()), func() string { return "" })
+	if got != "" {
+		t.Errorf("expected empty pass-through, got %q", got)
+	}
+}
+
 func TestProcessInteractiveLineDispatchesMultiline(t *testing.T) {
 	// When the user types the multiline trigger, the function must
 	// hand off to runMultilineSession and feed the continuation


### PR DESCRIPTION
## Summary

Regression fix for the `---` multiline trigger in coder mode, broken since the go-prompt rewrite (#893 / commit 86f4333).

## Symptom (reported)

In `/coder` mode, after the agent asks for input:
1. User types `---` and hits Enter
2. The "📝 Modo multilinha" hint prints
3. Cursor blinks, terminal stops echoing, Enter does nothing — no way to recover except Ctrl+C

## Root cause

`go-prompt.Input()` switches stdin to raw mode internally. Its `tearDown()` is supposed to restore the original state, but on macOS that cleanup is unreliable — `icanon`/`icrnl` sometimes stay off. The bufio reader used for multiline continuation lines then hangs on `ReadString('\n')` forever, because Enter delivers a literal `\r` (raw mode) and never gets translated to `\n`.

The pre-rewrite implementation handled this explicitly:
```go
oldState, _ := term.MakeRaw(fd)
...
if multiline {
    _ = term.Restore(fd, oldState) // restore cooked mode for multiline
    reader := bufio.NewReader(os.Stdin)
    ...
}
```

I dropped that `term.Restore` call when migrating to go-prompt, assuming tearDown was authoritative. It's not on macOS.

## Fix

Snapshot the cooked-mode state via `term.GetState(fd)` before `go-prompt.Input()` runs, then `term.Restore(fd, cookedState)` right after it returns — _before_ any subsequent stdin read. The bufio reader sees a guaranteed-cooked terminal on every multiline session.

## Cleanup

`processInteractiveLine` no longer takes a `readRaw func() string` closure — `readLineWithEditing` reads the line itself (since it now owns the terminal-mode dance) and passes a string in. Cleaner contract, single point of stdin/go-prompt contact.

## Test plan

- [x] `go build ./...`
- [x] `go test -race -count=1 ./...` — all green
- [x] All three `TestProcessInteractiveLine*` cases keep their coverage with the new string-based signature
- [x] Manual: `/coder`, agent asks for input, type `---` + Enter, confirm multiline mode now accepts continuation lines and the closing `---` returns the accumulated text
- [x] Manual: same flow with `` ``` `` as the trigger