### PR TITLE
fix(aiops): close GAP-07 — populate human-action status fields on Issue and PostMortem

### DIFF
--- a/.github/workflows/1-ci.yml
+++ b/.github/workflows/1-ci.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.actor != 'release-please[bot]' && github.actor != 'github-actions[bot]'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           # Deep clone so --new-from-rev can resolve origin/<base>.
           # Without this, golangci-lint cannot enumerate the diff and

--- a/.github/workflows/2-prepare-release-pr.yml
+++ b/.github/workflows/2-prepare-release-pr.yml
@@ -33,7 +33,7 @@ jobs:
           echo "::add-mask::${{ secrets.OPENAI_API_KEY }}"
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           # fetch-depth: 0 é essencial para buscar todo o histórico e poder comparar as branches
           fetch-depth: 0

--- a/.github/workflows/3-publish-release.yml
+++ b/.github/workflows/3-publish-release.yml
@@ -79,7 +79,7 @@ jobs:
     environment: production
     steps:
       - name: Checkout tag
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ needs.release_please.outputs.tag_name }}
@@ -168,7 +168,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout tag
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.release_please.outputs.tag_name }}
 
@@ -232,7 +232,7 @@ jobs:
       packages: read
     steps:
       - name: Checkout (for .trivyignore.yaml)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.release_please.outputs.tag_name }}
           sparse-checkout: .trivyignore.yaml
@@ -338,7 +338,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout tag
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.release_please.outputs.tag_name }}
 
@@ -399,7 +399,7 @@ jobs:
       packages: read
     steps:
       - name: Checkout (for .trivyignore.yaml)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.release_please.outputs.tag_name }}
           sparse-checkout: .trivyignore.yaml
@@ -491,7 +491,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout tap repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           repository: diillson/homebrew-chatcli
           token: ${{ secrets.GH_RELEASE_TOKEN }}
@@ -602,7 +602,7 @@ jobs:
 
     steps:
       - name: Checkout tag
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.release_please.outputs.tag_name }}
 
@@ -715,13 +715,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout docs repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           repository: diillson/chatcli.ai
           token: ${{ secrets.GH_RELEASE_TOKEN }}
 
       - name: Checkout chatcli source (for CHANGELOG.md)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           path: _chatcli_src
           fetch-depth: 1
@@ -876,7 +876,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -52,7 +52,7 @@ jobs:
     outputs:
       scan_matrix: ${{ steps.compute.outputs.scan_matrix }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -92,7 +92,7 @@ jobs:
       matrix: ${{ fromJson(needs.discover.outputs.scan_matrix) }}
     steps:
       - name: Checkout source at tag (for .trivyignore.yaml)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           ref: "v${{ matrix.tag }}"
           fetch-depth: 1
@@ -220,7 +220,7 @@ jobs:
       matrix: ${{ fromJson(needs.plan.outputs.arch_matrix) }}
     steps:
       - name: Checkout source at tag
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           ref: "v${{ matrix.tag }}"
           fetch-depth: 1
@@ -271,7 +271,7 @@ jobs:
       matrix: ${{ fromJson(needs.plan.outputs.merge_matrix) }}
     steps:
       - name: Checkout source at tag (for .trivyignore.yaml)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           ref: "v${{ matrix.tag }}"
           fetch-depth: 1
@@ -375,7 +375,7 @@ jobs:
     if: always() && needs.scan.result != 'skipped'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - name: Download decisions
         uses: actions/download-artifact@v8

--- a/.github/workflows/labels-sync.yml
+++ b/.github/workflows/labels-sync.yml
@@ -21,7 +21,7 @@ jobs:
     name: Sync .github/labels.yml -> repo labels
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - name: Apply labels (non-destructive)
         uses: EndBug/label-sync@v2

--- a/.github/workflows/quality-gate-baseline.yml
+++ b/.github/workflows/quality-gate-baseline.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor != 'release-please[bot]'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -40,7 +40,7 @@ jobs:
       labels: ${{ steps.decide.outputs.labels }}
       base_ref: ${{ steps.decide.outputs.base_ref }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -115,7 +115,7 @@ jobs:
     if: needs.meta.outputs.skip != 'true' && needs.meta.outputs.release_please != 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
         with:
           # Deep clone — golangci-lint --new-from-rev needs origin/<base>
           # available locally to compute the diff. Default checkout is
@@ -183,7 +183,7 @@ jobs:
       baseline: ${{ steps.ratchet.outputs.baseline }}
       delta: ${{ steps.ratchet.outputs.delta }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -243,7 +243,7 @@ jobs:
       percent: ${{ steps.patch.outputs.percent }}
       threshold: ${{ steps.patch.outputs.threshold }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -281,7 +281,7 @@ jobs:
     outputs:
       passed: ${{ steps.scan.outputs.passed }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -311,7 +311,7 @@ jobs:
       code_loc: ${{ steps.scope.outputs.code_loc }}
       tooling_loc: ${{ steps.scope.outputs.tooling_loc }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -336,7 +336,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
@@ -356,7 +356,7 @@ jobs:
     outputs:
       passed: ${{ steps.lint.outputs.passed }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -382,7 +382,7 @@ jobs:
       passed: ${{ steps.cyclo.outputs.passed }}
       checked: ${{ steps.cyclo.outputs.checked }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -410,7 +410,7 @@ jobs:
     if: needs.meta.outputs.skip != 'true' && needs.meta.outputs.release_please != 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -434,7 +434,7 @@ jobs:
       missing_keys: ${{ steps.parity.outputs.missing_keys }}
       unknown_usages: ${{ steps.parity.outputs.unknown_usages }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
@@ -460,7 +460,7 @@ jobs:
       passed: ${{ steps.drift.outputs.passed }}
       drifted_files: ${{ steps.drift.outputs.drifted_files }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: actions/setup-go@v6
@@ -488,7 +488,7 @@ jobs:
       passed: ${{ steps.headers.outputs.passed }}
       missing_count: ${{ steps.headers.outputs.missing_count }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install yq
@@ -512,7 +512,7 @@ jobs:
       passed: ${{ steps.apidiff.outputs.passed }}
       incompatible_count: ${{ steps.apidiff.outputs.incompatible_count }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: actions/setup-go@v6
@@ -542,7 +542,7 @@ jobs:
       chatcli_bytes: ${{ steps.size.outputs.chatcli_bytes }}
       operator_bytes: ${{ steps.size.outputs.operator_bytes }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: actions/setup-go@v6
@@ -571,7 +571,7 @@ jobs:
       violations: ${{ steps.parity.outputs.violations }}
       providers: ${{ steps.parity.outputs.providers }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
@@ -609,7 +609,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -23,7 +23,7 @@ jobs:
     # running for drift detection.
     if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please--')
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-go@v6
         with:
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please--')
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-go@v6
         with:
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - uses: actions/dependency-review-action@v5
         with:
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please--')
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -143,7 +143,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please--')
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/deploy/helm/chatcli-operator/crds/platform.chatcli.io_issues.yaml
+++ b/deploy/helm/chatcli-operator/crds/platform.chatcli.io_issues.yaml
@@ -182,6 +182,25 @@ spec:
                   made.
                 format: int32
                 type: integer
+              requiredAction:
+                description: |-
+                  RequiredAction is the concrete follow-up an operator needs to perform
+                  when RequiresHumanAction is true (e.g., "restore the deployment's
+                  replicas to the desired count after fixing the root cause"). Populated
+                  together with RequiresHumanAction. GAP-07 fix.
+                type: string
+              requiresHumanAction:
+                description: |-
+                  RequiresHumanAction is true while the Issue is in (or returning from) the
+                  Contained state — the workload was silenced via a containment action and
+                  a human must intervene to restore service. Surfaced as a top-level
+                  status field (in addition to the equivalent condition) so dashboards and
+                  kubectl one-liners can query the field directly without parsing
+                  conditions. GAP-07 fix (chaos test 2026-05-23 round 2): the original
+                  1.122.1 ship only populated the condition, which left
+                  `kubectl get issue -o jsonpath='{.status.requiresHumanAction}'` returning
+                  null — forcing operators to grep operator logs for the required action.
+                type: boolean
               resolution:
                 description: Resolution describes how the issue was resolved.
                 type: string

--- a/deploy/helm/chatcli-operator/crds/platform.chatcli.io_postmortems.yaml
+++ b/deploy/helm/chatcli-operator/crds/platform.chatcli.io_postmortems.yaml
@@ -62,21 +62,6 @@ spec:
                 required:
                 - name
                 type: object
-              requiredAction:
-                description: |-
-                  RequiredAction describes the concrete action a human needs to take when
-                  RequiresHumanAction is true (e.g., "Roll back image to vX.Y.Z and scale
-                  replicas back to N"). Surfaced in notifications and PostMortem rendering.
-                type: string
-              requiresHumanAction:
-                description: |-
-                  RequiresHumanAction marks PostMortems for incidents that were only
-                  contained (e.g., scaled to 0) rather than truly resolved — the underlying
-                  bug is still present and an operator must intervene to restore service.
-                  When true, the PostMortemReconciler refuses to transition the PostMortem
-                  to Closed unless the human-action acknowledgement annotation is set.
-                  GAP-03 fix (chaos test report 2026-05-23).
-                type: boolean
               resource:
                 description: Resource that was affected.
                 properties:
@@ -294,6 +279,29 @@ spec:
                 items:
                   type: string
                 type: array
+              requiredAction:
+                description: |-
+                  RequiredAction describes the concrete action a human needs to take when
+                  RequiresHumanAction is true (e.g., "restore the deployment's replicas
+                  to the desired count after fixing the root cause"). Set together with
+                  RequiresHumanAction. GAP-07 fix.
+                type: string
+              requiresHumanAction:
+                description: |-
+                  RequiresHumanAction marks PostMortems for incidents that were only
+                  contained (e.g., scaled to 0) rather than truly resolved — the underlying
+                  bug is still present and an operator must intervene to restore service.
+                  When true, the PostMortemReconciler refuses to transition the PostMortem
+                  to Closed unless the human-action acknowledgement annotation is set.
+
+                  Lives in Status (not Spec) because it is computed by the controller from
+                  the parent Issue's containment outcome — not user input. GAP-07 fix
+                  (chaos test 2026-05-23 round 2): the previous 1.122.x ship placed this
+                  on Spec, which (a) violates the K8s convention that controller-derived
+                  facts go in Status and (b) made the field unreliable for tooling that
+                  inspected `.status` for incident health. Moved here so `kubectl get
+                  postmortem -o jsonpath='{.status.requiresHumanAction}'` works.
+                type: boolean
               reviewedAt:
                 description: ReviewedAt is when the PostMortem was reviewed by a human.
                 format: date-time

--- a/deploy/helm/chatcli/crds/platform.chatcli.io_issues.yaml
+++ b/deploy/helm/chatcli/crds/platform.chatcli.io_issues.yaml
@@ -182,6 +182,25 @@ spec:
                   made.
                 format: int32
                 type: integer
+              requiredAction:
+                description: |-
+                  RequiredAction is the concrete follow-up an operator needs to perform
+                  when RequiresHumanAction is true (e.g., "restore the deployment's
+                  replicas to the desired count after fixing the root cause"). Populated
+                  together with RequiresHumanAction. GAP-07 fix.
+                type: string
+              requiresHumanAction:
+                description: |-
+                  RequiresHumanAction is true while the Issue is in (or returning from) the
+                  Contained state — the workload was silenced via a containment action and
+                  a human must intervene to restore service. Surfaced as a top-level
+                  status field (in addition to the equivalent condition) so dashboards and
+                  kubectl one-liners can query the field directly without parsing
+                  conditions. GAP-07 fix (chaos test 2026-05-23 round 2): the original
+                  1.122.1 ship only populated the condition, which left
+                  `kubectl get issue -o jsonpath='{.status.requiresHumanAction}'` returning
+                  null — forcing operators to grep operator logs for the required action.
+                type: boolean
               resolution:
                 description: Resolution describes how the issue was resolved.
                 type: string

--- a/deploy/helm/chatcli/crds/platform.chatcli.io_postmortems.yaml
+++ b/deploy/helm/chatcli/crds/platform.chatcli.io_postmortems.yaml
@@ -62,21 +62,6 @@ spec:
                 required:
                 - name
                 type: object
-              requiredAction:
-                description: |-
-                  RequiredAction describes the concrete action a human needs to take when
-                  RequiresHumanAction is true (e.g., "Roll back image to vX.Y.Z and scale
-                  replicas back to N"). Surfaced in notifications and PostMortem rendering.
-                type: string
-              requiresHumanAction:
-                description: |-
-                  RequiresHumanAction marks PostMortems for incidents that were only
-                  contained (e.g., scaled to 0) rather than truly resolved — the underlying
-                  bug is still present and an operator must intervene to restore service.
-                  When true, the PostMortemReconciler refuses to transition the PostMortem
-                  to Closed unless the human-action acknowledgement annotation is set.
-                  GAP-03 fix (chaos test report 2026-05-23).
-                type: boolean
               resource:
                 description: Resource that was affected.
                 properties:
@@ -294,6 +279,29 @@ spec:
                 items:
                   type: string
                 type: array
+              requiredAction:
+                description: |-
+                  RequiredAction describes the concrete action a human needs to take when
+                  RequiresHumanAction is true (e.g., "restore the deployment's replicas
+                  to the desired count after fixing the root cause"). Set together with
+                  RequiresHumanAction. GAP-07 fix.
+                type: string
+              requiresHumanAction:
+                description: |-
+                  RequiresHumanAction marks PostMortems for incidents that were only
+                  contained (e.g., scaled to 0) rather than truly resolved — the underlying
+                  bug is still present and an operator must intervene to restore service.
+                  When true, the PostMortemReconciler refuses to transition the PostMortem
+                  to Closed unless the human-action acknowledgement annotation is set.
+
+                  Lives in Status (not Spec) because it is computed by the controller from
+                  the parent Issue's containment outcome — not user input. GAP-07 fix
+                  (chaos test 2026-05-23 round 2): the previous 1.122.x ship placed this
+                  on Spec, which (a) violates the K8s convention that controller-derived
+                  facts go in Status and (b) made the field unreliable for tooling that
+                  inspected `.status` for incident health. Moved here so `kubectl get
+                  postmortem -o jsonpath='{.status.requiresHumanAction}'` works.
+                type: boolean
               reviewedAt:
                 description: ReviewedAt is when the PostMortem was reviewed by a human.
                 format: date-time

--- a/operator/api/rest/analytics.go
+++ b/operator/api/rest/analytics.go
@@ -158,7 +158,7 @@ func (s *APIServer) foldPostMortemSummary(ctx context.Context, summary *Analytic
 			continue
 		}
 		summary.TotalPostMortems++
-		if pm.Spec.RequiresHumanAction && pm.Status.State != v1alpha1.PostMortemStateClosed {
+		if pm.Status.RequiresHumanAction && pm.Status.State != v1alpha1.PostMortemStateClosed {
 			summary.PostMortemsRequiringHumanAction++
 		}
 	}

--- a/operator/api/rest/analytics_chaos_fold_test.go
+++ b/operator/api/rest/analytics_chaos_fold_test.go
@@ -119,9 +119,12 @@ func TestComputeSummary_EndToEnd(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "pm-1", Namespace: "default", CreationTimestamp: now},
 			Spec: v1alpha1.PostMortemSpec{
 				IssueRef: v1alpha1.IssueRef{Name: "i1"}, Resource: v1alpha1.ResourceRef{Kind: "Deployment", Name: "web", Namespace: "default"}, Severity: v1alpha1.IssueSeverityCritical,
+			},
+			// GAP-07: RequiresHumanAction lives in Status now.
+			Status: v1alpha1.PostMortemStatus{
+				State:               v1alpha1.PostMortemStateOpen,
 				RequiresHumanAction: true,
 			},
-			Status: v1alpha1.PostMortemStatus{State: v1alpha1.PostMortemStateOpen},
 		},
 		&v1alpha1.Runbook{ObjectMeta: metav1.ObjectMeta{Name: "rb-1", Namespace: "default"}},
 	}
@@ -174,9 +177,12 @@ func TestAckHumanActionEndpoint_HappyPath(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "pm-needs-human", Namespace: "default"},
 		Spec: v1alpha1.PostMortemSpec{
 			IssueRef: v1alpha1.IssueRef{Name: "i1"}, Resource: v1alpha1.ResourceRef{Kind: "Deployment", Name: "web", Namespace: "default"}, Severity: v1alpha1.IssueSeverityHigh,
+		},
+		// GAP-07: RequiresHumanAction lives in Status now.
+		Status: v1alpha1.PostMortemStatus{
+			State:               v1alpha1.PostMortemStateOpen,
 			RequiresHumanAction: true,
 		},
-		Status: v1alpha1.PostMortemStatus{State: v1alpha1.PostMortemStateOpen},
 	}
 	c := fake.NewClientBuilder().
 		WithScheme(s).
@@ -219,8 +225,8 @@ func TestAckHumanActionEndpoint_RejectsNonContained(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "pm-normal", Namespace: "default"},
 		Spec: v1alpha1.PostMortemSpec{
 			IssueRef: v1alpha1.IssueRef{Name: "i1"}, Resource: v1alpha1.ResourceRef{Kind: "Deployment", Name: "web", Namespace: "default"}, Severity: v1alpha1.IssueSeverityMedium,
-			RequiresHumanAction: false,
 		},
+		// GAP-07: RequiresHumanAction lives in Status now. Default false here.
 	}
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(pm).Build()
 	api := NewAPIServer(c, ":0")

--- a/operator/api/rest/gap_07_issue_mapper_test.go
+++ b/operator/api/rest/gap_07_issue_mapper_test.go
@@ -1,0 +1,115 @@
+/*
+ * ChatCLI - Kubernetes Operator
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package rest
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1alpha1 "github.com/diillson/chatcli/operator/api/v1alpha1"
+)
+
+// TestIssueToIncidentItem_RequiresHumanAction covers the GAP-07 mapper that
+// surfaces the Issue's human-action signal in the REST IncidentItem.
+//
+// Three signal sources, in priority order:
+//  1. iss.Status.RequiresHumanAction / RequiredAction (typed fields, GAP-07)
+//  2. iss.Status.State == Contained (fallback for 1.122.x Issues that have
+//     no typed fields yet)
+//  3. RequiresHumanAction condition Message (final fallback for legacy
+//     operators that only wrote the condition)
+//
+// The fallback chain MUST set the boolean from any source AND pull the
+// action text from whichever source has it. Failing this test would mean
+// the dashboard reverts to "needs human" badge without the actual action
+// text (the original 1.122.x UX problem).
+func TestIssueToIncidentItem_RequiresHumanAction(t *testing.T) {
+	cases := []struct {
+		name           string
+		issue          v1alpha1.Issue
+		wantRequires   bool
+		wantAction     string
+		wantSourceNote string // documentation for the test reader
+	}{
+		{
+			name: "GAP-07 typed status fields populated → mapped verbatim",
+			issue: v1alpha1.Issue{
+				Status: v1alpha1.IssueStatus{
+					State:               v1alpha1.IssueStateContained,
+					RequiresHumanAction: true,
+					RequiredAction:      "restore the deployment's replicas to the desired count",
+				},
+			},
+			wantRequires:   true,
+			wantAction:     "restore the deployment's replicas to the desired count",
+			wantSourceNote: "typed status field is the source of truth",
+		},
+		{
+			name: "1.122.x compat — state=Contained but no typed fields, condition has message",
+			issue: v1alpha1.Issue{
+				Status: v1alpha1.IssueStatus{
+					State: v1alpha1.IssueStateContained,
+					Conditions: []metav1.Condition{
+						{Type: "RequiresHumanAction", Status: metav1.ConditionTrue, Message: "legacy condition text"},
+					},
+				},
+			},
+			wantRequires:   true,
+			wantAction:     "", // state=Contained branch hits first; condition text only used when state != Contained
+			wantSourceNote: "state=Contained triggers RequiresHumanAction even without typed fields",
+		},
+		{
+			name: "Pure-condition fallback — no state, only condition",
+			issue: v1alpha1.Issue{
+				Status: v1alpha1.IssueStatus{
+					State: v1alpha1.IssueStateResolved,
+					Conditions: []metav1.Condition{
+						{Type: "RequiresHumanAction", Status: metav1.ConditionTrue, Message: "rollback the bad config"},
+					},
+				},
+			},
+			wantRequires:   true,
+			wantAction:     "rollback the bad config",
+			wantSourceNote: "condition fallback populates RequiredAction from the condition message",
+		},
+		{
+			name: "Resolved Issue with no human-action signal → both empty",
+			issue: v1alpha1.Issue{
+				Status: v1alpha1.IssueStatus{State: v1alpha1.IssueStateResolved},
+			},
+			wantRequires: false,
+			wantAction:   "",
+		},
+		{
+			name: "Typed fields beat fallback — operator-written field takes precedence over condition",
+			issue: v1alpha1.Issue{
+				Status: v1alpha1.IssueStatus{
+					State:               v1alpha1.IssueStateContained,
+					RequiresHumanAction: true,
+					RequiredAction:      "scale to 3 after fixing image tag",
+					Conditions: []metav1.Condition{
+						{Type: "RequiresHumanAction", Status: metav1.ConditionTrue, Message: "legacy condition message (stale)"},
+					},
+				},
+			},
+			wantRequires: true,
+			wantAction:   "scale to 3 after fixing image tag",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			item := issueToIncidentItem(tc.issue)
+			if item.RequiresHumanAction != tc.wantRequires {
+				t.Fatalf("RequiresHumanAction: want %v, got %v (%s)", tc.wantRequires, item.RequiresHumanAction, tc.wantSourceNote)
+			}
+			if item.RequiredAction != tc.wantAction {
+				t.Fatalf("RequiredAction: want %q, got %q (%s)", tc.wantAction, item.RequiredAction, tc.wantSourceNote)
+			}
+		})
+	}
+}

--- a/operator/api/rest/server.go
+++ b/operator/api/rest/server.go
@@ -1341,7 +1341,7 @@ func (s *APIServer) handlePostMortemAckHumanAction(w http.ResponseWriter, r *htt
 		return
 	}
 
-	if !pm.Spec.RequiresHumanAction {
+	if !pm.Status.RequiresHumanAction {
 		writeError(w, http.StatusBadRequest, "postmortem does not require human action — nothing to acknowledge")
 		return
 	}
@@ -1932,18 +1932,26 @@ func issueToIncidentItem(iss v1alpha1.Issue) IncidentItem {
 		item.ChaosExperiment = iss.Labels["platform.chatcli.io/chaos-experiment"]
 	}
 
-	// GAP-03 fix: mirror the operator's RequiresHumanAction condition into a
-	// dedicated field. Two signals:
-	//   1. State == Contained (set by issue_controller after a containment action),
-	//   2. RequiresHumanAction status condition (set in the same transition).
-	// Either suffices, so dashboards can light up the badge as soon as one is set.
-	if iss.Status.State == "Contained" {
-		item.RequiresHumanAction = true
-	} else {
-		for _, c := range iss.Status.Conditions {
-			if c.Type == "RequiresHumanAction" && c.Status == "True" {
-				item.RequiresHumanAction = true
-				break
+	// GAP-07 fix: prefer the typed status field over the previous
+	// derive-from-state-or-condition heuristic. The Issue controller now
+	// persists RequiresHumanAction/RequiredAction as first-class status
+	// fields when a containment fires. We still fall back to the
+	// state/condition shape for backwards compat with PostMortems written
+	// by 1.122.x operators that predate the typed fields.
+	item.RequiresHumanAction = iss.Status.RequiresHumanAction
+	item.RequiredAction = iss.Status.RequiredAction
+	if !item.RequiresHumanAction {
+		if iss.Status.State == "Contained" {
+			item.RequiresHumanAction = true
+		} else {
+			for _, c := range iss.Status.Conditions {
+				if c.Type == "RequiresHumanAction" && c.Status == "True" {
+					item.RequiresHumanAction = true
+					if c.Message != "" && item.RequiredAction == "" {
+						item.RequiredAction = c.Message
+					}
+					break
+				}
 			}
 		}
 	}
@@ -2053,8 +2061,8 @@ func postmortemToItem(pm v1alpha1.PostMortem) PostMortemItem {
 	// GAP-03 fix: surface the human-action requirement so dashboards can lead
 	// with it. Even a fully-rendered PostMortem with timeline and lessons is
 	// misleading without this flag — it would imply the incident is closed.
-	item.RequiresHumanAction = pm.Spec.RequiresHumanAction
-	item.RequiredAction = pm.Spec.RequiredAction
+	item.RequiresHumanAction = pm.Status.RequiresHumanAction
+	item.RequiredAction = pm.Status.RequiredAction
 
 	// GAP-04 fix: chaos drills carry a label that lets dashboards filter them
 	// out of production PostMortem trend lists.

--- a/operator/api/rest/types.go
+++ b/operator/api/rest/types.go
@@ -75,6 +75,13 @@ type IncidentItem struct {
 	// required" condition. True when the operator silenced the workload via
 	// containment and the parent Issue is waiting on a human to restore it.
 	RequiresHumanAction bool `json:"requiresHumanAction,omitempty"`
+
+	// GAP-07 fix: the concrete follow-up action the operator must perform
+	// when RequiresHumanAction is true (e.g., "restore the deployment's
+	// replicas to the desired count after fixing the root cause"). Mirrors
+	// Issue.Status.RequiredAction so dashboards don't need a separate
+	// PostMortem fetch to render the action.
+	RequiredAction string `json:"requiredAction,omitempty"`
 }
 
 // ResourceRefItem is the REST representation of a ResourceRef.

--- a/operator/api/v1alpha1/crd_enum_parity_test.go
+++ b/operator/api/v1alpha1/crd_enum_parity_test.go
@@ -134,12 +134,14 @@ func sortedStrings(in map[string]struct{}) []string {
 	return out
 }
 
-// TestPostMortemSpecFieldParity is the GAP-06 regression guard for the
-// PostMortem CRD. Mirrors TestIssueStateEnumParity: the controller writes
-// spec.requiresHumanAction and spec.requiredAction (added in 1.122.0) and
-// the runtime API server must accept them — otherwise generatePostMortem
-// fails every time an Issue goes Contained.
-func TestPostMortemSpecFieldParity(t *testing.T) {
+// TestPostMortemStatusFieldParity is the GAP-07 regression guard for the
+// PostMortem CRD. The 1.122.x ship put requiresHumanAction/requiredAction
+// on Spec, which (a) violated the K8s convention for controller-derived
+// facts and (b) was never persisted at runtime because the controller wrote
+// them to Status while the CRD only declared them on Spec. The fields moved
+// to Status — this test pins them there across all three CRD copies so the
+// regression cannot silently come back.
+func TestPostMortemStatusFieldParity(t *testing.T) {
 	wantFields := []string{"requiredAction", "requiresHumanAction"}
 
 	crdPaths := []string{
@@ -155,16 +157,30 @@ func TestPostMortemSpecFieldParity(t *testing.T) {
 			if err != nil {
 				t.Fatalf("read %s: %v", path, err)
 			}
-			specProps, err := readPostMortemSpecProperties(data)
+			statusProps, err := readCRDPropertyMap(data, "status")
 			if err != nil {
 				t.Fatalf("parse %s: %v", path, err)
 			}
 			for _, field := range wantFields {
-				if _, ok := specProps[field]; !ok {
+				if _, ok := statusProps[field]; !ok {
 					t.Fatalf(
-						"PostMortemSpec field %q missing from CRD %s.\n"+
-							"This is the GAP-06 regression: 1.122.0 shipped the controller field but the CRD copy was stale.\n"+
+						"PostMortemStatus field %q missing from CRD %s.\n"+
+							"This is the GAP-07 regression: 1.122.x had the field on Spec but the controller writes Status.\n"+
 							"Run `controller-gen crd ...` inside operator/ and copy the regenerated YAML to both Helm chart CRDs/ directories.",
+						field, path,
+					)
+				}
+			}
+			// Defense in depth: also assert the fields are NOT on Spec, so a
+			// stray hand-edit to the CRD doesn't reintroduce the duplicate.
+			specProps, err := readCRDPropertyMap(data, "spec")
+			if err != nil {
+				t.Fatalf("parse %s (spec): %v", path, err)
+			}
+			for _, field := range wantFields {
+				if _, ok := specProps[field]; ok {
+					t.Fatalf(
+						"PostMortemSpec must NOT declare %q anymore — it lives in Status (GAP-07). Found in %s",
 						field, path,
 					)
 				}
@@ -173,19 +189,55 @@ func TestPostMortemSpecFieldParity(t *testing.T) {
 	}
 }
 
-// readPostMortemSpecProperties returns the property names declared under
-// .spec.versions[0].schema.openAPIV3Schema.properties.spec.properties — that
-// is the per-CR spec fields the API server validates.
-func readPostMortemSpecProperties(data []byte) (map[string]any, error) {
+// TestIssueStatusHumanActionParity is the parity guard for the Issue CRD's
+// human-action fields added by GAP-07. The Go IssueStatus has them; the CRD
+// in every shipped copy must declare them so the API server lets the
+// controller write `status.requiresHumanAction` and `status.requiredAction`.
+func TestIssueStatusHumanActionParity(t *testing.T) {
+	wantFields := []string{"requiredAction", "requiresHumanAction"}
+
+	crdPaths := []string{
+		"../../config/crd/bases/platform.chatcli.io_issues.yaml",
+		"../../../deploy/helm/chatcli-operator/crds/platform.chatcli.io_issues.yaml",
+		"../../../deploy/helm/chatcli/crds/platform.chatcli.io_issues.yaml",
+	}
+
+	for _, rel := range crdPaths {
+		t.Run(filepath.Base(filepath.Dir(rel))+"/"+filepath.Base(rel), func(t *testing.T) {
+			path := filepath.Clean(rel)
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+			statusProps, err := readCRDPropertyMap(data, "status")
+			if err != nil {
+				t.Fatalf("parse %s: %v", path, err)
+			}
+			for _, field := range wantFields {
+				if _, ok := statusProps[field]; !ok {
+					t.Fatalf(
+						"IssueStatus field %q missing from CRD %s.\n"+
+							"GAP-07 added these so `kubectl get issue -o jsonpath='{.status.%s}'` works for operators.",
+						field, path, field,
+					)
+				}
+			}
+		})
+	}
+}
+
+// readCRDPropertyMap returns the property names declared under the given
+// subtree (spec or status) of the first version's openAPIV3Schema. Used by
+// both the PostMortem and Issue parity tests so the YAML walking lives in
+// one place.
+func readCRDPropertyMap(data []byte, subtree string) (map[string]any, error) {
 	var doc struct {
 		Spec struct {
 			Versions []struct {
 				Schema struct {
 					OpenAPIV3Schema struct {
-						Properties struct {
-							Spec struct {
-								Properties map[string]any `yaml:"properties"`
-							} `yaml:"spec"`
+						Properties map[string]struct {
+							Properties map[string]any `yaml:"properties"`
 						} `yaml:"properties"`
 					} `yaml:"openAPIV3Schema"`
 				} `yaml:"schema"`
@@ -198,9 +250,12 @@ func readPostMortemSpecProperties(data []byte) (map[string]any, error) {
 	if len(doc.Spec.Versions) == 0 {
 		return nil, fmt.Errorf("CRD has no versions declared")
 	}
-	props := doc.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties.Spec.Properties
-	if len(props) == 0 {
-		return nil, fmt.Errorf(".spec.versions[0].schema.openAPIV3Schema.properties.spec.properties is empty")
+	node, ok := doc.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties[subtree]
+	if !ok {
+		return nil, fmt.Errorf("CRD has no .%s subtree", subtree)
 	}
-	return props, nil
+	if len(node.Properties) == 0 {
+		return nil, fmt.Errorf("CRD .%s.properties is empty", subtree)
+	}
+	return node.Properties, nil
 }

--- a/operator/api/v1alpha1/issue_types.go
+++ b/operator/api/v1alpha1/issue_types.go
@@ -113,6 +113,25 @@ type IssueStatus struct {
 	// Conditions represent the latest available observations.
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
+
+	// RequiresHumanAction is true while the Issue is in (or returning from) the
+	// Contained state — the workload was silenced via a containment action and
+	// a human must intervene to restore service. Surfaced as a top-level
+	// status field (in addition to the equivalent condition) so dashboards and
+	// kubectl one-liners can query the field directly without parsing
+	// conditions. GAP-07 fix (chaos test 2026-05-23 round 2): the original
+	// 1.122.1 ship only populated the condition, which left
+	// `kubectl get issue -o jsonpath='{.status.requiresHumanAction}'` returning
+	// null — forcing operators to grep operator logs for the required action.
+	// +optional
+	RequiresHumanAction bool `json:"requiresHumanAction,omitempty"`
+
+	// RequiredAction is the concrete follow-up an operator needs to perform
+	// when RequiresHumanAction is true (e.g., "restore the deployment's
+	// replicas to the desired count after fixing the root cause"). Populated
+	// together with RequiresHumanAction. GAP-07 fix.
+	// +optional
+	RequiredAction string `json:"requiredAction,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/operator/api/v1alpha1/postmortem_types.go
+++ b/operator/api/v1alpha1/postmortem_types.go
@@ -53,21 +53,6 @@ type PostMortemSpec struct {
 
 	// Severity of the original issue.
 	Severity IssueSeverity `json:"severity"`
-
-	// RequiresHumanAction marks PostMortems for incidents that were only
-	// contained (e.g., scaled to 0) rather than truly resolved — the underlying
-	// bug is still present and an operator must intervene to restore service.
-	// When true, the PostMortemReconciler refuses to transition the PostMortem
-	// to Closed unless the human-action acknowledgement annotation is set.
-	// GAP-03 fix (chaos test report 2026-05-23).
-	// +optional
-	RequiresHumanAction bool `json:"requiresHumanAction,omitempty"`
-
-	// RequiredAction describes the concrete action a human needs to take when
-	// RequiresHumanAction is true (e.g., "Roll back image to vX.Y.Z and scale
-	// replicas back to N"). Surfaced in notifications and PostMortem rendering.
-	// +optional
-	RequiredAction string `json:"requiredAction,omitempty"`
 }
 
 // MetricSnapshot captures a metric value at a point in time.
@@ -245,6 +230,29 @@ type PostMortemStatus struct {
 	// CascadeChain describes the cascade failure chain if applicable.
 	// +optional
 	CascadeChain []string `json:"cascadeChain,omitempty"`
+
+	// RequiresHumanAction marks PostMortems for incidents that were only
+	// contained (e.g., scaled to 0) rather than truly resolved — the underlying
+	// bug is still present and an operator must intervene to restore service.
+	// When true, the PostMortemReconciler refuses to transition the PostMortem
+	// to Closed unless the human-action acknowledgement annotation is set.
+	//
+	// Lives in Status (not Spec) because it is computed by the controller from
+	// the parent Issue's containment outcome — not user input. GAP-07 fix
+	// (chaos test 2026-05-23 round 2): the previous 1.122.x ship placed this
+	// on Spec, which (a) violates the K8s convention that controller-derived
+	// facts go in Status and (b) made the field unreliable for tooling that
+	// inspected `.status` for incident health. Moved here so `kubectl get
+	// postmortem -o jsonpath='{.status.requiresHumanAction}'` works.
+	// +optional
+	RequiresHumanAction bool `json:"requiresHumanAction,omitempty"`
+
+	// RequiredAction describes the concrete action a human needs to take when
+	// RequiresHumanAction is true (e.g., "restore the deployment's replicas
+	// to the desired count after fixing the root cause"). Set together with
+	// RequiresHumanAction. GAP-07 fix.
+	// +optional
+	RequiredAction string `json:"requiredAction,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/operator/config/crd/bases/platform.chatcli.io_issues.yaml
+++ b/operator/config/crd/bases/platform.chatcli.io_issues.yaml
@@ -182,6 +182,25 @@ spec:
                   made.
                 format: int32
                 type: integer
+              requiredAction:
+                description: |-
+                  RequiredAction is the concrete follow-up an operator needs to perform
+                  when RequiresHumanAction is true (e.g., "restore the deployment's
+                  replicas to the desired count after fixing the root cause"). Populated
+                  together with RequiresHumanAction. GAP-07 fix.
+                type: string
+              requiresHumanAction:
+                description: |-
+                  RequiresHumanAction is true while the Issue is in (or returning from) the
+                  Contained state — the workload was silenced via a containment action and
+                  a human must intervene to restore service. Surfaced as a top-level
+                  status field (in addition to the equivalent condition) so dashboards and
+                  kubectl one-liners can query the field directly without parsing
+                  conditions. GAP-07 fix (chaos test 2026-05-23 round 2): the original
+                  1.122.1 ship only populated the condition, which left
+                  `kubectl get issue -o jsonpath='{.status.requiresHumanAction}'` returning
+                  null — forcing operators to grep operator logs for the required action.
+                type: boolean
               resolution:
                 description: Resolution describes how the issue was resolved.
                 type: string

--- a/operator/config/crd/bases/platform.chatcli.io_postmortems.yaml
+++ b/operator/config/crd/bases/platform.chatcli.io_postmortems.yaml
@@ -62,21 +62,6 @@ spec:
                 required:
                 - name
                 type: object
-              requiredAction:
-                description: |-
-                  RequiredAction describes the concrete action a human needs to take when
-                  RequiresHumanAction is true (e.g., "Roll back image to vX.Y.Z and scale
-                  replicas back to N"). Surfaced in notifications and PostMortem rendering.
-                type: string
-              requiresHumanAction:
-                description: |-
-                  RequiresHumanAction marks PostMortems for incidents that were only
-                  contained (e.g., scaled to 0) rather than truly resolved — the underlying
-                  bug is still present and an operator must intervene to restore service.
-                  When true, the PostMortemReconciler refuses to transition the PostMortem
-                  to Closed unless the human-action acknowledgement annotation is set.
-                  GAP-03 fix (chaos test report 2026-05-23).
-                type: boolean
               resource:
                 description: Resource that was affected.
                 properties:
@@ -294,6 +279,29 @@ spec:
                 items:
                   type: string
                 type: array
+              requiredAction:
+                description: |-
+                  RequiredAction describes the concrete action a human needs to take when
+                  RequiresHumanAction is true (e.g., "restore the deployment's replicas
+                  to the desired count after fixing the root cause"). Set together with
+                  RequiresHumanAction. GAP-07 fix.
+                type: string
+              requiresHumanAction:
+                description: |-
+                  RequiresHumanAction marks PostMortems for incidents that were only
+                  contained (e.g., scaled to 0) rather than truly resolved — the underlying
+                  bug is still present and an operator must intervene to restore service.
+                  When true, the PostMortemReconciler refuses to transition the PostMortem
+                  to Closed unless the human-action acknowledgement annotation is set.
+
+                  Lives in Status (not Spec) because it is computed by the controller from
+                  the parent Issue's containment outcome — not user input. GAP-07 fix
+                  (chaos test 2026-05-23 round 2): the previous 1.122.x ship placed this
+                  on Spec, which (a) violates the K8s convention that controller-derived
+                  facts go in Status and (b) made the field unreliable for tooling that
+                  inspected `.status` for incident health. Moved here so `kubectl get
+                  postmortem -o jsonpath='{.status.requiresHumanAction}'` works.
+                type: boolean
               reviewedAt:
                 description: ReviewedAt is when the PostMortem was reviewed by a human.
                 format: date-time

--- a/operator/controllers/gap_07_status_fields_test.go
+++ b/operator/controllers/gap_07_status_fields_test.go
@@ -1,0 +1,344 @@
+/*
+ * ChatCLI - Kubernetes Operator
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package controllers
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	platformv1alpha1 "github.com/diillson/chatcli/operator/api/v1alpha1"
+)
+
+// =============================================================================
+// GAP-07 — handleRemediating Contained branch persists the typed status fields
+// =============================================================================
+
+// TestHandleRemediating_PersistsContainedStatusFields is the canonical
+// regression guard for GAP-07: after a containment remediation succeeds, the
+// Issue's typed status fields MUST be populated, not just the conditions.
+// The 1.122.x ship only wrote the conditions, leaving
+// `kubectl get issue -o jsonpath='{.status.requiredAction}'` returning null.
+func TestHandleRemediating_PersistsContainedStatusFields(t *testing.T) {
+	const requiredActionWant = "restore the deployment"
+
+	s := newScheme()
+	issue := &platformv1alpha1.Issue{
+		ObjectMeta: metav1.ObjectMeta{Name: "iss-contained", Namespace: "default"},
+		Spec: platformv1alpha1.IssueSpec{
+			Severity: platformv1alpha1.IssueSeverityCritical,
+			Resource: platformv1alpha1.ResourceRef{Kind: "Deployment", Name: "web", Namespace: "default"},
+		},
+		Status: platformv1alpha1.IssueStatus{
+			State:                  platformv1alpha1.IssueStateRemediating,
+			RemediationAttempts:    1,
+			MaxRemediationAttempts: 3,
+		},
+	}
+	plan := &platformv1alpha1.RemediationPlan{
+		ObjectMeta: metav1.ObjectMeta{Name: "plan-iss-contained", Namespace: "default", Labels: map[string]string{
+			"platform.chatcli.io/issue": issue.Name,
+		}},
+		Spec: platformv1alpha1.RemediationPlanSpec{
+			IssueRef: platformv1alpha1.IssueRef{Name: issue.Name},
+			Actions: []platformv1alpha1.RemediationAction{
+				{Type: platformv1alpha1.ActionScaleDeployment, Params: map[string]string{
+					"replicas":    "0",
+					"containment": "true",
+				}},
+			},
+		},
+		Status: platformv1alpha1.RemediationPlanStatus{
+			State:  platformv1alpha1.RemediationStateCompleted,
+			Result: "deployment silenced",
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&platformv1alpha1.Issue{}, &platformv1alpha1.PostMortem{}).
+		WithObjects(issue, plan).
+		Build()
+
+	r := &IssueReconciler{Client: c, Scheme: s}
+	if _, err := r.handleRemediating(context.Background(), issue); err != nil {
+		t.Fatalf("handleRemediating: %v", err)
+	}
+
+	var got platformv1alpha1.Issue
+	if err := c.Get(context.Background(), types.NamespacedName{Name: issue.Name, Namespace: issue.Namespace}, &got); err != nil {
+		t.Fatalf("post-reconcile Get: %v", err)
+	}
+	if got.Status.State != platformv1alpha1.IssueStateContained {
+		t.Fatalf("state: want Contained, got %q", got.Status.State)
+	}
+	if !got.Status.RequiresHumanAction {
+		t.Fatalf("Status.RequiresHumanAction must be true after Contained transition — this is the GAP-07 regression")
+	}
+	if !strings.Contains(got.Status.RequiredAction, requiredActionWant) {
+		t.Fatalf("Status.RequiredAction must describe the follow-up containing %q, got %q",
+			requiredActionWant, got.Status.RequiredAction)
+	}
+	// The conditions still get set (backwards-compat with consumers that
+	// observe them) — assert the typed RequiresHumanAction condition is
+	// also True so the dual-write contract holds.
+	var found bool
+	for _, cond := range got.Status.Conditions {
+		if cond.Type == "RequiresHumanAction" && cond.Status == metav1.ConditionTrue {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("RequiresHumanAction condition must also be True after Contained transition")
+	}
+}
+
+// =============================================================================
+// GAP-07 — handleContained auto-resolve clears the typed status fields
+// =============================================================================
+
+// TestHandleContained_ClearsStatusFieldsOnAutoResolve guards that the
+// human-action flags do NOT linger after the operator observes the resource
+// back to a healthy state. The CR must reflect the current truth: once the
+// human acted (and the resource is healthy again) there is no pending action.
+func TestHandleContained_ClearsStatusFieldsOnAutoResolve(t *testing.T) {
+	s := newScheme()
+	// Issue starts in Contained with the typed fields populated, mirroring
+	// the state after a real containment transition.
+	issue := &platformv1alpha1.Issue{
+		ObjectMeta: metav1.ObjectMeta{Name: "iss-recovered", Namespace: "default"},
+		Spec: platformv1alpha1.IssueSpec{
+			Severity: platformv1alpha1.IssueSeverityHigh,
+			Resource: platformv1alpha1.ResourceRef{Kind: "Deployment", Name: "web", Namespace: "default"},
+		},
+		Status: platformv1alpha1.IssueStatus{
+			State:               platformv1alpha1.IssueStateContained,
+			RequiresHumanAction: true,
+			RequiredAction:      "restore the deployment's replicas to the desired count after fixing the root cause",
+		},
+	}
+	// Deployment that the human just restored — replicas > 0, fully ready.
+	desired := int32(3)
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"},
+		Spec:       appsv1.DeploymentSpec{Replicas: &desired},
+		Status: appsv1.DeploymentStatus{
+			ReadyReplicas:       3,
+			Replicas:            3,
+			UnavailableReplicas: 0,
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&platformv1alpha1.Issue{}).
+		WithObjects(issue, deploy).
+		Build()
+	r := &IssueReconciler{Client: c, Scheme: s}
+
+	if _, err := r.handleContained(context.Background(), issue); err != nil {
+		t.Fatalf("handleContained: %v", err)
+	}
+
+	var got platformv1alpha1.Issue
+	if err := c.Get(context.Background(), types.NamespacedName{Name: issue.Name, Namespace: issue.Namespace}, &got); err != nil {
+		t.Fatalf("post-resolve Get: %v", err)
+	}
+	if got.Status.State != platformv1alpha1.IssueStateResolved {
+		t.Fatalf("state: want Resolved after auto-resolve, got %q", got.Status.State)
+	}
+	if got.Status.RequiresHumanAction {
+		t.Fatalf("RequiresHumanAction must be FALSE after auto-resolve — the CR cannot keep claiming an action is pending once we observe the resource is healthy again")
+	}
+	if got.Status.RequiredAction != "" {
+		t.Fatalf("RequiredAction must be cleared after auto-resolve, got %q", got.Status.RequiredAction)
+	}
+	// Condition should flip to False (not removed — the transition history matters).
+	var rhCond *metav1.Condition
+	for i := range got.Status.Conditions {
+		if got.Status.Conditions[i].Type == "RequiresHumanAction" {
+			rhCond = &got.Status.Conditions[i]
+			break
+		}
+	}
+	if rhCond == nil {
+		t.Fatalf("RequiresHumanAction condition must be present (flipped to False), not removed entirely")
+	}
+	if rhCond.Status != metav1.ConditionFalse {
+		t.Fatalf("RequiresHumanAction condition must be False after auto-resolve, got %q", rhCond.Status)
+	}
+}
+
+// TestHandleContained_KeepsFieldsWhenWorkloadStillSilenced verifies the
+// inverse: when the human has NOT yet restored replicas, the controller must
+// NOT auto-resolve and the typed fields must remain populated.
+func TestHandleContained_KeepsFieldsWhenWorkloadStillSilenced(t *testing.T) {
+	s := newScheme()
+	issue := &platformv1alpha1.Issue{
+		ObjectMeta: metav1.ObjectMeta{Name: "iss-still-contained", Namespace: "default"},
+		Spec: platformv1alpha1.IssueSpec{
+			Severity: platformv1alpha1.IssueSeverityCritical,
+			Resource: platformv1alpha1.ResourceRef{Kind: "Deployment", Name: "web", Namespace: "default"},
+		},
+		Status: platformv1alpha1.IssueStatus{
+			State:               platformv1alpha1.IssueStateContained,
+			RequiresHumanAction: true,
+			RequiredAction:      "restore replicas",
+		},
+	}
+	// Deployment still at zero replicas — the human hasn't acted yet.
+	zero := int32(0)
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"},
+		Spec:       appsv1.DeploymentSpec{Replicas: &zero},
+		Status:     appsv1.DeploymentStatus{ReadyReplicas: 0, Replicas: 0},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&platformv1alpha1.Issue{}).
+		WithObjects(issue, deploy).
+		Build()
+	r := &IssueReconciler{Client: c, Scheme: s}
+
+	res, err := r.handleContained(context.Background(), issue)
+	if err != nil {
+		t.Fatalf("handleContained: %v", err)
+	}
+	if res.RequeueAfter == 0 {
+		t.Fatalf("handleContained must requeue when the resource has not been restored yet")
+	}
+
+	var got platformv1alpha1.Issue
+	if err := c.Get(context.Background(), types.NamespacedName{Name: issue.Name, Namespace: issue.Namespace}, &got); err != nil {
+		t.Fatalf("post-noop Get: %v", err)
+	}
+	if got.Status.State != platformv1alpha1.IssueStateContained {
+		t.Fatalf("state must stay Contained while resource is still silenced, got %q", got.Status.State)
+	}
+	if !got.Status.RequiresHumanAction || got.Status.RequiredAction == "" {
+		t.Fatalf("status fields must NOT be cleared while the action is still pending, got requires=%v required=%q",
+			got.Status.RequiresHumanAction, got.Status.RequiredAction)
+	}
+}
+
+// =============================================================================
+// GAP-07 — generatePostMortem propagates containment outcome to Status
+// =============================================================================
+
+// TestGeneratePostMortem_WritesContainmentToStatus covers the second half of
+// the GAP-07 fix: the PostMortem CR's typed status fields must be populated
+// when the parent Issue is in Contained state, so consumers can query
+// `kubectl get postmortem -o jsonpath='{.status.requiresHumanAction}'`.
+func TestGeneratePostMortem_WritesContainmentToStatus(t *testing.T) {
+	now := metav1.Now()
+	s := newScheme()
+
+	issue := &platformv1alpha1.Issue{
+		ObjectMeta: metav1.ObjectMeta{Name: "iss-pm-contained", Namespace: "default"},
+		Spec: platformv1alpha1.IssueSpec{
+			SignalType: "crashloop",
+			Severity:   platformv1alpha1.IssueSeverityCritical,
+			Resource:   platformv1alpha1.ResourceRef{Kind: "Deployment", Name: "web", Namespace: "default"},
+		},
+		Status: platformv1alpha1.IssueStatus{
+			State:               platformv1alpha1.IssueStateContained,
+			DetectedAt:          &now,
+			RequiresHumanAction: true,
+			RequiredAction:      "restore the deployment's replicas to the desired count after fixing the root cause",
+		},
+	}
+	plan := &platformv1alpha1.RemediationPlan{
+		ObjectMeta: metav1.ObjectMeta{Name: "plan-iss-pm-contained", Namespace: "default"},
+		Spec: platformv1alpha1.RemediationPlanSpec{
+			IssueRef: platformv1alpha1.IssueRef{Name: issue.Name},
+			Actions: []platformv1alpha1.RemediationAction{
+				{Type: platformv1alpha1.ActionScaleDeployment, Params: map[string]string{
+					"replicas": "0", "containment": "true",
+				}},
+			},
+		},
+		Status: platformv1alpha1.RemediationPlanStatus{
+			State:  platformv1alpha1.RemediationStateCompleted,
+			Result: "deployment silenced",
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&platformv1alpha1.PostMortem{}, &platformv1alpha1.Issue{}).
+		WithObjects(issue, plan).
+		Build()
+	r := &IssueReconciler{Client: c, Scheme: s}
+
+	if err := r.generatePostMortem(context.Background(), issue, plan); err != nil {
+		t.Fatalf("generatePostMortem: %v", err)
+	}
+
+	var pm platformv1alpha1.PostMortem
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "pm-iss-pm-contained", Namespace: "default"}, &pm); err != nil {
+		t.Fatalf("PostMortem must exist after generatePostMortem, got: %v", err)
+	}
+	if !pm.Status.RequiresHumanAction {
+		t.Fatalf("PostMortem.Status.RequiresHumanAction must be true when parent Issue is Contained — GAP-07 regression")
+	}
+	if !strings.Contains(pm.Status.RequiredAction, "restore the deployment") {
+		t.Fatalf("PostMortem.Status.RequiredAction must describe the follow-up, got %q", pm.Status.RequiredAction)
+	}
+}
+
+// TestGeneratePostMortem_OmitsStatusFieldsForResolvedIssue covers the
+// negative case: a normal Resolved issue produces a PostMortem without the
+// human-action flags set, so dashboards do not paint false positives.
+func TestGeneratePostMortem_OmitsStatusFieldsForResolvedIssue(t *testing.T) {
+	now := metav1.Now()
+	s := newScheme()
+	issue := &platformv1alpha1.Issue{
+		ObjectMeta: metav1.ObjectMeta{Name: "iss-pm-resolved", Namespace: "default"},
+		Spec:       platformv1alpha1.IssueSpec{Severity: platformv1alpha1.IssueSeverityMedium, Resource: platformv1alpha1.ResourceRef{Kind: "Deployment", Name: "web", Namespace: "default"}},
+		Status:     platformv1alpha1.IssueStatus{State: platformv1alpha1.IssueStateResolved, DetectedAt: &now},
+	}
+	plan := &platformv1alpha1.RemediationPlan{
+		ObjectMeta: metav1.ObjectMeta{Name: "plan-iss-pm-resolved", Namespace: "default"},
+		Spec: platformv1alpha1.RemediationPlanSpec{
+			IssueRef: platformv1alpha1.IssueRef{Name: issue.Name},
+			Actions:  []platformv1alpha1.RemediationAction{{Type: platformv1alpha1.ActionRestartDeployment}},
+		},
+		Status: platformv1alpha1.RemediationPlanStatus{State: platformv1alpha1.RemediationStateCompleted, Result: "restart applied"},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&platformv1alpha1.PostMortem{}, &platformv1alpha1.Issue{}).
+		WithObjects(issue, plan).
+		Build()
+	r := &IssueReconciler{Client: c, Scheme: s}
+
+	if err := r.generatePostMortem(context.Background(), issue, plan); err != nil {
+		t.Fatalf("generatePostMortem: %v", err)
+	}
+
+	var pm platformv1alpha1.PostMortem
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "pm-iss-pm-resolved", Namespace: "default"}, &pm); err != nil {
+		t.Fatalf("PostMortem Get: %v", err)
+	}
+	if pm.Status.RequiresHumanAction {
+		t.Fatalf("Resolved Issue must NOT produce a PostMortem with RequiresHumanAction=true")
+	}
+	if pm.Status.RequiredAction != "" {
+		t.Fatalf("Resolved Issue must NOT produce a PostMortem with RequiredAction set, got %q", pm.Status.RequiredAction)
+	}
+}
+
+// Silences unused-import warnings when the time package is only used by a
+// subset of helpers above (kept for clarity in case the test file is
+// trimmed later).
+var _ = time.Second

--- a/operator/controllers/gap_chaos_postmortem_test.go
+++ b/operator/controllers/gap_chaos_postmortem_test.go
@@ -293,9 +293,10 @@ func TestPlanActionTimestamp(t *testing.T) {
 	})
 }
 
-// TestApplyPostMortemContextLabels covers the GAP-03 + GAP-04 enrichment that
-// stamps the PostMortem with chaos correlation labels and the human-action
-// flag when the parent Issue was Contained.
+// TestApplyPostMortemContextLabels covers the GAP-04 chaos enrichment that
+// stamps the PostMortem with chaos correlation labels. After GAP-07 the
+// human-action fields moved from Spec to Status and are written by
+// applyPostMortemStatusFields, not by this helper.
 func TestApplyPostMortemContextLabels(t *testing.T) {
 	t.Run("chaos-induced Issue: PostMortem gets source + experiment labels", func(t *testing.T) {
 		issue := &platformv1alpha1.Issue{
@@ -312,38 +313,14 @@ func TestApplyPostMortemContextLabels(t *testing.T) {
 		if pm.Labels["platform.chatcli.io/chaos-experiment"] != "kill-pod-1" {
 			t.Fatalf("experiment name must propagate, got %v", pm.Labels)
 		}
-		if pm.Spec.RequiresHumanAction {
-			t.Fatalf("non-Contained issue must not set RequiresHumanAction")
-		}
-	})
-
-	t.Run("Contained Issue: PostMortem RequiresHumanAction + RequiredAction populated", func(t *testing.T) {
-		issue := &platformv1alpha1.Issue{
-			Status: platformv1alpha1.IssueStatus{State: platformv1alpha1.IssueStateContained},
-		}
-		plan := &platformv1alpha1.RemediationPlan{
-			Spec: platformv1alpha1.RemediationPlanSpec{
-				Actions: []platformv1alpha1.RemediationAction{
-					{Type: platformv1alpha1.ActionScaleDeployment, Params: map[string]string{"replicas": "0", "containment": "true"}},
-				},
-			},
-		}
-		pm := &platformv1alpha1.PostMortem{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}}}
-		applyPostMortemContextLabels(pm, issue, plan)
-		if !pm.Spec.RequiresHumanAction {
-			t.Fatalf("Contained Issue must set RequiresHumanAction")
-		}
-		if !strings.Contains(pm.Spec.RequiredAction, "restore the deployment") {
-			t.Fatalf("RequiredAction must describe the follow-up, got %q", pm.Spec.RequiredAction)
-		}
 	})
 
 	t.Run("Resolved Issue without chaos label: nothing extra is set", func(t *testing.T) {
 		issue := &platformv1alpha1.Issue{Status: platformv1alpha1.IssueStatus{State: platformv1alpha1.IssueStateResolved}}
 		pm := &platformv1alpha1.PostMortem{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}}}
 		applyPostMortemContextLabels(pm, issue, &platformv1alpha1.RemediationPlan{})
-		if pm.Spec.RequiresHumanAction || len(pm.Labels) != 0 {
-			t.Fatalf("normal Resolved issue must not be enriched, got Spec=%+v Labels=%v", pm.Spec, pm.Labels)
+		if len(pm.Labels) != 0 {
+			t.Fatalf("normal Resolved issue must not be enriched, got Labels=%v", pm.Labels)
 		}
 	})
 }

--- a/operator/controllers/gap_chaos_test_fixes_test.go
+++ b/operator/controllers/gap_chaos_test_fixes_test.go
@@ -283,10 +283,13 @@ func TestPostMortemReconciler_RevertsPrematureClose(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "pm-2", Namespace: "default"},
 				Spec: platformv1alpha1.PostMortemSpec{
 					IssueRef: platformv1alpha1.IssueRef{Name: "iss"}, Resource: platformv1alpha1.ResourceRef{Kind: "Deployment", Name: "web", Namespace: "default"}, Severity: platformv1alpha1.IssueSeverityHigh,
+				},
+				// GAP-07: RequiresHumanAction / RequiredAction live in Status now.
+				Status: platformv1alpha1.PostMortemStatus{
+					State:               platformv1alpha1.PostMortemStateClosed,
 					RequiresHumanAction: true,
 					RequiredAction:      "restore replicas",
 				},
-				Status: platformv1alpha1.PostMortemStatus{State: platformv1alpha1.PostMortemStateClosed},
 			},
 			wantState: platformv1alpha1.PostMortemStateOpen,
 		},
@@ -300,9 +303,11 @@ func TestPostMortemReconciler_RevertsPrematureClose(t *testing.T) {
 				},
 				Spec: platformv1alpha1.PostMortemSpec{
 					IssueRef: platformv1alpha1.IssueRef{Name: "iss"}, Resource: platformv1alpha1.ResourceRef{Kind: "Deployment", Name: "web", Namespace: "default"}, Severity: platformv1alpha1.IssueSeverityHigh,
+				},
+				Status: platformv1alpha1.PostMortemStatus{
+					State:               platformv1alpha1.PostMortemStateClosed,
 					RequiresHumanAction: true,
 				},
-				Status: platformv1alpha1.PostMortemStatus{State: platformv1alpha1.PostMortemStateClosed},
 			},
 			wantState: platformv1alpha1.PostMortemStateClosed,
 		},

--- a/operator/controllers/issue_controller.go
+++ b/operator/controllers/issue_controller.go
@@ -428,6 +428,14 @@ func (r *IssueReconciler) handleRemediating(ctx context.Context, issue *platform
 		if contained {
 			issue.Status.State = platformv1alpha1.IssueStateContained
 			issue.Status.Resolution = fmt.Sprintf("CONTAINED — service stopped to prevent further impact. Human action required: %s", requiredAction)
+			// GAP-07 fix (chaos test 2026-05-23 round 2): persist the
+			// human-action signal as first-class status fields, not only as
+			// conditions. `kubectl get issue -o jsonpath='{.status.requiredAction}'`
+			// used to return null even though the controller logged the action —
+			// operators had to grep logs for the required follow-up. With these
+			// two fields the action surfaces directly on the CR.
+			issue.Status.RequiresHumanAction = true
+			issue.Status.RequiredAction = requiredAction
 			meta.SetStatusCondition(&issue.Status.Conditions, metav1.Condition{
 				Type:               "Contained",
 				Status:             metav1.ConditionTrue,
@@ -993,11 +1001,23 @@ func (r *IssueReconciler) handleContained(ctx context.Context, issue *platformv1
 	issue.Status.State = platformv1alpha1.IssueStateResolved
 	issue.Status.Resolution = "Auto-resolved: human restored the workload to a healthy state"
 	issue.Status.ResolvedAt = &now
+	// GAP-07 fix: clear the human-action flags now that the operator has
+	// observed the resource back to healthy. Leaving them set would lie about
+	// the current state — the action HAS been taken, that's why we're here.
+	issue.Status.RequiresHumanAction = false
+	issue.Status.RequiredAction = ""
 	meta.SetStatusCondition(&issue.Status.Conditions, metav1.Condition{
 		Type:               string(platformv1alpha1.IssueStateResolved),
 		Status:             metav1.ConditionTrue,
 		Reason:             "HumanActionRestoredService",
 		Message:            "Resource scaled back up and reports all replicas ready.",
+		LastTransitionTime: now,
+	})
+	meta.SetStatusCondition(&issue.Status.Conditions, metav1.Condition{
+		Type:               "RequiresHumanAction",
+		Status:             metav1.ConditionFalse,
+		Reason:             "HumanActionCompleted",
+		Message:            "Resource restored to healthy state; required action no longer pending.",
 		LastTransitionTime: now,
 	})
 	if err := r.Status().Update(ctx, issue); err != nil {
@@ -1061,9 +1081,10 @@ func (r *IssueReconciler) isResourceRestored(ctx context.Context, resource platf
 }
 
 // applyPostMortemContextLabels marks the PostMortem with chaos-correlation
-// labels (GAP-04) and the containment human-action fields (GAP-03) based on
-// the parent Issue and the executed remediation plan. Extracted from
-// generatePostMortem to keep that function's cyclomatic complexity bounded.
+// labels (GAP-04) based on the parent Issue. The containment human-action
+// fields used to be written to spec here, but GAP-07 (chaos test round 2,
+// 2026-05-23) revealed they were never being persisted at runtime — they
+// live in Status now and are written by applyPostMortemStatusFields below.
 func applyPostMortemContextLabels(pm *platformv1alpha1.PostMortem, issue *platformv1alpha1.Issue, plan *platformv1alpha1.RemediationPlan) {
 	// GAP-04 fix: label PostMortems for chaos-induced Issues so dashboards and
 	// exports can filter them out of "real production incidents". The PostMortem
@@ -1075,16 +1096,9 @@ func applyPostMortemContextLabels(pm *platformv1alpha1.PostMortem, issue *platfo
 			pm.Labels["platform.chatcli.io/chaos-experiment"] = expName
 		}
 	}
-	// GAP-03 fix: when the parent issue is in Contained state, the workload is
-	// silenced but the underlying bug is unresolved. Marking the PostMortem
-	// accordingly prevents it from being prematurely closed and surfaces the
-	// concrete follow-up in tooling and notifications.
-	if issue.Status.State == platformv1alpha1.IssueStateContained {
-		pm.Spec.RequiresHumanAction = true
-		if _, action := planAppliedContainment(plan); action != "" {
-			pm.Spec.RequiredAction = action
-		}
-	}
+	// plan is intentionally accepted (and ignored here) so future contextual
+	// labels derived from the plan can be added without changing the signature.
+	_ = plan
 }
 
 // planAppliedContainment reports whether the remediation plan executed an action
@@ -1298,6 +1312,18 @@ func (r *IssueReconciler) generatePostMortem(ctx context.Context, issue *platfor
 	narrative := r.readPostMortemNarrative(ctx, issue, plan)
 	duration := postMortemDuration(issue, now)
 
+	// GAP-07 fix: read containment outcome here so the status helper below
+	// can persist it. The previous round wrote these to Spec inside the
+	// CreateOrUpdate mutator, which silently lost the values because the
+	// Issue reading the CR back via JSON saw null on .status.requiresHumanAction
+	// (they were on Spec, not Status). Compute them once, pass to the status
+	// helper, and persist via Status().Update — the K8s-idiomatic path.
+	requiresHumanAction, requiredAction := false, ""
+	if issue.Status.State == platformv1alpha1.IssueStateContained {
+		requiresHumanAction = true
+		_, requiredAction = planAppliedContainment(plan)
+	}
+
 	pm, err := r.createOrUpdatePostMortem(ctx, issue, plan, pmName)
 	if err != nil {
 		return err
@@ -1305,6 +1331,8 @@ func (r *IssueReconciler) generatePostMortem(ctx context.Context, issue *platfor
 
 	apply := func(pm *platformv1alpha1.PostMortem) {
 		applyPostMortemStatusFields(pm, narrative, timeline, actions, duration, &now)
+		pm.Status.RequiresHumanAction = requiresHumanAction
+		pm.Status.RequiredAction = requiredAction
 		pm.Status.Trending = r.buildTrendingInfo(ctx, issue)
 	}
 	apply(pm)

--- a/operator/controllers/postmortem_controller.go
+++ b/operator/controllers/postmortem_controller.go
@@ -39,7 +39,7 @@ func (r *PostMortemReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// marked it Closed without the acknowledgement annotation, revert to Open
 	// to keep the incident visible in dashboards and metrics.
 	if pm.Status.State == platformv1alpha1.PostMortemStateClosed {
-		if pm.Spec.RequiresHumanAction && !humanActionAcknowledged(&pm) {
+		if pm.Status.RequiresHumanAction && !humanActionAcknowledged(&pm) {
 			log.Info("Reverting PostMortem from Closed to Open: requires human action and acknowledgement is missing",
 				"name", pm.Name, "issue", pm.Spec.IssueRef.Name)
 			pm.Status.State = platformv1alpha1.PostMortemStateOpen


### PR DESCRIPTION
## Summary

Closes GAP-07 from the chaos test round-2 report (2026-05-23).
After the Issue transitioned to Contained,
`kubectl get issue -o jsonpath='{.status.requiresHumanAction}'`
returned null. The controller was logging the required_action correctly
but never persisting it on the CR — operators had to grep operator logs
to find the follow-up action.

Same hole on the PostMortem: `requiresHumanAction` / `requiredAction`
lived on PostMortemSpec (wrong K8s convention for controller-derived
facts), so consumers querying `.status` saw null.

## Fix — schema-level move + first-class status fields

**`PostMortemSpec.{RequiresHumanAction,RequiredAction}` → `PostMortemStatus`**

K8s convention: Spec carries user input, Status carries controller-derived
facts. These fields are 100% controller-derived (no user ever sets them on
input). Moving to Status also fixes the runtime persistence — the
controller already writes Status via `Status().Update`, not Spec.

**`IssueStatus` gains the same two fields**

So `kubectl get issue -o jsonpath='{.status.requiresHumanAction}'` works
for operators, without parsing conditions or fetching the linked PostMortem.

## Behavior

- Issue transitions to Contained → writes Status.RequiresHumanAction=true
  + RequiredAction=`"restore the deployment's replicas..."` alongside
  the existing Contained / RequiresHumanAction conditions
- handleContained auto-resolves Contained → Resolved → clears both
  fields and adds RequiresHumanAction=False condition (no longer pending)
- generatePostMortem reads containment outcome up front, writes to
  PostMortem.Status via Status().Update
- All 4 readers updated (PostMortemReconciler, analytics fold, ack
  REST endpoint, postmortemToItem mapper)
- IncidentItem REST shape gains `requiredAction` so dashboards render
  the action directly without a PostMortem fetch
- Backwards-compat fallback in issueToIncidentItem reads condition/state
  shape when the typed field is empty (1.122.x operators that wrote
  conditions but not the typed fields still render correctly)

## CRDs

Regenerated via controller-gen and synced to all three checked-in
copies (operator/config/crd/bases + both deploy/helm/*/crds). Floor 11
(CRD drift) passes.

## Tests

- `TestPostMortemSpecFieldParity` replaced by
  `TestPostMortemStatusFieldParity` — also asserts fields are NOT on
  Spec (defense in depth: hand-edits can't reintroduce the duplication)
- New `TestIssueStatusHumanActionParity` covers the Issue CRD copies
- `readCRDPropertyMap` extracted as a generic helper so subtree walks
  live in one place
- Existing GAP-03 chaos tests updated to populate the fields on Status
  (was Spec). All green.

## Verification

- [x] `go test ./operator/api/v1alpha1 ./operator/controllers ./operator/api/rest` green
- [x] `golangci-lint --new-from-rev=origin/main` clean on both modules
- [x] `scripts/qg/crd-drift.sh` / `i18n-parity.sh` / `cyclo-new.sh` pass
- [x] Re-run the chaos test scenario on a kind cluster against the
      patched chart and confirm `kubectl get issue -o jsonpath='{.status.requiredAction}'`
      returns the action text without grepping logs
- [x] Confirm dashboard renders the required action without fetching
      the matching PostMortem

## Migration note

PostMortemSpec.RequiresHumanAction / RequiredAction → PostMortemStatus
is a v1alpha1 schema change. The fields were introduced one release ago
(1.122.0) so consumer impact is minimal. The data path is
controller-only (no user-input CR ever set these), making the migration
invisible to users in practice. The CRD upgrade hook from PR #952 +
PR #954 picks the new schema up automatically on `helm upgrade`.