### PR TITLE
ci(release-workflow): inject Update block for unscoped release-please bullets

### DIFF
--- a/.github/workflows/3-publish-release.yml
+++ b/.github/workflows/3-publish-release.yml
@@ -731,6 +731,12 @@ jobs:
           TAG_NAME: ${{ needs.release_please.outputs.tag_name }}
         run: |
           set -euo pipefail
+          # Always remove the embedded chatcli checkout, even on early-exit
+          # paths. Without this, an early "exit 0" below leaves _chatcli_src
+          # in the work tree and the next "git add -A" step commits it as
+          # a stray gitlink (mode 160000).
+          trap 'rm -rf _chatcli_src' EXIT
+
           NEW_VERSION="${TAG_NAME#v}"
           OLD_VERSION=$(cat VERSION | tr -d '[:space:]')
           MAJOR_MINOR="$(echo "$NEW_VERSION" | cut -d. -f1,2)"
@@ -768,22 +774,35 @@ jobs:
             echo "::warning::CHANGELOG.md not found in chatcli source — skipping Update-block injection"
           else
             DATE_RAW="$(awk '/^## \[/{ print; exit }' "$CHANGELOG" | sed -E 's/.*\(([0-9]{4}-[0-9]{2}-[0-9]{2})\).*/\1/')"
+            # Handle BOTH bullet formats release-please can emit:
+            #   "* **scope:** message ..."  (conventional commit with scope)
+            #   "* message ..."             (no scope; e.g. plain `feat: …`)
+            # The previous version only matched the scoped form and
+            # silently emitted no bullets for unscoped releases (which
+            # is what broke the 1.118.0 docs injection — both commits
+            # in that release used `feat:` without a scope).
             BULLETS_PT="$(awk '
               /^## \[/{ if (seen) exit; seen=1; next }
-              /^\* \*\*/{
-                # "* **scope:** message ([#PR](...)) ([sha](...))" → "- **scope** — message"
-                sub(/^\* /, "- ")
-                sub(/:\*\*/, "**", $0)
-                sub(/ — /, " — ", $0)
-                # Replace ":** " with " — " on the first occurrence
-                sub(/\*\* /, "** — ")
-                # Strip trailing PR/commit links
+              /^\* /{
+                # Strip trailing release-please link blocks first.
+                # Format with PR + commit: " ([#NNN](...)) ([hex](...))"
+                # Format with PR only:     " ([#NNN](...))"
                 sub(/ \(\[#[0-9]+\].*\) \(\[[0-9a-f]+\].*\)$/, "")
                 sub(/ \(\[#[0-9]+\].*\)$/, "")
+
+                if (/^\* \*\*[^*]+:\*\* /) {
+                  # Scoped: "* **scope:** msg" -> "  - **scope** — msg"
+                  sub(/^\* /, "- ")
+                  sub(/:\*\*/, "**")
+                  sub(/\*\* /, "** — ")
+                } else {
+                  # Unscoped: "* msg" -> "  - msg"
+                  sub(/^\* /, "- ")
+                }
                 print "  " $0
               }
-            ' "$CHANGELOG")"
-            BULLETS_EN="$BULLETS_PT" # Bullets are scope-prefixed and language-neutral
+            ' "$CHANGELOG" | sed -E 's/\[(@[A-Za-z0-9_-]+)\]\([^)]*\)/\1/g')"
+            BULLETS_EN="$BULLETS_PT" # Bullets are language-neutral
 
             if [ -n "$DATE_RAW" ] && [ -n "$BULLETS_PT" ]; then
               # Build the Update block. Done via temp file so the


### PR DESCRIPTION
## Summary

- Awk em `3-publish-release.yml` agora aceita tanto bullets com escopo (`* **scope:** msg`) quanto sem escopo (`* msg`). O matcher antigo `/^\* \*\*/` deixava releases unscoped (como 1.118.0 com PRs #920 e #922 usando `feat:`) sem bullets — o step seguia "verde" via `::warning::Could not parse CHANGELOG.md`, mas o bloco `<Update label="…">` nunca era injetado em `introduction.mdx` / `en/introduction.mdx`.
- Sed pós-awk desfaz auto-link `[@user](url)` que release-please faz em menções `@xyz` dentro do subject (ex.: `[@todo](https://github.com/todo)` → `@todo`).
- `trap 'rm -rf _chatcli_src' EXIT` garante cleanup do checkout embedded em todos os caminhos de saída. Sem isso, o `exit 0` precoce (quando `OLD_VERSION == NEW_VERSION`) deixou `_chatcli_src` no work tree e o step seguinte commitou como gitlink mode 160000 — comportamento bizarro visto no commit 1dc29d5 do repo de docs após a 1.118.0.

## Root cause da 1.118.0

PRs `#920` (`feat: tool layer enterprise refactor …`) e `#922` (`feat: Claude Code parity tool layer …`) entraram no CHANGELOG.md sem escopo. O awk antigo (linha 773 do arquivo pré-fix) só matchava `/^\* \*\*/`, então `BULLETS_PT` ficou vazio, caiu no `else`, emitiu warning e seguiu — sem injetar o block. O run `26004977658` (Update docs version job `76435589488`) registra exatamente esse fluxo.

## Test plan

- [x] Testado localmente contra `CHANGELOG.md` real:
  - **1.117.0** (scoped, 1 bullet) → `  - **mcp** — add Streamable HTTP transport (MCP 2025-03-26)`
  - **1.116.0** (scoped, 2 bullets) → `  - **moonshot** — …` + `  - **qg** — …`
  - **1.118.0** (unscoped, 2 bullets) → `  - Claude Code parity tool layer (atomic tools, @todo, …)` + `  - tool layer enterprise refactor (…)`
- [x] Próximo release vai exercer o fix end-to-end. Como cleanup, o repo de docs vai receber, em paralelo, um commit manual injetando o bloco `<Update label="1.118" description="2026-05-17">` que ficou faltando (~chatcli.ai direct-to-main).