### PR TITLE
fix(aiops): dashboard PostMortem Close button missing and Ack does nothing

### DIFF
--- a/operator/api/rest/ack_status_error_paths_test.go
+++ b/operator/api/rest/ack_status_error_paths_test.go
@@ -1,0 +1,132 @@
+/*
+ * ChatCLI - Kubernetes Operator
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package rest
+
+import (
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	v1alpha1 "github.com/diillson/chatcli/operator/api/v1alpha1"
+)
+
+// TestAckHumanActionEndpoint_StatusUpdateConflictReturns409 covers the
+// dashboard-UX guard added to handlePostMortemAckHumanAction: when the
+// Status().Update call to clear RequiresHumanAction races with another
+// writer (controller reconciler, parallel API call), the handler returns
+// HTTP 409 instead of swallowing the error or returning a misleading 500.
+// The dashboard's retry-on-409 logic then kicks in cleanly.
+//
+// Without explicit coverage of this branch, a regression that swapped the
+// conflict check for a generic error path would only surface as silent
+// failures in production — the patch-coverage gate caught the gap on the
+// first run of PR #957.
+func TestAckHumanActionEndpoint_StatusUpdateConflictReturns409(t *testing.T) {
+	s := newRestScheme()
+	pm := &v1alpha1.PostMortem{
+		ObjectMeta: metav1.ObjectMeta{Name: "pm-conflict", Namespace: "default"},
+		Spec: v1alpha1.PostMortemSpec{
+			IssueRef: v1alpha1.IssueRef{Name: "iss"}, Resource: v1alpha1.ResourceRef{Kind: "Deployment", Name: "web", Namespace: "default"}, Severity: v1alpha1.IssueSeverityHigh,
+		},
+		Status: v1alpha1.PostMortemStatus{
+			State:               v1alpha1.PostMortemStateOpen,
+			RequiresHumanAction: true,
+			RequiredAction:      "restore replicas",
+		},
+	}
+
+	// Interceptor returns a Conflict error on the Status().Update path only.
+	// The Spec Update (annotation persistence) still goes through, then the
+	// follow-up Status update races.
+	conflict := apierrors.NewConflict(
+		schema.GroupResource{Group: "platform.chatcli.io", Resource: "postmortems"},
+		pm.Name,
+		fmt.Errorf("the object has been modified; please apply your changes to the latest version and try again"),
+	)
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&v1alpha1.PostMortem{}).
+		WithObjects(pm).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+				if subResourceName == "status" {
+					return conflict
+				}
+				return client.Status().Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	api := NewAPIServer(c, ":0")
+
+	body := strings.NewReader(`{"acknowledgedBy":"sre"}`)
+	req := httptest.NewRequest("POST", "/api/v1/postmortems/pm-conflict/ack-human-action?namespace=default", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	api.handlePostMortemAckHumanAction(w, req, "pm-conflict")
+
+	if w.Code != 409 {
+		t.Fatalf("status: want 409 Conflict on Status().Update conflict, got %d (body=%s)", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "modified concurrently") {
+		t.Fatalf("response body should mention concurrent modification so the dashboard knows to retry, got %q", w.Body.String())
+	}
+}
+
+// TestAckHumanActionEndpoint_StatusUpdateGenericErrorReturns500 covers the
+// non-conflict error branch: anything other than IsConflict (network blip,
+// permission denied, malformed payload from the apiserver) surfaces as a
+// 500 with the original error message so the operator can diagnose without
+// digging through pod logs.
+func TestAckHumanActionEndpoint_StatusUpdateGenericErrorReturns500(t *testing.T) {
+	s := newRestScheme()
+	pm := &v1alpha1.PostMortem{
+		ObjectMeta: metav1.ObjectMeta{Name: "pm-status-broken", Namespace: "default"},
+		Spec: v1alpha1.PostMortemSpec{
+			IssueRef: v1alpha1.IssueRef{Name: "iss"}, Resource: v1alpha1.ResourceRef{Kind: "Deployment", Name: "web", Namespace: "default"}, Severity: v1alpha1.IssueSeverityHigh,
+		},
+		Status: v1alpha1.PostMortemStatus{
+			State:               v1alpha1.PostMortemStateOpen,
+			RequiresHumanAction: true,
+			RequiredAction:      "restore replicas",
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&v1alpha1.PostMortem{}).
+		WithObjects(pm).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+				if subResourceName == "status" {
+					return fmt.Errorf("apiserver unavailable: broken-pipe")
+				}
+				return client.Status().Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	api := NewAPIServer(c, ":0")
+
+	req := httptest.NewRequest("POST", "/api/v1/postmortems/pm-status-broken/ack-human-action?namespace=default", strings.NewReader(""))
+	w := httptest.NewRecorder()
+	api.handlePostMortemAckHumanAction(w, req, "pm-status-broken")
+
+	if w.Code != 500 {
+		t.Fatalf("status: want 500 on non-conflict Status().Update error, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "apiserver unavailable") {
+		t.Fatalf("response body should surface the underlying error so operators can diagnose, got %q", w.Body.String())
+	}
+}

--- a/operator/api/rest/analytics_chaos_fold_test.go
+++ b/operator/api/rest/analytics_chaos_fold_test.go
@@ -178,10 +178,13 @@ func TestAckHumanActionEndpoint_HappyPath(t *testing.T) {
 		Spec: v1alpha1.PostMortemSpec{
 			IssueRef: v1alpha1.IssueRef{Name: "i1"}, Resource: v1alpha1.ResourceRef{Kind: "Deployment", Name: "web", Namespace: "default"}, Severity: v1alpha1.IssueSeverityHigh,
 		},
-		// GAP-07: RequiresHumanAction lives in Status now.
+		// GAP-07: RequiresHumanAction lives in Status now. RequiredAction
+		// is populated so the post-ack assertion can verify it is preserved
+		// as historical context (not cleared along with RequiresHumanAction).
 		Status: v1alpha1.PostMortemStatus{
 			State:               v1alpha1.PostMortemStateOpen,
 			RequiresHumanAction: true,
+			RequiredAction:      "restore the deployment's replicas after fixing the root cause",
 		},
 	}
 	c := fake.NewClientBuilder().
@@ -214,6 +217,17 @@ func TestAckHumanActionEndpoint_HappyPath(t *testing.T) {
 	}
 	if got.Annotations["aiops.chatcli.io/human-action-note"] != "rolled back to v1.2.3" {
 		t.Fatalf("note annotation must reflect the request body")
+	}
+	// Dashboard UX fix: Status.RequiresHumanAction MUST be cleared the
+	// moment the ack lands so the dashboard re-render shows the Close
+	// button (and the Ack button hides). Without this the operator
+	// clicks Ack, sees the toast, but the buttons do not change — and
+	// the symptom reported as "the button does not do anything" returns.
+	if got.Status.RequiresHumanAction {
+		t.Fatalf("Status.RequiresHumanAction must be cleared on successful ack — dashboard buttons key off this field")
+	}
+	if got.Status.RequiredAction == "" {
+		t.Fatalf("Status.RequiredAction must be preserved as historical context; cleared by mistake")
 	}
 }
 

--- a/operator/api/rest/server.go
+++ b/operator/api/rest/server.go
@@ -1367,6 +1367,28 @@ func (s *APIServer) handlePostMortemAckHumanAction(w http.ResponseWriter, r *htt
 		return
 	}
 
+	// Dashboard UX fix: clear Status.RequiresHumanAction the moment the ack
+	// lands so the dashboard re-render shows the "Close" button immediately
+	// (and the "Ack Human Action" button disappears). Without this, the
+	// status field stayed true until the next PostMortemReconciler tick,
+	// leaving operators staring at an unchanged UI after clicking Ack —
+	// the bug surfaced as "the button does not do anything".
+	//
+	// We keep Status.RequiredAction populated as historical context for the
+	// rendered PostMortem; the action HAS been performed, but operators
+	// reading the CR later still want to see what was required.
+	if pm.Status.RequiresHumanAction {
+		pm.Status.RequiresHumanAction = false
+		if err := s.client.Status().Update(ctx, &pm); err != nil {
+			if apierrors.IsConflict(err) {
+				writeError(w, http.StatusConflict, "postmortem status was modified concurrently, please retry")
+				return
+			}
+			writeError(w, http.StatusInternalServerError, "failed to clear requiresHumanAction after ack: "+err.Error())
+			return
+		}
+	}
+
 	item := postmortemToItem(pm)
 	writeJSON(w, http.StatusOK, APIResponse{
 		APIVersion: "v1",

--- a/operator/controllers/gap_dashboard_ack_close_flow_test.go
+++ b/operator/controllers/gap_dashboard_ack_close_flow_test.go
@@ -1,0 +1,125 @@
+/*
+ * ChatCLI - Kubernetes Operator
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	platformv1alpha1 "github.com/diillson/chatcli/operator/api/v1alpha1"
+)
+
+// TestPostMortemReconciler_AckClearedStatusAllowsClose covers the dashboard
+// UX fix where the operator clicks "Ack Human Action" and then "Close" right
+// after. The end-to-end contract:
+//
+//  1. /api/v1/postmortems/{name}/ack-human-action sets the ack annotation
+//     AND clears Status.RequiresHumanAction in the same handler so the
+//     dashboard re-render shows the Close button immediately
+//  2. /api/v1/postmortems/{name}/close transitions Status.State to Closed
+//  3. The PostMortemReconciler runs and MUST NOT revert that Closed state
+//     because (a) RequiresHumanAction is now false AND (b) the ack
+//     annotation is set
+//
+// Without the status clear in step (1), the dashboard left operators with
+// no Close button (the symptom reported as "no button to close a postmortem
+// with needs-human tag" and "the Ack button does not do anything").
+func TestPostMortemReconciler_AckClearedStatusAllowsClose(t *testing.T) {
+	s := newScheme()
+	// Initial state simulates a PostMortem after the /ack-human-action endpoint
+	// has done its job: annotation set, Status.RequiresHumanAction cleared,
+	// State=Closed (operator clicked Close right after Ack).
+	pm := &platformv1alpha1.PostMortem{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pm-acked-then-closed",
+			Namespace: "default",
+			Annotations: map[string]string{
+				AnnotationHumanActionAcknowledged: "true",
+			},
+		},
+		Spec: platformv1alpha1.PostMortemSpec{
+			IssueRef: platformv1alpha1.IssueRef{Name: "iss"},
+			Resource: platformv1alpha1.ResourceRef{Kind: "Deployment", Name: "web", Namespace: "default"},
+			Severity: platformv1alpha1.IssueSeverityHigh,
+		},
+		Status: platformv1alpha1.PostMortemStatus{
+			State:               platformv1alpha1.PostMortemStateClosed,
+			RequiresHumanAction: false, // <— cleared by the ack endpoint
+			RequiredAction:      "restore the deployment's replicas after fixing the root cause",
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&platformv1alpha1.PostMortem{}).
+		WithObjects(pm).
+		Build()
+	r := &PostMortemReconciler{Client: c, Scheme: s}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: pm.Name, Namespace: pm.Namespace}}
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("Reconcile: unexpected error %v", err)
+	}
+
+	var got platformv1alpha1.PostMortem
+	if err := c.Get(context.Background(), types.NamespacedName{Name: pm.Name, Namespace: pm.Namespace}, &got); err != nil {
+		t.Fatalf("post-reconcile Get: %v", err)
+	}
+	if got.Status.State != platformv1alpha1.PostMortemStateClosed {
+		t.Fatalf("Closed state must stick after Ack-then-Close — the reconciler should not revert when RequiresHumanAction is false. Got state=%q",
+			got.Status.State)
+	}
+	if got.Status.RequiredAction == "" {
+		t.Fatalf("RequiredAction must be preserved as historical context even after the action was performed")
+	}
+}
+
+// TestPostMortemReconciler_StillRevertsWhenAckMissingAndStatusTrue keeps the
+// inverse contract: a Closed PostMortem with RequiresHumanAction still true
+// and no ack annotation MUST be reverted to Open. This is the original
+// GAP-03 guardrail; the dashboard UX fix above must not weaken it.
+func TestPostMortemReconciler_StillRevertsWhenAckMissingAndStatusTrue(t *testing.T) {
+	s := newScheme()
+	pm := &platformv1alpha1.PostMortem{
+		ObjectMeta: metav1.ObjectMeta{Name: "pm-stale-close", Namespace: "default"},
+		Spec: platformv1alpha1.PostMortemSpec{
+			IssueRef: platformv1alpha1.IssueRef{Name: "iss"},
+			Resource: platformv1alpha1.ResourceRef{Kind: "Deployment", Name: "web", Namespace: "default"},
+			Severity: platformv1alpha1.IssueSeverityHigh,
+		},
+		Status: platformv1alpha1.PostMortemStatus{
+			State:               platformv1alpha1.PostMortemStateClosed,
+			RequiresHumanAction: true, // <— still pending, no ack
+			RequiredAction:      "restore replicas",
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&platformv1alpha1.PostMortem{}).
+		WithObjects(pm).
+		Build()
+	r := &PostMortemReconciler{Client: c, Scheme: s}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: pm.Name, Namespace: pm.Namespace}}
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("Reconcile: unexpected error %v", err)
+	}
+
+	var got platformv1alpha1.PostMortem
+	if err := c.Get(context.Background(), types.NamespacedName{Name: pm.Name, Namespace: pm.Namespace}, &got); err != nil {
+		t.Fatalf("post-reconcile Get: %v", err)
+	}
+	if got.Status.State != platformv1alpha1.PostMortemStateOpen {
+		t.Fatalf("Closed state must be reverted to Open when RequiresHumanAction is still true and ack is missing — GAP-03 guardrail. Got state=%q",
+			got.Status.State)
+	}
+}

--- a/operator/web/static/index.html
+++ b/operator/web/static/index.html
@@ -2104,9 +2104,9 @@ async function loadPostMortems() {
         <td>${escapeHtml(item.issueRef || '-')}</td>
         <td data-sort-value="${new Date(item.creationTimestamp || 0).getTime()}">${timeAgo(item.creationTimestamp)}</td>
         <td class="btn-group">
-          ${item.state !== 'Closed' ? `<button class="btn" onclick="event.stopPropagation(); reviewPM('${escapeHtml(item.name)}', '${escapeHtml(item.namespace)}')">Review</button>` : ''}
-          ${item.state === 'InReview' && !item.requiresHumanAction ? `<button class="btn btn-success" onclick="event.stopPropagation(); closePM('${escapeHtml(item.name)}', '${escapeHtml(item.namespace)}')">Close</button>` : ''}
-          ${item.requiresHumanAction ? `<button class="btn" style="background:#9b59b6;color:#fff;font-weight:700" onclick="event.stopPropagation(); ackHumanAction('${escapeHtml(item.name)}', '${escapeHtml(item.namespace)}')" title="Acknowledge that the required action has been performed">Ack Human Action</button>` : ''}
+          ${item.state !== 'Closed' && !item.requiresHumanAction ? `<button class="btn" onclick="event.stopPropagation(); reviewPM('${escapeHtml(item.name)}', '${escapeHtml(item.namespace)}')">Review</button>` : ''}
+          ${item.state !== 'Closed' && !item.requiresHumanAction ? `<button class="btn btn-success" onclick="event.stopPropagation(); closePM('${escapeHtml(item.name)}', '${escapeHtml(item.namespace)}')">Close</button>` : ''}
+          ${item.requiresHumanAction ? `<button class="btn" style="background:#9b59b6;color:#fff;font-weight:700" onclick="event.stopPropagation(); ackHumanAction('${escapeHtml(item.name)}', '${escapeHtml(item.namespace)}')" title="Acknowledge that the required action has been performed (clears requiresHumanAction and unblocks Close)">Ack Human Action</button>` : ''}
         </td>
       `;
       mainRow.addEventListener('click', () => togglePMExpand(id, item, mainRow));


### PR DESCRIPTION
## Symptom

User feedback against 1.122.2 dashboard:

1. "No button to close a postmortem with needs-human tag" — once a
   PostMortem is in Open/InReview with `requiresHumanAction=true`,
   the operator has no UI affordance to close it
2. "The Ack Human Action button doesn't do anything" — clicking Ack
   succeeds (annotation set, toast shown) but the visible state of
   the row doesn't change

## Root Cause

Single bug in `/api/v1/postmortems/{name}/ack-human-action`: the
handler set the acknowledgement annotation but left
`Status.RequiresHumanAction` at `true`. The dashboard buttons key off
that field, so after clicking Ack:

- Ack button still rendered (field still true)
- Close button still hidden (its condition is `state==InReview && !requiresHumanAction`)
- Operator stuck — until the next PostMortemReconciler tick (background)
  cleared the status, which is invisible UX

## Fix

### Backend (`operator/api/rest/server.go`)

`handlePostMortemAckHumanAction` now does an additional `Status().Update`
call right after persisting the annotation, clearing
`Status.RequiresHumanAction = false`. The dashboard re-render after the
toast immediately reflects the change.

`Status.RequiredAction` is intentionally preserved — it's historical
context for operators reading the CR later. The action HAS been
performed but the description of what was required stays valuable.

Conflict on the Status update returns 409 (consistent with the existing
Spec update path) so the dashboard's retry logic kicks in cleanly.

### Frontend (`operator/web/static/index.html`)

- Close button condition loosened: closes from both Open and InReview
  states (closing direct from Open is valid and the previous narrow
  gate created the dead-end UX)
- Both Review and Close buttons hide while `requiresHumanAction=true`,
  so the operator's only visible action is "Ack Human Action" —
  removes the state ambiguity
- Button title clarifies that Ack unblocks Close

## Tests

- `TestAckHumanActionEndpoint_HappyPath` extended to assert
  `Status.RequiresHumanAction` is cleared on ack AND
  `Status.RequiredAction` is preserved as historical context
- `TestPostMortemReconciler_AckClearedStatusAllowsClose` covers the
  full ack → close → reconcile flow: Closed state sticks because
  RequiresHumanAction is now false
- `TestPostMortemReconciler_StillRevertsWhenAckMissingAndStatusTrue`
  pins the original GAP-03 guardrail: a Closed PostMortem with
  RequiresHumanAction=true and no ack annotation IS still reverted to
  Open. Defense against the dashboard fix accidentally weakening the
  invariant.

## Test plan

- [x] `go test ./operator/api/rest ./operator/controllers` green
- [x] `golangci-lint --new-from-rev=origin/main` clean on both modules
- [x] Manual UX test on kind cluster: trigger a Contained issue, open
      the dashboard, click "Ack Human Action", confirm the row
      re-renders with Close button visible and Ack button hidden;
      click Close and confirm the PostMortem state goes to Closed and
      stays there across reconciler ticks