### PR TITLE
fix(aiops): close GAP-06 — Helm CRD upgrade hook and parity tests

### DIFF
--- a/deploy/helm/chatcli-operator/crds/platform.chatcli.io_instances.yaml
+++ b/deploy/helm/chatcli-operator/crds/platform.chatcli.io_instances.yaml
@@ -123,7 +123,7 @@ spec:
                 description: |-
                   APIKeys references a Secret containing provider API keys and config.
                   Expected keys: OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLEAI_API_KEY, XAI_API_KEY,
-                  ZAI_API_KEY, MINIMAX_API_KEY, MINIMAX_API_COMPAT, GITHUB_COPILOT_TOKEN, OPENROUTER_API_KEY.
+                  ZAI_API_KEY, MINIMAX_API_KEY, MINIMAX_API_COMPAT, MOONSHOT_API_KEY, GITHUB_COPILOT_TOKEN, OPENROUTER_API_KEY.
                   For BEDROCK: AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY (+ optional AWS_SESSION_TOKEN),
                   or leave unset and use IRSA by annotating the pod's ServiceAccount with
                   eks.amazonaws.com/role-arn. Region is set via AWS_REGION or BEDROCK_REGION.
@@ -336,8 +336,8 @@ spec:
                           type: string
                         name:
                           description: Name is the provider name (OPENAI, OPENAI_ASSISTANT,
-                            CLAUDEAI, BEDROCK, GOOGLEAI, XAI, ZAI, MINIMAX, STACKSPOT,
-                            OLLAMA, COPILOT, GITHUB_MODELS, OPENROUTER).
+                            CLAUDEAI, BEDROCK, GOOGLEAI, XAI, ZAI, MINIMAX, MOONSHOT,
+                            STACKSPOT, OLLAMA, COPILOT, GITHUB_MODELS, OPENROUTER).
                           enum:
                           - OPENAI
                           - OPENAI_ASSISTANT
@@ -347,6 +347,7 @@ spec:
                           - XAI
                           - ZAI
                           - MINIMAX
+                          - MOONSHOT
                           - STACKSPOT
                           - OLLAMA
                           - COPILOT
@@ -483,7 +484,7 @@ spec:
                 type: object
               provider:
                 description: |-
-                  Provider is the LLM provider (OPENAI, OPENAI_ASSISTANT, CLAUDEAI, BEDROCK, GOOGLEAI, XAI, ZAI, MINIMAX, STACKSPOT, OLLAMA, COPILOT, GITHUB_MODELS, OPENROUTER).
+                  Provider is the LLM provider (OPENAI, OPENAI_ASSISTANT, CLAUDEAI, BEDROCK, GOOGLEAI, XAI, ZAI, MINIMAX, MOONSHOT, STACKSPOT, OLLAMA, COPILOT, GITHUB_MODELS, OPENROUTER).
                   BEDROCK uses the AWS credentials chain (IAM role via IRSA, static keys in the Secret, or instance profile).
                 type: string
               replicas:

--- a/deploy/helm/chatcli-operator/templates/NOTES.txt
+++ b/deploy/helm/chatcli-operator/templates/NOTES.txt
@@ -7,6 +7,25 @@ Thank you for installing {{ .Chart.Name }} {{ .Chart.AppVersion }}.
 The ChatCLI AIOps operator is now reconciling Anomaly / Issue / RemediationPlan /
 PostMortem CRs in your cluster.
 
+{{- if .Values.crdUpgrade.enabled }}
+A pre-install/pre-upgrade Helm hook already re-applied every CRD shipped with
+this chart (GAP-06 fix). You don't need to run any manual `kubectl apply -f`
+to refresh the CRD schema — that is handled automatically on every
+`helm upgrade`. Disable via `--set crdUpgrade.enabled=false` if you manage
+CRDs out of band.
+{{- else }}
+
+⚠️  CRD UPGRADE HOOK DISABLED — you opted out of the GAP-06 fix.
+   Helm 3 does not refresh CRDs on `helm upgrade` by design. If you bump
+   the chart version, run this BEFORE upgrading the binary so the API
+   server accepts the new fields and enum values:
+
+       kubectl apply -f https://github.com/diillson/chatcli/raw/main/deploy/helm/chatcli-operator/crds/
+
+   Otherwise the new controller logic will be silently rejected at runtime
+   (Issue.status.state=Contained, PostMortemSpec.RequiresHumanAction, etc.).
+{{- end }}
+
 ==================================================================================
  Post-install checklist (GAP-05 fix, chaos test report 2026-05-23)
 ==================================================================================

--- a/deploy/helm/chatcli-operator/templates/crd-upgrade-hook.yaml
+++ b/deploy/helm/chatcli-operator/templates/crd-upgrade-hook.yaml
@@ -1,0 +1,177 @@
+{{- /*
+  CRD upgrade hook — GAP-06 fix (chaos test 2026-05-23).
+
+  Helm 3 only applies CRDs from the chart's crds/ directory on first install;
+  helm upgrade leaves them untouched. That asymmetry caused the 1.122.0 chaos
+  test regression where users upgrading from 1.121.0 ran the new controller
+  binary (which writes status.state=Contained and PostMortemSpec.RequiresHumanAction)
+  against the still-1.121.0 CRD schema in the cluster, and the API server
+  rejected every reconcile with "Unsupported value: Contained" and
+  "unknown field spec.requiresHumanAction".
+
+  This template ships the CRDs a SECOND time as a pre-install / pre-upgrade
+  Helm hook: a ConfigMap bundles every YAML from the chart's crds/ directory
+  (via .Files.Glob), and a Job uses kubectl apply -f to push them into the
+  cluster before the controller Deployment rolls out. The hook is idempotent
+  (kubectl apply) and short-lived (typically <30s on a Helm rollout).
+
+  The Job, ServiceAccount, ClusterRole and ClusterRoleBinding are all hook
+  resources (helm.sh/hook annotations below). Helm cleans them up after the
+  release succeeds — except the CRDs themselves, which stay in the cluster.
+
+  Disabling the hook (.Values.crdUpgrade.enabled=false) is supported for
+  installations that manage CRDs out of band (e.g. a separate CRDs chart or
+  GitOps with explicit CRD application).
+*/}}
+{{- if .Values.crdUpgrade.enabled }}
+{{- $crdData := .Files.Glob "crds/*.yaml" }}
+{{- if not $crdData }}
+{{- fail "crdUpgrade is enabled but the chart's crds/ directory is empty — refuse to apply an empty CRD bundle and silently regress GAP-06" }}
+{{- end }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "chatcli-operator.fullname" . }}-crd-upgrade
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "chatcli-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: crd-upgrade-hook
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "chatcli-operator.fullname" . }}-crd-upgrade
+  labels:
+    {{- include "chatcli-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: crd-upgrade-hook
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  # CRD lifecycle. update + patch + create cover the apply path; get + list
+  # let kubectl detect when no diff exists and short-circuit. delete is NOT
+  # granted — the hook should never destroy CRDs even on a botched rollout.
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "chatcli-operator.fullname" . }}-crd-upgrade
+  labels:
+    {{- include "chatcli-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: crd-upgrade-hook
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "chatcli-operator.fullname" . }}-crd-upgrade
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "chatcli-operator.fullname" . }}-crd-upgrade
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "chatcli-operator.fullname" . }}-crd-bundle
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "chatcli-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: crd-upgrade-hook
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-9"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+data:
+  {{- /* AsConfig embeds every CRD YAML as a key under data. ~236 KiB total,
+         well under the 1 MiB ConfigMap limit. */ -}}
+  {{- ($crdData).AsConfig | nindent 2 }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "chatcli-operator.fullname" . }}-crd-upgrade
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "chatcli-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: crd-upgrade-hook
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  # Bound the job aggressively: a stuck hook would block every upgrade.
+  activeDeadlineSeconds: 300
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        {{- include "chatcli-operator.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: crd-upgrade-hook
+    spec:
+      serviceAccountName: {{ include "chatcli-operator.fullname" . }}-crd-upgrade
+      restartPolicy: OnFailure
+      {{- with .Values.crdUpgrade.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.crdUpgrade.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: kubectl-apply
+          image: "{{ .Values.crdUpgrade.image.repository }}:{{ .Values.crdUpgrade.image.tag }}"
+          imagePullPolicy: {{ .Values.crdUpgrade.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            capabilities:
+              drop: ["ALL"]
+          # kubectl apply on every CRD in the bundled ConfigMap. Server-side
+          # apply (--server-side) handles concurrent edits cleanly and lets
+          # kubectl reconcile field ownership instead of blanket overwriting.
+          # --force-conflicts is needed in case a prior client owned the
+          # field set (e.g. controller-gen output from a previous chart
+          # version). Without it, server-side apply errors out on conflict.
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -euo pipefail
+              echo "Applying $(ls /crds | wc -l) CRD(s) from chart {{ .Chart.Name }}-{{ .Chart.Version }}"
+              kubectl apply --server-side --force-conflicts -f /crds
+              echo "CRD upgrade complete"
+          volumeMounts:
+            - name: crds
+              mountPath: /crds
+              readOnly: true
+          resources:
+            {{- toYaml .Values.crdUpgrade.resources | nindent 12 }}
+      volumes:
+        - name: crds
+          configMap:
+            name: {{ include "chatcli-operator.fullname" . }}-crd-bundle
+{{- end }}

--- a/deploy/helm/chatcli-operator/values.schema.json
+++ b/deploy/helm/chatcli-operator/values.schema.json
@@ -147,6 +147,43 @@
         }
       }
     },
+    "crdUpgrade": {
+      "type": "object",
+      "description": "GAP-06 fix: pre-install/pre-upgrade hook that re-applies CRDs on every Helm upgrade. Helm 3 only applies files from the chart's crds/ directory on first install; this hook closes that gap so the CRD schema stays in sync with the controller binary across version bumps.",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to install the CRD upgrade hook. Disable only when managing CRDs out of band (separate chart, GitOps, etc.).",
+          "default": true
+        },
+        "image": {
+          "type": "object",
+          "description": "Container image for the kubectl-apply Job that ships with the hook.",
+          "additionalProperties": false,
+          "properties": {
+            "repository": {"type": "string", "description": "Image repository.", "default": "bitnami/kubectl"},
+            "tag": {"type": "string", "description": "Image tag.", "default": "1.31"},
+            "pullPolicy": {"type": "string", "enum": ["Always", "IfNotPresent", "Never"], "description": "Image pull policy.", "default": "IfNotPresent"}
+          }
+        },
+        "resources": {
+          "type": "object",
+          "description": "Resource requests/limits for the hook Job pod.",
+          "additionalProperties": true
+        },
+        "tolerations": {
+          "type": "array",
+          "description": "Tolerations for the hook Job pod.",
+          "items": {"type": "object"}
+        },
+        "nodeSelector": {
+          "type": "object",
+          "description": "NodeSelector for the hook Job pod.",
+          "additionalProperties": {"type": "string"}
+        }
+      }
+    },
     "service": {
       "type": "object",
       "description": "Kubernetes Service configuration.",

--- a/deploy/helm/chatcli-operator/values.yaml
+++ b/deploy/helm/chatcli-operator/values.yaml
@@ -45,6 +45,46 @@ serviceAccount:
 rbac:
   create: true
 
+# CRD lifecycle management.
+#
+# Helm only applies files from the chart's crds/ directory on first install —
+# `helm upgrade` skips them by design (Helm 3 hard restriction). That leaves
+# operators upgrading between chart versions running the new controller binary
+# against the OLD CRD schema, which surfaced as GAP-06 in the 2026-05-23 chaos
+# test (chart 1.121.0 -> 1.122.0 introduced the IssueState Contained and the
+# PostMortemSpec.RequiresHumanAction/RequiredAction fields in the binary but
+# users upgrading saw "Unsupported value: Contained" rejections from the API
+# server because the cluster still carried the 1.121.0 CRD schema).
+#
+# This block controls the pre-install/pre-upgrade hook that re-applies every
+# CRD shipped with the chart so the schema is always in sync with the binary.
+# Disable only if you manage CRDs out of band (separate cert-manager-crds-style
+# chart, GitOps with explicit CRD application, etc.).
+crdUpgrade:
+  enabled: true
+  # Image used by the pre-upgrade Job to run `kubectl apply -f`. The default
+  # is the bitnami/kubectl image because it's the only minimal kubectl image
+  # without ImageMagick / curl / shell-utility bloat. Override when running in
+  # an air-gapped environment.
+  image:
+    repository: bitnami/kubectl
+    tag: "1.31"
+    pullPolicy: IfNotPresent
+  # Pod resource limits for the hook Job. Defaults keep it lightweight — the
+  # job is short-lived (typically <30s) and only runs kubectl apply.
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+  # Tolerations on the hook Job so it can run on tainted control-plane nodes
+  # during cluster-wide chart upgrades. Empty by default.
+  tolerations: []
+  # NodeSelector for the hook Job. Empty by default.
+  nodeSelector: {}
+
 service:
   type: ClusterIP
 

--- a/deploy/helm/chatcli/crds/platform.chatcli.io_instances.yaml
+++ b/deploy/helm/chatcli/crds/platform.chatcli.io_instances.yaml
@@ -123,8 +123,11 @@ spec:
                 description: |-
                   APIKeys references a Secret containing provider API keys and config.
                   Expected keys: OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLEAI_API_KEY, XAI_API_KEY,
-                  ZAI_API_KEY, MINIMAX_API_KEY, MINIMAX_API_COMPAT, GITHUB_COPILOT_TOKEN, OPENROUTER_API_KEY, etc.
-                  All providers used in the fallback chain must have their API keys in this Secret.
+                  ZAI_API_KEY, MINIMAX_API_KEY, MINIMAX_API_COMPAT, MOONSHOT_API_KEY, GITHUB_COPILOT_TOKEN, OPENROUTER_API_KEY.
+                  For BEDROCK: AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY (+ optional AWS_SESSION_TOKEN),
+                  or leave unset and use IRSA by annotating the pod's ServiceAccount with
+                  eks.amazonaws.com/role-arn. Region is set via AWS_REGION or BEDROCK_REGION.
+                  All providers used in the fallback chain must have their credentials in this Secret.
                 properties:
                   name:
                     description: Name is the Secret name.
@@ -333,8 +336,8 @@ spec:
                           type: string
                         name:
                           description: Name is the provider name (OPENAI, OPENAI_ASSISTANT,
-                            CLAUDEAI, BEDROCK, GOOGLEAI, XAI, ZAI, MINIMAX, STACKSPOT,
-                            OLLAMA, COPILOT, GITHUB_MODELS, OPENROUTER).
+                            CLAUDEAI, BEDROCK, GOOGLEAI, XAI, ZAI, MINIMAX, MOONSHOT,
+                            STACKSPOT, OLLAMA, COPILOT, GITHUB_MODELS, OPENROUTER).
                           enum:
                           - OPENAI
                           - OPENAI_ASSISTANT
@@ -344,6 +347,7 @@ spec:
                           - XAI
                           - ZAI
                           - MINIMAX
+                          - MOONSHOT
                           - STACKSPOT
                           - OLLAMA
                           - COPILOT
@@ -370,8 +374,11 @@ spec:
                     description: Repository is the container image repository.
                     type: string
                   tag:
-                    default: latest
-                    description: Tag is the container image tag.
+                    description: |-
+                      Tag is the container image tag. When unset, the operator resolves it from the
+                      CHATCLI_OPERATOR_APP_VERSION env var (set by the Helm chart to the chart's
+                      appVersion), falling back to "latest". This lets a helm upgrade of the operator
+                      also roll managed server pods without patching each Instance.
                     type: string
                 type: object
               mcp:
@@ -476,9 +483,9 @@ spec:
                     type: string
                 type: object
               provider:
-                description: Provider is the LLM provider (OPENAI, OPENAI_ASSISTANT,
-                  CLAUDEAI, GOOGLEAI, XAI, ZAI, MINIMAX, STACKSPOT, OLLAMA, COPILOT,
-                  GITHUB_MODELS, OPENROUTER).
+                description: |-
+                  Provider is the LLM provider (OPENAI, OPENAI_ASSISTANT, CLAUDEAI, BEDROCK, GOOGLEAI, XAI, ZAI, MINIMAX, MOONSHOT, STACKSPOT, OLLAMA, COPILOT, GITHUB_MODELS, OPENROUTER).
+                  BEDROCK uses the AWS credentials chain (IAM role via IRSA, static keys in the Secret, or instance profile).
                 type: string
               replicas:
                 default: 1
@@ -868,8 +875,12 @@ spec:
                         description: Enabled enables TLS.
                         type: boolean
                       secretName:
-                        description: SecretName is the name of the Secret containing
-                          tls.crt and tls.key.
+                        description: |-
+                          SecretName is the name of the Secret containing tls.crt and tls.key.
+                          If the Secret also contains a ca.crt key, the operator will use it as
+                          the trust root when dialing the gRPC server — required for self-signed
+                          certificates, otherwise the connection fails with
+                          "certificate signed by unknown authority".
                         type: string
                     type: object
                   token:

--- a/deploy/helm/chatcli/templates/crd-upgrade-hook.yaml
+++ b/deploy/helm/chatcli/templates/crd-upgrade-hook.yaml
@@ -1,0 +1,157 @@
+{{- /*
+  CRD upgrade hook — GAP-06 fix (chaos test 2026-05-23).
+
+  Mirror of the chatcli-operator chart's hook. Helm 3 only applies CRDs from
+  the chart's crds/ directory on first install; helm upgrade leaves them
+  untouched. That asymmetry caused the 1.122.0 chaos test regression where
+  the new chatcli binary writes status.state=Contained and
+  PostMortemSpec.RequiresHumanAction but cluster CRDs were still 1.121.0,
+  yielding API-server "Unsupported value: Contained" rejections.
+
+  This template bundles every YAML from the chart's crds/ directory into a
+  ConfigMap and runs kubectl apply -f as a pre-install/pre-upgrade hook.
+  The job is idempotent (kubectl apply --server-side) and short-lived.
+
+  Disable via .Values.crdUpgrade.enabled=false when CRDs are managed out of
+  band (separate CRD chart, GitOps, etc.).
+*/}}
+{{- if .Values.crdUpgrade.enabled }}
+{{- $crdData := .Files.Glob "crds/*.yaml" }}
+{{- if not $crdData }}
+{{- fail "crdUpgrade is enabled but the chart's crds/ directory is empty — refuse to apply an empty CRD bundle and silently regress GAP-06" }}
+{{- end }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "chatcli.fullname" . }}-crd-upgrade
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "chatcli.labels" . | nindent 4 }}
+    app.kubernetes.io/component: crd-upgrade-hook
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "chatcli.fullname" . }}-crd-upgrade
+  labels:
+    {{- include "chatcli.labels" . | nindent 4 }}
+    app.kubernetes.io/component: crd-upgrade-hook
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "chatcli.fullname" . }}-crd-upgrade
+  labels:
+    {{- include "chatcli.labels" . | nindent 4 }}
+    app.kubernetes.io/component: crd-upgrade-hook
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "chatcli.fullname" . }}-crd-upgrade
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "chatcli.fullname" . }}-crd-upgrade
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "chatcli.fullname" . }}-crd-bundle
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "chatcli.labels" . | nindent 4 }}
+    app.kubernetes.io/component: crd-upgrade-hook
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-9"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+data:
+  {{- ($crdData).AsConfig | nindent 2 }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "chatcli.fullname" . }}-crd-upgrade
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "chatcli.labels" . | nindent 4 }}
+    app.kubernetes.io/component: crd-upgrade-hook
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  activeDeadlineSeconds: 300
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        {{- include "chatcli.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: crd-upgrade-hook
+    spec:
+      serviceAccountName: {{ include "chatcli.fullname" . }}-crd-upgrade
+      restartPolicy: OnFailure
+      {{- with .Values.crdUpgrade.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.crdUpgrade.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: kubectl-apply
+          image: "{{ .Values.crdUpgrade.image.repository }}:{{ .Values.crdUpgrade.image.tag }}"
+          imagePullPolicy: {{ .Values.crdUpgrade.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            capabilities:
+              drop: ["ALL"]
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -euo pipefail
+              echo "Applying $(ls /crds | wc -l) CRD(s) from chart {{ .Chart.Name }}-{{ .Chart.Version }}"
+              kubectl apply --server-side --force-conflicts -f /crds
+              echo "CRD upgrade complete"
+          volumeMounts:
+            - name: crds
+              mountPath: /crds
+              readOnly: true
+          resources:
+            {{- toYaml .Values.crdUpgrade.resources | nindent 12 }}
+      volumes:
+        - name: crds
+          configMap:
+            name: {{ include "chatcli.fullname" . }}-crd-bundle
+{{- end }}

--- a/deploy/helm/chatcli/values.schema.json
+++ b/deploy/helm/chatcli/values.schema.json
@@ -486,6 +486,43 @@
         }
       }
     },
+    "crdUpgrade": {
+      "type": "object",
+      "description": "GAP-06 fix: pre-install/pre-upgrade hook that re-applies CRDs on every Helm upgrade. Helm 3 only applies files from the chart's crds/ directory on first install; this hook closes that gap so the CRD schema stays in sync with the binary across version bumps.",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to install the CRD upgrade hook. Disable only when managing CRDs out of band.",
+          "default": true
+        },
+        "image": {
+          "type": "object",
+          "description": "Container image for the kubectl-apply Job that ships with the hook.",
+          "additionalProperties": false,
+          "properties": {
+            "repository": {"type": "string", "description": "Image repository.", "default": "bitnami/kubectl"},
+            "tag": {"type": "string", "description": "Image tag.", "default": "1.31"},
+            "pullPolicy": {"type": "string", "enum": ["Always", "IfNotPresent", "Never"], "description": "Image pull policy.", "default": "IfNotPresent"}
+          }
+        },
+        "resources": {
+          "type": "object",
+          "description": "Resource requests/limits for the hook Job pod.",
+          "additionalProperties": true
+        },
+        "tolerations": {
+          "type": "array",
+          "description": "Tolerations for the hook Job pod.",
+          "items": {"type": "object"}
+        },
+        "nodeSelector": {
+          "type": "object",
+          "description": "NodeSelector for the hook Job pod.",
+          "additionalProperties": {"type": "string"}
+        }
+      }
+    },
     "service": {
       "type": "object",
       "description": "Kubernetes Service configuration.",

--- a/deploy/helm/chatcli/values.yaml
+++ b/deploy/helm/chatcli/values.yaml
@@ -170,6 +170,35 @@ rbac:
   # Additional rules beyond the defaults
   additionalRules: []
 
+# CRD lifecycle management.
+#
+# Helm only applies files from the chart's crds/ directory on first install —
+# `helm upgrade` skips them by design (Helm 3 hard restriction). That leaves
+# users upgrading between chart versions running the new chatcli binary
+# against the OLD CRD schema, which surfaced as GAP-06 in the 2026-05-23 chaos
+# test (chart 1.121.0 -> 1.122.0 added IssueState Contained and the
+# PostMortemSpec.RequiresHumanAction/RequiredAction fields).
+#
+# This block controls the pre-install/pre-upgrade hook that re-applies every
+# CRD shipped with the chart so the schema is always in sync with the binary.
+# Disable only if you manage CRDs out of band (separate cert-manager-crds-style
+# chart, GitOps with explicit CRD application, etc.).
+crdUpgrade:
+  enabled: true
+  image:
+    repository: bitnami/kubectl
+    tag: "1.31"
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+  tolerations: []
+  nodeSelector: {}
+
 service:
   type: ClusterIP
   port: 50051

--- a/operator/api/v1alpha1/crd_enum_parity_test.go
+++ b/operator/api/v1alpha1/crd_enum_parity_test.go
@@ -1,0 +1,206 @@
+/*
+ * ChatCLI - Kubernetes Operator
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package v1alpha1
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestIssueStateEnumParity is the GAP-06 regression guard.
+//
+// GAP-06 (chaos test report 2026-05-23): the 1.122.0 chart shipped the new
+// IssueState `Contained` constant in the controller binary but the runtime
+// CRD enum on cluster only listed the 1.121.0 values, so the API server
+// rejected every Issue update with "Unsupported value: Contained". Floor 11
+// catches drift between Go types and the regenerated YAML; this test catches
+// the harder-to-find drift between the IssueState Go enum and what each of
+// the THREE checked-in CRD YAML copies actually validates.
+//
+// Failure here means: a developer added an IssueState constant in Go and
+// forgot to either (a) regenerate the CRDs with controller-gen, or (b)
+// sync the regenerated CRD to the two Helm chart copies. Without this
+// test the regression only surfaces in a live cluster.
+func TestIssueStateEnumParity(t *testing.T) {
+	// Source of truth: the Go IssueState constants declared in this file.
+	wantStates := sortedStrings(map[string]struct{}{
+		string(IssueStateDetected):    {},
+		string(IssueStateAnalyzing):   {},
+		string(IssueStateRemediating): {},
+		string(IssueStateContained):   {},
+		string(IssueStateResolved):    {},
+		string(IssueStateEscalated):   {},
+		string(IssueStateFailed):      {},
+	})
+
+	// Every CRD copy that ships with the project. Adding a new chart that
+	// vendors a CRD copy requires adding the path here AND updating the
+	// scripts/qg/crd-drift.sh Floor 11 extension.
+	crdPaths := []string{
+		"../../config/crd/bases/platform.chatcli.io_issues.yaml",
+		"../../../deploy/helm/chatcli-operator/crds/platform.chatcli.io_issues.yaml",
+		"../../../deploy/helm/chatcli/crds/platform.chatcli.io_issues.yaml",
+	}
+
+	for _, rel := range crdPaths {
+		t.Run(filepath.Base(filepath.Dir(rel))+"/"+filepath.Base(rel), func(t *testing.T) {
+			path := filepath.Clean(rel)
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+			gotStates, err := readIssueStateEnumFromCRD(data)
+			if err != nil {
+				t.Fatalf("parse %s: %v", path, err)
+			}
+			gotSorted := sortedStrings(toSet(gotStates))
+			if !reflect.DeepEqual(gotSorted, wantStates) {
+				t.Fatalf(
+					"IssueState enum drift in %s:\n  CRD lists:  %v\n  Go declares: %v\n\n"+
+						"Run `controller-gen crd ...` inside operator/ and copy the regenerated YAML "+
+						"to deploy/helm/chatcli-operator/crds/ AND deploy/helm/chatcli/crds/ — see "+
+						"GAP-06 (chaos test report 2026-05-23) for the regression this guards against.",
+					path, gotSorted, wantStates,
+				)
+			}
+		})
+	}
+}
+
+// readIssueStateEnumFromCRD parses the multi-document CRD YAML and returns
+// the enum values declared on the .status.state field. The CRD schema is
+// nested deep enough that we use a typed walk rather than a brittle string
+// search — that way a structural rename surfaces as a parse failure here
+// instead of a silent miss in the parity check.
+func readIssueStateEnumFromCRD(data []byte) ([]string, error) {
+	var doc struct {
+		Spec struct {
+			Versions []struct {
+				Schema struct {
+					OpenAPIV3Schema struct {
+						Properties struct {
+							Status struct {
+								Properties struct {
+									State struct {
+										Enum []string `yaml:"enum"`
+									} `yaml:"state"`
+								} `yaml:"properties"`
+							} `yaml:"status"`
+						} `yaml:"properties"`
+					} `yaml:"openAPIV3Schema"`
+				} `yaml:"schema"`
+			} `yaml:"versions"`
+		} `yaml:"spec"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("yaml unmarshal: %w", err)
+	}
+	if len(doc.Spec.Versions) == 0 {
+		return nil, fmt.Errorf("CRD has no versions declared")
+	}
+	enum := doc.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties.Status.Properties.State.Enum
+	if len(enum) == 0 {
+		return nil, fmt.Errorf(".spec.versions[0].schema.openAPIV3Schema.properties.status.properties.state.enum is empty — CRD structure may have changed")
+	}
+	return enum, nil
+}
+
+// toSet builds a deduplicated string set from a slice.
+func toSet(in []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(in))
+	for _, v := range in {
+		out[strings.TrimSpace(v)] = struct{}{}
+	}
+	return out
+}
+
+// sortedStrings turns a set into a deterministic sorted slice for comparison.
+func sortedStrings(in map[string]struct{}) []string {
+	out := make([]string, 0, len(in))
+	for k := range in {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestPostMortemSpecFieldParity is the GAP-06 regression guard for the
+// PostMortem CRD. Mirrors TestIssueStateEnumParity: the controller writes
+// spec.requiresHumanAction and spec.requiredAction (added in 1.122.0) and
+// the runtime API server must accept them — otherwise generatePostMortem
+// fails every time an Issue goes Contained.
+func TestPostMortemSpecFieldParity(t *testing.T) {
+	wantFields := []string{"requiredAction", "requiresHumanAction"}
+
+	crdPaths := []string{
+		"../../config/crd/bases/platform.chatcli.io_postmortems.yaml",
+		"../../../deploy/helm/chatcli-operator/crds/platform.chatcli.io_postmortems.yaml",
+		"../../../deploy/helm/chatcli/crds/platform.chatcli.io_postmortems.yaml",
+	}
+
+	for _, rel := range crdPaths {
+		t.Run(filepath.Base(filepath.Dir(rel))+"/"+filepath.Base(rel), func(t *testing.T) {
+			path := filepath.Clean(rel)
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+			specProps, err := readPostMortemSpecProperties(data)
+			if err != nil {
+				t.Fatalf("parse %s: %v", path, err)
+			}
+			for _, field := range wantFields {
+				if _, ok := specProps[field]; !ok {
+					t.Fatalf(
+						"PostMortemSpec field %q missing from CRD %s.\n"+
+							"This is the GAP-06 regression: 1.122.0 shipped the controller field but the CRD copy was stale.\n"+
+							"Run `controller-gen crd ...` inside operator/ and copy the regenerated YAML to both Helm chart CRDs/ directories.",
+						field, path,
+					)
+				}
+			}
+		})
+	}
+}
+
+// readPostMortemSpecProperties returns the property names declared under
+// .spec.versions[0].schema.openAPIV3Schema.properties.spec.properties — that
+// is the per-CR spec fields the API server validates.
+func readPostMortemSpecProperties(data []byte) (map[string]any, error) {
+	var doc struct {
+		Spec struct {
+			Versions []struct {
+				Schema struct {
+					OpenAPIV3Schema struct {
+						Properties struct {
+							Spec struct {
+								Properties map[string]any `yaml:"properties"`
+							} `yaml:"spec"`
+						} `yaml:"properties"`
+					} `yaml:"openAPIV3Schema"`
+				} `yaml:"schema"`
+			} `yaml:"versions"`
+		} `yaml:"spec"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("yaml unmarshal: %w", err)
+	}
+	if len(doc.Spec.Versions) == 0 {
+		return nil, fmt.Errorf("CRD has no versions declared")
+	}
+	props := doc.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties.Spec.Properties
+	if len(props) == 0 {
+		return nil, fmt.Errorf(".spec.versions[0].schema.openAPIV3Schema.properties.spec.properties is empty")
+	}
+	return props, nil
+}

--- a/scripts/qg/crd-drift.sh
+++ b/scripts/qg/crd-drift.sh
@@ -59,9 +59,65 @@ export PATH="$GOBIN:$PATH"
       output:crd:dir=config/crd/bases ) >/dev/null
 
 if git -C "$QG_REPO_ROOT" diff --quiet -- 'operator/config/crd/bases/'; then
-  qg_set_output passed true
-  qg_set_output drifted_files 0
-  qg_set_summary_line "✅ **CRD drift**: regenerated YAML matches commit"
+  # Generator-vs-checked-in YAML is clean — but the chart copies under
+  # deploy/helm/*/crds/ must also match. This is GAP-06 territory: the
+  # 1.122.0 release shipped controller logic that wrote new fields and an
+  # enum value the chart CRDs did NOT carry, and runtime rejections went
+  # silently undetected by the gate. Below we diff the canonical
+  # operator/config/crd/bases/ against each chart's crds/ directory file-by-file.
+  chart_drifted=""
+  for chart_crds in "$QG_REPO_ROOT/deploy/helm/chatcli-operator/crds" "$QG_REPO_ROOT/deploy/helm/chatcli/crds"; do
+    if [[ ! -d "$chart_crds" ]]; then
+      continue
+    fi
+    for src in "$QG_REPO_ROOT/operator/config/crd/bases/"*.yaml; do
+      name=$(basename "$src")
+      dst="$chart_crds/$name"
+      if [[ ! -f "$dst" ]]; then
+        chart_drifted+="$chart_crds/$name (missing) "
+        continue
+      fi
+      if ! diff -q "$src" "$dst" >/dev/null 2>&1; then
+        chart_drifted+="$chart_crds/$name "
+      fi
+    done
+  done
+
+  if [[ -z "$chart_drifted" ]]; then
+    qg_set_output passed true
+    qg_set_output drifted_files 0
+    qg_set_summary_line "✅ **CRD drift**: regenerated YAML matches commit AND chart copies in sync"
+    exit 0
+  fi
+
+  qg_set_output passed false
+  qg_set_output drifted_files "${chart_drifted% }"
+  {
+    echo "## CRD drift detected (chart copies out of sync — GAP-06 class)"
+    echo
+    echo "The canonical CRDs under \`operator/config/crd/bases/\` match the Go"
+    echo "types, but one or more Helm chart copies diverge. Users upgrading the"
+    echo "chart will run the new controller binary against a stale CRD schema"
+    echo "(exactly the GAP-06 regression from the 2026-05-23 chaos test)."
+    echo
+    echo "Drifted chart copies:"
+    echo '```'
+    echo "${chart_drifted% }"
+    echo '```'
+    echo
+    echo "Sync them locally:"
+    echo '```bash'
+    echo "cp operator/config/crd/bases/*.yaml deploy/helm/chatcli-operator/crds/"
+    echo "cp operator/config/crd/bases/*.yaml deploy/helm/chatcli/crds/"
+    echo '```'
+  } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+  msg="CRD drift (chart copies): ${chart_drifted% }"
+  if [[ "$enforcement" == "blocking" ]]; then
+    qg_fail "$msg"
+    exit 1
+  fi
+  qg_warn "$msg"
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

Closes GAP-06 from the chaos test report of 2026-05-23. Chart 1.122.0
shipped the new controller binary (Contained IssueState, PostMortemSpec
RequiresHumanAction / RequiredAction) but the cluster CRDs were still
1.121.0 because Helm 3 only applies files from crds/ on first install,
never on upgrade. GAP-03 was code-complete but inoperante at runtime —
every Issue transitioning to Contained was rejected by the API server.

This PR fixes it structurally so the schema and the binary can never
diverge again on a Helm release.

## Changes

### Helm CRD upgrade hook (both charts)
A pre-install/pre-upgrade Helm Job re-applies every CRD shipped with the
chart, in the same Helm transaction that rolls out the new binary. The
Job uses `kubectl apply --server-side --force-conflicts`, mounts the
CRDs from a ConfigMap built via `Files.Glob`, and runs under a dedicated
ServiceAccount with only `get/list/create/update/patch` on
`customresourcedefinitions` (no delete — a botched hook can never
destroy CRDs). Disable via `crdUpgrade.enabled=false` if you manage
CRDs out of band.

### CRD drift gate extension (Floor 11)
The existing gate only diffed generator output against
`operator/config/crd/bases/`. Now it also diffs each chart's `crds/`
directory file-by-file against the canonical YAML — the exact class of
drift GAP-06 fell into.

### CRD parity unit tests
Two new tests assert the Go IssueState enum matches every CRD copy and
that the PostMortem CRD copies all carry `requiresHumanAction` and
`requiredAction`. Failures print the sync recipe.

## Verification

- [x] `helm lint` clean on both charts
- [x] `helm template` renders the hook with correct hook-weight ordering
- [x] `go test ./operator/api/v1alpha1 ./operator/controllers` green
- [x] `scripts/qg/crd-drift.sh` and `scripts/qg/i18n-parity.sh` pass
- [x] Reproduce the chaos test scenario on a kind cluster against the
      patched chart (1.122.1) and confirm Issue transitions to Contained
      without API-server rejection
- [x] Confirm the pre-upgrade Job logs `CRD upgrade complete` on the
      first `helm upgrade` from 1.121.0 → 1.122.1

## Schema breaking changes

None. The hook is opt-out (`crdUpgrade.enabled=true` by default). The
new values keys are additive on `values.schema.json`. The Floor 11
extension and parity tests only assert invariants the codebase already
upholds today.

## Follow-ups

- Patch release 1.122.1 to ship the hook to existing users
- Document the upgrade hook in `chatcli.ai` features/aiops page