### PR TITLE
feat(ui): unified bordered response envelope and responsive welcome

### DIFF
--- a/cli/agent/response_envelope.go
+++ b/cli/agent/response_envelope.go
@@ -124,8 +124,8 @@ type ResponseEnvelopeOptions struct {
 // RenderResponseEnvelope paints the assistant's reply in a bordered
 // box. Mechanics:
 //
-//  1. Resolve the cap (caller-pinned Width, otherwise live terminal).
-//  2. Wrap body to inner = cap − borders (2) − padding (4).
+//  1. Resolve the max width (caller-pinned Width, otherwise live terminal).
+//  2. Wrap body to inner = maxWidth − borders (2) − padding (4).
 //  3. Measure the widest wrapped body line.
 //  4. Grow the card so it also fits the header & footer labels with
 //     at least 2 dashes of breathing room on each side. Without this
@@ -145,17 +145,17 @@ type ResponseEnvelopeOptions struct {
 // the terminal. Thanks to the init() normalization, they now usually
 // agree with the terminal too.
 func (r *UIRenderer) RenderResponseEnvelope(opts ResponseEnvelopeOptions) {
-	cap := opts.Width
-	if cap <= 0 {
-		cap = EnvelopeWidth()
+	maxWidth := opts.Width
+	if maxWidth <= 0 {
+		maxWidth = EnvelopeWidth()
 	}
-	if cap < 24 {
-		cap = 24
+	if maxWidth < 24 {
+		maxWidth = 24
 	}
 
 	// innerOverhead: 2 borders + 4 horizontal padding (Padding(0,2)).
 	const innerOverhead = 6
-	maxInner := cap - innerOverhead
+	maxInner := maxWidth - innerOverhead
 	if maxInner < 16 {
 		maxInner = 16
 	}
@@ -272,7 +272,7 @@ func (r *UIRenderer) RenderResponseEnvelope(opts ResponseEnvelopeOptions) {
 // labels alone exceed targetWidth falls back to a minimal border (the
 // labels survive; the fill goes to zero).
 func buildBilateralBorder(lc, rc rune, leftLabel, rightLabel string, targetWidth int, color string, r *UIRenderer) string {
-	const cornerCols = 1   // lc / rc themselves
+	const cornerCols = 1    // lc / rc themselves
 	const dashCornerPad = 1 // the "─" that hugs each corner
 
 	leftBlock := string(lc) + "─"

--- a/cli/agent/response_envelope.go
+++ b/cli/agent/response_envelope.go
@@ -1,0 +1,245 @@
+/*
+ * ChatCLI - Unified response envelope rendering
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Renders the assistant's final reply inside a bordered, responsive,
+ * ANSI-aware lipgloss box. The envelope is the single source of truth
+ * for chat, coder and agent modes: each caller supplies bilateral
+ * header/footer labels and a body, and the renderer guarantees:
+ *
+ *   - The card width follows the live terminal width (no hardcoded cols).
+ *   - The body is wrapped to the box inner width preserving ANSI escapes.
+ *   - Top, sides and bottom borders are drawn by lipgloss so widths agree.
+ *   - Emoji widths are normalized so the right border never drifts.
+ *   - An optional typewriter effect plays the body progressively.
+ *
+ * Why a dedicated file instead of stuffing this into ui_renderer.go:
+ * the timeline-card path (RenderTimelineEvent) is legacy and biased
+ * toward icon+title headers; chat needs a bilateral header (model on
+ * the left, latency/tokens on the right). Sharing the math without
+ * blurring the two APIs keeps each call site readable.
+ */
+package agent
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/mattn/go-runewidth"
+	"golang.org/x/term"
+)
+
+// init normalizes go-runewidth so emoji-bearing content reports its
+// real terminal-cell width. With the library defaults
+// (EastAsianWidth=false, StrictEmojiNeutral=true) emojis such as
+// "🏟️", "⚫", "🔴" are measured as 1 cell while almost every modern
+// terminal renders them as 2 — and the drift compounded into right
+// borders being pushed off the screen. Pinning StrictEmojiNeutral
+// to false makes the measurement match the rendering across iTerm2,
+// Terminal.app, VSCode, Windows Terminal, and Alacritty.
+func init() {
+	runewidth.DefaultCondition.StrictEmojiNeutral = false
+	runewidth.DefaultCondition.EastAsianWidth = false
+}
+
+// TerminalWidth reports the live terminal width in columns, falling
+// back to a safe default when stdout is not a TTY (CI, tests, piped
+// runs). The 100-column fallback is wider than the legacy 87-col
+// constant so piped runs still produce a readable box; callers that
+// need a tighter cap clamp the result themselves.
+func TerminalWidth() int {
+	w, _, err := term.GetSize(int(os.Stdout.Fd())) //#nosec G115 -- bounded by domain
+	if err != nil || w <= 0 {
+		return 100
+	}
+	return w
+}
+
+// EnvelopeWidth returns the width to use for a response envelope on
+// the current terminal. It reserves 2 columns of right-edge margin so
+// iTerm/VSCode native scrollbars never clip the border, and clamps to
+// a minimum of 40 cols so the box never collapses on tiny terminals.
+// No upper cap is applied — full-screen terminals should use their
+// full width (this was a direct user preference).
+func EnvelopeWidth() int {
+	w := TerminalWidth() - 2
+	if w < 40 {
+		return 40
+	}
+	return w
+}
+
+// ResponseEnvelopeOptions configures a unified bordered envelope. All
+// label fields are PRE-FORMATTED: callers own colorization and any
+// leading/trailing spaces they want carved out of the dash fill.
+// Empty fields are omitted (no extra space reserved).
+type ResponseEnvelopeOptions struct {
+	// HeaderLeft is the visible label on the top border's left side.
+	// Conventionally the icon + title (e.g. " 💬 RESPOSTA ") in color.
+	HeaderLeft string
+
+	// HeaderRight is the visible label on the top border's right side.
+	// Conventionally the metrics block (e.g. " 1.4s · 312↑ 1.8k↓ ").
+	// Pass an empty string to draw only the left label.
+	HeaderRight string
+
+	// FooterLeft and FooterRight mirror the header on the bottom
+	// border. Most callers leave them empty (the body's terminal
+	// punctuation closes the thought) and the bottom is a plain
+	// ╰────╯ line. Provided for future telemetry / status surfaces.
+	FooterLeft  string
+	FooterRight string
+
+	// Body is the message content to render inside the box. Typically
+	// glamour-rendered markdown (ANSI escapes preserved); the envelope
+	// wraps it to the resolved inner width.
+	Body string
+
+	// Color is the package-local ANSI color constant used for borders
+	// (e.g. ColorGray, ColorPurple). Maps to lipgloss internally.
+	Color string
+
+	// Typewriter enables progressive rune-by-rune painting of the body
+	// for the "alive" reply feel. ANSI escapes flush instantly so
+	// colors never pause the eye.
+	Typewriter bool
+
+	// TypewriterDelay overrides the per-rune delay. Zero uses the
+	// default of 2ms — fast enough for long replies, slow enough to
+	// register as animation. Set to a positive value to slow down or
+	// to a negative value (caller-side check) to disable.
+	TypewriterDelay time.Duration
+
+	// Width pins the card width in columns. Zero asks the envelope to
+	// pick EnvelopeWidth() automatically — the right choice for almost
+	// every caller. Tests and special UIs (split-pane reports) can
+	// override this.
+	Width int
+}
+
+// RenderResponseEnvelope paints the assistant's reply in a bordered
+// box. Mechanics:
+//
+//  1. Resolve target card width (caller override or live terminal).
+//  2. Wrap body to inner width = card width − borders (2) − padding (4).
+//  3. Render body with lipgloss (left + right border only) so widths
+//     are computed in one place.
+//  4. Paint a bilateral top border whose visible width matches the
+//     lipgloss-measured body.
+//  5. Optionally typewriter the body; otherwise paint instantly.
+//  6. Paint a bilateral bottom border at the same measured width.
+//
+// The whole point of routing every border through lipgloss.Width is
+// that emoji width disagreements stop mattering: both edges agree
+// with each other, even when they disagree with the terminal — and
+// thanks to the init() normalization above, they now usually agree
+// with the terminal too.
+func (r *UIRenderer) RenderResponseEnvelope(opts ResponseEnvelopeOptions) {
+	width := opts.Width
+	if width <= 0 {
+		width = EnvelopeWidth()
+	}
+	if width < 24 {
+		width = 24
+	}
+
+	// Inner = card width − 2 borders − 4 padding (Padding(0,2)).
+	const innerOverhead = 2 + 4
+	innerWrap := width - innerOverhead
+	if innerWrap < 20 {
+		innerWrap = 20
+	}
+
+	body := strings.Trim(opts.Body, "\n\r")
+	if body == "" {
+		body = " " // lipgloss collapses fully-empty content; keep the box drawable
+	}
+	wrapped := strings.Join(wrapText(body, innerWrap), "\n")
+
+	bodyStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderTop(false).
+		BorderBottom(false).
+		BorderForeground(ansiColorToLip(opts.Color)).
+		Padding(0, 2)
+
+	bodyRendered := bodyStyle.Render(wrapped)
+	bodyRendered = trimBlankBoxBodyRows(bodyRendered)
+
+	// Final card width measured AFTER lipgloss rendered the body.
+	// Anchoring both borders to this number is what keeps the visible
+	// box square even when runewidth and the terminal disagree on a
+	// glyph.
+	cardWidth := lipgloss.Width(bodyRendered)
+
+	topLine := buildBilateralBorder('╭', '╮', opts.HeaderLeft, opts.HeaderRight, cardWidth, opts.Color, r)
+	bottomLine := buildBilateralBorder('╰', '╯', opts.FooterLeft, opts.FooterRight, cardWidth, opts.Color, r)
+
+	delay := opts.TypewriterDelay
+	if delay == 0 {
+		delay = 2 * time.Millisecond
+	}
+
+	fmt.Println()
+	fmt.Println(topLine)
+	if opts.Typewriter {
+		typewriterPrint(bodyRendered, delay)
+		fmt.Println()
+	} else {
+		fmt.Println(bodyRendered)
+	}
+	fmt.Println(bottomLine)
+}
+
+// buildBilateralBorder constructs a horizontal border with optional
+// left and right labels embedded between the corner glyphs:
+//
+//	<lc>─ HeaderLeft ──────── HeaderRight ─<rc>
+//
+// Layout rules (in visible columns):
+//   - <lc> + '─' + leftLabel  if leftLabel != ""   (else <lc> + '─')
+//   - fill of '─' to absorb remaining width
+//   - rightLabel + '─' + <rc> if rightLabel != ""  (else '─' + <rc>)
+//
+// targetWidth is the EXACT visible width we must produce, measured by
+// lipgloss.Width on the matching body. A degenerate case where the
+// labels alone exceed targetWidth falls back to a minimal border (the
+// labels survive; the fill goes to zero).
+func buildBilateralBorder(lc, rc rune, leftLabel, rightLabel string, targetWidth int, color string, r *UIRenderer) string {
+	const cornerCols = 1   // lc / rc themselves
+	const dashCornerPad = 1 // the "─" that hugs each corner
+
+	leftBlock := string(lc) + "─"
+	rightBlock := "─" + string(rc)
+	reserved := cornerCols*2 + dashCornerPad*2 // 4 cols of "<lc>─...─<rc>"
+
+	leftVis := lipgloss.Width(leftLabel)
+	rightVis := lipgloss.Width(rightLabel)
+
+	fill := targetWidth - reserved - leftVis - rightVis
+	if fill < 0 {
+		// Labels overflow the target — emit minimal border with the
+		// labels intact so callers can still read them. This is a
+		// safety net; in practice the envelope sizes the body to
+		// accommodate normal labels.
+		return r.Colorize(leftBlock+leftLabel+rightLabel+rightBlock, color+ColorBold)
+	}
+
+	dashes := strings.Repeat("─", fill)
+
+	var sb strings.Builder
+	sb.WriteString(leftBlock)
+	if leftVis > 0 {
+		sb.WriteString(leftLabel)
+	}
+	sb.WriteString(dashes)
+	if rightVis > 0 {
+		sb.WriteString(rightLabel)
+	}
+	sb.WriteString(rightBlock)
+	return r.Colorize(sb.String(), color+ColorBold)
+}

--- a/cli/agent/response_envelope.go
+++ b/cli/agent/response_envelope.go
@@ -124,41 +124,104 @@ type ResponseEnvelopeOptions struct {
 // RenderResponseEnvelope paints the assistant's reply in a bordered
 // box. Mechanics:
 //
-//  1. Resolve target card width (caller override or live terminal).
-//  2. Wrap body to inner width = card width − borders (2) − padding (4).
-//  3. Render body with lipgloss (left + right border only) so widths
-//     are computed in one place.
-//  4. Paint a bilateral top border whose visible width matches the
-//     lipgloss-measured body.
-//  5. Optionally typewriter the body; otherwise paint instantly.
-//  6. Paint a bilateral bottom border at the same measured width.
+//  1. Resolve the cap (caller-pinned Width, otherwise live terminal).
+//  2. Wrap body to inner = cap − borders (2) − padding (4).
+//  3. Measure the widest wrapped body line.
+//  4. Grow the card so it also fits the header & footer labels with
+//     at least 2 dashes of breathing room on each side. Without this
+//     step a short body + long header (model name + metrics) painted
+//     a top border wider than the body+bottom and the box read as
+//     broken — exactly the regression the user reported on 2026-05-20.
+//  5. Pad every wrapped line to the chosen inner width so lipgloss
+//     produces a rectangular block (no Width() needed, no surprises
+//     from lipgloss's "minimum width" semantics).
+//  6. Render body with lipgloss left + right borders only, then paint
+//     bilateral top and bottom borders at the measured card width.
+//  7. Optionally typewriter the body.
 //
 // The whole point of routing every border through lipgloss.Width is
-// that emoji width disagreements stop mattering: both edges agree
-// with each other, even when they disagree with the terminal — and
-// thanks to the init() normalization above, they now usually agree
-// with the terminal too.
+// that emoji width disagreements stop mattering: every border row
+// agrees with every other border row, even when they disagree with
+// the terminal. Thanks to the init() normalization, they now usually
+// agree with the terminal too.
 func (r *UIRenderer) RenderResponseEnvelope(opts ResponseEnvelopeOptions) {
-	width := opts.Width
-	if width <= 0 {
-		width = EnvelopeWidth()
+	cap := opts.Width
+	if cap <= 0 {
+		cap = EnvelopeWidth()
 	}
-	if width < 24 {
-		width = 24
+	if cap < 24 {
+		cap = 24
 	}
 
-	// Inner = card width − 2 borders − 4 padding (Padding(0,2)).
-	const innerOverhead = 2 + 4
-	innerWrap := width - innerOverhead
-	if innerWrap < 20 {
-		innerWrap = 20
+	// innerOverhead: 2 borders + 4 horizontal padding (Padding(0,2)).
+	const innerOverhead = 6
+	maxInner := cap - innerOverhead
+	if maxInner < 16 {
+		maxInner = 16
 	}
 
 	body := strings.Trim(opts.Body, "\n\r")
 	if body == "" {
 		body = " " // lipgloss collapses fully-empty content; keep the box drawable
 	}
-	wrapped := strings.Join(wrapText(body, innerWrap), "\n")
+	wrapped := wrapText(body, maxInner)
+
+	bodyMax := 0
+	for _, ln := range wrapped {
+		if w := lipgloss.Width(ln); w > bodyMax {
+			bodyMax = w
+		}
+	}
+
+	// minLabelFill: dashes of breathing room around the header/footer
+	// labels. Without this, a header that just barely fits would render
+	// flush against both corners ("╭─Label─╮"), which reads as cramped.
+	const minLabelFill = 2
+
+	leftW := lipgloss.Width(opts.HeaderLeft)
+	rightW := lipgloss.Width(opts.HeaderRight)
+	hdrFloor := 0
+	if leftW > 0 || rightW > 0 {
+		hdrFloor = leftW + rightW + minLabelFill
+	}
+
+	flw := lipgloss.Width(opts.FooterLeft)
+	frw := lipgloss.Width(opts.FooterRight)
+	ftrFloor := 0
+	if flw > 0 || frw > 0 {
+		ftrFloor = flw + frw + minLabelFill
+	}
+
+	// chosenInner = max(bodyMax, header floor, footer floor), capped at
+	// maxInner. This is the contract that fixes the "top wider than
+	// body" bug: when header labels need more room than the body, the
+	// card grows to fit them; the body just pads out to match.
+	chosenInner := bodyMax
+	if chosenInner < hdrFloor {
+		chosenInner = hdrFloor
+	}
+	if chosenInner < ftrFloor {
+		chosenInner = ftrFloor
+	}
+	if chosenInner > maxInner {
+		chosenInner = maxInner
+	}
+	if chosenInner < 16 {
+		chosenInner = 16
+	}
+
+	// Pad every wrapped line to chosenInner so lipgloss renders a
+	// rectangular block. Skipping this and relying on lipgloss .Width()
+	// is tempting but lipgloss's width semantics make the math fragile
+	// once Padding is in the mix; padding here keeps it explicit.
+	padded := make([]string, 0, len(wrapped))
+	for _, ln := range wrapped {
+		gap := chosenInner - lipgloss.Width(ln)
+		if gap < 0 {
+			gap = 0
+		}
+		padded = append(padded, ln+strings.Repeat(" ", gap))
+	}
 
 	bodyStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
@@ -167,13 +230,12 @@ func (r *UIRenderer) RenderResponseEnvelope(opts ResponseEnvelopeOptions) {
 		BorderForeground(ansiColorToLip(opts.Color)).
 		Padding(0, 2)
 
-	bodyRendered := bodyStyle.Render(wrapped)
+	bodyRendered := bodyStyle.Render(strings.Join(padded, "\n"))
 	bodyRendered = trimBlankBoxBodyRows(bodyRendered)
 
-	// Final card width measured AFTER lipgloss rendered the body.
-	// Anchoring both borders to this number is what keeps the visible
-	// box square even when runewidth and the terminal disagree on a
-	// glyph.
+	// Anchoring both borders to lipgloss.Width(bodyRendered) keeps
+	// every row in agreement on visible width, even under emoji-width
+	// drift.
 	cardWidth := lipgloss.Width(bodyRendered)
 
 	topLine := buildBilateralBorder('╭', '╮', opts.HeaderLeft, opts.HeaderRight, cardWidth, opts.Color, r)

--- a/cli/agent/response_envelope_test.go
+++ b/cli/agent/response_envelope_test.go
@@ -209,6 +209,41 @@ func TestRenderResponseEnvelope_LongLineWraps(t *testing.T) {
 	}
 }
 
+// TestRenderResponseEnvelope_ShortBodyLongHeader is the regression
+// test for the bug the user reported on 2026-05-20: when the header
+// bilateral labels (model + latency · tokens) measured wider than the
+// body content, the top border painted wider than the body+bottom and
+// the box read as broken. The envelope must now grow the card to fit
+// the header, padding the body out to match.
+func TestRenderResponseEnvelope_ShortBodyLongHeader(t *testing.T) {
+	r := NewUIRendererWithStyle(zap.NewNop(), UIStyleFull)
+	out := captureEnvStdout(t, func() {
+		r.RenderResponseEnvelope(ResponseEnvelopeOptions{
+			HeaderLeft:  " Claude sonnet 4.6 (1M context) ",
+			HeaderRight: " 3.3s · 2↑ 12↓ ",
+			Body:        "Boa tarde, Edilson! Tudo certo?\nComo posso ajudar?",
+			Color:       ColorGray,
+			Width:       192,
+		})
+	})
+	plain := stripANSIEnv(out)
+
+	var widths []int
+	for _, row := range strings.Split(plain, "\n") {
+		if startsWithBorder(row) {
+			widths = append(widths, lipgloss.Width(row))
+		}
+	}
+	if len(widths) < 4 {
+		t.Fatalf("expected top + 2 body rows + bottom, got %d rows", len(widths))
+	}
+	first := widths[0]
+	for _, got := range widths {
+		assert.Equal(t, first, got,
+			"short body + long header must produce a closed box — every row same width")
+	}
+}
+
 // TestRenderResponseEnvelope_NoLabels covers the minimal-call shape:
 // no labels, just a body and a color. The envelope must still draw a
 // valid closed box (corners + sides + bottom).

--- a/cli/agent/response_envelope_test.go
+++ b/cli/agent/response_envelope_test.go
@@ -1,0 +1,286 @@
+/*
+ * ChatCLI - tests for the unified response envelope
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * These tests defend three invariants that the user-visible bug
+ * report hinged on:
+ *
+ *  1. The right border never drifts when the body contains emojis
+ *     with variation selectors / ZWJ sequences (🏟️, ⚫, 🔴, ⚪).
+ *  2. Long lines wrap to the inner width — they never escape the box.
+ *  3. The card width follows the requested Width, with both borders
+ *     measuring the same number of visible columns.
+ */
+
+package agent
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/mattn/go-runewidth"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+// captureEnvStdout runs fn and returns whatever it wrote to stdout.
+// Stand-alone helper so we don't depend on the cli package's
+// captureStdout (different package, different file scope).
+func captureEnvStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+
+	done := make(chan struct{})
+	var buf bytes.Buffer
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		close(done)
+	}()
+
+	fn()
+	_ = w.Close()
+	os.Stdout = old
+	<-done
+	return buf.String()
+}
+
+// stripANSIEnv strips CSI color sequences so visible-width checks can
+// run on plain text. Mirrors stripANSIForCard but inline so this test
+// file stays self-contained.
+func stripANSIEnv(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == 0x1b && i+1 < len(s) && s[i+1] == '[' {
+			i += 2
+			for i < len(s) && (s[i] < 0x40 || s[i] > 0x7e) {
+				i++
+			}
+			continue
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
+// TestRenderResponseEnvelope_BoxIsClosed asserts the envelope draws
+// matching top + side + bottom borders for a simple body. Without
+// this guarantee long bodies could escape on the right.
+func TestRenderResponseEnvelope_BoxIsClosed(t *testing.T) {
+	r := NewUIRendererWithStyle(zap.NewNop(), UIStyleFull)
+	out := captureEnvStdout(t, func() {
+		r.RenderResponseEnvelope(ResponseEnvelopeOptions{
+			HeaderLeft:  " 💬 RESPOSTA ",
+			HeaderRight: " 1.4s · 312↑ 1.8k↓ ",
+			Body:        "Hello, world.",
+			Color:       ColorGray,
+			Width:       80,
+		})
+	})
+	plain := stripANSIEnv(out)
+
+	assert.Contains(t, plain, "╭", "top-left corner present")
+	assert.Contains(t, plain, "╮", "top-right corner present")
+	assert.Contains(t, plain, "╰", "bottom-left corner present")
+	assert.Contains(t, plain, "╯", "bottom-right corner present")
+	assert.Contains(t, plain, "│", "vertical side border present")
+	assert.Contains(t, plain, "RESPOSTA", "header left label surfaces")
+	assert.Contains(t, plain, "1.4s", "header right label surfaces")
+	assert.Contains(t, plain, "Hello, world.", "body content surfaces")
+}
+
+// TestRenderResponseEnvelope_BordersAlignAcrossWidths verifies that
+// at multiple terminal widths the top, every body row, and the bottom
+// all measure the same visible width. This is the contract that
+// prevents the "text outside the box" regression.
+func TestRenderResponseEnvelope_BordersAlignAcrossWidths(t *testing.T) {
+	cases := []int{40, 60, 80, 120, 180}
+	for _, w := range cases {
+		r := NewUIRendererWithStyle(zap.NewNop(), UIStyleFull)
+		out := captureEnvStdout(t, func() {
+			r.RenderResponseEnvelope(ResponseEnvelopeOptions{
+				HeaderLeft:  " 💬 RESPOSTA ",
+				HeaderRight: " 1.4s ",
+				Body:        "Curta resposta com algumas palavras.",
+				Color:       ColorGray,
+				Width:       w,
+			})
+		})
+		plain := stripANSIEnv(out)
+		rows := splitNonEmpty(plain)
+
+		// Each row that is part of the box (i.e. starts with one of the
+		// border glyphs) must report the same visible width.
+		var widths []int
+		for _, row := range rows {
+			if startsWithBorder(row) {
+				widths = append(widths, lipgloss.Width(row))
+			}
+		}
+		if len(widths) < 3 {
+			t.Fatalf("width=%d: expected at least top+body+bottom rows, got %d (rows=%v)", w, len(widths), rows)
+		}
+		first := widths[0]
+		for _, got := range widths {
+			assert.Equalf(t, first, got, "width=%d: every border row must agree on visible width", w)
+		}
+	}
+}
+
+// TestRenderResponseEnvelope_EmojiHeavyContent feeds the box the same
+// emoji-heavy body pattern the user reported overflowing in the bug
+// report. After the runewidth.StrictEmojiNeutral normalization, the
+// right border must stay aligned with the rest of the box.
+func TestRenderResponseEnvelope_EmojiHeavyContent(t *testing.T) {
+	r := NewUIRendererWithStyle(zap.NewNop(), UIStyleFull)
+	body := strings.Join([]string{
+		"Tem sim! 🔥",
+		"Flamengo x Estudiantes (ARG)",
+		"• 📅 Hoje, quarta-feira (20/05)",
+		"• ⏰ 21h30 (horário de Brasília)",
+		"• 🏟️ Maracanã, Rio de Janeiro",
+		"• 🏆 Copa Libertadores 2026",
+		"No primeiro confronto: 🏟️⚫🔴",
+	}, "\n")
+	out := captureEnvStdout(t, func() {
+		r.RenderResponseEnvelope(ResponseEnvelopeOptions{
+			HeaderLeft:  " 💬 RESPOSTA ",
+			HeaderRight: " 1.4s · 312↑ 1.8k↓ ",
+			Body:        body,
+			Color:       ColorGray,
+			Width:       90,
+		})
+	})
+	plain := stripANSIEnv(out)
+
+	rows := splitNonEmpty(plain)
+	var widths []int
+	for _, row := range rows {
+		if startsWithBorder(row) {
+			widths = append(widths, lipgloss.Width(row))
+		}
+	}
+	if len(widths) < 3 {
+		t.Fatalf("expected at least top+body+bottom rows, got rows=%v", rows)
+	}
+	first := widths[0]
+	for _, got := range widths {
+		assert.Equal(t, first, got,
+			"emoji-heavy content must not drift the right border")
+	}
+}
+
+// TestRenderResponseEnvelope_LongLineWraps proves the renderer wraps
+// long single-line bodies inside the inner width so no row ever
+// exceeds the card width. Reproduces the chat-mode failure mode the
+// user described ("não respeita o mesmo tab de linha que o tamanho
+// da box").
+func TestRenderResponseEnvelope_LongLineWraps(t *testing.T) {
+	r := NewUIRendererWithStyle(zap.NewNop(), UIStyleFull)
+	long := strings.Repeat("palavra ", 60)
+	out := captureEnvStdout(t, func() {
+		r.RenderResponseEnvelope(ResponseEnvelopeOptions{
+			HeaderLeft: " 💬 ",
+			Body:       long,
+			Color:      ColorGray,
+			Width:      60,
+		})
+	})
+	plain := stripANSIEnv(out)
+
+	for _, row := range strings.Split(plain, "\n") {
+		if !startsWithBorder(row) {
+			continue
+		}
+		// Borders + padding consume at most 6 cols of the requested
+		// width — every visible row must therefore be ≤ requested width.
+		assert.LessOrEqual(t, lipgloss.Width(row), 60,
+			"long body row must wrap inside the box: %q", row)
+	}
+}
+
+// TestRenderResponseEnvelope_NoLabels covers the minimal-call shape:
+// no labels, just a body and a color. The envelope must still draw a
+// valid closed box (corners + sides + bottom).
+func TestRenderResponseEnvelope_NoLabels(t *testing.T) {
+	r := NewUIRendererWithStyle(zap.NewNop(), UIStyleFull)
+	out := captureEnvStdout(t, func() {
+		r.RenderResponseEnvelope(ResponseEnvelopeOptions{
+			Body:  "Plain body, no labels.",
+			Color: ColorGray,
+			Width: 50,
+		})
+	})
+	plain := stripANSIEnv(out)
+
+	assert.Contains(t, plain, "╭")
+	assert.Contains(t, plain, "╮")
+	assert.Contains(t, plain, "╰")
+	assert.Contains(t, plain, "╯")
+	assert.Contains(t, plain, "│")
+	assert.Contains(t, plain, "Plain body, no labels.")
+}
+
+// TestRunewidthNormalization_EmojiIsTwoCells locks the init() side
+// effect: with our normalization, runewidth reports emojis as 2 cols,
+// matching what modern terminals actually paint. If a future refactor
+// removes the init() call, this test fires.
+func TestRunewidthNormalization_EmojiIsTwoCells(t *testing.T) {
+	cases := []struct {
+		glyph string
+		want  int
+	}{
+		{"🔥", 2},
+		{"⚫", 2},
+		{"🔴", 2},
+		{"📅", 2},
+		{"🏆", 2},
+	}
+	for _, tc := range cases {
+		got := runewidth.StringWidth(tc.glyph)
+		assert.Equalf(t, tc.want, got,
+			"runewidth normalization must report %q as %d cols, got %d",
+			tc.glyph, tc.want, got)
+	}
+}
+
+// TestEnvelopeWidth_FallbackOutsideTTY asserts the helper returns a
+// safe positive number when no TTY is attached (the test runner case).
+// The exact value isn't part of the contract — only that it's ≥ 40
+// (so the box never collapses).
+func TestEnvelopeWidth_FallbackOutsideTTY(t *testing.T) {
+	w := EnvelopeWidth()
+	assert.GreaterOrEqual(t, w, 40, "envelope width must always be ≥ 40")
+}
+
+// --- small local helpers (avoid leaking into the package surface) ---
+
+func splitNonEmpty(s string) []string {
+	var out []string
+	for _, line := range strings.Split(s, "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		out = append(out, line)
+	}
+	return out
+}
+
+func startsWithBorder(row string) bool {
+	trim := strings.TrimLeft(row, " ")
+	if trim == "" {
+		return false
+	}
+	first := []rune(trim)[0]
+	return first == '╭' || first == '╮' || first == '╰' || first == '╯' || first == '│'
+}

--- a/cli/agent/ui_renderer.go
+++ b/cli/agent/ui_renderer.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/diillson/chatcli/i18n"
-	"github.com/mattn/go-runewidth"
 	"go.uber.org/zap"
 	"golang.org/x/term"
 )
@@ -447,11 +446,17 @@ func (r *UIRenderer) PrintPrompt() string {
 }
 
 // VisibleLen calcula comprimento visível em colunas do terminal (sem ANSI codes).
-// Usa runewidth para tratar emojis e caracteres wide corretamente.
+//
+// Delegates to lipgloss.Width — the same function the bordered box
+// renderer uses to size top/bottom borders. Sharing one measurement
+// path is what keeps wrap math and border math in agreement when the
+// content has emoji presentation sequences (e.g. "🏟️" = stadium + VS-16
+// = U+1F3DF + U+FE0F) that pure runewidth.StringWidth reports as 1 col
+// while every modern terminal renders as 2. Mismatch there used to
+// drift the right border outside the visible box; routing both sides
+// through lipgloss.Width removes the disagreement entirely.
 func VisibleLen(s string) int {
-	ansiRe := regexp.MustCompile(`\x1b\[[0-9;]*m`)
-	cleaned := ansiRe.ReplaceAllString(s, "")
-	return runewidth.StringWidth(cleaned)
+	return lipgloss.Width(s)
 }
 
 // RenderTimelineEvent desenha um "card" estilizado com:

--- a/cli/chat_envelope_render_test.go
+++ b/cli/chat_envelope_render_test.go
@@ -1,7 +1,14 @@
 /*
- * ChatCLI - chat envelope header/footer rendering tests
+ * ChatCLI - chat envelope rendering tests
  * Copyright (c) 2024 Edilson Freitas
  * License: Apache-2.0
+ *
+ * The chat envelope used to live in two helpers (buildChatEnvelopeHeader,
+ * buildChatEnvelopeFooter) that hand-rolled the dash math and a hardcoded
+ * 87-column width. With the unified agent.RenderResponseEnvelope in place
+ * we test the public contract instead: the bilateral labels emit the
+ * right components, and the full render produces a closed bordered box
+ * whose corners, sides, and emoji-bearing rows all line up.
  */
 
 package cli
@@ -16,10 +23,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// fakeChatClient is a stub LLMClient used by buildChatEnvelopeHeader.
-// Only GetModelName is exercised by the envelope code; SendPrompt is
-// here just to satisfy the interface and panics if anything in the
-// header path accidentally invokes it.
+// fakeChatClient is a stub LLMClient used by the envelope path. Only
+// GetModelName is exercised by the render code; SendPrompt is here to
+// satisfy the interface and panics if anything in the header path
+// accidentally invokes it.
 type fakeChatClient struct{ model string }
 
 func (f *fakeChatClient) GetModelName() string { return f.model }
@@ -27,51 +34,71 @@ func (f *fakeChatClient) SendPrompt(_ context.Context, _ string, _ []models.Mess
 	panic("SendPrompt must not be called from envelope rendering tests")
 }
 
-func TestBuildChatEnvelopeHeader_ShowsModelAndMetrics(t *testing.T) {
-	cli := &ChatCLI{}
-	header := cli.buildChatEnvelopeHeader(
+// TestChatEnvelopeLabels_ShowsModelAndMetrics locks the label builder
+// contract: the left label carries the model in purple+bold with the
+// surrounding spaces the renderer needs, and the right label carries
+// the latency · tokens summary in gray. The leading/trailing spaces
+// inside each label exist so the dash fill bites into the colored
+// text instead of sitting flush against it.
+func TestChatEnvelopeLabels_ShowsModelAndMetrics(t *testing.T) {
+	left, right := chatEnvelopeLabels(
 		&fakeChatClient{model: "claude-opus-4-7"},
 		1400*time.Millisecond,
 		&models.UsageInfo{PromptTokens: 312, CompletionTokens: 1800},
 	)
 
-	plain := stripANSIWelcome(header)
-	assert.True(t, strings.HasPrefix(plain, "╭─"),
-		"header must open with the rounded corner ╭─")
-	assert.True(t, strings.HasSuffix(plain, "─╮"),
-		"header must close with ─╮")
-	assert.Contains(t, plain, "claude-opus-4-7", "model name visible")
-	assert.Contains(t, plain, "1.4s", "latency formatted")
-	assert.Contains(t, plain, "312", "prompt tokens visible")
+	plainLeft := stripANSIWelcome(left)
+	plainRight := stripANSIWelcome(right)
+
+	assert.Contains(t, plainLeft, "claude-opus-4-7", "model name visible on the left label")
+	assert.True(t, strings.HasPrefix(plainLeft, " ") && strings.HasSuffix(plainLeft, " "),
+		"left label must carry the leading/trailing space the envelope expects")
+
+	assert.Contains(t, plainRight, "1.4s", "latency formatted on the right label")
+	assert.Contains(t, plainRight, "312", "prompt tokens visible on the right label")
+	assert.Contains(t, plainRight, "↑", "right label includes the prompt-tokens arrow")
+	assert.Contains(t, plainRight, "↓", "right label includes the completion-tokens arrow")
 }
 
-func TestBuildChatEnvelopeFooter_MatchesHeaderWidth(t *testing.T) {
-	cli := &ChatCLI{}
-	header := cli.buildChatEnvelopeHeader(
-		&fakeChatClient{model: "gpt-4o"},
-		800*time.Millisecond,
-		&models.UsageInfo{PromptTokens: 100, CompletionTokens: 50},
-	)
-	footer := cli.buildChatEnvelopeFooter(header)
-
-	plainHead := stripANSIWelcome(header)
-	plainFoot := stripANSIWelcome(footer)
-	assert.Equal(t, visibleLen(plainHead), visibleLen(plainFoot),
-		"footer width must match the header — same envelope shape")
-	assert.True(t, strings.HasPrefix(plainFoot, "╰"),
-		"footer opens with ╰")
-	assert.True(t, strings.HasSuffix(plainFoot, "╯"),
-		"footer closes with ╯")
-}
-
-func TestBuildChatEnvelopeHeader_NoUsage(t *testing.T) {
-	cli := &ChatCLI{}
-	header := cli.buildChatEnvelopeHeader(
+// TestChatEnvelopeLabels_NoUsage covers the unmetered branch: when the
+// provider didn't return token counts, the right label falls back to
+// the i18n placeholder instead of showing "0↑ 0↓" (which would look
+// like a real zero-cost turn).
+func TestChatEnvelopeLabels_NoUsage(t *testing.T) {
+	_, right := chatEnvelopeLabels(
 		&fakeChatClient{model: "claude"},
 		200*time.Millisecond,
 		nil,
 	)
-	plain := stripANSIWelcome(header)
+	plain := stripANSIWelcome(right)
 	assert.Contains(t, plain, "—",
 		"missing usage must render as the i18n placeholder, not '0↑ 0↓'")
+}
+
+// TestRenderAssistantResponse_BoxedOutput exercises the full chat
+// envelope through renderAssistantResponse: the body must sit inside
+// a closed box with matching top/side/bottom borders, no dangling
+// dashes, and the model + metrics labels must surface on the top row.
+// This is the end-to-end contract that prevents the regression the
+// user reported (text overflowing outside the envelope).
+func TestRenderAssistantResponse_BoxedOutput(t *testing.T) {
+	cli := &ChatCLI{}
+	out := captureStdout(t, func() {
+		cli.renderAssistantResponse(
+			&fakeChatClient{model: "claude-opus-4-7"},
+			"Hello from the assistant.",
+			1400*time.Millisecond,
+			&models.UsageInfo{PromptTokens: 312, CompletionTokens: 1800},
+		)
+	})
+	plain := stripANSIWelcome(out)
+
+	assert.Contains(t, plain, "╭", "top-left corner must be drawn")
+	assert.Contains(t, plain, "╮", "top-right corner must be drawn")
+	assert.Contains(t, plain, "╰", "bottom-left corner must be drawn")
+	assert.Contains(t, plain, "╯", "bottom-right corner must be drawn")
+	assert.Contains(t, plain, "│", "vertical side borders must be drawn — body must sit inside the box")
+	assert.Contains(t, plain, "claude-opus-4-7", "model name must surface on the top border")
+	assert.Contains(t, plain, "1.4s", "latency must surface on the top border")
+	assert.Contains(t, plain, "Hello from the assistant.", "body content must survive inside the box")
 }

--- a/cli/chat_pipeline.go
+++ b/cli/chat_pipeline.go
@@ -34,6 +34,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/diillson/chatcli/cli/agent"
 	"github.com/diillson/chatcli/cli/agent/quality"
 	"github.com/diillson/chatcli/cli/ctxmgr"
 	"github.com/diillson/chatcli/cli/workspace/memory"
@@ -584,11 +585,19 @@ func (cli *ChatCLI) handleChatTurnResult(
 }
 
 // renderAssistantResponse draws the assistant message wrapped in a
-// lipgloss envelope:
+// fully bordered, responsive envelope:
 //
 //	╭─ <model> ─────────── <latency> · <tokens> ─╮
-//	│  <markdown body>                           │
+//	│  <wrapped markdown body>                   │
+//	│  …                                         │
 //	╰────────────────────────────────────────────╯
+//
+// All width math is delegated to agent.RenderResponseEnvelope, which:
+//   - reads the live terminal width (no hardcoded columns),
+//   - wraps the body to the inner width preserving ANSI escapes,
+//   - normalizes emoji width so the right border never drifts,
+//   - paints both vertical borders so long lines stay inside the box,
+//   - drives the typewriter effect on the body.
 //
 // Streaming clients already painted raw chunks inline during the call;
 // we clear that line and overwrite with the markdown-rendered version
@@ -605,58 +614,37 @@ func (cli *ChatCLI) renderAssistantResponse(
 		fmt.Print("\033[2K\r")
 	}
 
-	header := cli.buildChatEnvelopeHeader(activeClient, elapsed, usage)
-	footer := cli.buildChatEnvelopeFooter(header)
-
-	fmt.Println()
-	fmt.Println(header)
-	// Indent body so it visually sits inside the envelope. The body
-	// already contains its own glamour-rendered formatting, which we
-	// preserve as-is — we only add a left gutter. Typewriter the body
-	// so the response feels alive instead of pasted; ANSI escape
-	// sequences embedded in the markdown are streamed without delay.
-	indented := "  " + strings.ReplaceAll(strings.TrimRight(rendered, "\n"), "\n", "\n  ") + "\n"
-	cli.typewriterEffect(indented, 2*time.Millisecond)
-	fmt.Println(footer)
+	left, right := chatEnvelopeLabels(activeClient, elapsed, usage)
+	renderer := agent.NewUIRendererWithStyle(cli.logger, agent.UIStyleFull)
+	renderer.RenderResponseEnvelope(agent.ResponseEnvelopeOptions{
+		HeaderLeft:  left,
+		HeaderRight: right,
+		Body:        rendered,
+		Color:       agent.ColorGray,
+		Typewriter:  true,
+	})
 	fmt.Println()
 }
 
-// buildChatEnvelopeHeader produces the top border line:
+// chatEnvelopeLabels builds the bilateral labels for the chat reply
+// envelope: model name on the left (purple + bold), latency · tokens
+// on the right (gray). Each label includes the leading/trailing space
+// the envelope renderer expects so the dash fill bites cleanly into
+// the labels instead of sitting flush against the text.
 //
-//	╭─ claude-opus-4-7 ──────────── 1.4s · 312↑ 1.8k↓ ─╮
-//
-// The model name lives on the left in purple+bold; the latency/token
-// summary sits on the right in gray. The dashes in between expand to
-// fill the configured screen width.
-func (cli *ChatCLI) buildChatEnvelopeHeader(activeClient client.LLMClient, elapsed time.Duration, usage *models.UsageInfo) string {
+// Returning the two strings separately (instead of a pre-built header
+// line) lets the unified envelope renderer own the border math while
+// the chat path still owns its content. Locale-aware token formatting
+// flows through formatTokenSummary, which respects the active i18n
+// locale (en/pt) for the digit grouping separator.
+func chatEnvelopeLabels(activeClient client.LLMClient, elapsed time.Duration, usage *models.UsageInfo) (string, string) {
 	model := activeClient.GetModelName()
 	latency := formatLatency(elapsed)
 	tokens := formatTokenSummary(usage)
 
-	leftLabel := colorize(" "+model+" ", ColorPurple+ColorBold)
-	rightLabel := colorize(" "+latency+" · "+tokens+" ", ColorGray)
-
-	target := screenWidth - 2 // leave room for "╭" + "╮"
-	leftLen := visibleLen(leftLabel)
-	rightLen := visibleLen(rightLabel)
-	pad := target - leftLen - rightLen
-	if pad < 4 {
-		pad = 4
-	}
-	fill := colorize(strings.Repeat("─", pad), ColorGray)
-	return colorize("╭─", ColorGray) + leftLabel + fill + rightLabel + colorize("─╮", ColorGray)
-}
-
-// buildChatEnvelopeFooter mirrors the header's width so the envelope
-// reads as a balanced box. We measure the header's visible width and
-// produce a footer of the same total length.
-func (cli *ChatCLI) buildChatEnvelopeFooter(header string) string {
-	width := visibleLen(header)
-	if width < 4 {
-		width = 4
-	}
-	inner := width - 2
-	return colorize("╰"+strings.Repeat("─", inner)+"╯", ColorGray)
+	left := colorize(" "+model+" ", ColorPurple+ColorBold)
+	right := colorize(" "+latency+" · "+tokens+" ", ColorGray)
+	return left, right
 }
 
 // formatLatency renders a duration in a human-friendly shape:

--- a/cli/welcome.go
+++ b/cli/welcome.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/diillson/chatcli/cli/agent"
 	"github.com/diillson/chatcli/i18n"
 	"github.com/diillson/chatcli/version"
 	"github.com/mattn/go-runewidth"
@@ -28,46 +27,21 @@ var tipKeys = []string{ // <-- 2. ALTERADO DE 'tips' PARA 'tipKeys'
 	"tip.agent_last_result",
 }
 
-// cardMaxWidth caps the inner width of welcome-screen cards (tip box,
-// active-model card). The number was tuned around the original 87-col
-// global constant and matches the layout the welcome screen was
-// originally designed around. On wider terminals we keep the cards at
-// this width and center them so the layout stays balanced; on narrower
-// terminals the cards shrink to fit.
-const cardMaxWidth = 87
+// screenWidth is the anchor width used to center welcome-screen
+// content (logo, tip box, active-model card, footer). It is a fixed
+// 87 columns by design: anchoring at the terminal width left the
+// banner pushed far to the right on wide terminals and read as
+// awkward — the welcome reads more naturally hugging the left edge
+// like the rest of the prompt does. Keeping a const here means tip
+// box and model card stay centered relative to the logo regardless
+// of how the user has sized their terminal.
+const screenWidth = 87
 
-// screenWidth reports the live terminal width — the surface we center
-// the welcome content over. Falls back to cardMaxWidth when stdout is
-// not a TTY (CI / piped runs) so the layout still looks sane outside
-// an interactive shell. Reads at call time so a window resize between
-// PrintWelcomeScreen invocations is picked up automatically.
-func screenWidth() int {
-	w := agent.TerminalWidth()
-	if w <= 0 {
-		return cardMaxWidth
-	}
-	return w
-}
-
-// cardWidth returns the inner card width clamped to [40, cardMaxWidth].
-// Used by the tip box and active-model card so they keep a comfortable
-// reading width regardless of the terminal size, while remaining
-// centered on screenWidth().
-func cardWidth() int {
-	w := screenWidth() - 2
-	if w > cardMaxWidth {
-		return cardMaxWidth
-	}
-	if w < 40 {
-		return 40
-	}
-	return w
-}
-
-// printLogo exibe o novo logo do ChatCLI em ASCII art, centralizado na
-// largura real do terminal. Quando o terminal é mais estreito que o
-// logo, imprimimos sem padding (o terminal cuida do wrap, melhor que
-// truncarmos cegamente).
+// printLogo exibe o novo logo do ChatCLI em ASCII art, centralizado
+// num bloco virtual de 80 colunas (mesma largura usada antes da
+// refatoração de envelope). Esse bloco fica na borda esquerda do
+// terminal, por preferência do usuário — uma centralização no
+// terminal inteiro empurra o banner pra direita em telas largas.
 func printLogo() {
 	logo := `
            ██████╗ ██╗  ██╗ █████╗ ████████╗ ██████╗██╗     ██╗
@@ -86,14 +60,15 @@ func printLogo() {
 	coloredLogo = strings.ReplaceAll(coloredLogo, "═", colorize("═", ColorGray))
 	coloredLogo = strings.ReplaceAll(coloredLogo, "║", colorize("║", ColorGray))
 
-	target := screenWidth()
+	width := 80
 	for _, line := range strings.Split(coloredLogo, "\n") {
 		if strings.TrimSpace(line) == "" {
 			continue
 		}
+		// calcula padding
 		visible := visibleLen(line)
-		if visible < target {
-			left := (target - visible) / 2
+		if visible < width {
+			left := (width - visible) / 2
 			fmt.Println(strings.Repeat(" ", left) + line)
 		} else {
 			fmt.Println(line)
@@ -166,12 +141,8 @@ func printTipBox() {
 	tip := i18n.T(tipKey)
 	title := i18n.T("welcome.tip.title")
 
-	card := cardWidth()
 	// Inner content width = card width − 2 borders − 2 of padding.
-	innerWidth := card - 4
-	if innerWidth < 20 {
-		innerWidth = 20
-	}
+	innerWidth := screenWidth - 4
 
 	// Title line: " ─── Did you know? ─── " centered above the body.
 	// We bake the title into the body so it appears INSIDE the box at
@@ -196,14 +167,13 @@ func printTipBox() {
 		Foreground(lipgloss.Color("7")).
 		Render(wrapped)
 
-	rendered := tipBoxBorderStyle.
+	card := tipBoxBorderStyle.
 		Padding(1, 1).
 		Render(titleLine + "\n\n" + body)
 
-	// Center the rendered card on the live terminal width so the
-	// overall welcome layout stays balanced regardless of how the
-	// user has sized their terminal.
-	fmt.Println(lipgloss.PlaceHorizontal(screenWidth(), lipgloss.Center, rendered))
+	// Center the card on the configured screenWidth so the overall
+	// welcome layout stays balanced.
+	fmt.Println(lipgloss.PlaceHorizontal(screenWidth, lipgloss.Center, card))
 }
 
 // PrintWelcomeScreen exibe a tela de boas-vindas completa e traduzida.
@@ -226,12 +196,10 @@ func printTipBox() {
 func (cli *ChatCLI) PrintWelcomeScreen() {
 	printLogo()
 
-	target := screenWidth()
-
 	v, c, _ := version.GetBuildInfo()
 	if v != "" && v != "dev" && v != "unknown" {
 		versionStr := i18n.T("version.label", v, c)
-		fmt.Println(lipgloss.PlaceHorizontal(target, lipgloss.Center,
+		fmt.Println(lipgloss.PlaceHorizontal(screenWidth, lipgloss.Center,
 			colorize(versionStr, ColorGray)))
 		fmt.Println()
 	}
@@ -258,7 +226,7 @@ func (cli *ChatCLI) PrintWelcomeScreen() {
 	modelCard := tipBoxBorderStyle.
 		Padding(0, 2).
 		Render(modelLine)
-	fmt.Println(lipgloss.PlaceHorizontal(target, lipgloss.Center, modelCard))
+	fmt.Println(lipgloss.PlaceHorizontal(screenWidth, lipgloss.Center, modelCard))
 
 	// Footer of quick commands, centered to match the rest of the
 	// layout. Plain Bullet (·) instead of the heavier "  •  " for a
@@ -274,6 +242,6 @@ func (cli *ChatCLI) PrintWelcomeScreen() {
 		colorize(" "+i18n.T("welcome.footer.switch_model.desc"), ColorGray),
 	)
 	fmt.Println()
-	fmt.Println(lipgloss.PlaceHorizontal(target, lipgloss.Center, footer))
+	fmt.Println(lipgloss.PlaceHorizontal(screenWidth, lipgloss.Center, footer))
 	fmt.Println()
 }

--- a/cli/welcome.go
+++ b/cli/welcome.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/diillson/chatcli/cli/agent"
 	"github.com/diillson/chatcli/i18n"
 	"github.com/diillson/chatcli/version"
 	"github.com/mattn/go-runewidth"
@@ -27,9 +28,46 @@ var tipKeys = []string{ // <-- 2. ALTERADO DE 'tips' PARA 'tipKeys'
 	"tip.agent_last_result",
 }
 
-const screenWidth = 87 // largura global para tudo
+// cardMaxWidth caps the inner width of welcome-screen cards (tip box,
+// active-model card). The number was tuned around the original 87-col
+// global constant and matches the layout the welcome screen was
+// originally designed around. On wider terminals we keep the cards at
+// this width and center them so the layout stays balanced; on narrower
+// terminals the cards shrink to fit.
+const cardMaxWidth = 87
 
-// printLogo exibe o novo logo do ChatCLI em ASCII art.
+// screenWidth reports the live terminal width — the surface we center
+// the welcome content over. Falls back to cardMaxWidth when stdout is
+// not a TTY (CI / piped runs) so the layout still looks sane outside
+// an interactive shell. Reads at call time so a window resize between
+// PrintWelcomeScreen invocations is picked up automatically.
+func screenWidth() int {
+	w := agent.TerminalWidth()
+	if w <= 0 {
+		return cardMaxWidth
+	}
+	return w
+}
+
+// cardWidth returns the inner card width clamped to [40, cardMaxWidth].
+// Used by the tip box and active-model card so they keep a comfortable
+// reading width regardless of the terminal size, while remaining
+// centered on screenWidth().
+func cardWidth() int {
+	w := screenWidth() - 2
+	if w > cardMaxWidth {
+		return cardMaxWidth
+	}
+	if w < 40 {
+		return 40
+	}
+	return w
+}
+
+// printLogo exibe o novo logo do ChatCLI em ASCII art, centralizado na
+// largura real do terminal. Quando o terminal é mais estreito que o
+// logo, imprimimos sem padding (o terminal cuida do wrap, melhor que
+// truncarmos cegamente).
 func printLogo() {
 	logo := `
            ██████╗ ██╗  ██╗ █████╗ ████████╗ ██████╗██╗     ██╗
@@ -48,15 +86,14 @@ func printLogo() {
 	coloredLogo = strings.ReplaceAll(coloredLogo, "═", colorize("═", ColorGray))
 	coloredLogo = strings.ReplaceAll(coloredLogo, "║", colorize("║", ColorGray))
 
-	width := 80
+	target := screenWidth()
 	for _, line := range strings.Split(coloredLogo, "\n") {
 		if strings.TrimSpace(line) == "" {
 			continue
 		}
-		// calcula padding
 		visible := visibleLen(line)
-		if visible < width {
-			left := (width - visible) / 2
+		if visible < target {
+			left := (target - visible) / 2
 			fmt.Println(strings.Repeat(" ", left) + line)
 		} else {
 			fmt.Println(line)
@@ -129,8 +166,12 @@ func printTipBox() {
 	tip := i18n.T(tipKey)
 	title := i18n.T("welcome.tip.title")
 
+	card := cardWidth()
 	// Inner content width = card width − 2 borders − 2 of padding.
-	innerWidth := screenWidth - 4
+	innerWidth := card - 4
+	if innerWidth < 20 {
+		innerWidth = 20
+	}
 
 	// Title line: " ─── Did you know? ─── " centered above the body.
 	// We bake the title into the body so it appears INSIDE the box at
@@ -155,13 +196,14 @@ func printTipBox() {
 		Foreground(lipgloss.Color("7")).
 		Render(wrapped)
 
-	card := tipBoxBorderStyle.
+	rendered := tipBoxBorderStyle.
 		Padding(1, 1).
 		Render(titleLine + "\n\n" + body)
 
-	// Center the card on the configured screenWidth so the overall
-	// welcome layout stays balanced even on wider terminals.
-	fmt.Println(lipgloss.PlaceHorizontal(screenWidth, lipgloss.Center, card))
+	// Center the rendered card on the live terminal width so the
+	// overall welcome layout stays balanced regardless of how the
+	// user has sized their terminal.
+	fmt.Println(lipgloss.PlaceHorizontal(screenWidth(), lipgloss.Center, rendered))
 }
 
 // PrintWelcomeScreen exibe a tela de boas-vindas completa e traduzida.
@@ -184,10 +226,12 @@ func printTipBox() {
 func (cli *ChatCLI) PrintWelcomeScreen() {
 	printLogo()
 
+	target := screenWidth()
+
 	v, c, _ := version.GetBuildInfo()
 	if v != "" && v != "dev" && v != "unknown" {
 		versionStr := i18n.T("version.label", v, c)
-		fmt.Println(lipgloss.PlaceHorizontal(screenWidth, lipgloss.Center,
+		fmt.Println(lipgloss.PlaceHorizontal(target, lipgloss.Center,
 			colorize(versionStr, ColorGray)))
 		fmt.Println()
 	}
@@ -214,7 +258,7 @@ func (cli *ChatCLI) PrintWelcomeScreen() {
 	modelCard := tipBoxBorderStyle.
 		Padding(0, 2).
 		Render(modelLine)
-	fmt.Println(lipgloss.PlaceHorizontal(screenWidth, lipgloss.Center, modelCard))
+	fmt.Println(lipgloss.PlaceHorizontal(target, lipgloss.Center, modelCard))
 
 	// Footer of quick commands, centered to match the rest of the
 	// layout. Plain Bullet (·) instead of the heavier "  •  " for a
@@ -230,6 +274,6 @@ func (cli *ChatCLI) PrintWelcomeScreen() {
 		colorize(" "+i18n.T("welcome.footer.switch_model.desc"), ColorGray),
 	)
 	fmt.Println()
-	fmt.Println(lipgloss.PlaceHorizontal(screenWidth, lipgloss.Center, footer))
+	fmt.Println(lipgloss.PlaceHorizontal(target, lipgloss.Center, footer))
 	fmt.Println()
 }


### PR DESCRIPTION
## Summary

- Chat mode used to draw the reply with a hardcoded 87-col header/footer and zero side borders, so long lines spilled outside the implied box and the layout ignored the user's terminal width entirely. Coder and agent already drew a closed card but their right border drifted on emoji-heavy content (🏟️, ⚫, 🔴) because runewidth measured variation selectors as 1 col while terminals render them as 2.
- This unifies all three modes behind a single renderer in `cli/agent/response_envelope.go`. The envelope reads the live terminal width, wraps the body to the inner width preserving ANSI escapes, normalizes emoji width via `runewidth.StrictEmojiNeutral = false`, and routes both wrap math and border math through `lipgloss.Width` so they always agree on a glyph.
- The welcome screen is now responsive too: `screenWidth()` returns the live terminal width with a safe fallback outside a TTY, internal cards are clamped to 40 to 87 cols, and the logo / version / tip box / model card / footer are centered on the real screen instead of a hardcoded constant.
- Coverage in `cli/agent/response_envelope_test.go` defends the border-alignment, emoji-heavy, long-word-wrap, no-labels, runewidth-normalization and TTY-fallback paths. The chat envelope test was rewritten to the new bilateral contract.

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./...` succeeds
- [x] `go vet ./...` clean
- [x] `golangci-lint run` clean on touched files
- [x] In a wide terminal (180+ cols), chat reply box fills the terminal width and stays balanced
- [x] In a narrow terminal (around 60 cols), chat reply box shrinks to fit and the body wraps inside the borders
- [x] Send a long single-paragraph reply in chat mode and confirm no line escapes the right border
- [x] Send an emoji-heavy reply (🏟️, ⚫, 🔴 mixed with ASCII) and confirm the right border stays aligned across rows
- [x] Launch ChatCLI fresh and confirm the welcome banner (logo, tip box, model card, footer) is centered on the terminal, on both wide and narrow widths
- [x] Run /agent and /coder and confirm the RESPOSTA / RESUMO cards keep their existing layout and the typewriter effect still plays