### PR TITLE
fix(ui): restore typewriter effect on assistant responses across chat/agent/coder

### DIFF
--- a/cli/agent/typewriter_test.go
+++ b/cli/agent/typewriter_test.go
@@ -1,0 +1,42 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+package agent
+
+import (
+	"testing"
+)
+
+// TestTypewriterPrint_PreservesAllBytes guards the invariant that the
+// typewriter helper is purely a pacing layer: every input rune must
+// land on stdout in order, including ANSI color escapes and newlines.
+// Any future "optimization" that drops or reorders bytes (e.g. a buffer
+// that flushes on rune boundaries and loses partial UTF-8) trips here.
+func TestTypewriterPrint_PreservesAllBytes(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"plain ascii", "hello world"},
+		{"with newline", "line one\nline two\n"},
+		{"ansi wrapped", "\x1b[32mgreen\x1b[0m and \x1b[31mred\x1b[0m"},
+		{"multibyte runes", "olá, mundo — café ☕"},
+		{"empty", ""},
+		{"only ansi", "\x1b[1;35m\x1b[0m"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := captureStdout(t, func() {
+				typewriterPrint(tc.input, 0)
+			})
+			if got != tc.input {
+				t.Fatalf("typewriterPrint mangled bytes:\n  input:  %q\n  output: %q", tc.input, got)
+			}
+		})
+	}
+}

--- a/cli/agent/typewriter_test.go
+++ b/cli/agent/typewriter_test.go
@@ -7,6 +7,7 @@
 package agent
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -38,5 +39,28 @@ func TestTypewriterPrint_PreservesAllBytes(t *testing.T) {
 				t.Fatalf("typewriterPrint mangled bytes:\n  input:  %q\n  output: %q", tc.input, got)
 			}
 		})
+	}
+}
+
+// TestRenderAssistantResponseTimelineEvent_TypesBodyContent guards the
+// happy path of the assistant-response card: the typewriter variant
+// must still produce the title, content, and a bottom border so the
+// card visually closes. Char-by-char ordering is already covered by
+// TestTypewriterPrint_PreservesAllBytes; here we only assert that
+// content flows through and the card frame is intact.
+func TestRenderAssistantResponseTimelineEvent_TypesBodyContent(t *testing.T) {
+	r := NewUIRenderer(nil)
+	out := captureStdout(t, func() {
+		r.RenderAssistantResponseTimelineEvent("💬", "RESPOSTA", "Hello from the assistant.", ColorGray)
+	})
+
+	if !strings.Contains(out, "RESPOSTA") {
+		t.Errorf("expected card title 'RESPOSTA' in output, got: %q", out)
+	}
+	if !strings.Contains(out, "Hello from the assistant.") {
+		t.Errorf("expected body text in output, got: %q", out)
+	}
+	if !strings.Contains(out, "╰") {
+		t.Errorf("expected bottom-border glyph in output (card must visually close), got: %q", out)
 	}
 }

--- a/cli/agent/ui_renderer.go
+++ b/cli/agent/ui_renderer.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/diillson/chatcli/i18n"
@@ -21,6 +22,27 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/term"
 )
+
+// typewriterPrint emits text rune-by-rune with a small delay between
+// printable runes so the line "types" onto the screen. ANSI escape
+// sequences are flushed instantly so colors/styles never pause the eye.
+func typewriterPrint(text string, delay time.Duration) {
+	inEsc := false
+	for _, ch := range text {
+		if ch == '\033' {
+			inEsc = true
+		}
+		fmt.Printf("%c", ch)
+		_ = os.Stdout.Sync()
+		if inEsc {
+			if ch == 'm' {
+				inEsc = false
+			}
+			continue
+		}
+		time.Sleep(delay)
+	}
+}
 
 // ANSI Color codes exportados
 const (
@@ -443,6 +465,19 @@ func VisibleLen(s string) int {
 // (b) largura do header — limitada pelo terminal. Lipgloss faz o cálculo de
 // largura visível corretamente (ANSI-aware) via lipgloss.Width.
 func (r *UIRenderer) RenderTimelineEvent(icon, title, content, color string) {
+	r.renderTimelineEventInner(icon, title, content, color, false)
+}
+
+// RenderAssistantResponseTimelineEvent draws the same card as
+// RenderTimelineEvent but types the body progressively so the final
+// assistant message feels alive instead of a single paste. Reserved for
+// the model's "RESPOSTA/RESUMO" card — tool calls and reasoning still use
+// the instant path because typing those would slow the agent loop down.
+func (r *UIRenderer) RenderAssistantResponseTimelineEvent(icon, title, content, color string) {
+	r.renderTimelineEventInner(icon, title, content, color, true)
+}
+
+func (r *UIRenderer) renderTimelineEventInner(icon, title, content, color string, typewrite bool) {
 	termWidth, _, err := term.GetSize(int(os.Stdout.Fd())) //#nosec G115 -- value bounded by domain
 	if err != nil || termWidth <= 0 {
 		termWidth = 80
@@ -504,7 +539,12 @@ func (r *UIRenderer) RenderTimelineEvent(icon, title, content, color string) {
 
 	fmt.Println()
 	fmt.Println(topLine)
-	fmt.Println(bodyRendered)
+	if typewrite {
+		typewriterPrint(bodyRendered, 2*time.Millisecond)
+		fmt.Println()
+	} else {
+		fmt.Println(bodyRendered)
+	}
 }
 
 // buildTitledTopBorder produces a `╭── icon title ─────╮` line whose
@@ -1091,12 +1131,15 @@ func (r *UIRenderer) CompactAssistantText(text string) {
 	icon := r.Colorize("◆", ColorCyan)
 	for i, line := range strings.Split(text, "\n") {
 		trimmed := strings.TrimRight(line, " \t")
+		var prefix string
 		if i == 0 {
-			fmt.Printf("  %s %s\n", icon, r.Colorize(trimmed, ColorReset))
-			continue
+			prefix = "  " + icon + " "
+		} else {
+			prefix = "    "
 		}
-		// continuation: align under the first line's text column
-		fmt.Printf("    %s\n", r.Colorize(trimmed, ColorReset))
+		fmt.Print(prefix)
+		typewriterPrint(r.Colorize(trimmed, ColorReset), 2*time.Millisecond)
+		fmt.Println()
 	}
 }
 

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -1124,6 +1124,18 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 		renderer.RenderMarkdownTimelineEvent(icon, title, rendered, color)
 	}
 
+	// Helper local: card de RESPOSTA final do assistente com efeito de
+	// máquina de escrever — restaura a sensação de "vivo" que se perdeu
+	// quando a UI passou a pintar tudo num bloco lipgloss estático.
+	renderAssistantMDCard := func(icon, title, md, color string) {
+		md = strings.TrimSpace(md)
+		if md == "" {
+			return
+		}
+		rendered := a.cli.renderMarkdown(md)
+		renderer.RenderAssistantResponseTimelineEvent(icon, title, rendered, color)
+	}
+
 	// Context recovery state for the session
 	contextRecovery := agent.NewContextRecovery(agent.DefaultContextRecoveryConfig(), a.logger)
 	currentMaxTokens := 0           // 0 = use provider default
@@ -1653,7 +1665,7 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 			case isMinimal:
 				renderer.RenderTimelineEvent("💬", "RESUMO", compactText(remaining, 2, 220), agent.ColorGray)
 			default:
-				renderMDCard("💬", "RESPOSTA", remaining, agent.ColorGray)
+				renderAssistantMDCard("💬", "RESPOSTA", remaining, agent.ColorGray)
 			}
 		}
 

--- a/cli/chat_pipeline.go
+++ b/cli/chat_pipeline.go
@@ -612,10 +612,11 @@ func (cli *ChatCLI) renderAssistantResponse(
 	fmt.Println(header)
 	// Indent body so it visually sits inside the envelope. The body
 	// already contains its own glamour-rendered formatting, which we
-	// preserve as-is — we only add a left gutter.
-	for _, ln := range strings.Split(strings.TrimRight(rendered, "\n"), "\n") {
-		fmt.Println("  " + ln)
-	}
+	// preserve as-is — we only add a left gutter. Typewriter the body
+	// so the response feels alive instead of pasted; ANSI escape
+	// sequences embedded in the markdown are streamed without delay.
+	indented := "  " + strings.ReplaceAll(strings.TrimRight(rendered, "\n"), "\n", "\n  ") + "\n"
+	cli.typewriterEffect(indented, 2*time.Millisecond)
 	fmt.Println(footer)
 	fmt.Println()
 }


### PR DESCRIPTION
## Summary

- The UI polish commit (2a47bdf) replaced the per-rune typewriter render with a static lipgloss envelope, so model replies started landing on screen as a single paste — the writing-in-progress feel that made the UX feel alive was lost.
- This restores the effect without rolling back the envelope: header, footer, markdown and colors are unchanged; only the body of the response card is now emitted progressively. ANSI escape sequences are flushed instantly so color transitions never pause the eye.
- Only the final assistant card and the compact assistant text are typed. Reasoning, tool calls and status cards keep the instant path on purpose, so the agent loop pacing is unaffected. Coder mode inherits the fix automatically because it shares the agent loop.

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./cli/... ./cli/agent/...` succeeds
- [x] In chat mode (`chatcli`), send a multi-paragraph question and confirm the response inside the envelope is typed rune-by-rune
- [x] In agent mode (`/agent`), confirm the RESPOSTA card body types out, while RACIOCÍNIO / AÇÃO / STATUS cards remain instant
- [x] In coder mode (`/coder`) with compact UI, confirm the assistant text after a turn types line-by-line
- [x] In agent mode with `CHATCLI_CODER_UI=minimal`, confirm the RESUMO single-line summary still renders instantly (intentional)