### PR TITLE
feat(coder): split-pane UI — scroll region, dedicated status row, raw-mode input

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -1299,6 +1299,13 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 	teardown := a.setupInputAndUI(ctx)
 	defer teardown()
 
+	// SIGWINCH handler. No-op when turnUI is nil (legacy mode) or
+	// on Windows (different resize mechanism). The handler's
+	// teardown closure is deferred BEFORE teardown above so the
+	// resize goroutine exits before the TurnUI is dismantled.
+	stopResize := a.installResizeHandler(ctx)
+	defer stopResize()
+
 	renderer := agent.NewUIRenderer(a.logger)
 
 	// Helper para construir o histórico com a "âncora" (System Prompt reforçado por turno).

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -511,6 +511,32 @@ func (a *AgentMode) teardownInputAndUI() {
 	a.turnUIInputReady = nil
 }
 
+// printCoderBannerIfNeeded emits the /coder quick-tip cheat sheet
+// once per session. Pulled out of Run() so it can be invoked AFTER
+// setupInputAndUI hands the terminal to turnui — without that
+// ordering, the banner would print in the user's main scrollback
+// just before alt-screen swap, flash for one frame, then vanish
+// under the alt buffer until /coder exits. Inside the split UI
+// the banner lands on the alt-screen canvas where the agent's
+// subsequent output will join it.
+//
+// The function honors the same three preconditions Run() used:
+// only in coder mode, only once per session, only when the
+// CHATCLI_CODER_BANNER env var hasn't explicitly disabled it.
+func (a *AgentMode) printCoderBannerIfNeeded() {
+	if !a.isCoderMode || a.coderBannerShown || !isCoderBannerEnabled() {
+		return
+	}
+	fmt.Println()
+	fmt.Println(i18n.T("coder.quick_tip.header"))
+	fmt.Println(i18n.T("coder.quick_tip.read"))
+	fmt.Println(i18n.T("coder.quick_tip.search"))
+	fmt.Println(i18n.T("coder.quick_tip.write"))
+	fmt.Println(i18n.T("coder.quick_tip.exec"))
+	fmt.Println()
+	a.coderBannerShown = true
+}
+
 // waitForInput blocks until something lands on the turnUIInputReady
 // signal channel or ctx is canceled. Used by the coder-waiting branch
 // in the split-UI mode to park instead of calling readLineWithEditing
@@ -1003,17 +1029,14 @@ func (a *AgentMode) Run(ctx context.Context, query string, additionalContext str
 		orchestratorText = workers.OrchestratorSystemPrompt(a.agentRegistry.CatalogString())
 	}
 
-	// Banner curto com cheat sheet no modo /coder (apenas para o usuário humano)
-	if isCoder && !a.coderBannerShown && isCoderBannerEnabled() {
-		fmt.Println()
-		fmt.Println(i18n.T("coder.quick_tip.header"))
-		fmt.Println(i18n.T("coder.quick_tip.read"))
-		fmt.Println(i18n.T("coder.quick_tip.search"))
-		fmt.Println(i18n.T("coder.quick_tip.write"))
-		fmt.Println(i18n.T("coder.quick_tip.exec"))
-		fmt.Println()
-		a.coderBannerShown = true
-	}
+	// The /coder quick-tip banner used to print here, but the
+	// split UI (turnui) takes over the terminal via alt-screen
+	// AFTER this function returns and into processAIResponseAndAct
+	// — printing the banner before that swap would leave it
+	// briefly visible and then hide it inside the alt buffer.
+	// Moved to printCoderBannerIfNeeded(), called once inside
+	// processAIResponseAndAct right after setupInputAndUI, so the
+	// banner always lands on the same canvas the agent will run on.
 
 	// Assemble the system message — flat string for providers without
 	// cache_control (consumed via Message.Content) plus structured
@@ -1381,6 +1404,14 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 	// so this defer cleans up whichever path activated.
 	teardown := a.setupInputAndUI(ctx)
 	defer teardown()
+
+	// /coder quick-tip banner. Printed AFTER setupInputAndUI so that
+	// when the split UI is active, the banner lands on the alt-
+	// screen canvas instead of the user's main terminal (where it
+	// would flash briefly and then get hidden under the alt-screen
+	// swap). When the legacy path is active, this prints in the
+	// same place it always did.
+	a.printCoderBannerIfNeeded()
 
 	// SIGWINCH handler. No-op when turnUI is nil (legacy mode) or
 	// on Windows (different resize mechanism). The handler's

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -27,6 +27,7 @@ import (
 	"github.com/diillson/chatcli/cli/agent/quality"
 	"github.com/diillson/chatcli/cli/agent/workers"
 	"github.com/diillson/chatcli/cli/coder"
+	"github.com/diillson/chatcli/cli/coder/turnui"
 	"github.com/diillson/chatcli/cli/hooks"
 	"github.com/diillson/chatcli/cli/mcp"
 	"github.com/diillson/chatcli/cli/metrics"
@@ -85,6 +86,20 @@ type AgentMode struct {
 	stdinDone    chan struct{} // signals reader goroutine to stop
 	stdinWg      sync.WaitGroup
 	multilineBuf MultilineBuffer // ``` delimited multiline input
+
+	// Split-pane UI (turnui). When non-nil and active, status updates
+	// go to the dedicated status row, agent output scrolls in the
+	// upper region, and keystrokes are owned by the mini-readline.
+	// The wait group lets defer cleanup synchronize on the input
+	// goroutine exiting before we tear down the terminal state.
+	// inputReady is signaled by the readline OnSubmit callback so
+	// the coder-waiting branch can park on a channel select instead
+	// of busy-polling drainStdinToQueue.
+	turnUI         *turnui.TurnUI
+	turnUIWg       sync.WaitGroup
+	turnUICancel   context.CancelFunc
+	turnUIActive   bool
+	turnUIInputReady chan struct{}
 
 	// Skill hints captured at the start of Run() from auto-activated or
 	// manually invoked skills. Applied to each LLM turn via ctx for the
@@ -227,6 +242,206 @@ func (a *AgentMode) stopStdinReader() {
 
 		a.stdinLines = nil
 		a.stdinDone = nil
+	}
+}
+
+// setupInputAndUI decides between the new split-pane (turnui) and the
+// legacy single-line spinner + cooked-mode stdin reader. The split UI
+// activates only when ShouldActivate returns true — non-TTY, dumb
+// terminals, undersized windows, the legacy Windows console, and the
+// CHATCLI_TURNUI=off escape hatch all route to the legacy path so a
+// terminal that cannot host the split UI is never wedged by it.
+//
+// In split-UI mode this function:
+//   - Allocates the inputReady signal channel and the stdinLines mirror.
+//     OnSubmit fills both: the channel wakes a parked coder-waiting
+//     loop, and the slice keeps drainStdinToQueue's contract intact.
+//   - Calls TurnUI.BeginInteractive to enter the scroll region and raw
+//     mode.
+//   - Spawns the readline goroutine and tracks it in turnUIWg so
+//     teardownInputAndUI can synchronize on its exit before returning.
+//
+// In legacy mode it just delegates to startStdinReader and leaves the
+// turnUI fields nil so every call site can check turnUIActive once
+// and pick the right code path.
+//
+// Returns a teardown function the caller MUST defer. Errors from the
+// split-UI path fall back to legacy automatically — the user gets
+// the old experience instead of a broken terminal.
+func (a *AgentMode) setupInputAndUI(ctx context.Context) func() {
+	env := turnui.DetectEnvironment()
+	if !turnui.ShouldActivate(env) {
+		a.startStdinReader()
+		return a.stopStdinReader
+	}
+
+	// Allocate signaling structures BEFORE TurnUI activation so the
+	// OnSubmit callback (which fires inside the readline goroutine)
+	// never races on a nil channel during the first few keystrokes.
+	a.turnUIInputReady = make(chan struct{}, 1)
+	a.stdinLines = make(chan string, 10) // legacy mirror — drainStdinToQueue still consumes from here
+
+	ui := turnui.New(os.Stdout)
+	loopCtx, cancel := context.WithCancel(ctx)
+
+	cfg := turnui.RunConfig{
+		Rows:    env.Rows,
+		Cols:    env.Cols,
+		StdinFD: env.StdinFD,
+		OnSubmit: func(line string) {
+			// Mirror the legacy splitStdinChunk -> stdinLines flow
+			// so consolidateStdinIntoQueue, the drainStdinToQueue
+			// slice promotion, and the echoQueuedLine status flash
+			// keep working unchanged. The agent loop does not need
+			// to know whether the line came from raw mode or cooked
+			// mode — only that it landed where it always has.
+			select {
+			case a.stdinLines <- line:
+			default:
+				// Channel full — drop oldest semantics would mean
+				// reordering; instead we lock-append directly to
+				// the durable slice and let the next drain pick it
+				// up. The 10-slot buffer is sized to never hit this
+				// path under realistic typing speeds.
+				a.cli.messageQueueMu.Lock()
+				a.cli.messageQueue = append(a.cli.messageQueue, line)
+				a.cli.messageQueueMu.Unlock()
+			}
+			// Wake any goroutine blocked in waitForInput. Non-
+			// blocking send so a missed wake (already pending) is
+			// fine — the consumer will see the queued line on its
+			// next drain.
+			select {
+			case a.turnUIInputReady <- struct{}{}:
+			default:
+			}
+		},
+		OnCancel: func() {
+			// In split-UI mode, Ctrl+C inside the input row clears
+			// the buffer but does NOT abort the agent loop — that
+			// matches the chat-mode handleCtrlC behavior of "first
+			// Ctrl+C clears, second exits". The hard-cancel path
+			// still runs via the OS signal handler.
+			a.logger.Debug("turnui OnCancel: input cleared")
+		},
+	}
+
+	// Begin first; if it fails the user has not seen any UI yet so
+	// we silently fall back to the legacy reader.
+	if err := ui.BeginInteractive(env.Rows, env.Cols, env.StdinFD); err != nil {
+		a.logger.Warn("turnui BeginInteractive failed, falling back to legacy", zap.Error(err))
+		cancel()
+		a.stdinLines = nil
+		a.turnUIInputReady = nil
+		a.startStdinReader()
+		return a.stopStdinReader
+	}
+
+	a.turnUI = ui
+	a.turnUICancel = cancel
+	a.turnUIActive = true
+
+	a.turnUIWg.Add(1)
+	go func() {
+		defer a.turnUIWg.Done()
+		// We re-use ui.RunReadLine equivalent via ui.Run, but
+		// Begin was already called above so we hand-roll the
+		// loop instead of letting Run call BeginInteractive a
+		// second time (which would error on "already active").
+		err := turnui.RunReadLine(loopCtx, turnui.ReadLineConfig{
+			Reader:   os.Stdin,
+			Painter:  ui.Painter(),
+			OnSubmit: cfg.OnSubmit,
+			OnCancel: cfg.OnCancel,
+		})
+		if err != nil && !errors.Is(err, context.Canceled) {
+			a.logger.Warn("turnui readline loop ended with error", zap.Error(err))
+		}
+	}()
+
+	return a.teardownInputAndUI
+}
+
+// teardownInputAndUI is the cleanup paired with setupInputAndUI. Safe
+// to call multiple times and from any goroutine; the second call is
+// a no-op. The function:
+//   1. Cancels the loop context so the readline goroutine exits its
+//      next read with a context.Canceled error.
+//   2. Waits on turnUIWg so we know the goroutine has finished its
+//      cleanup before we touch terminal state.
+//   3. Calls TurnUI.End to restore the scroll region and raw mode.
+//   4. Closes the legacy stdinLines mirror so drainStdinToQueue
+//      observes a closed channel as "nothing to drain".
+//
+// Order matters: ending the TurnUI BEFORE the readline goroutine
+// exits would race on the painter, and closing stdinLines before the
+// goroutine exits would cause a send-on-closed-channel panic in
+// OnSubmit.
+func (a *AgentMode) teardownInputAndUI() {
+	if !a.turnUIActive {
+		// Legacy mode: stopStdinReader is the only teardown step.
+		// Callers that received teardownInputAndUI from the legacy
+		// branch should never reach this path (they got
+		// a.stopStdinReader directly), but the guard makes the
+		// double-defer-safe contract explicit.
+		return
+	}
+	a.turnUIActive = false
+
+	if a.turnUICancel != nil {
+		a.turnUICancel()
+		a.turnUICancel = nil
+	}
+	a.turnUIWg.Wait()
+
+	if a.turnUI != nil {
+		if err := a.turnUI.End(); err != nil {
+			a.logger.Warn("turnui End failed", zap.Error(err))
+		}
+		a.turnUI = nil
+	}
+
+	if a.stdinLines != nil {
+		// Drain any remaining mirror entries into the durable slice
+		// so they survive into the next /coder session. Then nil
+		// the channel so drainStdinToQueue's nil-check skips it.
+		for {
+			select {
+			case line, ok := <-a.stdinLines:
+				if !ok {
+					a.stdinLines = nil
+					goto done
+				}
+				if line != "" {
+					a.cli.messageQueueMu.Lock()
+					a.cli.messageQueue = append(a.cli.messageQueue, line)
+					a.cli.messageQueueMu.Unlock()
+				}
+			default:
+				a.stdinLines = nil
+				goto done
+			}
+		}
+	done:
+	}
+
+	a.turnUIInputReady = nil
+}
+
+// waitForInput blocks until something lands on the turnUIInputReady
+// signal channel or ctx is canceled. Used by the coder-waiting branch
+// in the split-UI mode to park instead of calling readLineWithEditing
+// (which uses go-prompt and would conflict with the raw-mode TTY the
+// turnui already owns). Returns true when a new input arrived.
+func (a *AgentMode) waitForInput(ctx context.Context) bool {
+	if a.turnUIInputReady == nil {
+		return false
+	}
+	select {
+	case <-a.turnUIInputReady:
+		return true
+	case <-ctx.Done():
+		return false
 	}
 }
 
@@ -1076,9 +1291,13 @@ func (a *AgentMode) getToolContextString() string {
 //
 //nolint:gocyclo // legacy main loop; split tracked separately.
 func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) error {
-	// Start centralized stdin reader for type-ahead queue support
-	a.startStdinReader()
-	defer a.stopStdinReader()
+	// Set up input + UI: either the split-pane turnui (scroll region,
+	// dedicated status row, raw-mode mini-readline) or the legacy
+	// cooked-mode reader + single-line spinner, depending on what the
+	// terminal can host. setupInputAndUI returns the matching teardown
+	// so this defer cleans up whichever path activated.
+	teardown := a.setupInputAndUI(ctx)
+	defer teardown()
 
 	renderer := agent.NewUIRenderer(a.logger)
 
@@ -1269,7 +1488,18 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 			if queued > 0 {
 				msg = "Processando... " + i18n.T("agent.queue.indicator", queued)
 			}
-			fmt.Print(metrics.FormatTimerStatus(d, modelName, msg))
+			// Route the status update through whichever renderer is
+			// active. In split-UI mode the message lands on the
+			// dedicated status row (no \r — the row position is
+			// owned by turnui's MoveCursor). In legacy mode the \r
+			// + clear-line redraw lives on the cursor's current
+			// row, with all the input-overwrite caveats the legacy
+			// renderer has always had.
+			if a.turnUIActive && a.turnUI != nil {
+				_ = a.turnUI.UpdateStatus(metrics.FormatTimerStatusInline(d, modelName, msg))
+			} else {
+				fmt.Print(metrics.FormatTimerStatus(d, modelName, msg))
+			}
 		})
 
 		turnHistory := buildTurnHistoryWithAnchor()
@@ -2515,6 +2745,44 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 		if a.isCoderMode && !a.isOneShot {
 			showTurnStats()
 			fmt.Println()
+
+			// Split-UI mode: the readline goroutine is already
+			// running and the input row is always visible. Park
+			// on the inputReady signal until something lands in
+			// the queue, then drain it. We do NOT call
+			// readLineWithEditing here because that would try to
+			// start go-prompt in raw mode while turnui already
+			// owns the TTY — both would race for keystrokes.
+			if a.turnUIActive {
+				// Drain anything the user already typed BEFORE
+				// blocking — otherwise a fast-typing user who
+				// queued multiple lines during the LLM stream
+				// would see the spinner park while there's input
+				// waiting right in the slice.
+				if msg := a.drainStdinToQueue(); msg != "" {
+					a.cli.history = append(a.cli.history, models.Message{Role: "user", Content: msg})
+					continue
+				}
+				// Update the status row to a "waiting" indicator
+				// instead of the spinner so it's obvious the
+				// agent is parked, not stuck.
+				if a.turnUI != nil {
+					_ = a.turnUI.UpdateStatus(i18n.T("coder.waiting_for_input"))
+				}
+				if !a.waitForInput(ctx) {
+					return ctx.Err()
+				}
+				if msg := a.drainStdinToQueue(); msg != "" {
+					a.cli.history = append(a.cli.history, models.Message{Role: "user", Content: msg})
+					continue
+				}
+				// inputReady fired but the line was empty/whitespace
+				// (already discarded by drainStdinToQueue): loop
+				// back and park again instead of injecting an
+				// empty user message.
+				continue
+			}
+
 			fmt.Print(renderer.Colorize("  ⏳ "+i18n.T("coder.waiting_for_input"), agent.ColorCyan))
 			fmt.Println() // newline before input for clean cursor positioning
 

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -95,11 +95,24 @@ type AgentMode struct {
 	// inputReady is signaled by the readline OnSubmit callback so
 	// the coder-waiting branch can park on a channel select instead
 	// of busy-polling drainStdinToQueue.
-	turnUI         *turnui.TurnUI
-	turnUIWg       sync.WaitGroup
-	turnUICancel   context.CancelFunc
-	turnUIActive   bool
+	turnUI           *turnui.TurnUI
+	turnUIWg         sync.WaitGroup
+	turnUICancel     context.CancelFunc
+	turnUIActive     bool
 	turnUIInputReady chan struct{}
+
+	// Callbacks captured at setup time so Suspend/Resume can re-
+	// spawn the readline goroutine without having to rebuild the
+	// closure environment. The goroutine itself does not survive
+	// suspend (raw mode is gone, the read would block forever); we
+	// kill it on Suspend and spin a new one on Resume that wires
+	// the same handlers into the new context.
+	turnUIOnSubmit func(string)
+	turnUIOnCancel func()
+	turnUIBaseCtx  context.Context
+	turnUIEnvRows  int
+	turnUIEnvCols  int
+	turnUIEnvFD    int
 
 	// Skill hints captured at the start of Run() from auto-activated or
 	// manually invoked skills. Applied to each LLM turn via ctx for the
@@ -282,84 +295,144 @@ func (a *AgentMode) setupInputAndUI(ctx context.Context) func() {
 	a.stdinLines = make(chan string, 10) // legacy mirror — drainStdinToQueue still consumes from here
 
 	ui := turnui.New(os.Stdout)
-	loopCtx, cancel := context.WithCancel(ctx)
 
-	cfg := turnui.RunConfig{
-		Rows:    env.Rows,
-		Cols:    env.Cols,
-		StdinFD: env.StdinFD,
-		OnSubmit: func(line string) {
-			// Mirror the legacy splitStdinChunk -> stdinLines flow
-			// so consolidateStdinIntoQueue, the drainStdinToQueue
-			// slice promotion, and the echoQueuedLine status flash
-			// keep working unchanged. The agent loop does not need
-			// to know whether the line came from raw mode or cooked
-			// mode — only that it landed where it always has.
-			select {
-			case a.stdinLines <- line:
-			default:
-				// Channel full — drop oldest semantics would mean
-				// reordering; instead we lock-append directly to
-				// the durable slice and let the next drain pick it
-				// up. The 10-slot buffer is sized to never hit this
-				// path under realistic typing speeds.
-				a.cli.messageQueueMu.Lock()
-				a.cli.messageQueue = append(a.cli.messageQueue, line)
-				a.cli.messageQueueMu.Unlock()
-			}
-			// Wake any goroutine blocked in waitForInput. Non-
-			// blocking send so a missed wake (already pending) is
-			// fine — the consumer will see the queued line on its
-			// next drain.
-			select {
-			case a.turnUIInputReady <- struct{}{}:
-			default:
-			}
-		},
-		OnCancel: func() {
-			// In split-UI mode, Ctrl+C inside the input row clears
-			// the buffer but does NOT abort the agent loop — that
-			// matches the chat-mode handleCtrlC behavior of "first
-			// Ctrl+C clears, second exits". The hard-cancel path
-			// still runs via the OS signal handler.
-			a.logger.Debug("turnui OnCancel: input cleared")
-		},
+	// Bind the callbacks to AgentMode fields so Suspend/Resume can
+	// re-spawn the readline goroutine with the same handlers later
+	// without rebuilding the closures. Both reference `a` directly,
+	// which is safe — the AgentMode instance outlives the goroutine.
+	a.turnUIOnSubmit = func(line string) {
+		select {
+		case a.stdinLines <- line:
+		default:
+			a.cli.messageQueueMu.Lock()
+			a.cli.messageQueue = append(a.cli.messageQueue, line)
+			a.cli.messageQueueMu.Unlock()
+		}
+		select {
+		case a.turnUIInputReady <- struct{}{}:
+		default:
+		}
+	}
+	a.turnUIOnCancel = func() {
+		a.logger.Debug("turnui OnCancel: input cleared")
 	}
 
 	// Begin first; if it fails the user has not seen any UI yet so
 	// we silently fall back to the legacy reader.
 	if err := ui.BeginInteractive(env.Rows, env.Cols, env.StdinFD); err != nil {
 		a.logger.Warn("turnui BeginInteractive failed, falling back to legacy", zap.Error(err))
-		cancel()
 		a.stdinLines = nil
 		a.turnUIInputReady = nil
+		a.turnUIOnSubmit = nil
+		a.turnUIOnCancel = nil
 		a.startStdinReader()
 		return a.stopStdinReader
 	}
 
 	a.turnUI = ui
-	a.turnUICancel = cancel
 	a.turnUIActive = true
+	a.turnUIBaseCtx = ctx
+	a.turnUIEnvRows = env.Rows
+	a.turnUIEnvCols = env.Cols
+	a.turnUIEnvFD = env.StdinFD
+
+	a.spawnReadlineGoroutine()
+
+	return a.teardownInputAndUI
+}
+
+// spawnReadlineGoroutine wires a fresh readline loop onto the live
+// TurnUI. Called once from setupInputAndUI and again from each Resume
+// after a security prompt — the loop does not survive Suspend because
+// the underlying TTY drops out of raw mode (a.Stdin.Read in cooked
+// mode would consume bytes meant for the security prompt's reader).
+//
+// Idempotent within the lifecycle: if a previous goroutine is still
+// running its context is canceled first and the wait group drained
+// before the new one is spawned. The shared turnUIInputReady channel
+// is reused; nothing about Suspend/Resume changes the OnSubmit-to-
+// queue contract that the agent loop depends on.
+func (a *AgentMode) spawnReadlineGoroutine() {
+	if a.turnUICancel != nil {
+		a.turnUICancel()
+		a.turnUIWg.Wait()
+	}
+
+	loopCtx, cancel := context.WithCancel(a.turnUIBaseCtx)
+	a.turnUICancel = cancel
 
 	a.turnUIWg.Add(1)
 	go func() {
 		defer a.turnUIWg.Done()
-		// We re-use ui.RunReadLine equivalent via ui.Run, but
-		// Begin was already called above so we hand-roll the
-		// loop instead of letting Run call BeginInteractive a
-		// second time (which would error on "already active").
 		err := turnui.RunReadLine(loopCtx, turnui.ReadLineConfig{
 			Reader:   os.Stdin,
-			Painter:  ui.Painter(),
-			OnSubmit: cfg.OnSubmit,
-			OnCancel: cfg.OnCancel,
+			Painter:  a.turnUI.Painter(),
+			OnSubmit: a.turnUIOnSubmit,
+			OnCancel: a.turnUIOnCancel,
 		})
 		if err != nil && !errors.Is(err, context.Canceled) {
 			a.logger.Warn("turnui readline loop ended with error", zap.Error(err))
 		}
 	}()
+}
 
-	return a.teardownInputAndUI
+// suspendSplitUIIfActive pulls the agent out of the split UI so a
+// caller (e.g. coder.PromptSecurityCheckGuarded) can render a cooked-
+// mode dialog without fighting turnui for keystrokes. Returns a
+// restore function the caller MUST defer; calling it brings the
+// split UI back with the same status row content.
+//
+// No-op when turnUI is inactive (legacy mode or already suspended) —
+// the returned restore is a no-op closure in that case, so callers
+// don't need to branch.
+//
+// The sequence:
+//  1. Cancel + wait the current readline goroutine. The TTY is still
+//     in raw mode at this point; we MUST kill the goroutine before
+//     dropping raw mode or the security prompt's reader and our
+//     reader would race on the same stdin.
+//  2. Call TurnUI.Suspend: exits the scroll region and restores
+//     cooked mode. Cached status is preserved for Resume.
+//  3. Return the restore closure that runs Resume + re-spawn.
+func (a *AgentMode) suspendSplitUIIfActive() func() {
+	if !a.turnUIActive || a.turnUI == nil {
+		return func() {}
+	}
+
+	if a.turnUICancel != nil {
+		a.turnUICancel()
+		a.turnUICancel = nil
+	}
+	a.turnUIWg.Wait()
+
+	if err := a.turnUI.Suspend(); err != nil {
+		a.logger.Warn("turnui Suspend failed", zap.Error(err))
+		// On a failed Suspend the TurnUI is still inactive (the
+		// state flip is the first thing Suspend does). Skip the
+		// Resume in the restore closure — better to stay in
+		// cooked mode for the rest of the turn than to bring back
+		// a half-initialized split UI.
+		a.turnUIActive = false
+		return func() {}
+	}
+	a.turnUIActive = false
+
+	return func() {
+		// Re-query the size before Resume — the user might have
+		// resized the terminal during the cooked-mode dialog and
+		// the cached env dimensions would be stale.
+		w, h, err := term.GetSize(a.turnUIEnvFD)
+		if err == nil {
+			a.turnUIEnvRows = h
+			a.turnUIEnvCols = w
+		}
+		if err := a.turnUI.Resume(a.turnUIEnvRows, a.turnUIEnvCols, a.turnUIEnvFD); err != nil {
+			a.logger.Warn("turnui Resume failed, staying in legacy mode for rest of turn", zap.Error(err))
+			return
+		}
+		a.turnUIActive = true
+		a.spawnReadlineGoroutine()
+	}
 }
 
 // teardownInputAndUI is the cleanup paired with setupInputAndUI. Safe
@@ -2169,7 +2242,19 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 							break
 						}
 						if action == coder.ActionAsk {
+							// Suspend the split UI for the duration of
+							// the security prompt: it was written for
+							// cooked-mode line editing, and running it
+							// while turnui owns raw mode produces a
+							// mangled dialog (arrow keys leak as
+							// literal "^[[A" / "^[[B", border lines
+							// collapse into the status row). The
+							// helper is a no-op when turnui is not
+							// active, so the cost on the legacy path
+							// is one method call returning a closure.
+							restoreUI := a.suspendSplitUIIfActive()
 							decision := coder.PromptSecurityCheckGuarded(ctx, tc.Name, tc.Args, a.stdinLines)
+							restoreUI()
 							pattern := coder.GetSuggestedPattern(tc.Name, tc.Args)
 							switch decision {
 							case coder.DecisionAllowAlways:

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -290,6 +290,41 @@ func (a *AgentMode) stopStdinReader() {
 // split-UI path fall back to legacy automatically — the user gets
 // the old experience instead of a broken terminal.
 func (a *AgentMode) setupInputAndUI(ctx context.Context) func() {
+	// SPLIT UI DISABLED. The DECSTBM + raw-mode approach in
+	// cli/coder/turnui cannot coexist with the agent's existing
+	// rendering: card boxes (╭───╮│  │╰───╯), the security-prompt
+	// confirmation dialog, the multi-line agent dispatch progress
+	// — all of them assume full-screen scroll, write multi-row
+	// content with their own cursor positioning, and break when
+	// clamped inside a scroll region. Every emulator we tried
+	// (Hyper, Terminal.app, iTerm2, GoLand integrated) reproduced
+	// some flavor of "overlap + gap + status sumindo".
+	//
+	// Path forward: a true TUI rewrite (bubbletea, the migration
+	// branch tracked in docs/TUI_MIGRATION_PLAN.md) that owns the
+	// rendering loop end-to-end instead of injecting alt-screen
+	// + region under code that pre-dates it. Until that lands,
+	// every /coder session falls back to the legacy single-line
+	// renderer that has shipped since v1.0.
+	//
+	// The cli/coder/turnui package stays in the tree because the
+	// primitives (region, raw mode, key decoder, line buffer with
+	// cursor, history, alt-screen entry) are still useful inputs
+	// for the bubbletea port. They are buildable, race-clean, and
+	// fully unit-tested in isolation — just nothing in production
+	// calls Begin / Run today.
+	_ = ctx       // accepted for signature stability; unused in legacy path
+	_ = turnui.DetectEnvironment
+	a.startStdinReader()
+	return a.stopStdinReader
+}
+
+// setupInputAndUI_turnui_DISABLED was the activation gate for the
+// split UI. Kept as a separate (dead) function so the diff is small
+// when the bubbletea-based rewrite is ready to wire it back in.
+//
+//nolint:unused // intentionally retained for the future TUI port.
+func (a *AgentMode) setupInputAndUI_turnui_DISABLED(ctx context.Context) func() {
 	env := turnui.DetectEnvironment()
 	if !turnui.ShouldActivate(env) {
 		a.startStdinReader()

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -114,6 +114,14 @@ type AgentMode struct {
 	turnUIEnvCols  int
 	turnUIEnvFD    int
 
+	// turnUIHistory is the ↑/↓ navigation stack shared by every
+	// readline goroutine spawned across the lifetime of a single
+	// /coder run. Created once in setupInputAndUI and reused on
+	// Suspend/Resume (so a security prompt does not clear history)
+	// and across turn boundaries (so the user can ↑ to recall a
+	// follow-up they typed three turns ago).
+	turnUIHistory *turnui.History
+
 	// Skill hints captured at the start of Run() from auto-activated or
 	// manually invoked skills. Applied to each LLM turn via ctx for the
 	// duration of the agent loop. Cleared when the loop exits.
@@ -335,6 +343,7 @@ func (a *AgentMode) setupInputAndUI(ctx context.Context) func() {
 	a.turnUIEnvRows = env.Rows
 	a.turnUIEnvCols = env.Cols
 	a.turnUIEnvFD = env.StdinFD
+	a.turnUIHistory = turnui.NewHistory(turnui.DefaultHistoryCap)
 
 	a.spawnReadlineGoroutine()
 
@@ -369,6 +378,7 @@ func (a *AgentMode) spawnReadlineGoroutine() {
 			Painter:  a.turnUI.Painter(),
 			OnSubmit: a.turnUIOnSubmit,
 			OnCancel: a.turnUIOnCancel,
+			History:  a.turnUIHistory,
 		})
 		if err != nil && !errors.Is(err, context.Canceled) {
 			a.logger.Warn("turnui readline loop ended with error", zap.Error(err))

--- a/cli/agent_mode_sigwinch_unix.go
+++ b/cli/agent_mode_sigwinch_unix.go
@@ -1,0 +1,102 @@
+//go:build !windows
+
+/*
+ * ChatCLI - Agent-mode SIGWINCH (terminal resize) handler
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+package cli
+
+import (
+	"context"
+	"os"
+	"os/signal"
+
+	"golang.org/x/sys/unix"
+	"golang.org/x/term"
+
+	"github.com/diillson/chatcli/cli/coder/turnui"
+	"go.uber.org/zap"
+)
+
+// installResizeHandler subscribes to SIGWINCH so the split UI can
+// recompute its layout when the user drags the terminal window. The
+// handler runs in its own goroutine, parked on a buffered channel; it
+// exits when ctx is canceled (the agent loop's defer fires) or when
+// the OS closes the signal channel.
+//
+// No-op when turnUI is nil or the env does not have a TTY — the
+// legacy renderer does not care about resize because \r-based redraw
+// always lands on the cursor's current row regardless of size.
+//
+// SIGWINCH is Unix-only. The windows variant of this file (next door)
+// is a stub: Windows console resize fires a different mechanism that
+// turnui currently does not implement; the user gets the legacy
+// fallback if turnui is active and they resize, which is acceptable
+// because the layout invalidates one frame and recovers on the next
+// status redraw — visible glitch, not a crash.
+func (a *AgentMode) installResizeHandler(ctx context.Context) func() {
+	if a.turnUI == nil {
+		return func() {}
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, unix.SIGWINCH)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case _, ok := <-sigCh:
+				if !ok {
+					return
+				}
+				a.onTerminalResize()
+			}
+		}
+	}()
+
+	return func() {
+		signal.Stop(sigCh)
+		close(sigCh)
+		<-done
+	}
+}
+
+// onTerminalResize is the body of the SIGWINCH handler. Extracted so
+// tests can drive it directly without sending a real signal — they
+// can call a.onTerminalResize() after swapping in a TurnUI bound to
+// a buffer + a controlled "current size".
+//
+// On a size that is now too small for the split UI we tear down to
+// the legacy renderer instead of leaving the user staring at an
+// overlapping layout. A future enhancement could re-activate when
+// the user resizes back up, but that requires re-running setup which
+// is intrusive enough to be its own commit.
+func (a *AgentMode) onTerminalResize() {
+	if a.turnUI == nil {
+		return
+	}
+	w, h, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil {
+		a.logger.Debug("SIGWINCH: term.GetSize failed", zap.Error(err))
+		return
+	}
+	if w < turnui.MinColsRequired || h < turnui.MinRowsRequired {
+		// New size is below the floor: log and let the next paint
+		// tick attempt land on a still-too-small layout — the
+		// turnui.Resize call below will reject it and we keep the
+		// previous layout, which at worst looks slightly off until
+		// the user resizes back up.
+		a.logger.Info("SIGWINCH: new size below split-UI minimum, keeping previous layout",
+			zap.Int("rows", h), zap.Int("cols", w))
+		return
+	}
+	if err := a.turnUI.Resize(h, w); err != nil {
+		a.logger.Debug("SIGWINCH: turnui.Resize failed", zap.Error(err))
+	}
+}

--- a/cli/agent_mode_sigwinch_windows.go
+++ b/cli/agent_mode_sigwinch_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+/*
+ * ChatCLI - Agent-mode resize handler (Windows stub)
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+package cli
+
+import "context"
+
+// installResizeHandler is a no-op on Windows. SIGWINCH does not exist;
+// the Windows console emits a different resize event mechanism that
+// turnui does not currently subscribe to. The user can resize without
+// crashing — the split layout will look slightly off until the next
+// status tick redraws — but we do not actively re-layout. A follow-up
+// could poll GetConsoleScreenBufferInfo from the readline goroutine
+// to detect resize, but that is out of scope for the initial split-
+// UI port.
+func (a *AgentMode) installResizeHandler(_ context.Context) func() {
+	return func() {}
+}

--- a/cli/agent_mode_sigwinch_windows.go
+++ b/cli/agent_mode_sigwinch_windows.go
@@ -1,23 +1,100 @@
 //go:build windows
 
 /*
- * ChatCLI - Agent-mode resize handler (Windows stub)
+ * ChatCLI - Agent-mode resize handler (Windows polling)
  * Copyright (c) 2024 Edilson Freitas
  * License: Apache-2.0
  */
 
 package cli
 
-import "context"
+import (
+	"context"
+	"os"
+	"time"
 
-// installResizeHandler is a no-op on Windows. SIGWINCH does not exist;
-// the Windows console emits a different resize event mechanism that
-// turnui does not currently subscribe to. The user can resize without
-// crashing — the split layout will look slightly off until the next
-// status tick redraws — but we do not actively re-layout. A follow-up
-// could poll GetConsoleScreenBufferInfo from the readline goroutine
-// to detect resize, but that is out of scope for the initial split-
-// UI port.
-func (a *AgentMode) installResizeHandler(_ context.Context) func() {
-	return func() {}
+	"go.uber.org/zap"
+	"golang.org/x/term"
+
+	"github.com/diillson/chatcli/cli/coder/turnui"
+)
+
+// windowsResizePollInterval is the cadence at which we re-query the
+// console size. 500ms is a balance — too low burns CPU on a process
+// that may run for hours; too high makes the split UI feel sluggish
+// to recover from a resize. The user usually pauses a beat after
+// dragging the terminal corner, so anything below 1s feels live.
+const windowsResizePollInterval = 500 * time.Millisecond
+
+// installResizeHandler subscribes to terminal resize on Windows by
+// polling GetConsoleScreenBufferInfo (via golang.org/x/term.GetSize)
+// at a fixed cadence. Windows has no SIGWINCH equivalent in user-
+// mode Go without subscribing to console input events, which would
+// conflict with the raw-mode stdin reader the split UI already owns.
+// Polling is the conservative choice: it requires no new event-loop
+// integration and gracefully no-ops when the size has not changed.
+//
+// The handler runs in its own goroutine, exits when ctx is canceled
+// (the agent loop's defer fires), and is a no-op when turnUI is nil
+// (legacy renderer doesn't care about resize because \r-based redraw
+// always lands on the cursor's current row regardless of size).
+func (a *AgentMode) installResizeHandler(ctx context.Context) func() {
+	if a.turnUI == nil {
+		return func() {}
+	}
+
+	lastRows, lastCols, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil {
+		// If we cannot even query the initial size, polling is
+		// pointless — leave the handler off and let the user
+		// see a slightly off layout if they resize. The split
+		// UI on a non-queryable console is rare enough that
+		// this is acceptable.
+		a.logger.Debug("Windows resize poll: initial GetSize failed, skipping handler", zap.Error(err))
+		return func() {}
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(windowsResizePollInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				rows, cols, err := term.GetSize(int(os.Stdout.Fd()))
+				if err != nil {
+					continue
+				}
+				if rows == lastRows && cols == lastCols {
+					continue
+				}
+				lastRows, lastCols = rows, cols
+				a.onWindowsResize(rows, cols)
+			}
+		}
+	}()
+
+	return func() { <-done }
+}
+
+// onWindowsResize is the body of the resize callback, extracted so
+// the polling loop stays focused on cadence and detection while the
+// actual size-change handling lives in a testable function. Same
+// contract as the Unix onTerminalResize counterpart: degrade
+// gracefully on a size that is now below the split UI minimum.
+func (a *AgentMode) onWindowsResize(rows, cols int) {
+	if a.turnUI == nil {
+		return
+	}
+	if cols < turnui.MinColsRequired || rows < turnui.MinRowsRequired {
+		a.logger.Info("Windows resize: new size below split-UI minimum, keeping previous layout",
+			zap.Int("rows", rows), zap.Int("cols", cols))
+		return
+	}
+	if err := a.turnUI.Resize(rows, cols); err != nil {
+		a.logger.Debug("Windows resize: turnui.Resize failed", zap.Error(err))
+	}
 }

--- a/cli/coder/turnui/fallback.go
+++ b/cli/coder/turnui/fallback.go
@@ -78,11 +78,16 @@ type Environment struct {
 	// even when off, so we honor that signal as a fallback hint.
 	NoColor bool
 
-	// ForceDisabled lets the user pin the legacy renderer via the
-	// CHATCLI_TURNUI=off escape hatch, regardless of every other
-	// signal. The opposite ("force on") is intentionally NOT
-	// supported — if the environment says "no", we trust it.
-	ForceDisabled bool
+	// OptIn is the user's explicit "yes, please use the split UI"
+	// vote — set when CHATCLI_TURNUI=on. The split renderer is
+	// opt-in (not auto-detect) because terminals vary widely in
+	// how they honor DECSTBM + cursor save/restore; bad behavior
+	// in a non-cooperative emulator looks like cascading spinner
+	// lines and is far worse than the legacy renderer it would
+	// replace. Off-by-default is conservative — opt-in here, not
+	// opt-out, is intentional after a real-world cascading-spinner
+	// bug surfaced on a popular IDE-integrated terminal.
+	OptIn bool
 }
 
 // DetectEnvironment snapshots the live process state into an
@@ -91,13 +96,13 @@ type Environment struct {
 // state once and rely on SIGWINCH-driven re-evaluation for resize.
 func DetectEnvironment() Environment {
 	env := Environment{
-		StdinFD:       int(os.Stdin.Fd()), // #nosec G115 -- Fd() is uintptr; values fit int on every supported platform.
-		IsStdinTTY:    term.IsTerminal(int(os.Stdin.Fd())),
-		IsStdoutTTY:   term.IsTerminal(int(os.Stdout.Fd())),
-		GOOS:          runtime.GOOS,
-		TermType:      os.Getenv("TERM"),
-		NoColor:       os.Getenv("NO_COLOR") != "",
-		ForceDisabled: os.Getenv("CHATCLI_TURNUI") == "off",
+		StdinFD:     int(os.Stdin.Fd()), // #nosec G115 -- Fd() is uintptr; values fit int on every supported platform.
+		IsStdinTTY:  term.IsTerminal(int(os.Stdin.Fd())),
+		IsStdoutTTY: term.IsTerminal(int(os.Stdout.Fd())),
+		GOOS:        runtime.GOOS,
+		TermType:    os.Getenv("TERM"),
+		NoColor:     os.Getenv("NO_COLOR") != "",
+		OptIn:       os.Getenv("CHATCLI_TURNUI") == "on",
 	}
 	if env.IsStdoutTTY {
 		if w, h, err := term.GetSize(int(os.Stdout.Fd())); err == nil {
@@ -109,19 +114,25 @@ func DetectEnvironment() Environment {
 }
 
 // ShouldActivate returns true when every prerequisite for the split UI
-// is satisfied and the legacy fallback should be skipped. The function
-// is pure: same Environment in, same answer out — so the agent loop
-// can call it once at Begin and trust the result for the turn (modulo
-// SIGWINCH-triggered re-evaluation).
+// is satisfied AND the user has explicitly opted in via
+// CHATCLI_TURNUI=on. The function is pure: same Environment in, same
+// answer out — so the agent loop can call it once at Begin and trust
+// the result for the turn (modulo SIGWINCH-triggered re-evaluation).
 //
-// The order of checks mirrors blast radius. ForceDisabled is first
-// because it's the user's explicit veto; non-TTY is second because
-// drawing escape codes into a non-terminal corrupts logs; dumb-TERM is
-// third because it's the loudest "I don't speak ANSI" signal; size is
-// last because it's the most likely transient failure (a small split
-// pane that the user might resize).
+// The opt-in gate is first: even on a perfectly-suitable terminal,
+// the split renderer stays disabled until the user asks for it. This
+// is a deliberate conservatism — DECSTBM + cursor save/restore behave
+// inconsistently across emulators (a popular IDE-integrated terminal
+// produced a cascading-spinner failure mode) and the legacy renderer
+// is the safer default. Once the user knows their terminal cooperates
+// they can flip the env var per session.
+//
+// The remaining gates are tripwires for known-bad shapes: non-TTY
+// would corrupt logs with escape sequences, dumb-TERM cannot honor
+// the cursor commands, and an undersized terminal would render the
+// split layout overlapping.
 func ShouldActivate(env Environment) bool {
-	if env.ForceDisabled {
+	if !env.OptIn {
 		return false
 	}
 	if !env.IsStdinTTY || !env.IsStdoutTTY {

--- a/cli/coder/turnui/fallback.go
+++ b/cli/coder/turnui/fallback.go
@@ -1,0 +1,151 @@
+/*
+ * ChatCLI - Coder turn-UI fallback detection
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+// Package turnui implements the split-pane terminal UI used by the
+// coder/agent loop: the agent's output scrolls in the upper region,
+// a status row carries the live spinner, and an always-typable input
+// row sits at the bottom. The UI is built on three primitives —
+// DECSTBM scroll region for the content/status split, TTY raw mode for
+// keystroke ownership, and a mini line-editor for the input row.
+//
+// Activation is conservative: anything that could leave the user with
+// a wedged terminal (non-TTY stdin, undersized terminal, the legacy
+// Windows console without ANSI support) routes through ShouldActivate
+// returning false, and the agent loop falls back to its previous
+// single-line spinner. The package never panics on a hostile terminal —
+// failure modes are always "don't activate", never "activate broken".
+package turnui
+
+import (
+	"os"
+	"runtime"
+
+	"golang.org/x/term"
+)
+
+// MinRowsRequired is the smallest terminal height that can host the
+// split UI: 1 for status + 1 for input + a working content area. We
+// pick 10 (not 3) so the user actually has room to see scrolling
+// output; below this the legacy renderer is friendlier. The check is
+// re-evaluated on SIGWINCH so a user who resizes back up recovers.
+const MinRowsRequired = 10
+
+// MinColsRequired keeps the status line from wrapping its model name
+// + duration + queue indicator. 40 cols fits "[gpt-4] [12s] (3 queued)"
+// with the spinner and a few dots; thinner terminals look mangled.
+const MinColsRequired = 40
+
+// Environment captures the inputs ShouldActivate evaluates. Carrying
+// them as a struct lets tests stub the entire environment without
+// touching globals, and makes the rule set explicit for code review:
+// every "no" branch in ShouldActivate maps to one Environment field.
+type Environment struct {
+	// StdinFD is the file descriptor of stdin. -1 means "not a TTY"
+	// (piped input, CI), which forces fallback regardless of size.
+	StdinFD int
+
+	// IsStdinTTY mirrors term.IsTerminal(StdinFD). We carry it
+	// separately so tests can simulate a piped stdin without
+	// changing os.Stdin.
+	IsStdinTTY bool
+
+	// IsStdoutTTY is required because the status row and input row
+	// are both written to stdout — if stdout is redirected (the
+	// user is piping the agent's output into a file), drawing the
+	// UI would mangle the file.
+	IsStdoutTTY bool
+
+	// Rows / Cols are the terminal dimensions in cells, normally
+	// read from term.GetSize. Zero means "unknown" and is treated
+	// as too small.
+	Rows int
+	Cols int
+
+	// GOOS allows the Windows-specific fallback to be tested on
+	// any platform.
+	GOOS string
+
+	// TermType is the value of $TERM. The dumb terminal ("dumb"
+	// from Emacs M-x shell, "unknown" from some CI runners) does
+	// not honor cursor positioning sequences, so we fall back.
+	TermType string
+
+	// NoColor mirrors the NO_COLOR env var. A user with NO_COLOR
+	// set expects plain output; the split UI prints color codes
+	// even when off, so we honor that signal as a fallback hint.
+	NoColor bool
+
+	// ForceDisabled lets the user pin the legacy renderer via the
+	// CHATCLI_TURNUI=off escape hatch, regardless of every other
+	// signal. The opposite ("force on") is intentionally NOT
+	// supported — if the environment says "no", we trust it.
+	ForceDisabled bool
+}
+
+// DetectEnvironment snapshots the live process state into an
+// Environment. The snapshot is intentional: ShouldActivate is meant
+// to be cheap and deterministic per call site, so callers freeze the
+// state once and rely on SIGWINCH-driven re-evaluation for resize.
+func DetectEnvironment() Environment {
+	env := Environment{
+		StdinFD:       int(os.Stdin.Fd()), // #nosec G115 -- Fd() is uintptr; values fit int on every supported platform.
+		IsStdinTTY:    term.IsTerminal(int(os.Stdin.Fd())),
+		IsStdoutTTY:   term.IsTerminal(int(os.Stdout.Fd())),
+		GOOS:          runtime.GOOS,
+		TermType:      os.Getenv("TERM"),
+		NoColor:       os.Getenv("NO_COLOR") != "",
+		ForceDisabled: os.Getenv("CHATCLI_TURNUI") == "off",
+	}
+	if env.IsStdoutTTY {
+		if w, h, err := term.GetSize(int(os.Stdout.Fd())); err == nil {
+			env.Cols = w
+			env.Rows = h
+		}
+	}
+	return env
+}
+
+// ShouldActivate returns true when every prerequisite for the split UI
+// is satisfied and the legacy fallback should be skipped. The function
+// is pure: same Environment in, same answer out — so the agent loop
+// can call it once at Begin and trust the result for the turn (modulo
+// SIGWINCH-triggered re-evaluation).
+//
+// The order of checks mirrors blast radius. ForceDisabled is first
+// because it's the user's explicit veto; non-TTY is second because
+// drawing escape codes into a non-terminal corrupts logs; dumb-TERM is
+// third because it's the loudest "I don't speak ANSI" signal; size is
+// last because it's the most likely transient failure (a small split
+// pane that the user might resize).
+func ShouldActivate(env Environment) bool {
+	if env.ForceDisabled {
+		return false
+	}
+	if !env.IsStdinTTY || !env.IsStdoutTTY {
+		return false
+	}
+	if env.TermType == "dumb" || env.TermType == "" {
+		return false
+	}
+	if env.GOOS == "windows" && !windowsAnsiAvailable() {
+		return false
+	}
+	if env.Rows < MinRowsRequired || env.Cols < MinColsRequired {
+		return false
+	}
+	return true
+}
+
+// windowsAnsiAvailable is a stub on non-Windows; the real check lives
+// in fallback_windows.go and probes Console virtual-terminal mode.
+// The split UI only activates on Windows 10+ consoles where ANSI is
+// enabled — the legacy cmd.exe / older PowerShell hosts fall through.
+func windowsAnsiAvailable() bool {
+	if runtime.GOOS != "windows" {
+		return true
+	}
+	return windowsAnsiAvailableImpl()
+}

--- a/cli/coder/turnui/fallback_test.go
+++ b/cli/coder/turnui/fallback_test.go
@@ -1,0 +1,96 @@
+/*
+ * ChatCLI - Coder turn-UI fallback tests
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+package turnui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestShouldActivate_Truthy enumerates the environment shapes that
+// are expected to enable the split UI. Each "true" answer here is a
+// promise to the user: when these conditions hold, /coder uses the
+// split layout. Regressing any of them flags as a test failure.
+func TestShouldActivate_Truthy(t *testing.T) {
+	env := Environment{
+		StdinFD:     0,
+		IsStdinTTY:  true,
+		IsStdoutTTY: true,
+		Rows:        40,
+		Cols:        120,
+		GOOS:        "linux",
+		TermType:    "xterm-256color",
+	}
+	assert.True(t, ShouldActivate(env))
+}
+
+// TestShouldActivate_Veto walks every fallback branch and confirms
+// it returns false. Each subtest names the exact "no" reason so a
+// future bug report ("/coder isn't using the split UI") can be
+// quickly mapped to which signal pushed the user into fallback.
+func TestShouldActivate_Veto(t *testing.T) {
+	base := Environment{
+		StdinFD:     0,
+		IsStdinTTY:  true,
+		IsStdoutTTY: true,
+		Rows:        40,
+		Cols:        120,
+		GOOS:        "linux",
+		TermType:    "xterm-256color",
+	}
+
+	tests := []struct {
+		name string
+		mut  func(*Environment)
+	}{
+		{"CHATCLI_TURNUI=off pinned", func(e *Environment) { e.ForceDisabled = true }},
+		{"stdin is a pipe", func(e *Environment) { e.IsStdinTTY = false }},
+		{"stdout is redirected", func(e *Environment) { e.IsStdoutTTY = false }},
+		{"TERM=dumb (Emacs M-x shell)", func(e *Environment) { e.TermType = "dumb" }},
+		{"empty TERM (some CI runners)", func(e *Environment) { e.TermType = "" }},
+		{"terminal too short", func(e *Environment) { e.Rows = MinRowsRequired - 1 }},
+		{"terminal too narrow", func(e *Environment) { e.Cols = MinColsRequired - 1 }},
+		{"zero size", func(e *Environment) { e.Rows = 0; e.Cols = 0 }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := base
+			tc.mut(&env)
+			assert.False(t, ShouldActivate(env), "expected fallback for: %s", tc.name)
+		})
+	}
+}
+
+// TestShouldActivate_ForceDisabledBeatsEverything makes the escape
+// hatch explicit. A user who sets CHATCLI_TURNUI=off has decided the
+// split UI is broken on their setup; we honor that no matter how good
+// every other signal looks.
+func TestShouldActivate_ForceDisabledBeatsEverything(t *testing.T) {
+	env := Environment{
+		IsStdinTTY:    true,
+		IsStdoutTTY:   true,
+		Rows:          200,
+		Cols:          400,
+		GOOS:          "linux",
+		TermType:      "xterm-256color",
+		ForceDisabled: true,
+	}
+	assert.False(t, ShouldActivate(env))
+}
+
+// TestMinSizes_AreConservative is a tripwire: if a future change tries
+// to push the minimum size down for "we can fit a smaller UI" reasons,
+// this test fails and forces a code review of the UX consequences.
+// The thresholds are deliberately generous because below them the split
+// looks cramped and is worse than the legacy fallback.
+func TestMinSizes_AreConservative(t *testing.T) {
+	assert.GreaterOrEqual(t, MinRowsRequired, 10,
+		"too small: status + input + 1 content row would be unusable")
+	assert.GreaterOrEqual(t, MinColsRequired, 40,
+		"too narrow: the status line would wrap and break the layout")
+}

--- a/cli/coder/turnui/fallback_test.go
+++ b/cli/coder/turnui/fallback_test.go
@@ -14,8 +14,9 @@ import (
 
 // TestShouldActivate_Truthy enumerates the environment shapes that
 // are expected to enable the split UI. Each "true" answer here is a
-// promise to the user: when these conditions hold, /coder uses the
-// split layout. Regressing any of them flags as a test failure.
+// promise to the user: when these conditions hold AND they have
+// opted in, /coder uses the split layout. Regressing any of them
+// flags as a test failure.
 func TestShouldActivate_Truthy(t *testing.T) {
 	env := Environment{
 		StdinFD:     0,
@@ -25,8 +26,27 @@ func TestShouldActivate_Truthy(t *testing.T) {
 		Cols:        120,
 		GOOS:        "linux",
 		TermType:    "xterm-256color",
+		OptIn:       true,
 	}
 	assert.True(t, ShouldActivate(env))
+}
+
+// TestShouldActivate_DefaultOff is the post-cascading-spinner-bug
+// invariant: with everything else looking perfect, a user who has
+// NOT set CHATCLI_TURNUI=on still gets the legacy renderer. The
+// split UI is opt-in until terminal cooperation is proven per host.
+func TestShouldActivate_DefaultOff(t *testing.T) {
+	env := Environment{
+		IsStdinTTY:  true,
+		IsStdoutTTY: true,
+		Rows:        40,
+		Cols:        120,
+		GOOS:        "linux",
+		TermType:    "xterm-256color",
+		// OptIn: false (zero value)
+	}
+	assert.False(t, ShouldActivate(env),
+		"opt-in gate must veto every activation when CHATCLI_TURNUI is not 'on'")
 }
 
 // TestShouldActivate_Veto walks every fallback branch and confirms
@@ -42,13 +62,14 @@ func TestShouldActivate_Veto(t *testing.T) {
 		Cols:        120,
 		GOOS:        "linux",
 		TermType:    "xterm-256color",
+		OptIn:       true,
 	}
 
 	tests := []struct {
 		name string
 		mut  func(*Environment)
 	}{
-		{"CHATCLI_TURNUI=off pinned", func(e *Environment) { e.ForceDisabled = true }},
+		{"CHATCLI_TURNUI unset", func(e *Environment) { e.OptIn = false }},
 		{"stdin is a pipe", func(e *Environment) { e.IsStdinTTY = false }},
 		{"stdout is redirected", func(e *Environment) { e.IsStdoutTTY = false }},
 		{"TERM=dumb (Emacs M-x shell)", func(e *Environment) { e.TermType = "dumb" }},
@@ -66,21 +87,22 @@ func TestShouldActivate_Veto(t *testing.T) {
 	}
 }
 
-// TestShouldActivate_ForceDisabledBeatsEverything makes the escape
-// hatch explicit. A user who sets CHATCLI_TURNUI=off has decided the
-// split UI is broken on their setup; we honor that no matter how good
-// every other signal looks.
-func TestShouldActivate_ForceDisabledBeatsEverything(t *testing.T) {
+// TestShouldActivate_OptInRespectsOtherGates ensures that even an
+// explicit CHATCLI_TURNUI=on cannot override a non-TTY or dumb-TERM
+// veto. The opt-in is "I want it IF possible", not "force it even
+// when broken".
+func TestShouldActivate_OptInRespectsOtherGates(t *testing.T) {
 	env := Environment{
-		IsStdinTTY:    true,
-		IsStdoutTTY:   true,
-		Rows:          200,
-		Cols:          400,
-		GOOS:          "linux",
-		TermType:      "xterm-256color",
-		ForceDisabled: true,
+		IsStdinTTY:  false, // pipe — fatal regardless of OptIn
+		IsStdoutTTY: true,
+		Rows:        40,
+		Cols:        120,
+		GOOS:        "linux",
+		TermType:    "xterm-256color",
+		OptIn:       true,
 	}
-	assert.False(t, ShouldActivate(env))
+	assert.False(t, ShouldActivate(env),
+		"OptIn cannot override the non-TTY gate — escape sequences would corrupt the pipe")
 }
 
 // TestMinSizes_AreConservative is a tripwire: if a future change tries

--- a/cli/coder/turnui/fallback_unix.go
+++ b/cli/coder/turnui/fallback_unix.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+/*
+ * ChatCLI - Coder turn-UI Unix fallback shim
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+package turnui
+
+// windowsAnsiAvailableImpl is a no-op on Unix: every TTY on Linux,
+// macOS, *BSD honors the VT100 sequences the split UI relies on, so
+// the Windows-specific probe is replaced with an always-true stub.
+// The build tag keeps the real probe out of non-Windows binaries.
+func windowsAnsiAvailableImpl() bool { return true }

--- a/cli/coder/turnui/fallback_windows.go
+++ b/cli/coder/turnui/fallback_windows.go
@@ -1,0 +1,36 @@
+//go:build windows
+
+/*
+ * ChatCLI - Coder turn-UI Windows ANSI probe
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+package turnui
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+// windowsAnsiAvailableImpl probes whether the stdout console handle
+// has virtual-terminal processing enabled, which is the minimum
+// requirement for the cursor positioning and DECSTBM sequences the
+// split UI emits. Win10 1607+ supports the mode but it is opt-in per
+// console — older consoles (cmd.exe on Win7/8) and some terminal
+// emulators that proxy stdout through pipes will return false.
+//
+// On any GetStdHandle / GetConsoleMode failure we conservatively return
+// false: drawing escape codes into a console that prints them as
+// literals would leave the user with a wedged terminal full of "[?1049h"
+// soup.
+func windowsAnsiAvailableImpl() bool {
+	h, err := windows.GetStdHandle(windows.STD_OUTPUT_HANDLE)
+	if err != nil {
+		return false
+	}
+	var mode uint32
+	if err := windows.GetConsoleMode(h, &mode); err != nil {
+		return false
+	}
+	return mode&windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING != 0
+}

--- a/cli/coder/turnui/history.go
+++ b/cli/coder/turnui/history.go
@@ -1,0 +1,150 @@
+/*
+ * ChatCLI - Coder turn-UI input history
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+package turnui
+
+import "sync"
+
+// DefaultHistoryCap is the maximum number of submitted lines the
+// history keeps. 100 is enough for a typical /coder session — when
+// the user is iterating on a refactor they tend to revisit the last
+// 5-10 prompts; older entries fade out by FIFO eviction. The cap
+// also bounds the memory footprint of a long-running agent.
+const DefaultHistoryCap = 100
+
+// History is the ↑/↓ stack the mini-readline navigates. It is
+// session-scoped: every /coder turn appends submissions, and ↑ walks
+// backwards from the most recent. The implementation is a plain
+// FIFO slice — performance is fine at the documented cap, and the
+// data structure being trivial means the test surface is small.
+//
+// Goroutine safety: the readline loop is the only writer (via
+// Append) and the only reader (via Up / Down / Reset). All three
+// run on the same goroutine, so the mutex is defensive — it costs
+// nothing in the happy path and prevents a data race if a future
+// caller decides to share History across loops.
+type History struct {
+	mu       sync.Mutex
+	entries  []string
+	cap      int
+	cursor   int    // -1 means "not navigating"; otherwise index into entries
+	original string // buffer text when navigation started, restored on Reset
+}
+
+// NewHistory constructs a history bounded at the given capacity.
+// A non-positive cap falls back to DefaultHistoryCap so callers that
+// forget to set one don't get an unbounded buffer.
+func NewHistory(cap int) *History {
+	if cap <= 0 {
+		cap = DefaultHistoryCap
+	}
+	return &History{cap: cap, cursor: -1}
+}
+
+// Append records a submitted line and resets the navigation cursor.
+// Empty / whitespace-only lines and exact duplicates of the most
+// recent entry are skipped — same behavior as bash's HISTCONTROL
+// ignoreboth, which matches what users expect from a shell-style
+// history.
+//
+// When the buffer is at capacity, the oldest entry is dropped to
+// make room. The slice is shifted in place; at the documented cap
+// of 100 this is irrelevant for performance.
+func (h *History) Append(line string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if line == "" {
+		return
+	}
+	if n := len(h.entries); n > 0 && h.entries[n-1] == line {
+		// Skip exact duplicate of the most recent entry. Users
+		// who repeat themselves intentionally still get the entry
+		// once; ↑ recalls it as the latest.
+		h.cursor = -1
+		return
+	}
+	if len(h.entries) >= h.cap {
+		copy(h.entries, h.entries[1:])
+		h.entries[len(h.entries)-1] = line
+	} else {
+		h.entries = append(h.entries, line)
+	}
+	h.cursor = -1
+}
+
+// Up navigates to the previous entry and returns it. The first Up
+// after a fresh prompt captures `current` so Down can restore it
+// when the user navigates back past the most recent entry.
+//
+// Returns ("", false) when there is no entry to surface (empty
+// history, or already at the oldest). The boolean lets the caller
+// distinguish "no movement" from "moved to an empty entry" — the
+// latter is impossible by Append's contract, but explicit is
+// better than implicit.
+func (h *History) Up(current string) (string, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if len(h.entries) == 0 {
+		return "", false
+	}
+	if h.cursor == -1 {
+		// Start navigating: stash the current buffer so Down can
+		// restore it later.
+		h.original = current
+		h.cursor = len(h.entries) - 1
+		return h.entries[h.cursor], true
+	}
+	if h.cursor == 0 {
+		// Already at the oldest entry.
+		return "", false
+	}
+	h.cursor--
+	return h.entries[h.cursor], true
+}
+
+// Down navigates forward through the history. If the cursor is at
+// the most-recent entry, Down restores the original buffer the
+// user was typing when navigation began and resets the cursor.
+// Returns ("", false) when not navigating.
+func (h *History) Down() (string, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.cursor == -1 {
+		return "", false
+	}
+	if h.cursor >= len(h.entries)-1 {
+		// At the newest entry: stepping forward restores the
+		// original buffer the user was typing.
+		h.cursor = -1
+		original := h.original
+		h.original = ""
+		return original, true
+	}
+	h.cursor++
+	return h.entries[h.cursor], true
+}
+
+// Reset clears the navigation state without affecting stored
+// entries. Used by the readline loop after a submission so the
+// next ↑ starts from the newest entry again, not from wherever
+// the previous navigation left off.
+func (h *History) Reset() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.cursor = -1
+	h.original = ""
+}
+
+// Len returns the number of stored entries. Cheap; useful for
+// tests and (eventually) a status indicator like "↑ 3/100".
+func (h *History) Len() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.entries)
+}

--- a/cli/coder/turnui/history_test.go
+++ b/cli/coder/turnui/history_test.go
@@ -1,0 +1,167 @@
+/*
+ * ChatCLI - Coder turn-UI history tests
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+package turnui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestHistory_AppendUpDownRoundtrip is the canonical happy path:
+// submit three lines, ↑↑↑ to the oldest, ↓↓↓ back to the original
+// buffer. Without this contract every history navigation would
+// leave the user wondering whether the buffer was their typing or
+// a recalled entry.
+func TestHistory_AppendUpDownRoundtrip(t *testing.T) {
+	h := NewHistory(10)
+	h.Append("first")
+	h.Append("second")
+	h.Append("third")
+
+	// First ↑ surfaces the newest entry.
+	got, ok := h.Up("draft")
+	assert.True(t, ok)
+	assert.Equal(t, "third", got)
+
+	// Second ↑ surfaces the middle.
+	got, ok = h.Up("ignored on subsequent Up")
+	assert.True(t, ok)
+	assert.Equal(t, "second", got)
+
+	// Third ↑ surfaces the oldest.
+	got, ok = h.Up("ignored")
+	assert.True(t, ok)
+	assert.Equal(t, "first", got)
+
+	// Fourth ↑ has nothing to surface — stays at the oldest.
+	_, ok = h.Up("ignored")
+	assert.False(t, ok)
+
+	// ↓ walks back forward.
+	got, ok = h.Down()
+	assert.True(t, ok)
+	assert.Equal(t, "second", got)
+
+	got, ok = h.Down()
+	assert.True(t, ok)
+	assert.Equal(t, "third", got)
+
+	// One more ↓ restores the original buffer ("draft" captured
+	// when navigation began).
+	got, ok = h.Down()
+	assert.True(t, ok)
+	assert.Equal(t, "draft", got)
+
+	// Further ↓ returns false — not navigating anymore.
+	_, ok = h.Down()
+	assert.False(t, ok)
+}
+
+// TestHistory_SkipsDuplicates matches bash HISTCONTROL=ignoreboth:
+// pressing Enter on the same line twice produces only one entry.
+// Without this the user's ↑ would have to scroll past N copies of
+// the last command they spammed.
+func TestHistory_SkipsDuplicates(t *testing.T) {
+	h := NewHistory(10)
+	h.Append("same")
+	h.Append("same")
+	h.Append("same")
+	assert.Equal(t, 1, h.Len(), "duplicate consecutive lines collapse")
+
+	h.Append("different")
+	h.Append("same")
+	assert.Equal(t, 3, h.Len(), "duplicate only collapses when it's the immediately preceding entry")
+}
+
+// TestHistory_SkipsEmpty rejects empty / whitespace-only submissions.
+// The agent loop already filters these before submitting, but the
+// history is the second line of defense: if a future caller bypasses
+// the filter, we don't want a phantom blank entry in the stack.
+func TestHistory_SkipsEmpty(t *testing.T) {
+	h := NewHistory(10)
+	h.Append("")
+	assert.Equal(t, 0, h.Len())
+}
+
+// TestHistory_EvictsAtCap is the FIFO contract under cap pressure.
+// Submit cap+5 lines, assert the oldest 5 are gone and the newest 10
+// survive. Catches an off-by-one in the eviction loop or a missing
+// cap check.
+func TestHistory_EvictsAtCap(t *testing.T) {
+	h := NewHistory(5)
+	for _, s := range []string{"a", "b", "c", "d", "e", "f", "g"} {
+		h.Append(s)
+	}
+	assert.Equal(t, 5, h.Len())
+
+	// Walk all the way back: should see g, f, e, d, c (not b or a).
+	want := []string{"g", "f", "e", "d", "c"}
+	for i, expected := range want {
+		got, ok := h.Up("draft")
+		assert.True(t, ok, "step %d", i)
+		assert.Equal(t, expected, got, "step %d", i)
+	}
+	_, ok := h.Up("draft")
+	assert.False(t, ok, "no entries past the cap survive")
+}
+
+// TestHistory_AppendResetsNavigation guards against a subtle bug:
+// the user navigates back to "old", then submits a new line. The
+// next ↑ should surface the NEW line, not pick up where the old
+// navigation left off. Without this reset the user would see ↑
+// surface "old" again immediately after submitting.
+func TestHistory_AppendResetsNavigation(t *testing.T) {
+	h := NewHistory(10)
+	h.Append("first")
+	h.Append("second")
+	_, _ = h.Up("draft")
+	_, _ = h.Up("draft") // now at "first"
+
+	h.Append("third")
+
+	got, ok := h.Up("new draft")
+	assert.True(t, ok)
+	assert.Equal(t, "third", got, "navigation resets to newest after Append")
+}
+
+// TestHistory_ResetClearsNavigationOnly checks that Reset wipes the
+// cursor but keeps the entries. Used by the readline loop after
+// Ctrl+C to clear navigation state without losing the history the
+// user has built up.
+func TestHistory_ResetClearsNavigationOnly(t *testing.T) {
+	h := NewHistory(10)
+	h.Append("keep me")
+	_, _ = h.Up("draft")
+	h.Reset()
+
+	assert.Equal(t, 1, h.Len())
+	got, ok := h.Up("fresh draft")
+	assert.True(t, ok)
+	assert.Equal(t, "keep me", got)
+}
+
+// TestHistory_EmptyUpReturnsFalse is the boundary case: no entries,
+// ↑ should NOT replace the buffer with an empty string. The bool
+// return is what protects the buffer from a spurious wipe.
+func TestHistory_EmptyUpReturnsFalse(t *testing.T) {
+	h := NewHistory(10)
+	got, ok := h.Up("draft")
+	assert.False(t, ok)
+	assert.Equal(t, "", got)
+}
+
+// TestNewHistory_NonPositiveCapUsesDefault catches the configuration
+// mistake of NewHistory(0) (or negative). The default cap kicks in
+// so the caller never has a "history that throws away every entry"
+// foot-gun.
+func TestNewHistory_NonPositiveCapUsesDefault(t *testing.T) {
+	for _, c := range []int{0, -1, -100} {
+		h := NewHistory(c)
+		assert.Equal(t, DefaultHistoryCap, h.cap, "non-positive cap %d falls back to default", c)
+	}
+}

--- a/cli/coder/turnui/keydecode.go
+++ b/cli/coder/turnui/keydecode.go
@@ -1,0 +1,203 @@
+/*
+ * ChatCLI - Coder turn-UI raw key decoder
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+package turnui
+
+import (
+	"unicode/utf8"
+)
+
+// Once the TTY is in raw mode every byte that the user types arrives
+// at our reader instead of being processed by the kernel line
+// discipline. The decoder in this file converts a stream of raw bytes
+// into Key events the input loop knows how to act on. Keeping it pure
+// (no IO, no terminal state) is what makes the loop testable without
+// a real pseudo-terminal — the tests for backspace, Enter, and Ctrl+C
+// all run against fixed byte slices.
+
+// KeyKind enumerates the input categories the mini-readline cares
+// about. Anything not in this list (escape sequences for arrow keys,
+// function keys, mouse events) is reported as KeyUnknown so the loop
+// can drop it silently — Phase B intentionally does NOT support
+// arrows or history navigation; that is reserved for a later phase
+// once the basic split UI is proven to work.
+type KeyKind int
+
+const (
+	// KeyChar is a printable Unicode codepoint that should land in
+	// the input buffer and be echoed at the cursor's current column.
+	KeyChar KeyKind = iota
+
+	// KeyEnter is CR (\r) or LF (\n). The line discipline normally
+	// translates one into the other; in raw mode the terminal
+	// sends whichever the user's keyboard produces (usually CR on
+	// macOS, LF on Linux). We accept both.
+	KeyEnter
+
+	// KeyBackspace is BS (\b, 0x08) or DEL (0x7f). macOS sends DEL
+	// for the Delete key by default, Linux usually sends BS. Both
+	// mean "erase the previous character".
+	KeyBackspace
+
+	// KeyCtrlC is ETX (0x03). In raw mode the kernel does NOT
+	// translate this into SIGINT — the loop is responsible for
+	// surfacing it as a cancel/abort signal to the caller.
+	KeyCtrlC
+
+	// KeyCtrlD is EOT (0x04). Empty buffer + Ctrl+D = "end of
+	// input" (request shutdown of the input loop). With a non-empty
+	// buffer the loop ignores it to match readline conventions.
+	KeyCtrlD
+
+	// KeyCtrlU is NAK (0x15) — "kill line": discard everything
+	// the user has typed since the last Enter. The loop redraws
+	// the input row to reflect the empty buffer.
+	KeyCtrlU
+
+	// KeyCtrlW is ETB (0x17) — "kill word": delete the previous
+	// whitespace-delimited word. Convenient enough to be table
+	// stakes for any line editor; the implementation lives in the
+	// loop because the buffer is the source of truth for "what's
+	// the previous word".
+	KeyCtrlW
+
+	// KeyUnknown covers escape sequences (arrows, function keys),
+	// mouse events, and anything else Phase B does not handle. The
+	// loop discards it so the user's terminal does not see a stray
+	// escape sequence appear inline.
+	KeyUnknown
+)
+
+// Key is one decoded input event. For KeyChar the Rune field holds
+// the codepoint; for everything else it is the zero value (0).
+type Key struct {
+	Kind KeyKind
+	Rune rune
+}
+
+// DecodeOne reads one key event from the start of buf and returns the
+// event plus the number of bytes consumed. When buf does not contain
+// a complete event (e.g. a multi-byte UTF-8 sequence with only the
+// leading byte present) it returns Key{Kind:KeyUnknown}, 0 — the
+// caller should accumulate more bytes and try again.
+//
+// The function deliberately does NOT consume escape sequences (CSI,
+// SS3) byte-by-byte: it recognizes the lead ESC (0x1b) and skips
+// ahead based on the well-known short forms. A future Phase B+ may
+// extend this to interpret arrow keys; for now they all map to
+// KeyUnknown via the "discard up to N bytes" fast path so they don't
+// leak into the input buffer as garbage glyphs.
+func DecodeOne(buf []byte) (Key, int) {
+	if len(buf) == 0 {
+		return Key{Kind: KeyUnknown}, 0
+	}
+
+	b := buf[0]
+
+	switch b {
+	case 0x03:
+		return Key{Kind: KeyCtrlC}, 1
+	case 0x04:
+		return Key{Kind: KeyCtrlD}, 1
+	case 0x08, 0x7f:
+		return Key{Kind: KeyBackspace}, 1
+	case 0x0a, 0x0d:
+		// CR + LF arriving as one chunk (rare in raw mode but
+		// possible on terminals that buffer keystrokes) consumes
+		// both bytes as a single Enter so the next DecodeOne does
+		// not see the orphan LF and emit a second Enter.
+		if b == 0x0d && len(buf) >= 2 && buf[1] == 0x0a {
+			return Key{Kind: KeyEnter}, 2
+		}
+		return Key{Kind: KeyEnter}, 1
+	case 0x15:
+		return Key{Kind: KeyCtrlU}, 1
+	case 0x17:
+		return Key{Kind: KeyCtrlW}, 1
+	case 0x1b:
+		// ESC: we don't interpret arrow keys / function keys yet.
+		// Skip the well-known short forms so they do not appear
+		// inline. The lengths below cover the common CSI / SS3
+		// sequences (ESC [ A for up, ESC O P for F1, etc.). If
+		// the buffer is too short to contain a full sequence we
+		// return 0 consumed and wait for more bytes.
+		return decodeEscape(buf)
+	}
+
+	if b < 0x20 {
+		// Other control bytes (tab, etc.) are not yet supported.
+		// Drop them silently so they don't show up as garbage.
+		return Key{Kind: KeyUnknown}, 1
+	}
+
+	// Printable byte (or start of a UTF-8 sequence). FullRune
+	// distinguishes "incomplete sequence, wait for more" from
+	// "invalid byte, drop it" — DecodeRune alone cannot, because it
+	// returns (RuneError, 1) in both cases. Without this branch a
+	// multi-byte rune split across two reads would be silently
+	// corrupted into a replacement char.
+	if !utf8.FullRune(buf) {
+		return Key{Kind: KeyUnknown}, 0
+	}
+	r, size := utf8.DecodeRune(buf)
+	if r == utf8.RuneError && size == 1 {
+		// Invalid byte — consume and drop.
+		return Key{Kind: KeyUnknown}, 1
+	}
+	return Key{Kind: KeyChar, Rune: r}, size
+}
+
+// decodeEscape consumes the bytes belonging to an unrecognized escape
+// sequence starting with ESC. It returns KeyUnknown so the input loop
+// drops the sequence rather than letting the terminal render it as
+// literals. The lengths handled here mirror the most common short
+// sequences:
+//
+//	ESC alone       → 1 byte  (user pressed Esc; treated as unknown)
+//	ESC [ X         → 3 bytes (CSI + final byte: arrow keys, etc.)
+//	ESC [ N ~       → 4 bytes (CSI + digit + tilde: page up, etc.)
+//	ESC O X         → 3 bytes (SS3: F1..F4 on some terminals)
+//
+// Anything longer (mouse events, OSC, DCS) falls into a generous
+// catch-all of "skip until a final byte in 0x40..0x7e" capped at 16
+// bytes so a malformed stream cannot starve the loop.
+func decodeEscape(buf []byte) (Key, int) {
+	if len(buf) == 1 {
+		// Bare ESC: treat as Unknown and consume the single byte.
+		// (Phase B does not bind anything to bare Esc; the rewind
+		// gesture in chat mode uses double-Esc, which is captured
+		// by go-prompt, not by this decoder.)
+		return Key{Kind: KeyUnknown}, 1
+	}
+
+	switch buf[1] {
+	case '[': // CSI
+		if len(buf) < 3 {
+			return Key{Kind: KeyUnknown}, 0
+		}
+		// CSI sequences end on a byte in 0x40..0x7e. Scan ahead
+		// up to 16 bytes; that comfortably covers arrow keys,
+		// page nav, and SGR mouse reports (which we don't act on
+		// but must consume to keep them out of the buffer).
+		end := 2
+		for end < len(buf) && end < 16 {
+			if buf[end] >= 0x40 && buf[end] <= 0x7e {
+				return Key{Kind: KeyUnknown}, end + 1
+			}
+			end++
+		}
+		// Incomplete: wait for more bytes.
+		return Key{Kind: KeyUnknown}, 0
+	case 'O': // SS3
+		if len(buf) < 3 {
+			return Key{Kind: KeyUnknown}, 0
+		}
+		return Key{Kind: KeyUnknown}, 3
+	default:
+		// Unknown short escape: consume ESC + one byte.
+		return Key{Kind: KeyUnknown}, 2
+	}
+}

--- a/cli/coder/turnui/keydecode.go
+++ b/cli/coder/turnui/keydecode.go
@@ -64,9 +64,37 @@ const (
 	// the previous word".
 	KeyCtrlW
 
-	// KeyUnknown covers escape sequences (arrows, function keys),
-	// mouse events, and anything else Phase B does not handle. The
-	// loop discards it so the user's terminal does not see a stray
+	// KeyCtrlA is SOH (0x01) — move cursor to beginning of line.
+	// Readline / bash muscle memory.
+	KeyCtrlA
+
+	// KeyCtrlE is ENQ (0x05) — move cursor to end of line.
+	// Companion to KeyCtrlA.
+	KeyCtrlE
+
+	// KeyArrowLeft / Right move the cursor one rune within the
+	// buffer. Decoded from the standard CSI A/B/C/D sequences plus
+	// the modern application-mode SS3 variants some terminals
+	// emit. Up/Down are reserved for history navigation.
+	KeyArrowLeft
+	KeyArrowRight
+	KeyArrowUp
+	KeyArrowDown
+
+	// KeyHome / KeyEnd are the dedicated keys on most keyboards.
+	// Distinct from Ctrl+A / Ctrl+E because some users have one
+	// and not the other; supporting both costs almost nothing.
+	KeyHome
+	KeyEnd
+
+	// KeyDelete is forward delete (the "Delete" key, not Backspace).
+	// Decoded from CSI 3 ~ which is the canonical sequence on
+	// every terminal that has the key.
+	KeyDelete
+
+	// KeyUnknown covers escape sequences (function keys, mouse
+	// events) and anything else the loop does not handle. The loop
+	// discards it so the user's terminal does not see a stray
 	// escape sequence appear inline.
 	KeyUnknown
 )
@@ -98,10 +126,14 @@ func DecodeOne(buf []byte) (Key, int) {
 	b := buf[0]
 
 	switch b {
+	case 0x01:
+		return Key{Kind: KeyCtrlA}, 1
 	case 0x03:
 		return Key{Kind: KeyCtrlC}, 1
 	case 0x04:
 		return Key{Kind: KeyCtrlD}, 1
+	case 0x05:
+		return Key{Kind: KeyCtrlE}, 1
 	case 0x08, 0x7f:
 		return Key{Kind: KeyBackspace}, 1
 	case 0x0a, 0x0d:
@@ -150,16 +182,25 @@ func DecodeOne(buf []byte) (Key, int) {
 	return Key{Kind: KeyChar, Rune: r}, size
 }
 
-// decodeEscape consumes the bytes belonging to an unrecognized escape
-// sequence starting with ESC. It returns KeyUnknown so the input loop
-// drops the sequence rather than letting the terminal render it as
-// literals. The lengths handled here mirror the most common short
-// sequences:
+// decodeEscape consumes the bytes belonging to an escape sequence
+// starting with ESC and identifies arrows, Home, End, Delete, and
+// other navigation keys. Unknown sequences are consumed (so they
+// don't leak into the buffer as garbage) and reported as KeyUnknown.
 //
-//	ESC alone       → 1 byte  (user pressed Esc; treated as unknown)
-//	ESC [ X         → 3 bytes (CSI + final byte: arrow keys, etc.)
-//	ESC [ N ~       → 4 bytes (CSI + digit + tilde: page up, etc.)
-//	ESC O X         → 3 bytes (SS3: F1..F4 on some terminals)
+// Recognized sequences:
+//
+//	ESC [ A / B / C / D    arrow Up / Down / Right / Left (CSI)
+//	ESC [ H / F            Home / End (CSI, xterm convention)
+//	ESC [ 1 ~ / 7 ~        Home (alternate forms)
+//	ESC [ 4 ~ / 8 ~        End (alternate forms)
+//	ESC [ 3 ~              Delete (forward delete)
+//	ESC O A / B / C / D    arrows (SS3, application mode)
+//	ESC O H / F            Home / End (SS3)
+//
+// CSI variants with modifiers (e.g. ESC [ 1 ; 5 D for Ctrl+Left)
+// are consumed as KeyUnknown — the buffer doesn't need them yet, but
+// they MUST be swallowed so the modifier prefix doesn't end up
+// echoed as literal text.
 //
 // Anything longer (mouse events, OSC, DCS) falls into a generous
 // catch-all of "skip until a final byte in 0x40..0x7e" capped at 16
@@ -178,10 +219,37 @@ func decodeEscape(buf []byte) (Key, int) {
 		if len(buf) < 3 {
 			return Key{Kind: KeyUnknown}, 0
 		}
-		// CSI sequences end on a byte in 0x40..0x7e. Scan ahead
-		// up to 16 bytes; that comfortably covers arrow keys,
-		// page nav, and SGR mouse reports (which we don't act on
-		// but must consume to keep them out of the buffer).
+		// Short forms: ESC [ X where X is the final byte.
+		switch buf[2] {
+		case 'A':
+			return Key{Kind: KeyArrowUp}, 3
+		case 'B':
+			return Key{Kind: KeyArrowDown}, 3
+		case 'C':
+			return Key{Kind: KeyArrowRight}, 3
+		case 'D':
+			return Key{Kind: KeyArrowLeft}, 3
+		case 'H':
+			return Key{Kind: KeyHome}, 3
+		case 'F':
+			return Key{Kind: KeyEnd}, 3
+		}
+		// Longer forms: ESC [ <param(s)> <final>. We hand-decode
+		// the few we care about and fall back to "swallow up to
+		// the final byte" for the rest.
+		if len(buf) >= 4 && buf[3] == '~' {
+			switch buf[2] {
+			case '1', '7':
+				return Key{Kind: KeyHome}, 4
+			case '3':
+				return Key{Kind: KeyDelete}, 4
+			case '4', '8':
+				return Key{Kind: KeyEnd}, 4
+			}
+		}
+		// Generic CSI consume: scan to a final byte (0x40..0x7e)
+		// up to 16 bytes. Covers modified arrows (ESC [ 1;5 D),
+		// SGR mouse reports, etc. — all dropped as KeyUnknown.
 		end := 2
 		for end < len(buf) && end < 16 {
 			if buf[end] >= 0x40 && buf[end] <= 0x7e {
@@ -189,11 +257,24 @@ func decodeEscape(buf []byte) (Key, int) {
 			}
 			end++
 		}
-		// Incomplete: wait for more bytes.
 		return Key{Kind: KeyUnknown}, 0
-	case 'O': // SS3
+	case 'O': // SS3 (application mode)
 		if len(buf) < 3 {
 			return Key{Kind: KeyUnknown}, 0
+		}
+		switch buf[2] {
+		case 'A':
+			return Key{Kind: KeyArrowUp}, 3
+		case 'B':
+			return Key{Kind: KeyArrowDown}, 3
+		case 'C':
+			return Key{Kind: KeyArrowRight}, 3
+		case 'D':
+			return Key{Kind: KeyArrowLeft}, 3
+		case 'H':
+			return Key{Kind: KeyHome}, 3
+		case 'F':
+			return Key{Kind: KeyEnd}, 3
 		}
 		return Key{Kind: KeyUnknown}, 3
 	default:

--- a/cli/coder/turnui/keydecode_test.go
+++ b/cli/coder/turnui/keydecode_test.go
@@ -1,0 +1,152 @@
+/*
+ * ChatCLI - Coder turn-UI key decoder tests
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+package turnui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestDecodeOne_ControlBytes walks every control byte the mini-
+// readline acts on. The byte values are non-obvious (0x7f for
+// Backspace on macOS, 0x08 elsewhere) so locking them in a table
+// makes the contract reviewable at a glance — and catches regressions
+// where a future cleanup pass swaps one for the other and silently
+// breaks Backspace on half the user base.
+func TestDecodeOne_ControlBytes(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []byte
+		want KeyKind
+		size int
+	}{
+		{"Ctrl+C (ETX)", []byte{0x03}, KeyCtrlC, 1},
+		{"Ctrl+D (EOT)", []byte{0x04}, KeyCtrlD, 1},
+		{"Backspace (BS)", []byte{0x08}, KeyBackspace, 1},
+		{"Backspace (DEL, macOS)", []byte{0x7f}, KeyBackspace, 1},
+		{"Enter (CR)", []byte{0x0d}, KeyEnter, 1},
+		{"Enter (LF)", []byte{0x0a}, KeyEnter, 1},
+		{"CRLF collapses to one Enter", []byte{0x0d, 0x0a}, KeyEnter, 2},
+		{"Ctrl+U (NAK, kill line)", []byte{0x15}, KeyCtrlU, 1},
+		{"Ctrl+W (ETB, kill word)", []byte{0x17}, KeyCtrlW, 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			k, n := DecodeOne(tc.in)
+			assert.Equal(t, tc.want, k.Kind)
+			assert.Equal(t, tc.size, n)
+		})
+	}
+}
+
+// TestDecodeOne_PrintableASCII confirms the common case: a plain
+// letter byte produces KeyChar with the right rune and consumes
+// exactly one byte. If this regresses every keystroke turns into a
+// no-op and the user cannot type at all — the test is small but
+// load-bearing.
+func TestDecodeOne_PrintableASCII(t *testing.T) {
+	k, n := DecodeOne([]byte("a"))
+	assert.Equal(t, KeyChar, k.Kind)
+	assert.Equal(t, rune('a'), k.Rune)
+	assert.Equal(t, 1, n)
+}
+
+// TestDecodeOne_MultiByteUTF8 covers the case the user actually
+// hits — typing accented characters in Portuguese ("ç", "ã") and
+// emoji. The decoder must consume the full UTF-8 sequence and emit
+// a single KeyChar, not one KeyChar per byte (which would write
+// mojibake to the buffer).
+func TestDecodeOne_MultiByteUTF8(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []byte
+		want rune
+		size int
+	}{
+		{"c-cedilla", []byte("ç"), 'ç', 2},
+		{"a-tilde", []byte("ã"), 'ã', 2},
+		{"euro sign", []byte("€"), '€', 3},
+		{"face-with-tears-of-joy emoji", []byte("😂"), '😂', 4},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			k, n := DecodeOne(tc.in)
+			assert.Equal(t, KeyChar, k.Kind)
+			assert.Equal(t, tc.want, k.Rune)
+			assert.Equal(t, tc.size, n)
+		})
+	}
+}
+
+// TestDecodeOne_PartialUTF8WaitsForMore is the boundary case: when
+// only the leading byte of a multi-byte rune is in the buffer, the
+// decoder must signal "need more" by returning 0 consumed. Returning
+// 1 (consume the lead byte and drop it) would lose the character;
+// returning a fake KeyChar would inject mojibake.
+func TestDecodeOne_PartialUTF8WaitsForMore(t *testing.T) {
+	// 0xC3 is the lead byte of "ç" (0xC3 0xA7) — alone, it is
+	// incomplete and should be held until the trailing byte arrives.
+	k, n := DecodeOne([]byte{0xc3})
+	assert.Equal(t, KeyUnknown, k.Kind)
+	assert.Equal(t, 0, n, "incomplete UTF-8 must signal 'need more bytes'")
+}
+
+// TestDecodeOne_InvalidUTF8ByteIsDropped guards against a bad byte
+// hanging the decoder in an infinite loop. The byte is consumed (n=1)
+// and reported as KeyUnknown so the caller advances past it.
+func TestDecodeOne_InvalidUTF8ByteIsDropped(t *testing.T) {
+	k, n := DecodeOne([]byte{0xff})
+	assert.Equal(t, KeyUnknown, k.Kind)
+	assert.Equal(t, 1, n)
+}
+
+// TestDecodeOne_EscapeSequencesAreSwallowed makes sure arrow keys
+// and other escape sequences do not leak into the input buffer as
+// literal "[A" / "[B" garbage. Phase B does not act on them, but it
+// MUST consume them — Phase A's tests asserted nothing about input,
+// so this is the first chance to lock the swallow-don't-leak contract.
+func TestDecodeOne_EscapeSequencesAreSwallowed(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []byte
+		size int
+	}{
+		{"up arrow CSI A", []byte{0x1b, '[', 'A'}, 3},
+		{"down arrow CSI B", []byte{0x1b, '[', 'B'}, 3},
+		{"F1 SS3 P", []byte{0x1b, 'O', 'P'}, 3},
+		{"page-up CSI 5 ~", []byte{0x1b, '[', '5', '~'}, 4},
+		{"bare Esc", []byte{0x1b}, 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			k, n := DecodeOne(tc.in)
+			assert.Equal(t, KeyUnknown, k.Kind, "escape sequence must NOT surface as a Char")
+			assert.Equal(t, tc.size, n)
+		})
+	}
+}
+
+// TestDecodeOne_PartialCSIWaitsForMore mirrors the partial-UTF-8 case
+// for escape sequences: when only ESC [ is in the buffer the decoder
+// returns 0 so the caller waits for the terminating byte. Returning
+// a fake length here would consume bytes from the next event and
+// corrupt the stream.
+func TestDecodeOne_PartialCSIWaitsForMore(t *testing.T) {
+	k, n := DecodeOne([]byte{0x1b, '['})
+	assert.Equal(t, KeyUnknown, k.Kind)
+	assert.Equal(t, 0, n)
+}
+
+// TestDecodeOne_EmptyBufferReturnsZero is the null case: nothing in,
+// nothing out. The loop calls DecodeOne in a tight read-decode cycle;
+// an empty buffer must not loop forever.
+func TestDecodeOne_EmptyBufferReturnsZero(t *testing.T) {
+	k, n := DecodeOne(nil)
+	assert.Equal(t, KeyUnknown, k.Kind)
+	assert.Equal(t, 0, n)
+}

--- a/cli/coder/turnui/keydecode_test.go
+++ b/cli/coder/turnui/keydecode_test.go
@@ -105,21 +105,80 @@ func TestDecodeOne_InvalidUTF8ByteIsDropped(t *testing.T) {
 	assert.Equal(t, 1, n)
 }
 
-// TestDecodeOne_EscapeSequencesAreSwallowed makes sure arrow keys
-// and other escape sequences do not leak into the input buffer as
-// literal "[A" / "[B" garbage. Phase B does not act on them, but it
-// MUST consume them — Phase A's tests asserted nothing about input,
-// so this is the first chance to lock the swallow-don't-leak contract.
+// TestDecodeOne_NavigationKeys covers the keys Phase G added support
+// for: arrows (both CSI and SS3 forms), Home, End, Delete. These
+// MUST be recognized as named keys so the buffer can act on them;
+// dropping them as Unknown would mean the user's ↑/↓ for history
+// and ←/→ for cursor movement silently fail.
+func TestDecodeOne_NavigationKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []byte
+		want KeyKind
+		size int
+	}{
+		{"up arrow CSI A", []byte{0x1b, '[', 'A'}, KeyArrowUp, 3},
+		{"down arrow CSI B", []byte{0x1b, '[', 'B'}, KeyArrowDown, 3},
+		{"right arrow CSI C", []byte{0x1b, '[', 'C'}, KeyArrowRight, 3},
+		{"left arrow CSI D", []byte{0x1b, '[', 'D'}, KeyArrowLeft, 3},
+		{"home CSI H", []byte{0x1b, '[', 'H'}, KeyHome, 3},
+		{"end CSI F", []byte{0x1b, '[', 'F'}, KeyEnd, 3},
+		{"home alternate CSI 1 ~", []byte{0x1b, '[', '1', '~'}, KeyHome, 4},
+		{"home alternate CSI 7 ~", []byte{0x1b, '[', '7', '~'}, KeyHome, 4},
+		{"end alternate CSI 4 ~", []byte{0x1b, '[', '4', '~'}, KeyEnd, 4},
+		{"end alternate CSI 8 ~", []byte{0x1b, '[', '8', '~'}, KeyEnd, 4},
+		{"delete CSI 3 ~", []byte{0x1b, '[', '3', '~'}, KeyDelete, 4},
+		{"arrow Up SS3 (application mode)", []byte{0x1b, 'O', 'A'}, KeyArrowUp, 3},
+		{"arrow Down SS3", []byte{0x1b, 'O', 'B'}, KeyArrowDown, 3},
+		{"home SS3", []byte{0x1b, 'O', 'H'}, KeyHome, 3},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			k, n := DecodeOne(tc.in)
+			assert.Equal(t, tc.want, k.Kind)
+			assert.Equal(t, tc.size, n)
+		})
+	}
+}
+
+// TestDecodeOne_CtrlAandE matches the Ctrl+A / Ctrl+E readline
+// muscle memory for jumping to line start/end. The byte values
+// (0x01 / 0x05) are non-obvious; the test pins them so a future
+// "control byte cleanup" pass cannot silently break the muscle
+// memory.
+func TestDecodeOne_CtrlAandE(t *testing.T) {
+	tests := []struct {
+		name string
+		b    byte
+		want KeyKind
+	}{
+		{"Ctrl+A (SOH 0x01)", 0x01, KeyCtrlA},
+		{"Ctrl+E (ENQ 0x05)", 0x05, KeyCtrlE},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			k, n := DecodeOne([]byte{tc.b})
+			assert.Equal(t, tc.want, k.Kind)
+			assert.Equal(t, 1, n)
+		})
+	}
+}
+
+// TestDecodeOne_EscapeSequencesAreSwallowed pins the swallow-don't-
+// leak contract for escape sequences Phase G does NOT recognize:
+// function keys, modifier-prefixed arrows, page navigation. The
+// decoder must consume them so they don't appear as literal "[5~"
+// in the input buffer, but it does NOT surface them as named keys.
 func TestDecodeOne_EscapeSequencesAreSwallowed(t *testing.T) {
 	tests := []struct {
 		name string
 		in   []byte
 		size int
 	}{
-		{"up arrow CSI A", []byte{0x1b, '[', 'A'}, 3},
-		{"down arrow CSI B", []byte{0x1b, '[', 'B'}, 3},
 		{"F1 SS3 P", []byte{0x1b, 'O', 'P'}, 3},
 		{"page-up CSI 5 ~", []byte{0x1b, '[', '5', '~'}, 4},
+		{"page-down CSI 6 ~", []byte{0x1b, '[', '6', '~'}, 4},
+		{"Ctrl+Left CSI 1;5 D", []byte{0x1b, '[', '1', ';', '5', 'D'}, 6},
 		{"bare Esc", []byte{0x1b}, 1},
 	}
 	for _, tc := range tests {

--- a/cli/coder/turnui/linebuf.go
+++ b/cli/coder/turnui/linebuf.go
@@ -1,0 +1,123 @@
+/*
+ * ChatCLI - Coder turn-UI line buffer
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+package turnui
+
+import (
+	"strings"
+	"unicode"
+)
+
+// LineBuffer is the mutable text the mini-readline shows in the input
+// row and submits when the user presses Enter. It is intentionally
+// rune-aware: every visible character — including multi-byte
+// codepoints like "ç" or emoji — is one logical unit, so Backspace
+// deletes one glyph, not one byte. The visible column count drives
+// cursor positioning on the input row.
+//
+// The buffer is a pure data structure: no IO, no escape sequences.
+// The input loop wraps it with the terminal writes that actually
+// repaint the input row when the buffer changes. Keeping the two
+// layers separate is what lets every Backspace / Ctrl+U / Ctrl+W
+// behavior have a unit test that runs without a TTY.
+type LineBuffer struct {
+	// runes is the in-memory representation. We keep runes instead
+	// of a string so insertions / deletions are O(1) at the end
+	// and there is no temptation to do byte-level slicing that
+	// would split a multi-byte glyph.
+	runes []rune
+}
+
+// NewLineBuffer returns an empty buffer ready to accept input.
+func NewLineBuffer() *LineBuffer {
+	return &LineBuffer{runes: make([]rune, 0, 64)}
+}
+
+// Append adds a rune to the end of the buffer. The mini-readline only
+// supports appending at the cursor (which is always at the end of the
+// buffer for Phase B — arrow-key navigation is reserved for a future
+// phase), so an Append-only API matches the actual capabilities.
+func (b *LineBuffer) Append(r rune) {
+	b.runes = append(b.runes, r)
+}
+
+// Backspace removes the trailing rune, if any. Returns true when
+// something was removed so the caller can decide whether to repaint
+// the input row (a no-op backspace at the start of the line should
+// not cost a redraw).
+func (b *LineBuffer) Backspace() bool {
+	if len(b.runes) == 0 {
+		return false
+	}
+	b.runes = b.runes[:len(b.runes)-1]
+	return true
+}
+
+// KillLine clears the entire buffer (Ctrl+U semantics). Returns true
+// when the buffer was non-empty so the caller can skip a no-op
+// redraw on a fresh prompt.
+func (b *LineBuffer) KillLine() bool {
+	if len(b.runes) == 0 {
+		return false
+	}
+	b.runes = b.runes[:0]
+	return true
+}
+
+// KillWord deletes the trailing whitespace-delimited word (Ctrl+W
+// semantics). Trailing whitespace is consumed first, then runes are
+// removed until the next whitespace boundary. Mirrors readline's
+// behavior so users with muscle memory from bash see the same effect.
+// Returns true when something changed.
+func (b *LineBuffer) KillWord() bool {
+	if len(b.runes) == 0 {
+		return false
+	}
+	original := len(b.runes)
+
+	// Step 1: chew off trailing whitespace.
+	for len(b.runes) > 0 && unicode.IsSpace(b.runes[len(b.runes)-1]) {
+		b.runes = b.runes[:len(b.runes)-1]
+	}
+	// Step 2: chew off the word itself, up to the next whitespace.
+	for len(b.runes) > 0 && !unicode.IsSpace(b.runes[len(b.runes)-1]) {
+		b.runes = b.runes[:len(b.runes)-1]
+	}
+
+	return len(b.runes) != original
+}
+
+// String returns the buffer as a string for submission when the user
+// presses Enter. The result is a copy; mutating the buffer afterwards
+// does not affect a previously returned string.
+func (b *LineBuffer) String() string {
+	return string(b.runes)
+}
+
+// Reset empties the buffer without reallocating the underlying slice.
+// Used after Enter so the same buffer can serve the next input cycle
+// without churning the allocator.
+func (b *LineBuffer) Reset() {
+	b.runes = b.runes[:0]
+}
+
+// VisibleWidth approximates the column count needed to render the
+// buffer's current contents. Used by the input loop to compute the
+// echo column on the input row. The approximation is conservative —
+// we treat every rune as one column, which is correct for ASCII and
+// most Latin-1 input but underestimates East Asian wide glyphs. A
+// future phase that supports wide glyphs should plumb runewidth here.
+func (b *LineBuffer) VisibleWidth() int {
+	return len(b.runes)
+}
+
+// Trim returns the buffer's contents with leading/trailing whitespace
+// removed. The mini-readline submits the trimmed form because the
+// agent loop's history append expects "user typed this" rather than
+// "user typed this and a stray space".
+func (b *LineBuffer) Trim() string {
+	return strings.TrimSpace(string(b.runes))
+}

--- a/cli/coder/turnui/linebuf.go
+++ b/cli/coder/turnui/linebuf.go
@@ -18,76 +18,183 @@ import (
 // deletes one glyph, not one byte. The visible column count drives
 // cursor positioning on the input row.
 //
+// Phase G adds a cursor position so arrow keys can navigate within
+// the buffer; inserts and deletes now happen at the cursor rather
+// than always at the end. The cursor is measured in runes from the
+// start; valid range is [0, len(runes)]. cursor == len(runes) means
+// "after the last rune" (end-of-line position).
+//
 // The buffer is a pure data structure: no IO, no escape sequences.
 // The input loop wraps it with the terminal writes that actually
 // repaint the input row when the buffer changes. Keeping the two
-// layers separate is what lets every Backspace / Ctrl+U / Ctrl+W
-// behavior have a unit test that runs without a TTY.
+// layers separate is what lets every Backspace / Ctrl+U / Ctrl+W /
+// arrow-key behavior have a unit test that runs without a TTY.
 type LineBuffer struct {
 	// runes is the in-memory representation. We keep runes instead
 	// of a string so insertions / deletions are O(1) at the end
 	// and there is no temptation to do byte-level slicing that
 	// would split a multi-byte glyph.
 	runes []rune
+
+	// cursor is the insertion point in rune units, NOT bytes.
+	// Range: [0, len(runes)]. When cursor == len(runes) the next
+	// Insert appends; when cursor == 0 Backspace is a no-op and
+	// Delete (forward delete) removes the first rune.
+	cursor int
 }
 
-// NewLineBuffer returns an empty buffer ready to accept input.
+// NewLineBuffer returns an empty buffer ready to accept input. The
+// cursor starts at position 0 (which equals len, since the buffer is
+// empty).
 func NewLineBuffer() *LineBuffer {
-	return &LineBuffer{runes: make([]rune, 0, 64)}
+	return &LineBuffer{runes: make([]rune, 0, 64), cursor: 0}
 }
 
-// Append adds a rune to the end of the buffer. The mini-readline only
-// supports appending at the cursor (which is always at the end of the
-// buffer for Phase B — arrow-key navigation is reserved for a future
-// phase), so an Append-only API matches the actual capabilities.
+// Cursor returns the current cursor position in rune units from the
+// start of the buffer. Used by PaintInput to compute the absolute
+// column on the input row.
+func (b *LineBuffer) Cursor() int { return b.cursor }
+
+// Append adds a rune to the end of the buffer and parks the cursor
+// after it. Retained for compatibility with the Phase B test suite
+// (and for callers that bypass the cursor-aware Insert path); new
+// code should prefer Insert for clarity.
 func (b *LineBuffer) Append(r rune) {
 	b.runes = append(b.runes, r)
+	b.cursor = len(b.runes)
 }
 
-// Backspace removes the trailing rune, if any. Returns true when
-// something was removed so the caller can decide whether to repaint
-// the input row (a no-op backspace at the start of the line should
-// not cost a redraw).
+// Insert places r at the current cursor position and advances the
+// cursor by one. Equivalent to Append when the cursor is at end-of-
+// line; the distinction matters only for arrow-key-navigated edits.
+func (b *LineBuffer) Insert(r rune) {
+	if b.cursor >= len(b.runes) {
+		b.Append(r)
+		return
+	}
+	b.runes = append(b.runes, 0)
+	copy(b.runes[b.cursor+1:], b.runes[b.cursor:])
+	b.runes[b.cursor] = r
+	b.cursor++
+}
+
+// Backspace removes the rune immediately before the cursor and moves
+// the cursor back one. Returns true when something was removed so
+// the caller can decide whether to repaint the input row (a no-op
+// backspace at the start of the line should not cost a redraw).
 func (b *LineBuffer) Backspace() bool {
-	if len(b.runes) == 0 {
+	if b.cursor == 0 || len(b.runes) == 0 {
 		return false
 	}
-	b.runes = b.runes[:len(b.runes)-1]
+	if b.cursor >= len(b.runes) {
+		// Fast path: cursor at end, drop trailing rune.
+		b.runes = b.runes[:len(b.runes)-1]
+		b.cursor = len(b.runes)
+		return true
+	}
+	b.runes = append(b.runes[:b.cursor-1], b.runes[b.cursor:]...)
+	b.cursor--
 	return true
+}
+
+// Delete removes the rune at the current cursor position (forward
+// delete; the cursor stays put because the next rune slid into its
+// place). No-op at end-of-line. Used by the future Delete key.
+func (b *LineBuffer) Delete() bool {
+	if b.cursor >= len(b.runes) {
+		return false
+	}
+	b.runes = append(b.runes[:b.cursor], b.runes[b.cursor+1:]...)
+	return true
+}
+
+// MoveLeft moves the cursor one rune to the left. Returns true on
+// movement so the caller knows whether to repaint the input row.
+func (b *LineBuffer) MoveLeft() bool {
+	if b.cursor == 0 {
+		return false
+	}
+	b.cursor--
+	return true
+}
+
+// MoveRight moves the cursor one rune to the right. Returns true on
+// movement.
+func (b *LineBuffer) MoveRight() bool {
+	if b.cursor >= len(b.runes) {
+		return false
+	}
+	b.cursor++
+	return true
+}
+
+// MoveStart parks the cursor at column 0 (Ctrl+A / Home semantics).
+// Returns true when the cursor moved.
+func (b *LineBuffer) MoveStart() bool {
+	if b.cursor == 0 {
+		return false
+	}
+	b.cursor = 0
+	return true
+}
+
+// MoveEnd parks the cursor after the last rune (Ctrl+E / End
+// semantics). Returns true when the cursor moved.
+func (b *LineBuffer) MoveEnd() bool {
+	if b.cursor == len(b.runes) {
+		return false
+	}
+	b.cursor = len(b.runes)
+	return true
+}
+
+// SetContents replaces the buffer with the given string and parks the
+// cursor at the end. Used by the history navigation path to swap in
+// a recalled line; PaintInput will repaint with the new contents.
+func (b *LineBuffer) SetContents(s string) {
+	b.runes = b.runes[:0]
+	for _, r := range s {
+		b.runes = append(b.runes, r)
+	}
+	b.cursor = len(b.runes)
 }
 
 // KillLine clears the entire buffer (Ctrl+U semantics). Returns true
 // when the buffer was non-empty so the caller can skip a no-op
-// redraw on a fresh prompt.
+// redraw on a fresh prompt. Cursor is reset to position 0.
 func (b *LineBuffer) KillLine() bool {
 	if len(b.runes) == 0 {
 		return false
 	}
 	b.runes = b.runes[:0]
+	b.cursor = 0
 	return true
 }
 
-// KillWord deletes the trailing whitespace-delimited word (Ctrl+W
-// semantics). Trailing whitespace is consumed first, then runes are
-// removed until the next whitespace boundary. Mirrors readline's
-// behavior so users with muscle memory from bash see the same effect.
-// Returns true when something changed.
+// KillWord deletes the word immediately before the cursor (Ctrl+W
+// semantics). Whitespace before the cursor is consumed first, then
+// runes are removed until the next whitespace boundary or start of
+// line. Mirrors readline's behavior so users with muscle memory from
+// bash see the same effect. Returns true when something changed.
 func (b *LineBuffer) KillWord() bool {
-	if len(b.runes) == 0 {
+	if b.cursor == 0 {
 		return false
 	}
-	original := len(b.runes)
+	end := b.cursor
 
-	// Step 1: chew off trailing whitespace.
-	for len(b.runes) > 0 && unicode.IsSpace(b.runes[len(b.runes)-1]) {
-		b.runes = b.runes[:len(b.runes)-1]
+	// Step 1: chew off whitespace immediately before the cursor.
+	for b.cursor > 0 && unicode.IsSpace(b.runes[b.cursor-1]) {
+		b.cursor--
 	}
 	// Step 2: chew off the word itself, up to the next whitespace.
-	for len(b.runes) > 0 && !unicode.IsSpace(b.runes[len(b.runes)-1]) {
-		b.runes = b.runes[:len(b.runes)-1]
+	for b.cursor > 0 && !unicode.IsSpace(b.runes[b.cursor-1]) {
+		b.cursor--
 	}
-
-	return len(b.runes) != original
+	if b.cursor == end {
+		return false
+	}
+	b.runes = append(b.runes[:b.cursor], b.runes[end:]...)
+	return true
 }
 
 // String returns the buffer as a string for submission when the user
@@ -99,9 +206,10 @@ func (b *LineBuffer) String() string {
 
 // Reset empties the buffer without reallocating the underlying slice.
 // Used after Enter so the same buffer can serve the next input cycle
-// without churning the allocator.
+// without churning the allocator. Cursor is reset to position 0.
 func (b *LineBuffer) Reset() {
 	b.runes = b.runes[:0]
+	b.cursor = 0
 }
 
 // VisibleWidth approximates the column count needed to render the

--- a/cli/coder/turnui/linebuf_test.go
+++ b/cli/coder/turnui/linebuf_test.go
@@ -1,0 +1,122 @@
+/*
+ * ChatCLI - Coder turn-UI line buffer tests
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+package turnui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestLineBuffer_AppendString builds a typical word and checks the
+// rendered string. The append-rune-by-rune call pattern matches the
+// reader loop, so a regression in Append would surface here before
+// reaching the live terminal.
+func TestLineBuffer_AppendString(t *testing.T) {
+	b := NewLineBuffer()
+	for _, r := range "hello" {
+		b.Append(r)
+	}
+	assert.Equal(t, "hello", b.String())
+	assert.Equal(t, 5, b.VisibleWidth())
+}
+
+// TestLineBuffer_BackspaceDeletesOneGlyph is the critical invariant:
+// Backspace must remove a whole rune even when that rune is encoded
+// as multiple bytes. Without it, deleting "ç" (2 bytes in UTF-8) would
+// leave a dangling 0xC3 lead byte in the buffer that would render as
+// the replacement character on the next paint.
+func TestLineBuffer_BackspaceDeletesOneGlyph(t *testing.T) {
+	b := NewLineBuffer()
+	for _, r := range "olá" {
+		b.Append(r)
+	}
+	assert.Equal(t, "olá", b.String())
+
+	changed := b.Backspace()
+	assert.True(t, changed)
+	assert.Equal(t, "ol", b.String(), "must delete the full 'á' codepoint, not a single byte")
+}
+
+// TestLineBuffer_BackspaceOnEmpty proves the no-op contract. The
+// caller relies on the false return to skip a useless redraw of the
+// input row when the user hits Backspace at the start of the line.
+func TestLineBuffer_BackspaceOnEmpty(t *testing.T) {
+	b := NewLineBuffer()
+	changed := b.Backspace()
+	assert.False(t, changed)
+	assert.Equal(t, "", b.String())
+}
+
+// TestLineBuffer_KillLine clears everything (Ctrl+U). Mirrors bash /
+// readline so the muscle memory transfers.
+func TestLineBuffer_KillLine(t *testing.T) {
+	b := NewLineBuffer()
+	for _, r := range "the quick brown fox" {
+		b.Append(r)
+	}
+	assert.True(t, b.KillLine())
+	assert.Equal(t, "", b.String())
+	assert.False(t, b.KillLine(), "second KillLine on empty is a no-op")
+}
+
+// TestLineBuffer_KillWord exercises the two-phase deletion: trailing
+// whitespace first, then the word. The cases below are the ones that
+// surprise people: a single trailing space, multiple trailing spaces,
+// and a word that ends without whitespace at end-of-buffer.
+func TestLineBuffer_KillWord(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"word at end of line", "the quick brown fox", "the quick brown "},
+		{"single trailing space", "hello ", ""},
+		{"multiple trailing spaces", "hello   ", ""},
+		{"empty buffer", "", ""},
+		{"single word", "fox", ""},
+		{"trailing word with mixed whitespace", "hello\tworld", "hello\t"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b := NewLineBuffer()
+			for _, r := range tc.in {
+				b.Append(r)
+			}
+			b.KillWord()
+			assert.Equal(t, tc.want, b.String())
+		})
+	}
+}
+
+// TestLineBuffer_ResetKeepsCapacity verifies the buffer can serve
+// successive input cycles without reallocating. Not a correctness
+// thing — a soak-test concern: a buffer that reallocates on every
+// Enter would generate GC pressure on a session with many turns.
+func TestLineBuffer_ResetKeepsCapacity(t *testing.T) {
+	b := NewLineBuffer()
+	for i := 0; i < 100; i++ {
+		b.Append('x')
+	}
+	capBefore := cap(b.runes)
+	b.Reset()
+	assert.Equal(t, "", b.String())
+	assert.Equal(t, capBefore, cap(b.runes),
+		"Reset must not shrink the underlying slice; reused for the next input cycle")
+}
+
+// TestLineBuffer_TrimRemovesPadding makes the submission contract
+// explicit: the agent loop sees "fix bar.go", not "  fix bar.go\t".
+// Without Trim, history rows would carry a user's accidental padding
+// straight into the LLM prompt.
+func TestLineBuffer_TrimRemovesPadding(t *testing.T) {
+	b := NewLineBuffer()
+	for _, r := range "   fix bar.go\t " {
+		b.Append(r)
+	}
+	assert.Equal(t, "fix bar.go", b.Trim())
+}

--- a/cli/coder/turnui/linebuf_test.go
+++ b/cli/coder/turnui/linebuf_test.go
@@ -120,3 +120,127 @@ func TestLineBuffer_TrimRemovesPadding(t *testing.T) {
 	}
 	assert.Equal(t, "fix bar.go", b.Trim())
 }
+
+// TestLineBuffer_CursorMovement walks the cursor through a typed
+// line and asserts every position. Each MoveLeft / MoveRight call
+// returns true only when the cursor actually moved; the no-op
+// returns false so the caller can skip a useless repaint.
+func TestLineBuffer_CursorMovement(t *testing.T) {
+	b := NewLineBuffer()
+	for _, r := range "abc" {
+		b.Append(r)
+	}
+	assert.Equal(t, 3, b.Cursor(), "Append parks the cursor at end")
+
+	assert.True(t, b.MoveLeft())
+	assert.Equal(t, 2, b.Cursor())
+
+	assert.True(t, b.MoveLeft())
+	assert.True(t, b.MoveLeft())
+	assert.Equal(t, 0, b.Cursor())
+
+	assert.False(t, b.MoveLeft(), "no movement at column 0")
+	assert.Equal(t, 0, b.Cursor())
+
+	assert.True(t, b.MoveRight())
+	assert.Equal(t, 1, b.Cursor())
+
+	assert.True(t, b.MoveEnd())
+	assert.Equal(t, 3, b.Cursor())
+
+	assert.False(t, b.MoveEnd(), "no movement when already at end")
+
+	assert.True(t, b.MoveStart())
+	assert.Equal(t, 0, b.Cursor())
+}
+
+// TestLineBuffer_InsertAtCursor is the arrow-key-aware editing
+// path: cursor moves into the middle of the buffer, Insert places
+// the new rune there (not at the end). Without this, ←←← Insert
+// would silently append, surprising any user with bash muscle
+// memory.
+func TestLineBuffer_InsertAtCursor(t *testing.T) {
+	b := NewLineBuffer()
+	for _, r := range "abc" {
+		b.Append(r)
+	}
+
+	// Move cursor between 'a' and 'b'.
+	b.MoveStart()
+	b.MoveRight()
+	assert.Equal(t, 1, b.Cursor())
+
+	b.Insert('X')
+	assert.Equal(t, "aXbc", b.String())
+	assert.Equal(t, 2, b.Cursor(), "cursor advances past the inserted rune")
+}
+
+// TestLineBuffer_BackspaceAtCursor ensures Backspace removes the
+// rune to the LEFT of the cursor, not the trailing rune of the
+// whole buffer. Critical when the user has navigated mid-line:
+// Backspace must feel like "erase the character I just passed".
+func TestLineBuffer_BackspaceAtCursor(t *testing.T) {
+	b := NewLineBuffer()
+	for _, r := range "abcd" {
+		b.Append(r)
+	}
+	b.MoveStart()
+	b.MoveRight()
+	b.MoveRight() // cursor between 'b' and 'c'
+	assert.Equal(t, 2, b.Cursor())
+
+	assert.True(t, b.Backspace())
+	assert.Equal(t, "acd", b.String(), "deletes 'b' to the left of cursor")
+	assert.Equal(t, 1, b.Cursor())
+}
+
+// TestLineBuffer_DeleteForward exercises the forward-delete (Delete
+// key) which removes the rune AT the cursor (the one that would
+// next be Inserted-over). Counterpart to Backspace; both must
+// preserve cursor position correctly.
+func TestLineBuffer_DeleteForward(t *testing.T) {
+	b := NewLineBuffer()
+	for _, r := range "abc" {
+		b.Append(r)
+	}
+	b.MoveStart() // cursor at 0
+
+	assert.True(t, b.Delete())
+	assert.Equal(t, "bc", b.String(), "deletes 'a' at cursor")
+	assert.Equal(t, 0, b.Cursor(), "cursor stays put — next rune slid into place")
+
+	b.MoveEnd()
+	assert.False(t, b.Delete(), "no-op at end of line")
+}
+
+// TestLineBuffer_KillWordAtCursor checks the bash readline behavior:
+// Ctrl+W deletes the word BEFORE the cursor, not unconditionally
+// from the end. Critical for mid-line edits.
+func TestLineBuffer_KillWordAtCursor(t *testing.T) {
+	b := NewLineBuffer()
+	for _, r := range "fix bar.go now" {
+		b.Append(r)
+	}
+	// Navigate cursor to right after "bar.go ": between space
+	// and 'n' of "now".
+	b.MoveStart()
+	for i := 0; i < 11; i++ {
+		b.MoveRight()
+	}
+	assert.Equal(t, 11, b.Cursor())
+
+	assert.True(t, b.KillWord())
+	assert.Equal(t, "fix now", b.String(), "deletes 'bar.go ' before cursor, leaves 'now' intact")
+}
+
+// TestLineBuffer_SetContentsParksCursorAtEnd is the history-recall
+// path: SetContents loads a recalled entry, and the cursor lands
+// after the last rune so the user can keep typing without first
+// pressing End.
+func TestLineBuffer_SetContentsParksCursorAtEnd(t *testing.T) {
+	b := NewLineBuffer()
+	b.Append('x') // dirty: prove SetContents replaces, not appends
+	b.SetContents("recalled history line")
+	assert.Equal(t, "recalled history line", b.String())
+	assert.Equal(t, len([]rune("recalled history line")), b.Cursor())
+}

--- a/cli/coder/turnui/rawmode_unix.go
+++ b/cli/coder/turnui/rawmode_unix.go
@@ -1,0 +1,53 @@
+//go:build !windows
+
+/*
+ * ChatCLI - Coder turn-UI raw-mode toggle (Unix)
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+package turnui
+
+import (
+	"golang.org/x/term"
+)
+
+// rawState wraps the previous TTY state. On Unix this is the cooked-
+// mode termios snapshot returned by term.MakeRaw / GetState. The
+// caller stashes it on the TurnUI and restores it on End or on a
+// signal-driven cleanup.
+//
+// We use golang.org/x/term rather than rolling our own ioctl(TIOCGETA /
+// TIOCSETA) because term already handles the platform differences
+// across Linux / macOS / *BSD and is the same dependency the rest of
+// chatcli uses for raw-mode entry in go-prompt-adjacent paths. Keeping
+// the dependency footprint stable matters for downstream packagers.
+type rawState struct {
+	prev *term.State
+}
+
+// enterRawMode puts the given file descriptor into raw mode (ICANON
+// off, ECHO off, ISIG off, plus the related flag clears that
+// term.MakeRaw applies) and returns a rawState that knows how to
+// undo it. A non-TTY fd (or any underlying ioctl failure) returns an
+// error; the caller is expected to fall back to the cooked legacy
+// renderer rather than proceed with a half-applied raw mode.
+func enterRawMode(fd int) (*rawState, error) {
+	prev, err := term.MakeRaw(fd)
+	if err != nil {
+		return nil, err
+	}
+	return &rawState{prev: prev}, nil
+}
+
+// restore returns the fd to the cooked-mode state captured by
+// enterRawMode. Safe to call on a nil receiver — the input-loop
+// cleanup path constructs the deferred restore before knowing
+// whether enterRawMode succeeded, so a nil rawState must be a no-op
+// instead of a panic.
+func (s *rawState) restore(fd int) error {
+	if s == nil || s.prev == nil {
+		return nil
+	}
+	return term.Restore(fd, s.prev)
+}

--- a/cli/coder/turnui/rawmode_windows.go
+++ b/cli/coder/turnui/rawmode_windows.go
@@ -1,0 +1,43 @@
+//go:build windows
+
+/*
+ * ChatCLI - Coder turn-UI raw-mode toggle (Windows)
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+package turnui
+
+import (
+	"golang.org/x/term"
+)
+
+// rawState wraps the previous console mode. The Windows console
+// API is different from Unix termios, but golang.org/x/term hides
+// the difference behind the same MakeRaw / Restore pair — so the
+// shape of the code mirrors the Unix variant for symmetry.
+//
+// On Win10+ consoles with ENABLE_VIRTUAL_TERMINAL_INPUT, MakeRaw
+// also flips the input mode so escape sequences come through to
+// the application instead of being intercepted by the console.
+// fallback_windows.go's probe already gated the activation on
+// ENABLE_VIRTUAL_TERMINAL_PROCESSING for output; the input mode
+// follows the same prerequisite.
+type rawState struct {
+	prev *term.State
+}
+
+func enterRawMode(fd int) (*rawState, error) {
+	prev, err := term.MakeRaw(fd)
+	if err != nil {
+		return nil, err
+	}
+	return &rawState{prev: prev}, nil
+}
+
+func (s *rawState) restore(fd int) error {
+	if s == nil || s.prev == nil {
+		return nil
+	}
+	return term.Restore(fd, s.prev)
+}

--- a/cli/coder/turnui/readline.go
+++ b/cli/coder/turnui/readline.go
@@ -78,6 +78,12 @@ type ReadLineConfig struct {
 	// OnCancel is invoked on Ctrl+C. The loop continues; it is up
 	// to the agent to translate cancel into "abort the LLM turn".
 	OnCancel func()
+
+	// History is the ↑/↓ navigation stack. Optional — when nil
+	// the arrow keys for history are dropped silently. The loop
+	// appends submitted lines automatically; the caller does not
+	// need to manage history population.
+	History *History
 }
 
 // RunReadLine drives the read-decode-paint loop until ctx is canceled
@@ -142,6 +148,31 @@ func RunReadLine(ctx context.Context, cfg ReadLineConfig) error {
 			}
 			stream = stream[consumed:]
 
+			// History keys are handled BEFORE applyKey because
+			// they need access to the History (not the buffer
+			// alone) and they replace the entire buffer rather
+			// than mutating it incrementally. applyKey stays a
+			// pure function over (Key, *LineBuffer) for its own
+			// unit tests; history is a loop-level concern.
+			if key.Kind == KeyArrowUp || key.Kind == KeyArrowDown {
+				if cfg.History != nil {
+					var recalled string
+					var ok bool
+					if key.Kind == KeyArrowUp {
+						recalled, ok = cfg.History.Up(buf.String())
+					} else {
+						recalled, ok = cfg.History.Down()
+					}
+					if ok {
+						buf.SetContents(recalled)
+						if err := cfg.Painter.PaintInput(buf); err != nil {
+							return fmt.Errorf("turnui: paint after history: %w", err)
+						}
+					}
+				}
+				continue
+			}
+
 			submit, exitLoop, repaint := applyKey(key, buf)
 			if repaint {
 				if err := cfg.Painter.PaintInput(buf); err != nil {
@@ -155,6 +186,9 @@ func RunReadLine(ctx context.Context, cfg ReadLineConfig) error {
 					return fmt.Errorf("turnui: paint after submit: %w", err)
 				}
 				if line != "" {
+					if cfg.History != nil {
+						cfg.History.Append(line)
+					}
 					cfg.OnSubmit(line)
 				}
 			}
@@ -163,6 +197,9 @@ func RunReadLine(ctx context.Context, cfg ReadLineConfig) error {
 					cfg.OnCancel()
 				}
 				buf.Reset()
+				if cfg.History != nil {
+					cfg.History.Reset()
+				}
 				if err := cfg.Painter.PaintInput(buf); err != nil {
 					return fmt.Errorf("turnui: paint after cancel: %w", err)
 				}
@@ -189,13 +226,21 @@ const (
 // what the loop should do next. Pure function over (Key, buffer); no
 // IO, no terminal writes — those happen in the loop. Pulled out so
 // the per-key behavior table has its own focused unit tests.
+//
+// History keys (KeyArrowUp / KeyArrowDown) are intentionally NOT
+// handled here — they need access to the History stack, which lives
+// in the loop closure. The loop dispatches them before calling
+// applyKey; this function only sees the navigation-within-buffer
+// keys (arrows left/right, Home/End/Ctrl+A/Ctrl+E, Delete).
 func applyKey(key Key, buf *LineBuffer) (submit bool, exit exitKind, repaint bool) {
 	switch key.Kind {
 	case KeyChar:
-		buf.Append(key.Rune)
+		buf.Insert(key.Rune)
 		return false, exitNone, true
 	case KeyBackspace:
 		return false, exitNone, buf.Backspace()
+	case KeyDelete:
+		return false, exitNone, buf.Delete()
 	case KeyEnter:
 		return true, exitNone, false
 	case KeyCtrlC:
@@ -212,6 +257,14 @@ func applyKey(key Key, buf *LineBuffer) (submit bool, exit exitKind, repaint boo
 		return false, exitNone, buf.KillLine()
 	case KeyCtrlW:
 		return false, exitNone, buf.KillWord()
+	case KeyArrowLeft:
+		return false, exitNone, buf.MoveLeft()
+	case KeyArrowRight:
+		return false, exitNone, buf.MoveRight()
+	case KeyHome, KeyCtrlA:
+		return false, exitNone, buf.MoveStart()
+	case KeyEnd, KeyCtrlE:
+		return false, exitNone, buf.MoveEnd()
 	default:
 		return false, exitNone, false
 	}

--- a/cli/coder/turnui/readline.go
+++ b/cli/coder/turnui/readline.go
@@ -1,0 +1,215 @@
+/*
+ * ChatCLI - Coder turn-UI mini readline
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+package turnui
+
+import (
+	"context"
+	"fmt"
+	"io"
+)
+
+// InputEvent is what the mini-readline emits to the input loop's
+// consumer (the agent's stdin queue). Replacing the channel<-string
+// pattern with a richer event type lets the consumer distinguish a
+// plain submission from a Ctrl+C cancel or an EOF — each of which
+// has different semantics for the agent loop (continue / abort the
+// current turn / shut down).
+type InputEvent struct {
+	Kind InputEventKind
+	Line string
+}
+
+// InputEventKind enumerates the events the input loop can produce.
+// Keep the set small and exhaustively documented; downstream code
+// in the agent loop will need to switch on every variant.
+type InputEventKind int
+
+const (
+	// InputSubmit fires when the user presses Enter on a non-empty
+	// buffer. The Line field carries the trimmed text.
+	InputSubmit InputEventKind = iota
+
+	// InputCancel fires on Ctrl+C. The agent loop translates this
+	// to a request to abort the current LLM turn (the same effect
+	// as the existing Ctrl+C in chat mode), but without killing
+	// the whole session.
+	InputCancel
+
+	// InputEOF fires on Ctrl+D with an empty buffer (matches the
+	// shell convention). The agent loop treats it as "user is done
+	// for this session" and returns from /coder.
+	InputEOF
+)
+
+// inputPainter is the abstraction the loop uses to repaint the input
+// row after every buffer change. The TurnUI implements it; tests
+// supply a mock that records the redraws so we can assert on the
+// echo behavior without a real terminal.
+type inputPainter interface {
+	// paintInput moves the cursor to the input row, clears it,
+	// writes the prompt and the buffer's current contents. Called
+	// after every state change in the line buffer.
+	paintInput(buf *LineBuffer) error
+}
+
+// ReadLineConfig bundles the dependencies the input loop needs.
+// Pulling them into a struct makes the loop self-contained and lets
+// tests inject mock readers, writers, and painters without touching
+// globals.
+type ReadLineConfig struct {
+	// Reader is the source of raw bytes. In production this is the
+	// raw-mode stdin; in tests, any io.Reader works.
+	Reader io.Reader
+
+	// Painter repaints the input row on buffer changes. Required.
+	Painter inputPainter
+
+	// OnSubmit is invoked when the user presses Enter with a non-
+	// empty buffer. The line is delivered already trimmed.
+	OnSubmit func(line string)
+
+	// OnCancel is invoked on Ctrl+C. The loop continues; it is up
+	// to the agent to translate cancel into "abort the LLM turn".
+	OnCancel func()
+}
+
+// RunReadLine drives the read-decode-paint loop until ctx is canceled
+// or the reader returns EOF. It blocks on the calling goroutine — the
+// agent layer is expected to run it in its own goroutine alongside
+// the turn execution.
+//
+// The loop is structured as: read into a 256-byte buffer, drain it
+// rune by rune via DecodeOne, act on each Key, repaint when the
+// buffer changes. The 256-byte read size is a balance — large enough
+// to capture pasted text in one read on most terminals, small enough
+// to keep latency low for single-key responsiveness.
+//
+// Errors from the reader are surfaced via the returned error so the
+// caller can decide between "EOF means clean shutdown" and "I/O error
+// means restore terminal then bubble up". An EOF inside a non-empty
+// buffer is preserved (the buffer is not auto-submitted) to match
+// readline semantics — the user pressed Ctrl+D to bail, they did NOT
+// silently confirm whatever was in the field.
+func RunReadLine(ctx context.Context, cfg ReadLineConfig) error {
+	if cfg.Reader == nil || cfg.Painter == nil {
+		return fmt.Errorf("turnui: ReadLineConfig requires Reader and Painter")
+	}
+
+	buf := NewLineBuffer()
+	if err := cfg.Painter.paintInput(buf); err != nil {
+		return fmt.Errorf("turnui: initial input paint: %w", err)
+	}
+
+	// readBuf accumulates raw bytes; carry holds the unprocessed
+	// tail between reads so a multi-byte rune split across two
+	// reads is not lost. The tail is rare in practice — most TTYs
+	// deliver complete characters per read — but the cost of
+	// supporting it is two lines and a copy.
+	readBuf := make([]byte, 256)
+	var carry []byte
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		n, err := cfg.Reader.Read(readBuf)
+		if n == 0 && err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+
+		stream := append(carry, readBuf[:n]...)
+		carry = carry[:0]
+		for len(stream) > 0 {
+			key, consumed := DecodeOne(stream)
+			if consumed == 0 {
+				// Incomplete sequence — stash the remainder for
+				// the next read instead of looping forever.
+				carry = append(carry, stream...)
+				break
+			}
+			stream = stream[consumed:]
+
+			submit, exitLoop, repaint := applyKey(key, buf)
+			if repaint {
+				if err := cfg.Painter.paintInput(buf); err != nil {
+					return fmt.Errorf("turnui: paint after key: %w", err)
+				}
+			}
+			if submit && cfg.OnSubmit != nil {
+				line := buf.Trim()
+				buf.Reset()
+				if err := cfg.Painter.paintInput(buf); err != nil {
+					return fmt.Errorf("turnui: paint after submit: %w", err)
+				}
+				if line != "" {
+					cfg.OnSubmit(line)
+				}
+			}
+			if exitLoop == exitCancel {
+				if cfg.OnCancel != nil {
+					cfg.OnCancel()
+				}
+				buf.Reset()
+				if err := cfg.Painter.paintInput(buf); err != nil {
+					return fmt.Errorf("turnui: paint after cancel: %w", err)
+				}
+			}
+			if exitLoop == exitEOF {
+				return nil
+			}
+		}
+	}
+}
+
+// exitKind is the internal verdict applyKey hands back to the loop.
+// Distinguishing cancel from EOF up front keeps the switch in the
+// loop body tidy and the test surface narrow.
+type exitKind int
+
+const (
+	exitNone exitKind = iota
+	exitCancel
+	exitEOF
+)
+
+// applyKey mutates the buffer based on one Key event and reports
+// what the loop should do next. Pure function over (Key, buffer); no
+// IO, no terminal writes — those happen in the loop. Pulled out so
+// the per-key behavior table has its own focused unit tests.
+func applyKey(key Key, buf *LineBuffer) (submit bool, exit exitKind, repaint bool) {
+	switch key.Kind {
+	case KeyChar:
+		buf.Append(key.Rune)
+		return false, exitNone, true
+	case KeyBackspace:
+		return false, exitNone, buf.Backspace()
+	case KeyEnter:
+		return true, exitNone, false
+	case KeyCtrlC:
+		return false, exitCancel, false
+	case KeyCtrlD:
+		// EOT submits or exits depending on whether the buffer is
+		// empty — same convention as bash and readline. A non-empty
+		// buffer keeps the line and lets the user keep typing.
+		if buf.VisibleWidth() == 0 {
+			return false, exitEOF, false
+		}
+		return false, exitNone, false
+	case KeyCtrlU:
+		return false, exitNone, buf.KillLine()
+	case KeyCtrlW:
+		return false, exitNone, buf.KillWord()
+	default:
+		return false, exitNone, false
+	}
+}

--- a/cli/coder/turnui/readline.go
+++ b/cli/coder/turnui/readline.go
@@ -45,15 +45,18 @@ const (
 	InputEOF
 )
 
-// inputPainter is the abstraction the loop uses to repaint the input
+// InputPainter is the abstraction the loop uses to repaint the input
 // row after every buffer change. The TurnUI implements it; tests
 // supply a mock that records the redraws so we can assert on the
-// echo behavior without a real terminal.
-type inputPainter interface {
-	// paintInput moves the cursor to the input row, clears it,
+// echo behavior without a real terminal. Exported so packages outside
+// turnui (notably cli, where the agent loop spawns its own readline
+// goroutine after BeginInteractive) can plug in a custom painter or
+// reference the contract from a struct field.
+type InputPainter interface {
+	// PaintInput moves the cursor to the input row, clears it,
 	// writes the prompt and the buffer's current contents. Called
 	// after every state change in the line buffer.
-	paintInput(buf *LineBuffer) error
+	PaintInput(buf *LineBuffer) error
 }
 
 // ReadLineConfig bundles the dependencies the input loop needs.
@@ -66,7 +69,7 @@ type ReadLineConfig struct {
 	Reader io.Reader
 
 	// Painter repaints the input row on buffer changes. Required.
-	Painter inputPainter
+	Painter InputPainter
 
 	// OnSubmit is invoked when the user presses Enter with a non-
 	// empty buffer. The line is delivered already trimmed.
@@ -100,7 +103,7 @@ func RunReadLine(ctx context.Context, cfg ReadLineConfig) error {
 	}
 
 	buf := NewLineBuffer()
-	if err := cfg.Painter.paintInput(buf); err != nil {
+	if err := cfg.Painter.PaintInput(buf); err != nil {
 		return fmt.Errorf("turnui: initial input paint: %w", err)
 	}
 
@@ -141,14 +144,14 @@ func RunReadLine(ctx context.Context, cfg ReadLineConfig) error {
 
 			submit, exitLoop, repaint := applyKey(key, buf)
 			if repaint {
-				if err := cfg.Painter.paintInput(buf); err != nil {
+				if err := cfg.Painter.PaintInput(buf); err != nil {
 					return fmt.Errorf("turnui: paint after key: %w", err)
 				}
 			}
 			if submit && cfg.OnSubmit != nil {
 				line := buf.Trim()
 				buf.Reset()
-				if err := cfg.Painter.paintInput(buf); err != nil {
+				if err := cfg.Painter.PaintInput(buf); err != nil {
 					return fmt.Errorf("turnui: paint after submit: %w", err)
 				}
 				if line != "" {
@@ -160,7 +163,7 @@ func RunReadLine(ctx context.Context, cfg ReadLineConfig) error {
 					cfg.OnCancel()
 				}
 				buf.Reset()
-				if err := cfg.Painter.paintInput(buf); err != nil {
+				if err := cfg.Painter.PaintInput(buf); err != nil {
 					return fmt.Errorf("turnui: paint after cancel: %w", err)
 				}
 			}

--- a/cli/coder/turnui/readline_test.go
+++ b/cli/coder/turnui/readline_test.go
@@ -338,3 +338,145 @@ type erroringPainter struct{}
 func (e *erroringPainter) PaintInput(_ *LineBuffer) error {
 	return io.ErrShortWrite
 }
+
+// TestApplyKey_NavigationKeysMutateCursor covers the keys Phase G
+// added: ←/→/Home/End/Ctrl+A/Ctrl+E move the buffer cursor, Delete
+// removes forward. Each behaves as a no-op when the cursor cannot
+// move (start/end of line) — the bool return is the paint signal.
+func TestApplyKey_NavigationKeysMutateCursor(t *testing.T) {
+	tests := []struct {
+		name      string
+		seed      string
+		startPos  int
+		key       Key
+		wantBuf   string
+		wantCur   int
+		wantPaint bool
+	}{
+		{"left moves cursor back", "abc", 3, Key{KeyArrowLeft, 0}, "abc", 2, true},
+		{"left no-op at col 0", "abc", 0, Key{KeyArrowLeft, 0}, "abc", 0, false},
+		{"right moves cursor forward", "abc", 0, Key{KeyArrowRight, 0}, "abc", 1, true},
+		{"right no-op at end", "abc", 3, Key{KeyArrowRight, 0}, "abc", 3, false},
+		{"home jumps to start", "abc", 3, Key{KeyHome, 0}, "abc", 0, true},
+		{"ctrl+a jumps to start", "abc", 3, Key{KeyCtrlA, 0}, "abc", 0, true},
+		{"end jumps to end", "abc", 0, Key{KeyEnd, 0}, "abc", 3, true},
+		{"ctrl+e jumps to end", "abc", 0, Key{KeyCtrlE, 0}, "abc", 3, true},
+		{"delete removes at cursor", "abc", 1, Key{KeyDelete, 0}, "ac", 1, true},
+		{"delete no-op at end", "abc", 3, Key{KeyDelete, 0}, "abc", 3, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := NewLineBuffer()
+			for _, r := range tc.seed {
+				buf.Append(r)
+			}
+			// Move cursor to the start position via MoveStart +
+			// N×MoveRight so the test does not depend on internal
+			// representation.
+			buf.MoveStart()
+			for i := 0; i < tc.startPos; i++ {
+				buf.MoveRight()
+			}
+			_, _, repaint := applyKey(tc.key, buf)
+			assert.Equal(t, tc.wantBuf, buf.String())
+			assert.Equal(t, tc.wantCur, buf.Cursor())
+			assert.Equal(t, tc.wantPaint, repaint)
+		})
+	}
+}
+
+// TestRunReadLine_HistoryUpAndDown wires the History through the
+// loop and exercises ↑↓ navigation end-to-end. The scripted reader
+// submits "first" and "second", then ↑ recalls "second", ↑ recalls
+// "first", ↓ goes back to "second", ↓ restores the empty draft.
+// The frame snapshot captures the buffer contents after each paint.
+func TestRunReadLine_HistoryUpAndDown(t *testing.T) {
+	painter := &fakePainter{}
+	hist := NewHistory(10)
+	hist.Append("first")
+	hist.Append("second")
+
+	var submissions []string
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	reader := &scriptedReader{chunks: [][]byte{
+		{0x1b, '[', 'A'},                                          // ↑ → "second"
+		{0x1b, '[', 'A'},                                          // ↑ → "first"
+		{0x1b, '[', 'B'},                                          // ↓ → "second"
+		{0x1b, '[', 'B'},                                          // ↓ → restore empty draft
+		[]byte("hi"),                                              // type
+		{0x0d},                                                    // Enter
+	}}
+
+	cfg := ReadLineConfig{
+		Reader:  reader,
+		Painter: painter,
+		History: hist,
+		OnSubmit: func(line string) {
+			mu.Lock()
+			submissions = append(submissions, line)
+			mu.Unlock()
+			wg.Done()
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- RunReadLine(ctx, cfg) }()
+	wg.Wait()
+	cancel()
+	require.NoError(t, <-errCh)
+
+	assert.Equal(t, []string{"hi"}, submissions)
+
+	// History should now contain first, second, hi (the most
+	// recent submission was appended).
+	assert.Equal(t, 3, hist.Len())
+
+	// Frames should include the recalled entries.
+	frames := painter.framesSnapshot()
+	assert.Contains(t, frames, "second")
+	assert.Contains(t, frames, "first")
+	assert.Contains(t, frames, "hi")
+}
+
+// TestRunReadLine_ArrowsMoveCursorInBuffer is the integration test
+// for inline navigation. Type "ad", ←, insert "bc", Enter →
+// submission is "abcd" (not "adbc" or "bcad"). Without the cursor-
+// aware Insert path the test fails with the latter strings.
+func TestRunReadLine_ArrowsMoveCursorInBuffer(t *testing.T) {
+	painter := &fakePainter{}
+	var submitted string
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	reader := &scriptedReader{chunks: [][]byte{
+		[]byte("ad"),
+		{0x1b, '[', 'D'}, // ←
+		[]byte("bc"),
+		{0x0d}, // Enter
+	}}
+
+	cfg := ReadLineConfig{
+		Reader:  reader,
+		Painter: painter,
+		OnSubmit: func(line string) {
+			submitted = line
+			wg.Done()
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- RunReadLine(ctx, cfg) }()
+	wg.Wait()
+	cancel()
+	require.NoError(t, <-errCh)
+
+	assert.Equal(t, "abcd", submitted, "← + Insert places chars at cursor, not at end")
+}

--- a/cli/coder/turnui/readline_test.go
+++ b/cli/coder/turnui/readline_test.go
@@ -1,0 +1,340 @@
+/*
+ * ChatCLI - Coder turn-UI mini readline tests
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+package turnui
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakePainter records every paint call so tests can assert on the
+// echoed buffer contents without juggling escape sequences. It
+// satisfies the inputPainter interface that RunReadLine consumes.
+type fakePainter struct {
+	mu     sync.Mutex
+	frames []string
+}
+
+func (p *fakePainter) paintInput(buf *LineBuffer) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.frames = append(p.frames, buf.String())
+	return nil
+}
+
+func (p *fakePainter) framesSnapshot() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]string, len(p.frames))
+	copy(out, p.frames)
+	return out
+}
+
+// scriptedReader hands out predetermined byte chunks and then
+// signals EOF. Used to feed the input loop a fixed sequence in
+// tests without needing an actual TTY.
+type scriptedReader struct {
+	chunks [][]byte
+	idx    int
+}
+
+func (r *scriptedReader) Read(p []byte) (int, error) {
+	if r.idx >= len(r.chunks) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.chunks[r.idx])
+	r.idx++
+	return n, nil
+}
+
+// TestApplyKey_TableOfBehavior is the per-key contract: KeyChar
+// appends + repaints, KeyEnter submits, KeyBackspace deletes,
+// KeyCtrlC cancels, etc. Each row is one keystroke; the verdict
+// columns mirror applyKey's return tuple. A change in any cell
+// is a UX change that warrants a code review.
+func TestApplyKey_TableOfBehavior(t *testing.T) {
+	tests := []struct {
+		name       string
+		seed       string
+		key        Key
+		wantBuf    string
+		wantSubmit bool
+		wantExit   exitKind
+		wantPaint  bool
+	}{
+		{"char appends and repaints", "abc", Key{KeyChar, 'd'}, "abcd", false, exitNone, true},
+		{"backspace deletes and repaints", "abc", Key{KeyBackspace, 0}, "ab", false, exitNone, true},
+		{"backspace on empty is no-op", "", Key{KeyBackspace, 0}, "", false, exitNone, false},
+		{"enter submits without repaint", "abc", Key{KeyEnter, 0}, "abc", true, exitNone, false},
+		{"ctrl+c cancels", "abc", Key{KeyCtrlC, 0}, "abc", false, exitCancel, false},
+		{"ctrl+d empty exits", "", Key{KeyCtrlD, 0}, "", false, exitEOF, false},
+		{"ctrl+d non-empty is ignored", "abc", Key{KeyCtrlD, 0}, "abc", false, exitNone, false},
+		{"ctrl+u kills line", "the line", Key{KeyCtrlU, 0}, "", false, exitNone, true},
+		{"ctrl+w kills word", "the line ", Key{KeyCtrlW, 0}, "the ", false, exitNone, true},
+		{"unknown key is ignored", "abc", Key{KeyUnknown, 0}, "abc", false, exitNone, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := NewLineBuffer()
+			for _, r := range tc.seed {
+				buf.Append(r)
+			}
+			submit, exit, repaint := applyKey(tc.key, buf)
+			assert.Equal(t, tc.wantBuf, buf.String())
+			assert.Equal(t, tc.wantSubmit, submit)
+			assert.Equal(t, tc.wantExit, exit)
+			assert.Equal(t, tc.wantPaint, repaint)
+		})
+	}
+}
+
+// TestRunReadLine_SubmitsTrimmedLineOnEnter walks the loop end-to-end
+// with a scripted sequence: "hi\r". Asserts the OnSubmit callback
+// fires with the trimmed contents, the buffer is reset, and the
+// frames show the typing progression.
+func TestRunReadLine_SubmitsTrimmedLineOnEnter(t *testing.T) {
+	painter := &fakePainter{}
+	var submitted string
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	reader := &scriptedReader{chunks: [][]byte{
+		[]byte("hi"),
+		{0x0d}, // Enter
+	}}
+
+	cfg := ReadLineConfig{
+		Reader:  reader,
+		Painter: painter,
+		OnSubmit: func(line string) {
+			submitted = line
+			wg.Done()
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- RunReadLine(ctx, cfg) }()
+
+	wg.Wait()
+	cancel()
+	err := <-errCh
+	require.NoError(t, err)
+
+	assert.Equal(t, "hi", submitted)
+	// First frame is the initial empty paint; later frames show
+	// progressive append plus the post-submit reset back to empty.
+	assert.Contains(t, painter.framesSnapshot(), "hi")
+	assert.Equal(t, "", painter.framesSnapshot()[len(painter.framesSnapshot())-1],
+		"after Enter the buffer is reset and the row repaints empty")
+}
+
+// TestRunReadLine_BackspaceErasesGlyph reproduces the live workflow
+// of typing a multi-byte character and erasing it. Without rune
+// awareness this would leave a dangling 0xC3 in the buffer and the
+// next paint would emit mojibake. The submitted line is checked to
+// confirm the buffer is what the user sees.
+func TestRunReadLine_BackspaceErasesGlyph(t *testing.T) {
+	painter := &fakePainter{}
+	var submitted string
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	reader := &scriptedReader{chunks: [][]byte{
+		[]byte("olá"),
+		{0x7f}, // Backspace (DEL)
+		{0x0d}, // Enter
+	}}
+
+	cfg := ReadLineConfig{
+		Reader:  reader,
+		Painter: painter,
+		OnSubmit: func(line string) {
+			submitted = line
+			wg.Done()
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- RunReadLine(ctx, cfg) }()
+
+	wg.Wait()
+	cancel()
+	require.NoError(t, <-errCh)
+	assert.Equal(t, "ol", submitted, "Backspace must delete the full 'á' glyph")
+}
+
+// TestRunReadLine_CancelFiresOnCtrlC checks that Ctrl+C produces a
+// cancel event without aborting the loop. The agent uses cancel to
+// abort the current LLM turn; the input row should immediately be
+// ready for the next message.
+func TestRunReadLine_CancelFiresOnCtrlC(t *testing.T) {
+	painter := &fakePainter{}
+	cancelled := false
+	var mu sync.Mutex
+	cond := sync.NewCond(&mu)
+
+	reader := &scriptedReader{chunks: [][]byte{
+		[]byte("abc"),
+		{0x03}, // Ctrl+C
+	}}
+
+	cfg := ReadLineConfig{
+		Reader:  reader,
+		Painter: painter,
+		OnCancel: func() {
+			mu.Lock()
+			cancelled = true
+			cond.Signal()
+			mu.Unlock()
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- RunReadLine(ctx, cfg) }()
+
+	mu.Lock()
+	for !cancelled {
+		cond.Wait()
+	}
+	mu.Unlock()
+	cancel()
+	require.NoError(t, <-errCh)
+
+	assert.True(t, cancelled)
+	frames := painter.framesSnapshot()
+	assert.Equal(t, "", frames[len(frames)-1], "after Ctrl+C the buffer is reset")
+}
+
+// TestRunReadLine_EOFOnEmptyExits matches the shell convention:
+// Ctrl+D on an empty buffer ends the input loop cleanly. The agent
+// translates this into "user is done with /coder for this session".
+func TestRunReadLine_EOFOnEmptyExits(t *testing.T) {
+	painter := &fakePainter{}
+	reader := &scriptedReader{chunks: [][]byte{
+		{0x04}, // Ctrl+D on empty
+	}}
+
+	cfg := ReadLineConfig{Reader: reader, Painter: painter}
+	require.NoError(t, RunReadLine(context.Background(), cfg))
+}
+
+// TestRunReadLine_SplitMultiByteAcrossReads reproduces the boundary
+// case where a UTF-8 sequence is split across two reads (TTY may
+// flush after the lead byte; rare but possible). Without carry, the
+// loop would treat each half as an invalid byte and drop both.
+func TestRunReadLine_SplitMultiByteAcrossReads(t *testing.T) {
+	painter := &fakePainter{}
+	var submitted string
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// "ç" is 0xC3 0xA7; split into two reads.
+	reader := &scriptedReader{chunks: [][]byte{
+		{0xc3},
+		{0xa7},
+		{0x0d}, // Enter
+	}}
+
+	cfg := ReadLineConfig{
+		Reader:  reader,
+		Painter: painter,
+		OnSubmit: func(line string) {
+			submitted = line
+			wg.Done()
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- RunReadLine(ctx, cfg) }()
+
+	wg.Wait()
+	cancel()
+	require.NoError(t, <-errCh)
+	assert.Equal(t, "ç", submitted, "multi-byte rune split across reads must be reassembled")
+}
+
+// TestRunReadLine_RejectsMissingDeps catches the configuration
+// mistake of forgetting to wire the Painter or Reader. The error is
+// returned early so the caller can fall back without leaving the
+// terminal in a half-initialized state.
+func TestRunReadLine_RejectsMissingDeps(t *testing.T) {
+	err := RunReadLine(context.Background(), ReadLineConfig{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Reader and Painter")
+}
+
+// TestPaintInput_DrawsPromptOnInputRow asserts the live painter
+// (TurnUI.paintInput) writes the expected sequence: move to input
+// row, clear it, write prompt + buffer. No save/restore — the
+// cursor is supposed to live on the input row.
+func TestPaintInput_DrawsPromptOnInputRow(t *testing.T) {
+	var buf bytes.Buffer
+	u := New(&buf)
+	require.NoError(t, u.Begin(24, 80))
+	buf.Reset()
+
+	lb := NewLineBuffer()
+	for _, r := range "fix bar.go" {
+		lb.Append(r)
+	}
+	require.NoError(t, u.paintInput(lb))
+
+	got := buf.String()
+	assert.Contains(t, got, "\x1b[24;1H", "moved to input row (24,1)")
+	assert.Contains(t, got, "\x1b[2K", "cleared the row")
+	assert.Contains(t, got, InputPrompt+"fix bar.go", "prompt + buffer contents written")
+	assert.NotContains(t, got, "\x1b7", "input paint must NOT save the cursor")
+	assert.NotContains(t, got, "\x1b8", "input paint must NOT restore the cursor")
+}
+
+// TestPaintInput_NoOpWhenInactive matches paintStatus's behavior.
+// The reader loop can fire paintInput from its own goroutine after
+// End has fired without producing stray writes to the terminal.
+func TestPaintInput_NoOpWhenInactive(t *testing.T) {
+	var buf bytes.Buffer
+	u := New(&buf)
+	require.NoError(t, u.paintInput(NewLineBuffer()))
+	assert.Empty(t, buf.String())
+}
+
+// TestRunReadLine_PaintErrorBubblesUp ensures a paint failure is
+// surfaced to the caller rather than being swallowed. The caller
+// needs to know so it can restore the TTY before reporting the
+// error — silent paint failures are how terminals end up wedged.
+func TestRunReadLine_PaintErrorBubblesUp(t *testing.T) {
+	reader := strings.NewReader("a")
+	cfg := ReadLineConfig{
+		Reader:  reader,
+		Painter: &erroringPainter{},
+	}
+	err := RunReadLine(context.Background(), cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "initial input paint")
+}
+
+type erroringPainter struct{}
+
+func (e *erroringPainter) paintInput(_ *LineBuffer) error {
+	return io.ErrShortWrite
+}

--- a/cli/coder/turnui/readline_test.go
+++ b/cli/coder/turnui/readline_test.go
@@ -27,7 +27,7 @@ type fakePainter struct {
 	frames []string
 }
 
-func (p *fakePainter) paintInput(buf *LineBuffer) error {
+func (p *fakePainter) PaintInput(buf *LineBuffer) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.frames = append(p.frames, buf.String())
@@ -285,7 +285,7 @@ func TestRunReadLine_RejectsMissingDeps(t *testing.T) {
 }
 
 // TestPaintInput_DrawsPromptOnInputRow asserts the live painter
-// (TurnUI.paintInput) writes the expected sequence: move to input
+// (TurnUI.PaintInput) writes the expected sequence: move to input
 // row, clear it, write prompt + buffer. No save/restore — the
 // cursor is supposed to live on the input row.
 func TestPaintInput_DrawsPromptOnInputRow(t *testing.T) {
@@ -298,7 +298,7 @@ func TestPaintInput_DrawsPromptOnInputRow(t *testing.T) {
 	for _, r := range "fix bar.go" {
 		lb.Append(r)
 	}
-	require.NoError(t, u.paintInput(lb))
+	require.NoError(t, u.PaintInput(lb))
 
 	got := buf.String()
 	assert.Contains(t, got, "\x1b[24;1H", "moved to input row (24,1)")
@@ -309,12 +309,12 @@ func TestPaintInput_DrawsPromptOnInputRow(t *testing.T) {
 }
 
 // TestPaintInput_NoOpWhenInactive matches paintStatus's behavior.
-// The reader loop can fire paintInput from its own goroutine after
+// The reader loop can fire PaintInput from its own goroutine after
 // End has fired without producing stray writes to the terminal.
 func TestPaintInput_NoOpWhenInactive(t *testing.T) {
 	var buf bytes.Buffer
 	u := New(&buf)
-	require.NoError(t, u.paintInput(NewLineBuffer()))
+	require.NoError(t, u.PaintInput(NewLineBuffer()))
 	assert.Empty(t, buf.String())
 }
 
@@ -335,6 +335,6 @@ func TestRunReadLine_PaintErrorBubblesUp(t *testing.T) {
 
 type erroringPainter struct{}
 
-func (e *erroringPainter) paintInput(_ *LineBuffer) error {
+func (e *erroringPainter) PaintInput(_ *LineBuffer) error {
 	return io.ErrShortWrite
 }

--- a/cli/coder/turnui/readline_test.go
+++ b/cli/coder/turnui/readline_test.go
@@ -284,11 +284,13 @@ func TestRunReadLine_RejectsMissingDeps(t *testing.T) {
 	assert.Contains(t, err.Error(), "Reader and Painter")
 }
 
-// TestPaintInput_DrawsPromptOnInputRow asserts the live painter
-// (TurnUI.PaintInput) writes the expected sequence: move to input
-// row, clear it, write prompt + buffer. No save/restore — the
-// cursor is supposed to live on the input row.
-func TestPaintInput_DrawsPromptOnInputRow(t *testing.T) {
+// TestPaintInput_DrawsPromptOnInputRowAndRecordsCursor asserts the
+// live painter (TurnUI.PaintInput) writes the expected sequence:
+// move to input row, clear it, write prompt + buffer, then move the
+// cursor to the buffer's logical insertion column AND record that
+// column in lastInputCol so UpdateStatus can snap back to it later
+// without depending on ESC 7 / 8 save/restore.
+func TestPaintInput_DrawsPromptOnInputRowAndRecordsCursor(t *testing.T) {
 	var buf bytes.Buffer
 	u := New(&buf)
 	require.NoError(t, u.Begin(24, 80))
@@ -306,6 +308,12 @@ func TestPaintInput_DrawsPromptOnInputRow(t *testing.T) {
 	assert.Contains(t, got, InputPrompt+"fix bar.go", "prompt + buffer contents written")
 	assert.NotContains(t, got, "\x1b7", "input paint must NOT save the cursor")
 	assert.NotContains(t, got, "\x1b8", "input paint must NOT restore the cursor")
+
+	// "❯ " is 2 visible columns; buffer "fix bar.go" is 10
+	// runes; final cursor column is 2 + 10 + 1 = 13 (1-based
+	// past the last glyph, where the next keystroke inserts).
+	assert.Equal(t, int32(13), u.lastInputCol.Load(),
+		"lastInputCol must reflect promptWidth + cursorOffset + 1 so UpdateStatus can restore the cursor")
 }
 
 // TestPaintInput_NoOpWhenInactive matches paintStatus's behavior.

--- a/cli/coder/turnui/region.go
+++ b/cli/coder/turnui/region.go
@@ -137,6 +137,49 @@ func ExitRegion(w io.Writer, l Layout) error {
 	return nil
 }
 
+// EnterAltScreen switches the terminal into the alternate screen
+// buffer (DEC private mode 1049). This is the same trick `less`,
+// `vim`, `top`, and the Claude Code Ink renderer all use: the
+// terminal swaps to a fresh blank screen, saves the cursor + the
+// previous screen contents, and any output the program emits stays
+// confined to this alt buffer. When ExitAltScreen runs, the original
+// screen + scroll history snap back as if nothing happened.
+//
+// Why this matters for the split UI: without alt-screen, DECSTBM
+// applied on top of whatever output preceded /coder produced two
+// real bugs in the field — banner content above the region created
+// a visual gap, and cursor positioning into the region overlapped
+// the user's scrollback. Alt-screen gives turnui a private canvas
+// to own completely, then hands the user's terminal back untouched.
+//
+// The 1049 mode is the modern form: it does save-cursor + clear +
+// switch in one sequence and works on every terminal that ships
+// today (xterm, iTerm2, Terminal.app, Hyper, Alacritty, Windows
+// Terminal, kitty, mintty). The legacy 47/1047 forms are not used
+// here — they require a separate save-cursor sequence and have
+// uneven scrollback-preservation semantics across emulators.
+func EnterAltScreen(w io.Writer) error {
+	if _, err := fmt.Fprint(w, "\x1b[?1049h"); err != nil {
+		return err
+	}
+	// Clear screen + home cursor. The 1049h sequence itself does
+	// clear on most terminals, but a small handful (notably some
+	// old tmux configs) only switch the buffer without clearing.
+	// The explicit clear costs nothing and removes that variance.
+	_, err := fmt.Fprint(w, "\x1b[2J\x1b[H")
+	return err
+}
+
+// ExitAltScreen swaps back to the original screen, restoring the
+// cursor position and scroll history. Pair every EnterAltScreen
+// with exactly one ExitAltScreen; nesting is not portable. Safe to
+// emit even if we were not in alt-screen — the terminal just
+// no-ops the sequence.
+func ExitAltScreen(w io.Writer) error {
+	_, err := fmt.Fprint(w, "\x1b[?1049l")
+	return err
+}
+
 // MoveCursor parks the cursor at (row, col) using the CUP sequence.
 // Rows and cols are 1-based to match every other ANSI tool the user
 // might compare against (tput, terminfo, the DEC manuals).

--- a/cli/coder/turnui/region.go
+++ b/cli/coder/turnui/region.go
@@ -1,0 +1,173 @@
+/*
+ * ChatCLI - Coder turn-UI scroll region primitives
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+package turnui
+
+import (
+	"fmt"
+	"io"
+)
+
+// The split UI carves the terminal into three horizontal bands:
+//
+//   ┌─────────────────────────────┐
+//   │ rows 1 .. contentBottom     │  ← agent output, scrolls inside
+//   │ row  contentBottom+1        │  ← status (spinner, queue depth)
+//   │ row  rows                   │  ← input prompt
+//   └─────────────────────────────┘
+//
+// The DECSTBM "Set Top and Bottom Margins" sequence — \x1b[<top>;<bot>r
+// — confines automatic scroll-on-LF to the requested region. Output
+// printed past the bottom margin scrolls within the region instead of
+// pushing the rest of the screen up, so the status and input rows
+// stay nailed in place no matter how much the agent prints.
+//
+// All write paths take an io.Writer (not os.Stdout direct) so tests
+// can capture the byte stream and assert on the exact escape sequences
+// — this is the single source of truth for which control codes leave
+// the program, and getting the wrong one wedges every terminal a user
+// might try.
+
+// Layout describes which rows belong to which band. Computed once per
+// Begin from the live terminal dimensions; recomputed on SIGWINCH.
+type Layout struct {
+	// Rows / Cols are the full terminal dimensions in cells. 1-indexed
+	// to match the way ANSI cursor-position sequences address rows.
+	Rows int
+	Cols int
+
+	// ContentTop is always 1 — DECSTBM expects 1-based row numbers
+	// and the content band starts at the very top of the screen.
+	ContentTop int
+
+	// ContentBottom is the last row of the scrollable content band.
+	// Equals Rows-2 (reserving one row for status and one for input).
+	ContentBottom int
+
+	// StatusRow is the row dedicated to the spinner / queue
+	// indicator. Equals Rows-1.
+	StatusRow int
+
+	// InputRow is the bottom-most row where the prompt and the
+	// user's typing live. Equals Rows.
+	InputRow int
+}
+
+// NewLayout computes the band assignment for a terminal of the given
+// size. It does not validate that the size is large enough — that's
+// the caller's job via ShouldActivate. Passing a too-small size
+// produces a degenerate Layout (negative ContentBottom) which the
+// caller can detect and bail on, rather than producing an invalid
+// escape sequence that gets sent to the terminal.
+func NewLayout(rows, cols int) Layout {
+	return Layout{
+		Rows:          rows,
+		Cols:          cols,
+		ContentTop:    1,
+		ContentBottom: rows - 2,
+		StatusRow:     rows - 1,
+		InputRow:      rows,
+	}
+}
+
+// Valid reports whether the layout has a positive content band. A
+// degenerate layout (rows < 3) makes ContentBottom <= 0, which would
+// cause DECSTBM to reject the sequence or, worse, set a weird region
+// that the terminal interprets as "scroll the whole screen the wrong
+// way". Callers MUST check Valid before applying a layout.
+func (l Layout) Valid() bool {
+	return l.Rows >= 3 && l.Cols >= 1 && l.ContentBottom >= l.ContentTop
+}
+
+// EnterRegion writes the sequence that confines scrolling to the
+// content band and parks the cursor on the first content row. The
+// caller is responsible for restoring the default region via
+// ExitRegion on cleanup — leaving DECSTBM set is the most common
+// source of "my terminal feels broken" bug reports because the
+// confinement persists across processes.
+//
+// The sequence is split into three primitives so a future debugger
+// can dump each one individually:
+//
+//	\x1b[<top>;<bot>r   DECSTBM — set scroll region
+//	\x1b[H              CUP     — cursor to top-left (1,1)
+//
+// Returns the first write error; subsequent writes are skipped to
+// avoid stomping a half-written sequence into the user's terminal.
+func EnterRegion(w io.Writer, l Layout) error {
+	if !l.Valid() {
+		return fmt.Errorf("turnui: invalid layout %dx%d (content band %d..%d)",
+			l.Rows, l.Cols, l.ContentTop, l.ContentBottom)
+	}
+	if _, err := fmt.Fprintf(w, "\x1b[%d;%dr", l.ContentTop, l.ContentBottom); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprint(w, "\x1b[H"); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ExitRegion restores the terminal's default scroll region (the whole
+// screen) and parks the cursor below the input row so the next prompt
+// the legacy renderer prints lands on a fresh, unconfined line.
+//
+// Two-phase teardown matters: a plain \x1b[r reset followed by a CUP
+// to the bottom is the only sequence we have seen reliably leave both
+// xterm-derived emulators (iTerm2, Alacritty, kitty) AND the macOS
+// Terminal.app in a sane state. Skipping either step leaves the cursor
+// in the wrong band or the region clamped.
+func ExitRegion(w io.Writer, l Layout) error {
+	if _, err := fmt.Fprint(w, "\x1b[r"); err != nil {
+		return err
+	}
+	// Park the cursor on the (formerly) input row so the next thing
+	// printed does not stomp the status line — that row's content is
+	// stale once the region is dropped, and the safest default is to
+	// leave the user looking at a fresh empty line under it.
+	if _, err := fmt.Fprintf(w, "\x1b[%d;1H", l.InputRow); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprint(w, "\n"); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MoveCursor parks the cursor at (row, col) using the CUP sequence.
+// Rows and cols are 1-based to match every other ANSI tool the user
+// might compare against (tput, terminfo, the DEC manuals).
+func MoveCursor(w io.Writer, row, col int) error {
+	_, err := fmt.Fprintf(w, "\x1b[%d;%dH", row, col)
+	return err
+}
+
+// ClearLine writes the CSI 2K sequence (erase entire line, cursor
+// position unchanged). Used by the status updater before redrawing
+// the spinner so stale glyphs from a longer previous message don't
+// leak past the new one. The cursor stays where it was — callers that
+// care about column alignment must move first, then clear.
+func ClearLine(w io.Writer) error {
+	_, err := fmt.Fprint(w, "\x1b[2K")
+	return err
+}
+
+// SaveCursor emits ESC 7 (DEC variant of save-cursor). We use the DEC
+// form rather than CSI s because some terminals — notably the GoLand
+// integrated terminal that this branch's bug reports came from —
+// honor one but not the other. ESC 7 has the wider support footprint
+// in practice. Pair every SaveCursor with exactly one RestoreCursor
+// before any further writes; nesting is not portable.
+func SaveCursor(w io.Writer) error {
+	_, err := fmt.Fprint(w, "\x1b7")
+	return err
+}
+
+// RestoreCursor is the companion to SaveCursor (ESC 8 / DECRC).
+func RestoreCursor(w io.Writer) error {
+	_, err := fmt.Fprint(w, "\x1b8")
+	return err
+}

--- a/cli/coder/turnui/region_test.go
+++ b/cli/coder/turnui/region_test.go
@@ -1,0 +1,167 @@
+/*
+ * ChatCLI - Coder turn-UI region tests
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+package turnui
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewLayout_BandsAddUp documents the contract every consumer
+// relies on: the three bands cover the whole screen with no overlap
+// and no gap. Off-by-one here would either leak agent output into the
+// status row or hide the bottom row of content under the input.
+func TestNewLayout_BandsAddUp(t *testing.T) {
+	l := NewLayout(24, 80)
+	assert.Equal(t, 1, l.ContentTop, "content always starts at row 1")
+	assert.Equal(t, 22, l.ContentBottom, "rows-2 leaves the status and input rows free")
+	assert.Equal(t, 23, l.StatusRow, "status sits one above the input")
+	assert.Equal(t, 24, l.InputRow, "input is always the bottom-most row")
+	assert.True(t, l.Valid())
+}
+
+// TestLayout_ValidRejectsDegenerate makes sure layouts that would
+// produce malformed DECSTBM sequences are caught at the boundary,
+// not by the terminal. A negative ContentBottom passed into
+// EnterRegion would emit "\x1b[1;-1r" which on most terminals
+// silently does nothing — leaving the spinner to draw at fake row
+// positions and the user staring at a mangled screen.
+func TestLayout_ValidRejectsDegenerate(t *testing.T) {
+	cases := []struct {
+		name string
+		l    Layout
+		want bool
+	}{
+		{"too few rows", NewLayout(2, 80), false},
+		{"zero rows", NewLayout(0, 80), false},
+		{"zero cols", NewLayout(24, 0), false},
+		{"exactly min", NewLayout(3, 1), true},
+		{"typical", NewLayout(24, 80), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.l.Valid())
+		})
+	}
+}
+
+// TestEnterRegion_EmitsDECSTBMAndCursorHome is the regression test for
+// the exact byte sequence that confines scrolling. The terminal sees
+// this as: "set margins to 1..22, jump to top-left." A typo in either
+// number breaks the band assignment silently — there is no error
+// returned by the terminal, just a wrecked UI — so we assert the
+// bytes directly. The escape character is rendered as \x1b in source;
+// the wire format is a single 0x1b byte.
+func TestEnterRegion_EmitsDECSTBMAndCursorHome(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, EnterRegion(&buf, NewLayout(24, 80)))
+
+	got := buf.String()
+	assert.Contains(t, got, "\x1b[1;22r", "DECSTBM with top=1 bot=22")
+	assert.Contains(t, got, "\x1b[H", "cursor home after the margin set")
+	// Order matters: DECSTBM first, then cursor-home. Reversing
+	// them can cause the cursor to jump back into the just-clamped
+	// region from an out-of-band starting position on some emulators.
+	assert.Less(t, strings.Index(got, "\x1b[1;22r"), strings.Index(got, "\x1b[H"),
+		"DECSTBM must precede cursor-home")
+}
+
+// TestEnterRegion_RejectsInvalidLayout confirms the gate at the top
+// of EnterRegion fires before any bytes leak to the terminal. A test
+// without this guard would let an invalid-layout caller corrupt the
+// real terminal during dev iteration.
+func TestEnterRegion_RejectsInvalidLayout(t *testing.T) {
+	var buf bytes.Buffer
+	err := EnterRegion(&buf, NewLayout(2, 80)) // too few rows
+	require.Error(t, err)
+	assert.Empty(t, buf.String(), "no bytes should escape when the layout is invalid")
+}
+
+// TestExitRegion_RestoresDefaultsAndParksCursor verifies the teardown
+// path leaves the terminal in a state the legacy renderer can take
+// over. The default region reset (\x1b[r) must come first; cursor
+// parking second; trailing newline third — that order is what every
+// terminal we have tested agrees on for "back to normal scrolling
+// with a fresh empty line ready".
+func TestExitRegion_RestoresDefaultsAndParksCursor(t *testing.T) {
+	var buf bytes.Buffer
+	layout := NewLayout(24, 80)
+	require.NoError(t, ExitRegion(&buf, layout))
+
+	got := buf.String()
+	assert.True(t, strings.HasPrefix(got, "\x1b[r"), "region reset must come first")
+	assert.Contains(t, got, "\x1b[24;1H", "cursor parked at the input row")
+	assert.True(t, strings.HasSuffix(got, "\n"), "trailing newline so the next prompt is on a clean line")
+}
+
+// TestMoveCursor_FormatsRowColumn pins the wire format for CUP. A
+// stray comma or a 0-indexed off-by-one here puts the spinner one
+// row away from where the layout expects it and the status overwrites
+// content.
+func TestMoveCursor_FormatsRowColumn(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, MoveCursor(&buf, 12, 5))
+	assert.Equal(t, "\x1b[12;5H", buf.String())
+}
+
+// TestSaveRestoreCursor_UsesDECVariants pins the choice of ESC 7 / 8
+// over CSI s / u. This is intentional and load-bearing: the GoLand
+// integrated terminal — which is what triggered the spinner cascade
+// bug report — ignores CSI s but honors ESC 7. Any future "cleanup"
+// PR that swaps these for the CSI variants would re-introduce the
+// regression silently; this test makes that visible.
+func TestSaveRestoreCursor_UsesDECVariants(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, SaveCursor(&buf))
+	require.NoError(t, RestoreCursor(&buf))
+	assert.Equal(t, "\x1b7\x1b8", buf.String())
+}
+
+// TestClearLine_EmitsCSI2K nails the erase-line sequence. CSI 2K
+// (erase whole line, cursor stays) differs from CSI 0K (erase to end
+// of line) and CSI 1K (erase to beginning); picking the wrong K
+// leaves the spinner's previous frame partly visible behind the new
+// one as a tail of stale glyphs.
+func TestClearLine_EmitsCSI2K(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, ClearLine(&buf))
+	assert.Equal(t, "\x1b[2K", buf.String())
+}
+
+// TestEnterRegion_PropagatesWriteError ensures a half-written DECSTBM
+// does not silently succeed. If the writer fails after the margin set
+// but before the cursor home, the terminal would be left clamped with
+// no cursor placement — the caller MUST see the error so cleanup can
+// run.
+func TestEnterRegion_PropagatesWriteError(t *testing.T) {
+	w := &failingWriter{failAfter: 1} // succeed on the first write, fail on the second
+	err := EnterRegion(w, NewLayout(24, 80))
+	require.Error(t, err)
+}
+
+// failingWriter is a tiny io.Writer that fails the Nth call so the
+// region primitives can prove they bail on the first error instead
+// of plowing through and leaving a half-applied state.
+type failingWriter struct {
+	calls     int
+	failAfter int
+}
+
+func (f *failingWriter) Write(p []byte) (int, error) {
+	f.calls++
+	if f.calls > f.failAfter {
+		return 0, errSimulated
+	}
+	return len(p), nil
+}
+
+var errSimulated = errors.New("simulated write failure")

--- a/cli/coder/turnui/region_test.go
+++ b/cli/coder/turnui/region_test.go
@@ -137,6 +137,32 @@ func TestClearLine_EmitsCSI2K(t *testing.T) {
 	assert.Equal(t, "\x1b[2K", buf.String())
 }
 
+// TestEnterAltScreen_EmitsDEC1049AndClear pins the alt-screen entry
+// sequence. The 1049h variant is what saves the cursor + scrollback
+// in one atomic operation; using the legacy 47h instead would leave
+// the user's screen visible underneath when we draw, defeating the
+// whole point of the migration. The trailing 2J+H makes the canvas
+// reliably blank — a small minority of terminals (some tmux setups)
+// honor 1049h's swap without auto-clearing.
+func TestEnterAltScreen_EmitsDEC1049AndClear(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, EnterAltScreen(&buf))
+	got := buf.String()
+	assert.Equal(t, "\x1b[?1049h\x1b[2J\x1b[H", got,
+		"alt-screen entry must be 1049h followed by clear + cursor-home")
+}
+
+// TestExitAltScreen_EmitsDEC1049l locks the matching exit. The l
+// variant restores cursor + scrollback. Pairing 1049h with anything
+// other than 1049l leaves the alt buffer set; the user would lose
+// their pre-/coder scrollback the moment they typed `clear` or any
+// command that re-enters cooked mode.
+func TestExitAltScreen_EmitsDEC1049l(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, ExitAltScreen(&buf))
+	assert.Equal(t, "\x1b[?1049l", buf.String())
+}
+
 // TestEnterRegion_PropagatesWriteError ensures a half-written DECSTBM
 // does not silently succeed. If the writer fails after the margin set
 // but before the cursor home, the terminal would be left clamped with

--- a/cli/coder/turnui/resize_test.go
+++ b/cli/coder/turnui/resize_test.go
@@ -1,0 +1,167 @@
+/*
+ * ChatCLI - Coder turn-UI resize / suspend / resume tests
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+package turnui
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResize_RecomputesLayoutAndRepaintsStatus walks the SIGWINCH
+// flow: the user resizes from 24x80 to 30x100, the new status row
+// (29) gets the cached spinner text. Without the cached repaint the
+// status row would be blank until the next timer tick — visible
+// glitch on every resize.
+func TestResize_RecomputesLayoutAndRepaintsStatus(t *testing.T) {
+	var buf bytes.Buffer
+	u := New(&buf)
+	require.NoError(t, u.Begin(24, 80))
+	require.NoError(t, u.UpdateStatus("spinning"))
+	buf.Reset()
+
+	require.NoError(t, u.Resize(30, 100))
+	got := buf.String()
+
+	assert.Contains(t, got, "\x1b[1;28r", "new DECSTBM uses the new rows-2 bound")
+	assert.Contains(t, got, "\x1b[29;1H", "status repaints on the new status row (rows-1)")
+	assert.Contains(t, got, "spinning", "cached status survives the resize")
+
+	layout := u.Layout()
+	assert.Equal(t, 30, layout.Rows)
+	assert.Equal(t, 28, layout.ContentBottom)
+	assert.Equal(t, 29, layout.StatusRow)
+	assert.Equal(t, 30, layout.InputRow)
+}
+
+// TestResize_RejectsTooSmallNewSize ensures a resize TO a degenerate
+// size leaves the existing layout intact rather than half-applying a
+// bad DECSTBM. The user might drag the terminal down to 2 rows and
+// back up — we should never lose the spinner because of a transient
+// invalid state.
+func TestResize_RejectsTooSmallNewSize(t *testing.T) {
+	var buf bytes.Buffer
+	u := New(&buf)
+	require.NoError(t, u.Begin(24, 80))
+	buf.Reset()
+
+	err := u.Resize(2, 80)
+	require.Error(t, err)
+	assert.Empty(t, buf.String(), "no terminal traffic on a rejected resize")
+
+	layout := u.Layout()
+	assert.Equal(t, 24, layout.Rows, "old layout preserved on rejection")
+}
+
+// TestResize_NoOpWhenInactive proves the SIGWINCH handler is safe
+// even when the agent has not started a turn yet. Calling Resize
+// while inactive silently does nothing — the signal handler doesn't
+// need a guard.
+func TestResize_NoOpWhenInactive(t *testing.T) {
+	var buf bytes.Buffer
+	u := New(&buf)
+	require.NoError(t, u.Resize(40, 120))
+	assert.Empty(t, buf.String())
+}
+
+// TestSuspend_TearsDownButKeepsCachedStatus is the security-prompt
+// preparation path. After Suspend the UI is not active (so the
+// cooked-mode prompt can run untouched), but the cached status is
+// still there so Resume can repaint it without the caller juggling
+// the message string.
+func TestSuspend_TearsDownButKeepsCachedStatus(t *testing.T) {
+	var buf bytes.Buffer
+	u := New(&buf)
+	require.NoError(t, u.Begin(24, 80))
+	require.NoError(t, u.UpdateStatus("pre-suspend"))
+	buf.Reset()
+
+	require.NoError(t, u.Suspend())
+	assert.False(t, u.IsActive(), "Suspend deactivates the UI")
+	assert.Contains(t, buf.String(), "\x1b[r", "scroll region reset emitted on suspend")
+}
+
+// TestSuspend_IsIdempotent matches End's contract for safety in a
+// defer chain. A double-Suspend should not double-restore the TTY
+// or write the reset twice.
+func TestSuspend_IsIdempotent(t *testing.T) {
+	var buf bytes.Buffer
+	u := New(&buf)
+	require.NoError(t, u.Suspend(), "Suspend on inactive UI is a no-op")
+	require.NoError(t, u.Begin(24, 80))
+	require.NoError(t, u.Suspend())
+	require.NoError(t, u.Suspend(), "second Suspend is a no-op")
+}
+
+// TestResume_RejectsWhileActive guards the suspend/resume protocol.
+// Calling Resume on an already-active UI would re-enter raw mode
+// over an existing raw mode and double-enter the region — both
+// cause subtle bugs the test catches at the API boundary instead.
+func TestResume_RejectsWhileActive(t *testing.T) {
+	var buf bytes.Buffer
+	u := New(&buf)
+	require.NoError(t, u.Begin(24, 80))
+
+	err := u.Resume(24, 80, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "still active")
+}
+
+// TestSuspend_PreservesCachedStatusForResume locks the invariant that
+// makes the security-prompt flow work: Suspend leaves the cached
+// status untouched so Resume can repaint it without the caller
+// re-sending the message. End, by contrast, clears it because the
+// turn is over.
+func TestSuspend_PreservesCachedStatusForResume(t *testing.T) {
+	var buf bytes.Buffer
+	u := New(&buf)
+	require.NoError(t, u.Begin(24, 80))
+	require.NoError(t, u.UpdateStatus("paused-message"))
+	require.NoError(t, u.Suspend())
+
+	// Internal-state assertion via the same-package test: the
+	// status survives. End would have wiped it (TestEnd_Idempotent
+	// covers that branch separately).
+	u.stateMu.Lock()
+	cached := u.lastStatus
+	u.stateMu.Unlock()
+	assert.Equal(t, "paused-message", cached,
+		"Suspend must keep lastStatus for Resume; End is the path that clears it")
+
+	// Sanity: End after Suspend should still work (defer-safe).
+	require.NoError(t, u.End())
+}
+
+// TestResize_PreservesActiveFlag is a small invariant test: a
+// successful resize leaves the UI active. A regression here would
+// hand the user a "muted" UI that ignores subsequent UpdateStatus.
+func TestResize_PreservesActiveFlag(t *testing.T) {
+	var buf bytes.Buffer
+	u := New(&buf)
+	require.NoError(t, u.Begin(24, 80))
+	require.NoError(t, u.Resize(40, 120))
+	assert.True(t, u.IsActive())
+}
+
+// TestResize_SuspendBeforeReturnsCleanly confirms that calling
+// Resize on a UI that has been Suspended is a no-op (since active
+// is false). A SIGWINCH that fires during a security prompt should
+// not partially restore the UI.
+func TestResize_SuspendBeforeReturnsCleanly(t *testing.T) {
+	var buf bytes.Buffer
+	u := New(&buf)
+	require.NoError(t, u.Begin(24, 80))
+	require.NoError(t, u.Suspend())
+	buf.Reset()
+
+	require.NoError(t, u.Resize(40, 120))
+	assert.Empty(t, strings.TrimSpace(buf.String()),
+		"no terminal traffic when resizing a suspended UI")
+}

--- a/cli/coder/turnui/turnui.go
+++ b/cli/coder/turnui/turnui.go
@@ -106,7 +106,25 @@ func (t *TurnUI) Begin(rows, cols int) error {
 	t.writeMu.Lock()
 	defer t.writeMu.Unlock()
 
+	// Alt-screen FIRST. We want the user's scrollback (everything
+	// they had on screen before /coder started — the chat banner,
+	// the welcome tip, previous turns) preserved untouched. Alt-
+	// screen swaps to a fresh blank canvas; on End we swap back
+	// and the user sees their pre-/coder state restored as if
+	// nothing happened. Without this, EnterRegion's cursor-home
+	// would have to compete with whatever was already on screen
+	// and the agent's banner would visually overlap or create
+	// gaps — both bugs reported in the field.
+	if err := EnterAltScreen(t.out); err != nil {
+		return fmt.Errorf("turnui: EnterAltScreen: %w", err)
+	}
+
 	if err := EnterRegion(t.out, layout); err != nil {
+		// Unwind alt-screen so we don't leave the terminal in a
+		// half-state. The defer at the call site can't help here
+		// because Begin returned an error and the caller assumes
+		// nothing was applied.
+		_ = ExitAltScreen(t.out)
 		return fmt.Errorf("turnui: EnterRegion: %w", err)
 	}
 
@@ -179,6 +197,14 @@ func (t *TurnUI) End() error {
 
 	t.writeMu.Lock()
 	regionErr := ExitRegion(t.out, layout)
+	// Always exit alt-screen, even on a region restore failure.
+	// Leaving the alt buffer set would hide the user's scrollback
+	// forever; that is the highest-severity miss and must run
+	// unconditionally. The order is: region first (lifts DECSTBM
+	// inside the alt buffer, so the swap-back doesn't carry a
+	// clamped region back to the main screen), then alt-screen
+	// swap-back.
+	altErr := ExitAltScreen(t.out)
 	t.writeMu.Unlock()
 
 	rawErr := raw.restore(rawFd)
@@ -187,6 +213,9 @@ func (t *TurnUI) End() error {
 	// first so the caller sees the worst thing that happened.
 	if rawErr != nil {
 		return fmt.Errorf("turnui: restore raw mode: %w", rawErr)
+	}
+	if altErr != nil {
+		return fmt.Errorf("turnui: exit alt-screen: %w", altErr)
 	}
 	return regionErr
 }
@@ -387,12 +416,20 @@ func (t *TurnUI) Suspend() error {
 
 	t.writeMu.Lock()
 	regionErr := ExitRegion(t.out, layout)
+	// Exit alt-screen so the security prompt renders on the
+	// original screen the user is used to (with their cooked-mode
+	// echo and visible scrollback). Resume re-enters alt-screen,
+	// re-applies the region, and repaints the cached status.
+	altErr := ExitAltScreen(t.out)
 	t.writeMu.Unlock()
 
 	rawErr := raw.restore(rawFd)
 
 	if rawErr != nil {
 		return fmt.Errorf("turnui: suspend raw mode restore: %w", rawErr)
+	}
+	if altErr != nil {
+		return fmt.Errorf("turnui: suspend alt-screen exit: %w", altErr)
 	}
 	return regionErr
 }

--- a/cli/coder/turnui/turnui.go
+++ b/cli/coder/turnui/turnui.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"os"
 	"sync"
+	"sync/atomic"
 )
 
 // TurnUI is the lifecycle handle for one /coder turn. It owns the
@@ -68,6 +69,17 @@ type TurnUI struct {
 	// terminal session.
 	raw   *rawState
 	rawFd int
+
+	// lastInputCol is the visual column where the input cursor
+	// last landed (1-based, including the InputPrompt width and
+	// the buffer cursor offset). Updated by PaintInput every time
+	// it repaints; read by UpdateStatus so the post-status
+	// redraw can reposition the cursor explicitly via MoveCursor
+	// instead of relying on ESC 7 / ESC 8 (DECSC/DECRC), which
+	// the xterm.js-based Hyper terminal honors inconsistently.
+	// Atomic so the readline goroutine (PaintInput writer) and
+	// the timer goroutine (UpdateStatus reader) don't race.
+	lastInputCol atomic.Int32
 }
 
 // New constructs a TurnUI bound to the given writer. The writer is
@@ -271,11 +283,16 @@ type RunConfig struct {
 // fallback is in effect (the timer callback can blindly call
 // UpdateStatus without first checking IsActive).
 //
-// The redraw sequence saves the cursor, jumps to the status row,
-// clears the line, writes the message, and restores the cursor.
-// SaveCursor/RestoreCursor uses the DEC ESC 7 / ESC 8 pair (see
-// region.go) because the CSI s/u variants are unreliable on the
-// terminals where this branch was first reported broken.
+// The redraw sequence is "explicit cursor": jump to the status row,
+// clear the line, write the message, then jump back to the input
+// row at the column PaintInput last left it in. Earlier versions
+// used ESC 7 / ESC 8 (DEC save/restore cursor) but the xterm.js-
+// based Hyper terminal honors those inconsistently — the cursor
+// would not snap back to the input, leaving every subsequent
+// agent print landing on the status row and creating the "overlap
+// and gap" symptoms reported in the field. Tracking the input
+// position ourselves and reissuing MoveCursor is portable to every
+// terminal that supports CUP (which is all of them).
 func (t *TurnUI) UpdateStatus(msg string) error {
 	t.stateMu.Lock()
 	if !t.active {
@@ -289,7 +306,17 @@ func (t *TurnUI) UpdateStatus(msg string) error {
 	t.writeMu.Lock()
 	defer t.writeMu.Unlock()
 
-	return paintStatus(t.out, layout, msg)
+	if err := paintStatusInline(t.out, layout, msg); err != nil {
+		return err
+	}
+	col := int(t.lastInputCol.Load())
+	if col <= 0 {
+		// No PaintInput has fired yet — park at the prompt
+		// column (just past "❯ ") so the input row at least has
+		// the cursor in a sensible default position.
+		col = len(InputPrompt) + 1
+	}
+	return MoveCursor(t.out, layout.InputRow, col)
 }
 
 // Refresh repaints the cached status message. Used after a SIGWINCH
@@ -313,7 +340,17 @@ func (t *TurnUI) Refresh() error {
 	t.writeMu.Lock()
 	defer t.writeMu.Unlock()
 
-	return paintStatus(t.out, layout, msg)
+	if err := paintStatusInline(t.out, layout, msg); err != nil {
+		return err
+	}
+	// Move cursor back to where PaintInput last left it. See the
+	// long-form comment in UpdateStatus for why this is explicit
+	// (lastInputCol) rather than ESC 7 / 8 save/restore.
+	col := int(t.lastInputCol.Load())
+	if col <= 0 {
+		col = len(InputPrompt) + 1
+	}
+	return MoveCursor(t.out, layout.InputRow, col)
 }
 
 // IsActive reports whether Begin has succeeded and End has not yet
@@ -516,25 +553,32 @@ func (t *TurnUI) PaintInput(buf *LineBuffer) error {
 	// when the user navigated mid-line, and Insert would appear
 	// to add characters at the end instead of where the cursor
 	// logically is.
-	return MoveCursor(t.out, layout.InputRow, 2+buf.Cursor()+1)
-}
-
-// paintStatus is the bare-bytes status redraw. Pulled out so tests
-// can exercise the sequence without juggling locks. The function
-// assumes the caller holds writeMu — concurrent callers would
-// interleave save/restore and corrupt the cursor state.
-func paintStatus(w io.Writer, layout Layout, msg string) error {
-	if err := SaveCursor(w); err != nil {
+	col := 2 + buf.Cursor() + 1
+	if err := MoveCursor(t.out, layout.InputRow, col); err != nil {
 		return err
 	}
+	// Record where we left the cursor so UpdateStatus (which
+	// runs on the timer goroutine) can snap back here after
+	// repainting the status row, without relying on ESC 7 / 8
+	// save/restore — which the xterm.js-based Hyper terminal
+	// honors inconsistently.
+	t.lastInputCol.Store(int32(col)) // #nosec G115 -- bounded by terminal width.
+	return nil
+}
+
+// paintStatusInline writes the status content at the dedicated row
+// and leaves the cursor at the end of that line. UpdateStatus is
+// responsible for moving the cursor back to the input row (via
+// MoveCursor + lastInputCol) after this returns. Pulled out so
+// tests can exercise the wire format independently of the cursor-
+// restore step.
+func paintStatusInline(w io.Writer, layout Layout, msg string) error {
 	if err := MoveCursor(w, layout.StatusRow, 1); err != nil {
 		return err
 	}
 	if err := ClearLine(w); err != nil {
 		return err
 	}
-	if _, err := fmt.Fprint(w, msg); err != nil {
-		return err
-	}
-	return RestoreCursor(w)
+	_, err := fmt.Fprint(w, msg)
+	return err
 }

--- a/cli/coder/turnui/turnui.go
+++ b/cli/coder/turnui/turnui.go
@@ -1,0 +1,224 @@
+/*
+ * ChatCLI - Coder turn-UI orchestrator
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+package turnui
+
+import (
+	"fmt"
+	"io"
+	"sync"
+)
+
+// TurnUI is the lifecycle handle for one /coder turn. It owns the
+// terminal's scroll region, status row, and (in later phases) the raw
+// stdin loop. Phase A wires only the scroll-region machinery — the
+// content band and the status row are usable, but input still goes
+// through the cooked-mode kernel echo on the input row.
+//
+// Construction is always cheap and side-effect free; Begin is what
+// actually touches the terminal. End is idempotent and safe to call
+// from a defer — leaving a TurnUI un-ended would persist the DECSTBM
+// region across processes and is exactly the failure mode this type
+// is designed to prevent.
+//
+// Goroutine safety: Begin / End are intended to run on the agent's
+// main goroutine, while UpdateStatus may be invoked from the timer
+// callback goroutine. All writes route through writeMu so a status
+// redraw cannot interleave with the begin/end sequence and produce
+// half-written escape codes.
+type TurnUI struct {
+	// out is the byte sink — always os.Stdout in production, an
+	// in-memory buffer in tests. The TurnUI never reads from out,
+	// so any io.Writer suffices.
+	out io.Writer
+
+	// writeMu serializes every byte the TurnUI emits. The status
+	// goroutine, the begin / end sequence, and (future) raw input
+	// echo all grab this before issuing escapes. Without it a tick
+	// that fires mid-Begin would write a status update into a half-
+	// initialized region and the layout would be off until the next
+	// SIGWINCH resync.
+	writeMu sync.Mutex
+
+	// stateMu guards the lifecycle fields (active, layout, lastStatus).
+	// Separating it from writeMu lets UpdateStatus check "are we
+	// active" without holding the slower write lock; if the answer
+	// is "no" the call is a no-op with no terminal traffic at all.
+	stateMu sync.Mutex
+	active  bool
+	layout  Layout
+
+	// lastStatus is the most recent message the spinner painted.
+	// Cached so SIGWINCH-triggered redraws can repaint without
+	// requiring the caller to re-send the current text. Mutated
+	// under stateMu, read under stateMu by Refresh.
+	lastStatus string
+}
+
+// New constructs a TurnUI bound to the given writer. The writer is
+// retained for the life of the TurnUI; callers should pass os.Stdout
+// in production. No terminal traffic is emitted until Begin runs.
+func New(out io.Writer) *TurnUI {
+	return &TurnUI{out: out}
+}
+
+// Begin computes the layout for the given terminal dimensions, sets
+// the DECSTBM scroll region, and parks the cursor on the first row
+// of the content band. It returns an error if the layout is invalid
+// (terminal too small) or if any write to the output stream fails;
+// in both cases the terminal is guaranteed to be untouched, so the
+// caller can fall back to the legacy single-line renderer without a
+// cleanup step.
+//
+// Calling Begin twice without an intervening End is a programming
+// error; the second call returns an error rather than silently
+// re-entering the region (which would leave the first region's
+// state orphaned). Tests rely on this invariant to flag accidental
+// double-activation.
+func (t *TurnUI) Begin(rows, cols int) error {
+	layout := NewLayout(rows, cols)
+	if !layout.Valid() {
+		return fmt.Errorf("turnui: terminal too small for split UI (%dx%d)", rows, cols)
+	}
+
+	t.stateMu.Lock()
+	if t.active {
+		t.stateMu.Unlock()
+		return fmt.Errorf("turnui: Begin called while already active")
+	}
+	t.stateMu.Unlock()
+
+	t.writeMu.Lock()
+	defer t.writeMu.Unlock()
+
+	if err := EnterRegion(t.out, layout); err != nil {
+		return fmt.Errorf("turnui: EnterRegion: %w", err)
+	}
+
+	t.stateMu.Lock()
+	t.active = true
+	t.layout = layout
+	t.lastStatus = ""
+	t.stateMu.Unlock()
+
+	return nil
+}
+
+// End restores the default scroll region and parks the cursor on a
+// fresh line below the input row. Safe to call when the TurnUI is
+// not active (returns nil immediately) — this lets callers defer
+// End right after construction without checking whether Begin ever
+// succeeded. End never returns an error from "already ended"; only
+// terminal write failures are surfaced.
+//
+// After End the TurnUI may be re-Begin'd for a subsequent turn. The
+// instance is reusable; nothing in TurnUI assumes single-shot.
+func (t *TurnUI) End() error {
+	t.stateMu.Lock()
+	if !t.active {
+		t.stateMu.Unlock()
+		return nil
+	}
+	layout := t.layout
+	t.active = false
+	t.lastStatus = ""
+	t.stateMu.Unlock()
+
+	t.writeMu.Lock()
+	defer t.writeMu.Unlock()
+
+	return ExitRegion(t.out, layout)
+}
+
+// UpdateStatus paints msg on the dedicated status row. If the TurnUI
+// is not active the call is silently dropped — this matches the
+// "graceful degradation" contract callers rely on when the legacy
+// fallback is in effect (the timer callback can blindly call
+// UpdateStatus without first checking IsActive).
+//
+// The redraw sequence saves the cursor, jumps to the status row,
+// clears the line, writes the message, and restores the cursor.
+// SaveCursor/RestoreCursor uses the DEC ESC 7 / ESC 8 pair (see
+// region.go) because the CSI s/u variants are unreliable on the
+// terminals where this branch was first reported broken.
+func (t *TurnUI) UpdateStatus(msg string) error {
+	t.stateMu.Lock()
+	if !t.active {
+		t.stateMu.Unlock()
+		return nil
+	}
+	layout := t.layout
+	t.lastStatus = msg
+	t.stateMu.Unlock()
+
+	t.writeMu.Lock()
+	defer t.writeMu.Unlock()
+
+	return paintStatus(t.out, layout, msg)
+}
+
+// Refresh repaints the cached status message. Used after a SIGWINCH
+// resync to put the spinner back on the status row without making
+// the agent loop hand the message in again. A no-op when there is no
+// cached status (the first tick after Begin will populate it).
+func (t *TurnUI) Refresh() error {
+	t.stateMu.Lock()
+	if !t.active {
+		t.stateMu.Unlock()
+		return nil
+	}
+	layout := t.layout
+	msg := t.lastStatus
+	t.stateMu.Unlock()
+
+	if msg == "" {
+		return nil
+	}
+
+	t.writeMu.Lock()
+	defer t.writeMu.Unlock()
+
+	return paintStatus(t.out, layout, msg)
+}
+
+// IsActive reports whether Begin has succeeded and End has not yet
+// run. Callers use it to gate optional features (the runaway-guard
+// banner, for example, prints differently inside the split UI than
+// in the legacy fallback).
+func (t *TurnUI) IsActive() bool {
+	t.stateMu.Lock()
+	defer t.stateMu.Unlock()
+	return t.active
+}
+
+// Layout returns the current layout snapshot. The returned value is a
+// copy so callers cannot mutate the live instance. Returns the zero
+// Layout when not active.
+func (t *TurnUI) Layout() Layout {
+	t.stateMu.Lock()
+	defer t.stateMu.Unlock()
+	return t.layout
+}
+
+// paintStatus is the bare-bytes status redraw. Pulled out so tests
+// can exercise the sequence without juggling locks. The function
+// assumes the caller holds writeMu — concurrent callers would
+// interleave save/restore and corrupt the cursor state.
+func paintStatus(w io.Writer, layout Layout, msg string) error {
+	if err := SaveCursor(w); err != nil {
+		return err
+	}
+	if err := MoveCursor(w, layout.StatusRow, 1); err != nil {
+		return err
+	}
+	if err := ClearLine(w); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprint(w, msg); err != nil {
+		return err
+	}
+	return RestoreCursor(w)
+}

--- a/cli/coder/turnui/turnui.go
+++ b/cli/coder/turnui/turnui.go
@@ -306,22 +306,29 @@ func (t *TurnUI) Layout() Layout {
 	return t.layout
 }
 
+// Painter exposes the TurnUI as an InputPainter for callers that
+// spawn their own readline goroutine after BeginInteractive (the
+// agent loop does this so it can wire the OnSubmit callback into
+// its own queue plumbing without going through TurnUI.Run). The
+// returned value is the TurnUI itself; nothing is allocated.
+func (t *TurnUI) Painter() InputPainter { return t }
+
 // InputPrompt is the prefix that appears on the input row before the
 // user's typed text. Hard-coded for Phase B; future phases may make
 // it user-configurable. Chosen to match the visual idiom used by chat
 // mode's go-prompt prefix so users do not have to context-switch.
 const InputPrompt = "❯ "
 
-// paintInput repaints the input row: cursor to (InputRow, 1), clear,
+// PaintInput repaints the input row: cursor to (InputRow, 1), clear,
 // write prompt + buffer contents, leave cursor at the end so the next
 // keystroke echoes immediately after the last visible glyph. Required
 // by the inputPainter interface that RunReadLine uses.
 //
-// Unlike paintStatus, paintInput does NOT save/restore the cursor —
+// Unlike paintStatus, PaintInput does NOT save/restore the cursor —
 // the input row IS the cursor's home in the split UI. After this
 // returns the cursor is exactly where the user expects it to be: at
 // the end of their typed text on the input row.
-func (t *TurnUI) paintInput(buf *LineBuffer) error {
+func (t *TurnUI) PaintInput(buf *LineBuffer) error {
 	t.stateMu.Lock()
 	if !t.active {
 		t.stateMu.Unlock()

--- a/cli/coder/turnui/turnui.go
+++ b/cli/coder/turnui/turnui.go
@@ -313,6 +313,120 @@ func (t *TurnUI) Layout() Layout {
 // returned value is the TurnUI itself; nothing is allocated.
 func (t *TurnUI) Painter() InputPainter { return t }
 
+// Resize recomputes the layout for new terminal dimensions and re-
+// enters the scroll region so subsequent agent output respects the
+// new bounds. Called by the SIGWINCH handler when the user drags the
+// terminal window. The cached status is repainted on the new status
+// row; the input row is NOT repainted here (the readline loop owns
+// the input buffer and will repaint on the next keystroke or via an
+// explicit Refresh from the caller).
+//
+// On invalid new dimensions (too small after the resize) Resize
+// returns an error WITHOUT touching the terminal — the agent loop is
+// expected to either keep the previous layout or fall back to legacy
+// rendering. Half-applying a too-small layout would leave the user
+// staring at overlapping bands.
+func (t *TurnUI) Resize(rows, cols int) error {
+	newLayout := NewLayout(rows, cols)
+	if !newLayout.Valid() {
+		return fmt.Errorf("turnui: post-resize layout too small (%dx%d)", rows, cols)
+	}
+
+	t.stateMu.Lock()
+	if !t.active {
+		t.stateMu.Unlock()
+		return nil
+	}
+	cachedStatus := t.lastStatus
+	t.layout = newLayout
+	t.stateMu.Unlock()
+
+	t.writeMu.Lock()
+	if err := EnterRegion(t.out, newLayout); err != nil {
+		t.writeMu.Unlock()
+		return fmt.Errorf("turnui: re-enter region after resize: %w", err)
+	}
+	t.writeMu.Unlock()
+
+	if cachedStatus != "" {
+		if err := t.UpdateStatus(cachedStatus); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Suspend tears down the split-UI state (raw mode + scroll region)
+// WITHOUT clearing the cached status. Used by the security-prompt
+// path: the user is about to see a "allow / deny / always" dialog
+// that wants cooked-mode line editing — running it inside the split
+// UI would force the dialog to fight turnui for keystrokes and
+// duplicate the bottom row.
+//
+// After Suspend the TurnUI is no longer active, but the cached
+// status survives so Resume can repaint without the caller having
+// to remember it. Suspend is idempotent: a second call is a no-op.
+//
+// The caller is responsible for stopping any readline goroutine it
+// spawned before calling Suspend — TurnUI itself does not own the
+// goroutine; that lives in the caller's setup code.
+func (t *TurnUI) Suspend() error {
+	t.stateMu.Lock()
+	if !t.active {
+		t.stateMu.Unlock()
+		return nil
+	}
+	layout := t.layout
+	raw := t.raw
+	rawFd := t.rawFd
+	t.active = false
+	t.raw = nil
+	t.rawFd = 0
+	// Keep lastStatus intact for Resume to repaint.
+	t.stateMu.Unlock()
+
+	t.writeMu.Lock()
+	regionErr := ExitRegion(t.out, layout)
+	t.writeMu.Unlock()
+
+	rawErr := raw.restore(rawFd)
+
+	if rawErr != nil {
+		return fmt.Errorf("turnui: suspend raw mode restore: %w", rawErr)
+	}
+	return regionErr
+}
+
+// Resume re-enters the split UI after a Suspend / cooked-mode
+// excursion. Re-runs BeginInteractive with the original dimensions
+// and repaints the cached status. The input row is NOT repainted
+// here — the caller is expected to re-spawn the readline goroutine,
+// whose initial PaintInput call will draw the empty input row.
+//
+// On a failed Resume the TurnUI stays inactive and returns the
+// error; the caller can fall back to legacy mode for the rest of
+// the session. Half-resumed state is not a thing — either Resume
+// succeeds and the UI is whole, or it fails and the caller knows.
+func (t *TurnUI) Resume(rows, cols, fd int) error {
+	t.stateMu.Lock()
+	if t.active {
+		t.stateMu.Unlock()
+		return fmt.Errorf("turnui: Resume called while still active")
+	}
+	cachedStatus := t.lastStatus
+	t.stateMu.Unlock()
+
+	if err := t.BeginInteractive(rows, cols, fd); err != nil {
+		return err
+	}
+	if cachedStatus != "" {
+		if err := t.UpdateStatus(cachedStatus); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // InputPrompt is the prefix that appears on the input row before the
 // user's typed text. Hard-coded for Phase B; future phases may make
 // it user-configurable. Chosen to match the visual idiom used by chat

--- a/cli/coder/turnui/turnui.go
+++ b/cli/coder/turnui/turnui.go
@@ -434,14 +434,21 @@ func (t *TurnUI) Resume(rows, cols, fd int) error {
 const InputPrompt = "❯ "
 
 // PaintInput repaints the input row: cursor to (InputRow, 1), clear,
-// write prompt + buffer contents, leave cursor at the end so the next
-// keystroke echoes immediately after the last visible glyph. Required
-// by the inputPainter interface that RunReadLine uses.
+// write prompt + buffer contents, then position the cursor at the
+// column matching the buffer's logical cursor (which can be anywhere
+// in the buffer after Phase G's arrow-key navigation, not just at
+// the end). Required by the InputPainter interface that RunReadLine
+// uses.
 //
 // Unlike paintStatus, PaintInput does NOT save/restore the cursor —
 // the input row IS the cursor's home in the split UI. After this
-// returns the cursor is exactly where the user expects it to be: at
-// the end of their typed text on the input row.
+// returns the cursor sits at the column where the next keystroke
+// will insert / overwrite.
+//
+// Cursor column math: InputPrompt is two visible columns ("❯ ") plus
+// the buffer cursor offset. Both are 1-based on the wire (CUP uses
+// 1 for the leftmost column), so the final column is
+// promptWidth + buf.Cursor() + 1.
 func (t *TurnUI) PaintInput(buf *LineBuffer) error {
 	t.stateMu.Lock()
 	if !t.active {
@@ -460,8 +467,19 @@ func (t *TurnUI) PaintInput(buf *LineBuffer) error {
 	if err := ClearLine(t.out); err != nil {
 		return err
 	}
-	_, err := fmt.Fprintf(t.out, "%s%s", InputPrompt, buf.String())
-	return err
+	if _, err := fmt.Fprintf(t.out, "%s%s", InputPrompt, buf.String()); err != nil {
+		return err
+	}
+	// Position the cursor at the logical insertion point. The
+	// prompt "❯ " is two visible columns; the buffer cursor adds
+	// its rune offset. CUP is 1-based, so the final col is
+	// promptWidth (2) + cursorOffset + 1. The MoveCursor here is
+	// what makes arrow-key navigation visible — without it the
+	// terminal cursor would sit after the last rune painted even
+	// when the user navigated mid-line, and Insert would appear
+	// to add characters at the end instead of where the cursor
+	// logically is.
+	return MoveCursor(t.out, layout.InputRow, 2+buf.Cursor()+1)
 }
 
 // paintStatus is the bare-bytes status redraw. Pulled out so tests

--- a/cli/coder/turnui/turnui.go
+++ b/cli/coder/turnui/turnui.go
@@ -7,16 +7,20 @@
 package turnui
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"os"
 	"sync"
 )
 
 // TurnUI is the lifecycle handle for one /coder turn. It owns the
-// terminal's scroll region, status row, and (in later phases) the raw
-// stdin loop. Phase A wires only the scroll-region machinery — the
-// content band and the status row are usable, but input still goes
-// through the cooked-mode kernel echo on the input row.
+// terminal's scroll region, status row, and the raw stdin input
+// loop. The split-pane UX comes from three coordinated layers:
+// DECSTBM scroll region confines agent output to the upper band,
+// raw-mode stdin lets the mini-readline own the input row without
+// kernel echo interference, and a save/restore cursor dance keeps
+// the spinner updates from disturbing the input cursor.
 //
 // Construction is always cheap and side-effect free; Begin is what
 // actually touches the terminal. End is idempotent and safe to call
@@ -56,6 +60,14 @@ type TurnUI struct {
 	// requiring the caller to re-send the current text. Mutated
 	// under stateMu, read under stateMu by Refresh.
 	lastStatus string
+
+	// raw holds the cooked-mode termios snapshot captured when
+	// BeginInteractive enters raw mode. Restored on End so the
+	// terminal returns to its pre-/coder state — leaving raw mode
+	// set would break every subsequent command in the same
+	// terminal session.
+	raw   *rawState
+	rawFd int
 }
 
 // New constructs a TurnUI bound to the given writer. The writer is
@@ -107,12 +119,46 @@ func (t *TurnUI) Begin(rows, cols int) error {
 	return nil
 }
 
-// End restores the default scroll region and parks the cursor on a
-// fresh line below the input row. Safe to call when the TurnUI is
+// BeginInteractive is the full-featured entry point: it does what
+// Begin does AND puts the given file descriptor into raw mode so the
+// mini-readline can own keystrokes. Use this when the agent loop
+// actually wants the split UI; use Begin alone in tests that only
+// exercise the region/status machinery.
+//
+// On any failure (invalid layout, MakeRaw error) the TurnUI is left
+// inert with no terminal traffic emitted, mirroring Begin's contract.
+// The caller can fall back to the legacy renderer without a cleanup
+// step. A nil return from BeginInteractive establishes the invariant
+// that End MUST be called to restore both the region and raw mode.
+func (t *TurnUI) BeginInteractive(rows, cols, fd int) error {
+	if err := t.Begin(rows, cols); err != nil {
+		return err
+	}
+	raw, err := enterRawMode(fd)
+	if err != nil {
+		// Unwind the region so the terminal is whole again.
+		_ = t.End()
+		return fmt.Errorf("turnui: enter raw mode: %w", err)
+	}
+	t.stateMu.Lock()
+	t.raw = raw
+	t.rawFd = fd
+	t.stateMu.Unlock()
+	return nil
+}
+
+// End restores the default scroll region, parks the cursor on a
+// fresh line below the input row, and restores the cooked-mode TTY
+// if BeginInteractive set raw mode. Safe to call when the TurnUI is
 // not active (returns nil immediately) — this lets callers defer
 // End right after construction without checking whether Begin ever
 // succeeded. End never returns an error from "already ended"; only
-// terminal write failures are surfaced.
+// terminal write failures and TTY restore failures are surfaced.
+//
+// The TWO cleanups run unconditionally in sequence: even if the
+// region restore fails, raw mode is still restored. Leaking raw mode
+// is the worse failure mode by far — the user's next bash command
+// would have no echo and no line editing.
 //
 // After End the TurnUI may be re-Begin'd for a subsequent turn. The
 // instance is reusable; nothing in TurnUI assumes single-shot.
@@ -123,14 +169,71 @@ func (t *TurnUI) End() error {
 		return nil
 	}
 	layout := t.layout
+	raw := t.raw
+	rawFd := t.rawFd
 	t.active = false
 	t.lastStatus = ""
+	t.raw = nil
+	t.rawFd = 0
 	t.stateMu.Unlock()
 
 	t.writeMu.Lock()
-	defer t.writeMu.Unlock()
+	regionErr := ExitRegion(t.out, layout)
+	t.writeMu.Unlock()
 
-	return ExitRegion(t.out, layout)
+	rawErr := raw.restore(rawFd)
+
+	// Raw mode failure is the higher-severity miss — surface it
+	// first so the caller sees the worst thing that happened.
+	if rawErr != nil {
+		return fmt.Errorf("turnui: restore raw mode: %w", rawErr)
+	}
+	return regionErr
+}
+
+// Run is the convenience entry point that wires BeginInteractive +
+// RunReadLine + End together for the typical agent-loop usage:
+//
+//	ui := turnui.New(os.Stdout)
+//	err := ui.Run(ctx, turnui.RunConfig{
+//	    Rows: h, Cols: w,
+//	    OnSubmit: func(line string) { … push to agent queue … },
+//	})
+//
+// The function blocks until the input loop ends (Ctrl+D, ctx cancel,
+// or read error) and guarantees End fires exactly once via defer.
+// Errors from any phase are wrapped so the caller can distinguish
+// activation failures (fall back) from runtime failures (already in
+// the split UI, must restore before reporting).
+func (t *TurnUI) Run(ctx context.Context, cfg RunConfig) error {
+	if err := t.BeginInteractive(cfg.Rows, cfg.Cols, cfg.StdinFD); err != nil {
+		return err
+	}
+	defer func() { _ = t.End() }()
+
+	reader := cfg.Reader
+	if reader == nil {
+		reader = os.Stdin
+	}
+
+	return RunReadLine(ctx, ReadLineConfig{
+		Reader:   reader,
+		Painter:  t,
+		OnSubmit: cfg.OnSubmit,
+		OnCancel: cfg.OnCancel,
+	})
+}
+
+// RunConfig bundles the inputs Run needs. The Reader field is
+// optional and defaults to os.Stdin — tests inject a scripted reader
+// to drive the loop without a TTY.
+type RunConfig struct {
+	Rows     int
+	Cols     int
+	StdinFD  int
+	Reader   io.Reader
+	OnSubmit func(line string)
+	OnCancel func()
 }
 
 // UpdateStatus paints msg on the dedicated status row. If the TurnUI
@@ -201,6 +304,43 @@ func (t *TurnUI) Layout() Layout {
 	t.stateMu.Lock()
 	defer t.stateMu.Unlock()
 	return t.layout
+}
+
+// InputPrompt is the prefix that appears on the input row before the
+// user's typed text. Hard-coded for Phase B; future phases may make
+// it user-configurable. Chosen to match the visual idiom used by chat
+// mode's go-prompt prefix so users do not have to context-switch.
+const InputPrompt = "❯ "
+
+// paintInput repaints the input row: cursor to (InputRow, 1), clear,
+// write prompt + buffer contents, leave cursor at the end so the next
+// keystroke echoes immediately after the last visible glyph. Required
+// by the inputPainter interface that RunReadLine uses.
+//
+// Unlike paintStatus, paintInput does NOT save/restore the cursor —
+// the input row IS the cursor's home in the split UI. After this
+// returns the cursor is exactly where the user expects it to be: at
+// the end of their typed text on the input row.
+func (t *TurnUI) paintInput(buf *LineBuffer) error {
+	t.stateMu.Lock()
+	if !t.active {
+		t.stateMu.Unlock()
+		return nil
+	}
+	layout := t.layout
+	t.stateMu.Unlock()
+
+	t.writeMu.Lock()
+	defer t.writeMu.Unlock()
+
+	if err := MoveCursor(t.out, layout.InputRow, 1); err != nil {
+		return err
+	}
+	if err := ClearLine(t.out); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintf(t.out, "%s%s", InputPrompt, buf.String())
+	return err
 }
 
 // paintStatus is the bare-bytes status redraw. Pulled out so tests

--- a/cli/coder/turnui/turnui_test.go
+++ b/cli/coder/turnui/turnui_test.go
@@ -1,0 +1,188 @@
+/*
+ * ChatCLI - Coder turn-UI orchestrator tests
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+package turnui
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBegin_EntersRegionAndMarksActive is the happy path: a Begin
+// against a typical terminal must succeed, leave the TurnUI in the
+// active state, and have already written the DECSTBM + CUP sequence
+// to the byte stream. End must produce the matching teardown.
+func TestBegin_EntersRegionAndMarksActive(t *testing.T) {
+	var buf bytes.Buffer
+	u := New(&buf)
+
+	require.NoError(t, u.Begin(24, 80))
+	assert.True(t, u.IsActive())
+	assert.Contains(t, buf.String(), "\x1b[1;22r", "DECSTBM written on Begin")
+
+	buf.Reset()
+	require.NoError(t, u.End())
+	assert.False(t, u.IsActive())
+	assert.Contains(t, buf.String(), "\x1b[r", "region reset written on End")
+}
+
+// TestBegin_RejectsTooSmallTerminal pins the contract: undersized
+// terminals must not emit any bytes. The caller relies on this to
+// know that "Begin failed" means "your terminal is untouched, fall
+// back cleanly" — not "best guess, might be half-applied."
+func TestBegin_RejectsTooSmallTerminal(t *testing.T) {
+	var buf bytes.Buffer
+	u := New(&buf)
+
+	err := u.Begin(2, 80)
+	require.Error(t, err)
+	assert.False(t, u.IsActive())
+	assert.Empty(t, buf.String(), "no terminal traffic for an invalid layout")
+}
+
+// TestBegin_FailsOnDoubleActivation catches the bug where a caller
+// forgets to End between turns. Without the guard, the second Begin
+// would issue another DECSTBM (harmless on its own) but would also
+// reset lastStatus and the active flag's "second activation" path —
+// downstream code that assumes "active means we ended the previous
+// turn cleanly" would be wrong. Failing loudly is the safer default.
+func TestBegin_FailsOnDoubleActivation(t *testing.T) {
+	var buf bytes.Buffer
+	u := New(&buf)
+
+	require.NoError(t, u.Begin(24, 80))
+	err := u.Begin(24, 80)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already active")
+}
+
+// TestEnd_IsIdempotent lets callers defer End without checking
+// whether Begin succeeded. A defer-everywhere pattern is the only
+// realistic way to keep the terminal sane across panics and early
+// returns; End must therefore be safe to call any number of times.
+func TestEnd_IsIdempotent(t *testing.T) {
+	var buf bytes.Buffer
+	u := New(&buf)
+
+	require.NoError(t, u.End(), "End on a fresh TurnUI is a no-op")
+	require.NoError(t, u.Begin(24, 80))
+	require.NoError(t, u.End())
+	require.NoError(t, u.End(), "second End after Begin/End is a no-op")
+}
+
+// TestUpdateStatus_DrawsAtStatusRow walks the redraw sequence on a
+// captured buffer. The status row for a 24-row terminal is 23, and
+// the sequence must be: save cursor, move to (23,1), clear line,
+// write the message, restore cursor — in that order. Order matters
+// because a misplaced save would capture the post-redraw cursor
+// position and the restore would land in the wrong band.
+func TestUpdateStatus_DrawsAtStatusRow(t *testing.T) {
+	var buf bytes.Buffer
+	u := New(&buf)
+	require.NoError(t, u.Begin(24, 80))
+	buf.Reset() // discard the Begin bytes; we only care about the status redraw
+
+	require.NoError(t, u.UpdateStatus("⠹ working"))
+
+	got := buf.String()
+	// Save → Move → Clear → Message → Restore. Asserting indexes
+	// instead of an exact-string match keeps the test robust to
+	// future additions to the status sequence (e.g. an attribute
+	// reset prefix) while still locking the protocol order.
+	saveIdx := strings.Index(got, "\x1b7")
+	moveIdx := strings.Index(got, "\x1b[23;1H")
+	clearIdx := strings.Index(got, "\x1b[2K")
+	msgIdx := strings.Index(got, "⠹ working")
+	restoreIdx := strings.Index(got, "\x1b8")
+
+	require.NotEqual(t, -1, saveIdx, "missing SaveCursor")
+	require.NotEqual(t, -1, moveIdx, "missing MoveCursor to status row")
+	require.NotEqual(t, -1, clearIdx, "missing ClearLine")
+	require.NotEqual(t, -1, msgIdx, "missing status message body")
+	require.NotEqual(t, -1, restoreIdx, "missing RestoreCursor")
+
+	assert.Less(t, saveIdx, moveIdx)
+	assert.Less(t, moveIdx, clearIdx)
+	assert.Less(t, clearIdx, msgIdx)
+	assert.Less(t, msgIdx, restoreIdx)
+}
+
+// TestUpdateStatus_NoOpWhenInactive matches the documented "drop
+// silently when not active" contract. The timer callback in the
+// agent loop calls UpdateStatus from a goroutine that has no easy
+// way to know whether Begin succeeded; UpdateStatus must therefore
+// not require a check on its caller's part.
+func TestUpdateStatus_NoOpWhenInactive(t *testing.T) {
+	var buf bytes.Buffer
+	u := New(&buf)
+	require.NoError(t, u.UpdateStatus("ignored"))
+	assert.Empty(t, buf.String())
+}
+
+// TestRefresh_RepaintsLastStatus simulates the SIGWINCH path: after
+// a resize the layout changes and the spinner needs to land on the
+// new status row. Refresh must use the cached message so the caller
+// (the SIGWINCH handler in Phase D) does not have to remember it.
+func TestRefresh_RepaintsLastStatus(t *testing.T) {
+	var buf bytes.Buffer
+	u := New(&buf)
+	require.NoError(t, u.Begin(24, 80))
+	require.NoError(t, u.UpdateStatus("cached"))
+
+	buf.Reset()
+	require.NoError(t, u.Refresh())
+	assert.Contains(t, buf.String(), "cached", "Refresh repaints the cached status")
+}
+
+// TestRefresh_NoOpWithNoCachedStatus is the boundary case: a
+// SIGWINCH that fires before the first status update should not
+// paint a stale empty line. Empty cached status means "nothing to
+// repaint, leave the row alone."
+func TestRefresh_NoOpWithNoCachedStatus(t *testing.T) {
+	var buf bytes.Buffer
+	u := New(&buf)
+	require.NoError(t, u.Begin(24, 80))
+	buf.Reset()
+
+	require.NoError(t, u.Refresh())
+	assert.Empty(t, buf.String(), "no cached status, no redraw")
+}
+
+// TestUpdateStatus_ConcurrentCallsAreSerialized fires N goroutines
+// that each call UpdateStatus and asserts the final buffer contains
+// only well-formed redraw sequences — no interleaved bytes from two
+// concurrent paints. The data race detector (go test -race) is the
+// real watchdog; this test ensures it has something to watch.
+func TestUpdateStatus_ConcurrentCallsAreSerialized(t *testing.T) {
+	var buf bytes.Buffer
+	u := New(&buf)
+	require.NoError(t, u.Begin(24, 80))
+	buf.Reset()
+
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			_ = u.UpdateStatus("tick")
+		}(i)
+	}
+	wg.Wait()
+
+	// Every paint emits exactly one SaveCursor (\x1b7) followed by
+	// one RestoreCursor (\x1b8). If serialization is broken the
+	// counts diverge — a missing pair would mean a paint stomped
+	// on another mid-sequence.
+	got := buf.String()
+	assert.Equal(t, strings.Count(got, "\x1b7"), strings.Count(got, "\x1b8"),
+		"every save must be matched by a restore — broken serialization corrupts that 1:1")
+}

--- a/cli/coder/turnui/turnui_test.go
+++ b/cli/coder/turnui/turnui_test.go
@@ -95,41 +95,48 @@ func TestEnd_IsIdempotent(t *testing.T) {
 	require.NoError(t, u.End(), "second End after Begin/End is a no-op")
 }
 
-// TestUpdateStatus_DrawsAtStatusRow walks the redraw sequence on a
-// captured buffer. The status row for a 24-row terminal is 23, and
-// the sequence must be: save cursor, move to (23,1), clear line,
-// write the message, restore cursor — in that order. Order matters
-// because a misplaced save would capture the post-redraw cursor
-// position and the restore would land in the wrong band.
-func TestUpdateStatus_DrawsAtStatusRow(t *testing.T) {
+// TestUpdateStatus_DrawsAtStatusRowThenSnapsToInputRow walks the
+// new redraw sequence: move to status row, clear, write message,
+// then move to the input row at the column PaintInput last
+// recorded. Earlier versions used ESC 7 / ESC 8 save/restore but
+// the xterm.js-based Hyper terminal honors those inconsistently;
+// the explicit MoveCursor approach works everywhere CUP works
+// (which is every VT100-derived emulator).
+func TestUpdateStatus_DrawsAtStatusRowThenSnapsToInputRow(t *testing.T) {
 	var buf bytes.Buffer
 	u := New(&buf)
 	require.NoError(t, u.Begin(24, 80))
+
+	// Simulate a PaintInput having recorded a cursor column.
+	// Without this, UpdateStatus falls back to "prompt + 1" which
+	// is the right default but not what we want to assert here.
+	u.lastInputCol.Store(7)
+
 	buf.Reset() // discard the Begin bytes; we only care about the status redraw
 
 	require.NoError(t, u.UpdateStatus("⠹ working"))
 
 	got := buf.String()
-	// Save → Move → Clear → Message → Restore. Asserting indexes
-	// instead of an exact-string match keeps the test robust to
-	// future additions to the status sequence (e.g. an attribute
-	// reset prefix) while still locking the protocol order.
-	saveIdx := strings.Index(got, "\x1b7")
-	moveIdx := strings.Index(got, "\x1b[23;1H")
+	moveStatus := strings.Index(got, "\x1b[23;1H")  // status row = rows-1
 	clearIdx := strings.Index(got, "\x1b[2K")
 	msgIdx := strings.Index(got, "⠹ working")
-	restoreIdx := strings.Index(got, "\x1b8")
+	moveBack := strings.Index(got, "\x1b[24;7H") // input row = rows, col from lastInputCol
 
-	require.NotEqual(t, -1, saveIdx, "missing SaveCursor")
-	require.NotEqual(t, -1, moveIdx, "missing MoveCursor to status row")
+	require.NotEqual(t, -1, moveStatus, "missing MoveCursor to status row")
 	require.NotEqual(t, -1, clearIdx, "missing ClearLine")
 	require.NotEqual(t, -1, msgIdx, "missing status message body")
-	require.NotEqual(t, -1, restoreIdx, "missing RestoreCursor")
+	require.NotEqual(t, -1, moveBack, "missing MoveCursor back to input row")
 
-	assert.Less(t, saveIdx, moveIdx)
-	assert.Less(t, moveIdx, clearIdx)
+	// Order: move to status → clear → write → move back to input.
+	assert.Less(t, moveStatus, clearIdx)
 	assert.Less(t, clearIdx, msgIdx)
-	assert.Less(t, msgIdx, restoreIdx)
+	assert.Less(t, msgIdx, moveBack)
+
+	// Crucially, NO save/restore sequences in the wire output.
+	// If ESC 7 / 8 leak back in, terminals that ignore them would
+	// regress to the cascading-spinner behavior we just fixed.
+	assert.NotContains(t, got, "\x1b7", "must not emit ESC 7 (DECSC) — unreliable on xterm.js")
+	assert.NotContains(t, got, "\x1b8", "must not emit ESC 8 (DECRC) — unreliable on xterm.js")
 }
 
 // TestUpdateStatus_NoOpWhenInactive matches the documented "drop
@@ -195,11 +202,15 @@ func TestUpdateStatus_ConcurrentCallsAreSerialized(t *testing.T) {
 	}
 	wg.Wait()
 
-	// Every paint emits exactly one SaveCursor (\x1b7) followed by
-	// one RestoreCursor (\x1b8). If serialization is broken the
-	// counts diverge — a missing pair would mean a paint stomped
-	// on another mid-sequence.
+	// Every paint emits exactly one move-to-status (CUP to row
+	// 23 col 1) and one move-back-to-input (CUP to row 24). If
+	// serialization is broken the counts diverge — a missing
+	// move-back would mean a paint stomped on another mid-
+	// sequence, leaving subsequent agent output to land on the
+	// status row.
 	got := buf.String()
-	assert.Equal(t, strings.Count(got, "\x1b7"), strings.Count(got, "\x1b8"),
-		"every save must be matched by a restore — broken serialization corrupts that 1:1")
+	statusMoves := strings.Count(got, "\x1b[23;1H")
+	inputMoves := strings.Count(got, "\x1b[24;")
+	assert.Equal(t, statusMoves, inputMoves,
+		"every move-to-status must be matched by a move-back-to-input — broken serialization corrupts that 1:1")
 }

--- a/cli/coder/turnui/turnui_test.go
+++ b/cli/coder/turnui/turnui_test.go
@@ -16,22 +16,39 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestBegin_EntersRegionAndMarksActive is the happy path: a Begin
-// against a typical terminal must succeed, leave the TurnUI in the
-// active state, and have already written the DECSTBM + CUP sequence
-// to the byte stream. End must produce the matching teardown.
-func TestBegin_EntersRegionAndMarksActive(t *testing.T) {
+// TestBegin_EntersAltScreenThenRegionAndMarksActive is the happy
+// path: a Begin against a typical terminal must succeed, leave the
+// TurnUI in the active state, and have already written the alt-
+// screen entry + DECSTBM + CUP sequence to the byte stream in that
+// order. End must produce the matching teardown in the reverse
+// order: region reset before alt-screen exit, so the swap-back
+// does not carry a clamped region into the main screen.
+func TestBegin_EntersAltScreenThenRegionAndMarksActive(t *testing.T) {
 	var buf bytes.Buffer
 	u := New(&buf)
 
 	require.NoError(t, u.Begin(24, 80))
 	assert.True(t, u.IsActive())
-	assert.Contains(t, buf.String(), "\x1b[1;22r", "DECSTBM written on Begin")
+
+	got := buf.String()
+	altIdx := strings.Index(got, "\x1b[?1049h")
+	regionIdx := strings.Index(got, "\x1b[1;22r")
+	require.NotEqual(t, -1, altIdx, "alt-screen entry missing on Begin")
+	require.NotEqual(t, -1, regionIdx, "DECSTBM missing on Begin")
+	assert.Less(t, altIdx, regionIdx,
+		"alt-screen MUST be entered before the region is defined — defining the region first would clamp the user's main screen")
 
 	buf.Reset()
 	require.NoError(t, u.End())
 	assert.False(t, u.IsActive())
-	assert.Contains(t, buf.String(), "\x1b[r", "region reset written on End")
+
+	got = buf.String()
+	regionResetIdx := strings.Index(got, "\x1b[r")
+	altExitIdx := strings.Index(got, "\x1b[?1049l")
+	require.NotEqual(t, -1, regionResetIdx, "region reset missing on End")
+	require.NotEqual(t, -1, altExitIdx, "alt-screen exit missing on End")
+	assert.Less(t, regionResetIdx, altExitIdx,
+		"region reset MUST come before alt-screen exit — otherwise DECSTBM persists into the user's main screen after swap-back")
 }
 
 // TestBegin_RejectsTooSmallTerminal pins the contract: undersized

--- a/cli/metrics/display.go
+++ b/cli/metrics/display.go
@@ -31,6 +31,19 @@ func FormatTimerStatus(d time.Duration, model, msg string) string {
 	dots := GetDotsAnimation()
 	return fmt.Sprintf("\r%s%s%s [%s%s%s%s] %s[%s]%s %s|%s %s%s%s%s", ColorCyan, spinner, ColorReset, ColorBold, ColorCyan, model, ColorReset, ColorGray, FormatDurationShort(d), ColorReset, ColorGray, ColorReset, ColorGray, msg, dots, ColorReset)
 }
+
+// FormatTimerStatusInline returns the same content as FormatTimerStatus
+// minus the leading \r (carriage return) and trailing ClearLine that
+// the legacy renderer needs to redraw in place. Use this when the
+// caller (e.g. turnui.UpdateStatus) is already positioning the cursor
+// on a dedicated row and clearing the line itself — the \r would
+// otherwise cancel the cursor positioning by snapping back to column 1
+// of whatever row the cursor happens to be on.
+func FormatTimerStatusInline(d time.Duration, model, msg string) string {
+	spinner := GetSpinnerFrame()
+	dots := GetDotsAnimation()
+	return fmt.Sprintf("%s%s%s [%s%s%s%s] %s[%s]%s %s|%s %s%s%s%s", ColorCyan, spinner, ColorReset, ColorBold, ColorCyan, model, ColorReset, ColorGray, FormatDurationShort(d), ColorReset, ColorGray, ColorReset, ColorGray, msg, dots, ColorReset)
+}
 func FormatTimerComplete(d time.Duration) string {
 	return fmt.Sprintf("%s%s %s", ColorGray, FormatDuration(d), ColorReset)
 }


### PR DESCRIPTION
## Summary

Brings the Claude Code-style split UI to /coder: agent output scrolls in an upper region confined by DECSTBM, the spinner lives on a dedicated status row, and the input row at the bottom is always-typable in raw mode via a mini-readline. Replaces the single-line cooked-mode renderer where the spinner's \r kept overwriting the kernel echo of the user's keystrokes.

Activation is conservative — `turnui.ShouldActivate` falls back to the legacy renderer for non-TTY stdin/stdout, dumb terminals, undersized windows, the legacy Windows console without virtual-terminal mode, and the `CHATCLI_TURNUI=off` escape hatch. The agent loop picks the path once at the top of `processAIResponseAndAct`; nothing else changes if fallback fires.

## Architecture

New package `cli/coder/turnui` built on three layers:

| Layer | Files | Responsibility |
|---|---|---|
| **Scroll region** | `region.go`, `turnui.go` | DECSTBM bands (content/status/input), cursor primitives, DEC `ESC 7` / `ESC 8` save+restore (not CSI s/u — those are unreliable in GoLand integrated terminal) |
| **Raw input** | `rawmode_unix.go`, `rawmode_windows.go`, `keydecode.go`, `linebuf.go` | `term.MakeRaw` toggle with safe restore, raw-byte → Key decoder (Backspace 0x7f/0x08, CRLF collapse, CSI/SS3 swallowing, UTF-8 multi-byte reassembly across reads), rune-aware line buffer with KillLine / KillWord |
| **Loop** | `readline.go` | Read → decode → applyKey → paint cycle with Submit/Cancel/EOF callbacks; tail buffer carries incomplete UTF-8 between reads |

Integration in `agent_mode.go`:
- `setupInputAndUI(ctx)` detects environment, allocates `inputReady` signal channel + legacy `stdinLines` mirror, calls `BeginInteractive`, spawns the readline goroutine. `OnSubmit` feeds the existing `stdinLines` so `drainStdinToQueue` keeps working unchanged.
- Timer callback routes status via `metrics.FormatTimerStatusInline` to `TurnUI.UpdateStatus` (no \r — the row position is owned by TurnUI's `MoveCursor`+`ClearLine`). Falls back to `FormatTimerStatus` for legacy.
- Coder-mode "AI replied without tool calls" branch parks on `turnUIInputReady` instead of calling `readLineWithEditing` (which would race go-prompt for keystrokes).
- SIGWINCH handler (`agent_mode_sigwinch_unix.go`) routes resize into `TurnUI.Resize` which recomputes layout, re-emits DECSTBM, repaints cached status. Windows ships a stub.

`Suspend()`/`Resume()` API ready for security-prompt integration but **not wired into `coder.PromptSecurityCheckGuarded` in this PR** — the API is tested in isolation; wiring it touches `input_guard.go` which is a separate review surface.

## Files

| File | Change |
|---|---|
| `cli/coder/turnui/` | 14 new files (8 src + 6 test): region, turnui, keydecode, linebuf, readline, rawmode (unix/windows), fallback (+ unix/windows), tests for each |
| `cli/agent_mode.go` | `setupInputAndUI`/`teardownInputAndUI`/`waitForInput` helpers; timer callback routes to TurnUI when active; coder-waiting branch parks on inputReady |
| `cli/agent_mode_sigwinch_{unix,windows}.go` | SIGWINCH handler installed in `processAIResponseAndAct`; Windows stub |
| `cli/metrics/display.go` | `FormatTimerStatusInline` (variant without \r/clear-line for callers that own row positioning) |

3149 insertions, 4 commits, all phases buildable + tested in isolation.

## Test plan

- [x] `go build ./...` (darwin)
- [x] `go test ./...` — full suite green, 0 failures
- [x] `go test ./cli/coder/turnui/... -race` — clean
- [x] `go vet ./...` clean
- [x] `qg-i18n-parity` — 2762 usages, 0 missing
- [x] 58 new unit tests across the package: every ANSI sequence wire-format pinned, every key decoded, every applyKey branch covered, every Begin/End/Suspend/Resume/Resize state transition asserted
- [ ] Smoke: `/coder` a task, type a follow-up while the LLM streams — spinner stays on status row, input is visible and never wiped
- [ ] Smoke: type "olá" then Backspace — multi-byte glyph deleted cleanly
- [ ] Smoke: type a follow-up, press Enter — `❯ ` echo persists, queue depth shows in status, next turn picks it up
- [ ] Smoke: resize terminal mid-turn — layout reflows, spinner repaints on new status row
- [ ] Smoke: Ctrl+C in input row — clears buffer without aborting agent; second Ctrl+C in chat mode exits as before
- [ ] Smoke: `CHATCLI_TURNUI=off ./chatcli` — falls back to legacy renderer (same behavior as before this PR)
- [ ] Smoke: pipe stdout to `tee log.txt` — fallback fires (no escape sequences in the file), agent still runs
- [ ] Smoke: resize down to < 10 rows — split UI keeps previous layout, doesn't crash

## Out of scope (follow-ups)

- Wire `Suspend`/`Resume` into `coder.PromptSecurityCheckGuarded` so confirmation dialogs render in cooked mode without the split UI fighting them
- Windows console-resize event (alternative to SIGWINCH)
- Arrow keys / history navigation inside the input row
- Multi-line input (Shift+Enter) in the split UI