### PR TITLE
fix(mcp): preserve trailing slash on Streamable HTTP endpoint URL

### DIFF
--- a/cli/mcp/transport_http.go
+++ b/cli/mcp/transport_http.go
@@ -101,7 +101,19 @@ func newHTTPTransport(ctx context.Context, cfg ServerConfig, logger *zap.Logger,
 	initTimeout := cfg.InitializeTimeout()
 
 	t := &httpTransport{
-		endpoint: strings.TrimRight(cfg.URL, "/"),
+		// Preserve the URL path exactly as configured (whitespace
+		// trimmed). Trailing slash is SIGNIFICANT in HTTP path
+		// semantics — some MCP servers (FastMCP, ASGI mounts behind
+		// Starlette/FastAPI routers) answer only on /mcp/ and
+		// 307-redirect /mcp → /mcp/. Go's http.Client does follow
+		// 307 with POST when GetBody is set, but corporate proxies
+		// that sit between the client and the server frequently
+		// drop the body or custom headers across the redirect,
+		// manifesting as a 10s deadline hang on initialize.
+		// Stripping the slash here would force that redirect path
+		// on every call; preserving it lets the operator point
+		// straight at the canonical URL.
+		endpoint: strings.TrimSpace(cfg.URL),
 		// The http.Client timeout caps the entire request lifetime
 		// including streaming SSE bodies. We size it at max(call,
 		// init) so a slow tools/call doesn't get killed by a short

--- a/cli/mcp/transport_http_test.go
+++ b/cli/mcp/transport_http_test.go
@@ -60,6 +60,51 @@ func TestHTTPTransport_RequiresURL(t *testing.T) {
 	}
 }
 
+// TestHTTPTransport_PreservesTrailingSlashInURL locks in the fact
+// that a trailing slash in the configured URL survives unchanged
+// to the wire. FastMCP and other Starlette/FastAPI-mounted servers
+// only answer on the slashed path and 307-redirect the other, which
+// some corporate proxies break across — the only safe behavior is
+// to never normalize the path here.
+func TestHTTPTransport_PreservesTrailingSlashInURL(t *testing.T) {
+	cases := []struct {
+		name, configured, wantPath string
+	}{
+		{"slashed", "/mcp/", "/mcp/"},
+		{"bare", "/mcp", "/mcp"},
+		{"root-slash", "/", "/"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var seenPath string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				seenPath = r.URL.Path
+				w.Header().Set("Content-Type", "application/json")
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				_ = json.NewEncoder(w).Encode(jsonRPCResponse{
+					JSONRPC: "2.0", ID: req.ID, Result: json.RawMessage(`{}`),
+				})
+			}))
+			defer srv.Close()
+
+			cfg := newTestServerConfig(srv.URL + tc.configured)
+			tr, err := newHTTPTransport(context.Background(), cfg, zap.NewNop(), nil, "test")
+			if err != nil {
+				t.Fatalf("newHTTPTransport: %v", err)
+			}
+			t.Cleanup(func() { _ = tr.Close(context.Background()) })
+
+			if _, err := tr.Call("ping", nil); err != nil {
+				t.Fatalf("Call: %v", err)
+			}
+			if seenPath != tc.wantPath {
+				t.Errorf("server saw path %q, want %q (URL must be preserved verbatim)", seenPath, tc.wantPath)
+			}
+		})
+	}
+}
+
 func TestHTTPTransport_JSONOneShotResponse(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {


### PR DESCRIPTION
## Summary

The Streamable HTTP transport's constructor stripped the trailing slash from the configured URL via `strings.TrimRight(cfg.URL, \"/\")`. That broke deployments where the MCP server only answers on the slashed path (FastMCP and other ASGI mounts behind Starlette / FastAPI routers 307-redirect `/mcp` → `/mcp/`).

Go's `http.Client` does follow 307 with POST when `GetBody` is set — and it is for our `bytes.NewReader` body — but a corporate proxy between the client and the server can drop the body or custom headers across the redirect, which surfaces as a 10-second hang on `initialize` rather than a clean error.

Trailing slash is significant in HTTP path semantics, so the correct behavior is to use the operator-supplied URL verbatim. The defensive trim now only removes accidental whitespace from a hand-edited JSON config.

## How this was found

A user behind a corporate proxy reported `chatcli` timing out on `initialize` after 10s while `curl` succeeded against the same URL ending in `/`. Manual diff against `curl`'s wire showed the only meaningful difference: `curl` POSTed to `/mcp/`, the chatcli transport POSTed to `/mcp` and triggered the 307 dance that the corporate proxy did not handle cleanly.

## Test plan

- [x] New subtest matrix in `TestHTTPTransport_PreservesTrailingSlashInURL` locks verbatim behavior for `/mcp/`, `/mcp`, and `/` paths
- [x] All existing `cli/mcp` tests still pass
- [x] Full repo `go test ./...` passes
- [x] `golangci-lint --new-from-rev=main` clean
- [x] `gofmt -l` clean
- [x] User re-tests against the real corporate server after merge / release