### PR TITLE
docs: equalize operator install namespace to chatcli-system

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Pipeline AIOps autônomo com 17 CRDs, 54+ ações de remediação, SLO monitorin
 ```bash
 helm install chatcli-operator \
   oci://ghcr.io/diillson/charts/chatcli-operator \
-  --namespace aiops-system \
+  --namespace chatcli-system \
   --create-namespace
 ```
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -172,7 +172,7 @@ Autonomous AIOps pipeline with 17 CRDs, 54+ remediation actions, SLO monitoring,
 ```bash
 helm install chatcli-operator \
   oci://ghcr.io/diillson/charts/chatcli-operator \
-  --namespace aiops-system \
+  --namespace chatcli-system \
   --create-namespace
 ```
 

--- a/deploy/helm/chatcli-operator/Chart.yaml
+++ b/deploy/helm/chatcli-operator/Chart.yaml
@@ -99,7 +99,7 @@ annotations:
       kind: ApprovalPolicy
       metadata:
         name: production-approval
-        namespace: aiops-system
+        namespace: chatcli-system
       spec:
         enabled: true
         defaultMode: manual

--- a/deploy/helm/chatcli-operator/README.md
+++ b/deploy/helm/chatcli-operator/README.md
@@ -38,7 +38,7 @@ A production-grade, security-hardened Kubernetes operator for **autonomous incid
 
 ```bash
 helm install chatcli-operator oci://ghcr.io/diillson/charts/chatcli-operator \
-  --namespace aiops-system --create-namespace
+  --namespace chatcli-system --create-namespace
 ```
 
 ### From Source
@@ -46,7 +46,7 @@ helm install chatcli-operator oci://ghcr.io/diillson/charts/chatcli-operator \
 ```bash
 git clone https://github.com/diillson/chatcli.git
 helm install chatcli-operator deploy/helm/chatcli-operator \
-  --namespace aiops-system --create-namespace
+  --namespace chatcli-system --create-namespace
 ```
 
 ### Verify Signature
@@ -69,7 +69,7 @@ cosign verify ghcr.io/diillson/chatcli-operator:<version> \
 
 ```bash
 helm install chatcli-operator oci://ghcr.io/diillson/charts/chatcli-operator \
-  --namespace aiops-system --create-namespace \
+  --namespace chatcli-system --create-namespace \
   --set prometheusUrl=http://prometheus-server.monitoring.svc:9090 \
   --set serviceMonitor.enabled=true
 ```
@@ -405,14 +405,14 @@ spec:
 
 ```bash
 helm upgrade chatcli-operator oci://ghcr.io/diillson/charts/chatcli-operator \
-  --namespace aiops-system \
+  --namespace chatcli-system \
   --reuse-values
 ```
 
 ## Uninstalling
 
 ```bash
-helm uninstall chatcli-operator -n aiops-system
+helm uninstall chatcli-operator -n chatcli-system
 ```
 
 > **Note:** CRDs are not removed automatically by Helm. To remove them:
@@ -560,7 +560,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: chatcli-dashboard
-  namespace: aiops-system
+  namespace: chatcli-system
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:

--- a/deploy/helm/chatcli/Chart.yaml
+++ b/deploy/helm/chatcli/Chart.yaml
@@ -97,7 +97,7 @@ annotations:
       kind: ApprovalPolicy
       metadata:
         name: production-approval
-        namespace: aiops-system
+        namespace: chatcli-system
       spec:
         enabled: true
         defaultMode: manual


### PR DESCRIPTION
## Summary

- Replaces 6 residual `aiops-system` references with `chatcli-system` (the operator code default for `POD_NAMESPACE`/SA file).
- Affected files: root `README.md` / `README_EN.md` quickstarts, operator chart README (install/upgrade/uninstall/ingress), both Chart.yaml ArtifactHub ApprovalPolicy examples.
- Pairs with [diillson/chatcli.ai@5796c4f](https://github.com/diillson/chatcli.ai/commit/5796c4f) which clarifies the two distinct Secrets (`chatcli-operator-secrets` vs `chatcli-api-keys`) across security/k8s-operator/cookbook pages.

## Motivation

Users following the docs verbatim were dropping `chatcli-operator-secrets` and `ApprovalPolicy` resources in `aiops-system` while the operator (and every other doc page) lives in `chatcli-system`. Result: silent "operator never reads my Secret" without an obvious diagnostic. This PR closes that drift.

## Test plan

- [x] `grep -rn "aiops-system"` in repo returns zero matches
- [x] CI green
- [x] ArtifactHub re-renders chart README with corrected namespace after next release-please bump (manual verify on artifacthub.io after merge → release)

No code paths touched; pure docs.