### PR TITLE
fix(mcp): list text/event-stream first in Accept header

### DIFF
--- a/cli/mcp/transport_http.go
+++ b/cli/mcp/transport_http.go
@@ -10,7 +10,8 @@
  *
  *   - Single endpoint (e.g. https://server/mcp). Each JSON-RPC
  *     request is a POST to that endpoint with
- *     `Accept: application/json, text/event-stream`.
+ *     `Accept: text/event-stream, application/json` (SSE first so
+ *     strict-first servers do not reject with HTTP 406).
  *
  *   - The server responds with EITHER:
  *       * Content-Type: application/json — single response body, or
@@ -163,7 +164,16 @@ func (t *httpTransport) Call(method string, params interface{}) (json.RawMessage
 		return nil, err
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Accept", "application/json, text/event-stream")
+	// Order matters in the wild. The 2025-03-26 spec just requires
+	// both media types to be listed and a substring/`includes` check
+	// on the server is enough — but several real implementations
+	// (FastMCP, some Cloudflare Workers MCP gateways) interpret the
+	// FIRST listed type as the client's preference and return HTTP
+	// 406 / JSON-RPC -32600 ("Not Acceptable: Client must Accept
+	// text/event-stream") when SSE is not first. Putting SSE first
+	// is compatible with both naive first-match and spec-correct
+	// includes-match servers.
+	httpReq.Header.Set("Accept", "text/event-stream, application/json")
 	t.applyHeaders(httpReq)
 	t.attachSession(httpReq)
 

--- a/cli/mcp/transport_http_test.go
+++ b/cli/mcp/transport_http_test.go
@@ -65,11 +65,20 @@ func TestHTTPTransport_JSONOneShotResponse(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("method = %s, want POST", r.Method)
 		}
-		if !strings.Contains(r.Header.Get("Accept"), "application/json") {
-			t.Errorf("Accept missing application/json: %q", r.Header.Get("Accept"))
+		accept := r.Header.Get("Accept")
+		if !strings.Contains(accept, "application/json") {
+			t.Errorf("Accept missing application/json: %q", accept)
 		}
-		if !strings.Contains(r.Header.Get("Accept"), "text/event-stream") {
-			t.Errorf("Accept missing text/event-stream: %q", r.Header.Get("Accept"))
+		if !strings.Contains(accept, "text/event-stream") {
+			t.Errorf("Accept missing text/event-stream: %q", accept)
+		}
+		// Strict-first servers (FastMCP, some Workers MCP gateways)
+		// return HTTP 406 / JSON-RPC -32600 when text/event-stream is
+		// not the first listed type. Lock the order in so a future
+		// "simplification" of the header cannot silently reintroduce
+		// the bug.
+		if idxSSE, idxJSON := strings.Index(accept, "text/event-stream"), strings.Index(accept, "application/json"); idxSSE > idxJSON {
+			t.Errorf("Accept must list text/event-stream before application/json; got %q", accept)
 		}
 		var req jsonRPCRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {


### PR DESCRIPTION
## Summary

A real Streamable HTTP MCP server returned HTTP 406 with JSON-RPC `-32600` and message `"Not Acceptable: Client must Accept text/event-stream"` on the initialize POST, even though our Accept header in the just-shipped transport (#914, v1.117.0) listed both required media types:

```
Accept: application/json, text/event-stream
```

The 2025-03-26 MCP spec only mandates that both types be present — and a substring (`includes`) check on the server side is enough — but several real implementations (FastMCP / Python MCP SDK, some Cloudflare Workers MCP gateways) treat the **first** listed type as the client's preferred response shape and refuse the request when SSE is not first.

Reversing the order:

```
Accept: text/event-stream, application/json
```

works with both strict-first servers and includes-style spec-correct servers, so there is no regression on compliant implementations.

## Test plan

- [x] `TestHTTPTransport_JSONOneShotResponse` upgraded to also assert the order — `text/event-stream` MUST come before `application/json` so a future header tweak cannot silently regress
- [x] Full `cli/mcp` suite passes
- [x] `golangci-lint --new-from-rev=main` clean
- [x] `gofmt -l` clean
- [x] Re-run handshake against the user's real server (the one that returned -32600 before)