### PR TITLE
fix(agent): wrap streamed tool output to box width

### DIFF
--- a/cli/agent/ui_renderer.go
+++ b/cli/agent/ui_renderer.go
@@ -147,25 +147,96 @@ func (r *UIRenderer) StreamOutput(line string) {
 	// A borda lateral tem que ter a mesma cor do Header (ColorPurple geralmente)
 	prefix := r.Colorize("│", ColorPurple) + "  "
 
-	// Lógica de ícones (mantive a sua lógica de cores)
-	if strings.HasPrefix(line, "ERR: ") {
-		cleanLine := strings.TrimPrefix(line, "ERR: ")
-		fmt.Println(r.Colorize(prefix+"⚠️  "+cleanLine, ColorYellow))
-	} else {
-		icon := "  " // indentação padrão
-		//lower := strings.ToLower(line)
-		//
-		//if strings.Contains(lower, "sucesso") || strings.Contains(line, "✅") {
-		//	icon = " ✅ "
-		//} else if strings.Contains(lower, "erro") || strings.Contains(lower, "falha") {
-		//	icon = " ❌ "
-		//} else if strings.HasPrefix(strings.TrimSpace(line), "$") {
-		//	icon = "💲 "
-		//}
-
-		// Imprime: │  ICON Texto...
-		fmt.Println(prefix + r.Colorize(icon+line, ColorGray))
+	// Descobre a largura útil do box para quebrar linhas muito longas
+	// (ex.: `kubectl ... -o yaml` com annotations gigantes / blocos
+	// `last-applied-configuration`). Sem isso, uma linha que estoura a
+	// largura do terminal faz reflow e rasga a borda lateral/rodapé do box.
+	termWidth, err := terminalWidthForStream()
+	if err != nil || termWidth <= 0 {
+		termWidth = 80
 	}
+
+	// Cada linha emitida é: prefix("│  ") + icon + conteúdo. A largura
+	// visível total precisa caber em termWidth-2 (mesma gutter de 2 cols
+	// que o resto do renderer reserva pra scrollbar nativa de terminais).
+	emit := func(icon, text, color string) {
+		avail := termWidth - 2 - VisibleLen("│  ") - VisibleLen(icon)
+		if avail < 20 {
+			avail = 20
+		}
+		for _, seg := range wrapStreamLine(text, avail) {
+			fmt.Println(prefix + r.Colorize(icon+seg, color))
+		}
+	}
+
+	// O callback normalmente entrega uma linha por vez, mas defendemos
+	// contra blocos com \n embutido para nunca emitir uma linha sem prefixo.
+	for _, sub := range strings.Split(line, "\n") {
+		if strings.HasPrefix(sub, "ERR: ") {
+			emit("⚠️  ", strings.TrimPrefix(sub, "ERR: "), ColorYellow)
+		} else {
+			emit("  ", sub, ColorGray) // indentação padrão
+		}
+	}
+}
+
+// terminalWidthForStream retorna a largura atual do terminal (cols).
+func terminalWidthForStream() (int, error) {
+	w, _, err := term.GetSize(int(os.Stdout.Fd())) //#nosec G115 -- value bounded by domain
+	return w, err
+}
+
+// wrapStreamLine quebra UMA linha de output cru de tool na largura visível
+// informada. Diferente de wrapText, NÃO colapsa espaços em branco: a
+// indentação inicial é preservada (e repetida nas continuações) para que
+// YAML/JSON estruturado continue legível dentro do box. A quebra é por
+// runa (ANSI/wide-rune aware via lipgloss.Width), evitando cortar
+// sequências multibyte no meio.
+func wrapStreamLine(line string, width int) []string {
+	if width <= 0 || VisibleLen(line) <= width {
+		return []string{line}
+	}
+
+	trimmed := strings.TrimLeft(line, " \t")
+	indent := line[:len(line)-len(trimmed)]
+	indentW := VisibleLen(indent)
+	if indentW >= width-1 {
+		// Indentação maior que o box: desiste de preservá-la.
+		indent = ""
+		indentW = 0
+	}
+	chunkW := width - indentW
+	if chunkW < 1 {
+		chunkW = 1
+	}
+
+	var out []string
+	var cur strings.Builder
+	curW := 0
+	flush := func() {
+		out = append(out, indent+cur.String())
+		cur.Reset()
+		curW = 0
+	}
+
+	for _, rr := range trimmed {
+		rw := lipgloss.Width(string(rr))
+		if rw < 1 {
+			rw = 1
+		}
+		if curW+rw > chunkW && cur.Len() > 0 {
+			flush()
+		}
+		cur.WriteRune(rr)
+		curW += rw
+	}
+	if cur.Len() > 0 {
+		flush()
+	}
+	if len(out) == 0 {
+		out = append(out, indent)
+	}
+	return out
 }
 
 // Colorize aplica cores ANSI (exportada com C maiúsculo)

--- a/cli/agent/ui_renderer_stream_wrap_test.go
+++ b/cli/agent/ui_renderer_stream_wrap_test.go
@@ -1,0 +1,56 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestWrapStreamLineNeverExceedsWidth garante que nenhuma linha quebrada
+// ultrapassa a largura útil do box — é exatamente isso que evita o reflow
+// do terminal que rasgava a borda em outputs largos (ex.: kubectl -o yaml).
+func TestWrapStreamLineNeverExceedsWidth(t *testing.T) {
+	const width = 40
+
+	cases := []string{
+		strings.Repeat("a", 500),                       // palavra única gigante, sem espaços
+		"    annotations: " + strings.Repeat("x", 300), // YAML indentado, valor enorme
+		"short line",                                    // cabe sem quebrar
+		"",                                              // vazio
+		strings.Repeat("日", 100),                        // wide runes (2 cols cada)
+	}
+
+	for _, in := range cases {
+		for _, line := range wrapStreamLine(in, width) {
+			if w := VisibleLen(line); w > width {
+				t.Errorf("linha excedeu largura %d (got %d): %q", width, w, line)
+			}
+		}
+	}
+}
+
+// TestWrapStreamLinePreservesIndent confirma que a indentação inicial do
+// YAML é repetida nas continuações, mantendo a estrutura legível.
+func TestWrapStreamLinePreservesIndent(t *testing.T) {
+	const indent = "      "
+	in := indent + strings.Repeat("v", 200)
+
+	got := wrapStreamLine(in, 40)
+	if len(got) < 2 {
+		t.Fatalf("esperava múltiplas linhas, got %d", len(got))
+	}
+	for i, line := range got {
+		if !strings.HasPrefix(line, indent) {
+			t.Errorf("linha %d perdeu a indentação: %q", i, line)
+		}
+	}
+}
+
+// TestWrapStreamLineShortLineUnchanged garante que linhas que cabem não são
+// tocadas (sem alocação extra de continuação).
+func TestWrapStreamLineShortLineUnchanged(t *testing.T) {
+	in := "kubectl get pods"
+	got := wrapStreamLine(in, 80)
+	if len(got) != 1 || got[0] != in {
+		t.Errorf("linha curta foi alterada: %#v", got)
+	}
+}

--- a/cli/agent/ui_renderer_stream_wrap_test.go
+++ b/cli/agent/ui_renderer_stream_wrap_test.go
@@ -5,6 +5,42 @@ import (
 	"testing"
 )
 
+// TestStreamOutputWrapsAndPrefixesEveryLine exercita o caminho de streaming
+// ao vivo: toda linha emitida tem que carregar a borda lateral "│" e nenhuma
+// pode exceder a largura do terminal (fallback 80 fora de tty), garantindo
+// que o box não reflui com YAML largo.
+func TestStreamOutputWrapsAndPrefixesEveryLine(t *testing.T) {
+	r := NewUIRendererWithStyle(nil, UIStyleFull)
+
+	out := captureStdout(t, func() {
+		r.StreamOutput("kubectl get pods")                 // linha curta
+		r.StreamOutput("    annotations: " + longRun(400)) // YAML largo, indentado
+		r.StreamOutput("ERR: something failed " + longRun(300))
+		r.StreamOutput("first\nsecond") // bloco com \n embutido
+	})
+
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) == 0 {
+		t.Fatal("StreamOutput não emitiu nada")
+	}
+	for i, ln := range lines {
+		plain := stripANSI(ln)
+		if !strings.HasPrefix(plain, "│") {
+			t.Errorf("linha %d sem borda lateral: %q", i, plain)
+		}
+		if w := VisibleLen(plain); w > 80 {
+			t.Errorf("linha %d excedeu 80 cols (got %d): %q", i, w, plain)
+		}
+	}
+	// Garante que o bloco multi-linha gerou as duas linhas lógicas.
+	joined := stripANSI(out)
+	if !strings.Contains(joined, "first") || !strings.Contains(joined, "second") {
+		t.Errorf("bloco com \\n não foi dividido: %q", joined)
+	}
+}
+
+func longRun(n int) string { return strings.Repeat("x", n) }
+
 // TestWrapStreamLineNeverExceedsWidth garante que nenhuma linha quebrada
 // ultrapassa a largura útil do box — é exatamente isso que evita o reflow
 // do terminal que rasgava a borda em outputs largos (ex.: kubectl -o yaml).
@@ -14,9 +50,9 @@ func TestWrapStreamLineNeverExceedsWidth(t *testing.T) {
 	cases := []string{
 		strings.Repeat("a", 500),                       // palavra única gigante, sem espaços
 		"    annotations: " + strings.Repeat("x", 300), // YAML indentado, valor enorme
-		"short line",                                    // cabe sem quebrar
-		"",                                              // vazio
-		strings.Repeat("日", 100),                        // wide runes (2 cols cada)
+		"short line",             // cabe sem quebrar
+		"",                       // vazio
+		strings.Repeat("日", 100), // wide runes (2 cols cada)
 	}
 
 	for _, in := range cases {


### PR DESCRIPTION
## Problema

No streaming ao vivo de output de tool (modos `/coder` e `/agent`), linhas muito longas — tipicamente `kubectl get ... -o yaml` com annotations gigantes ou blocos `last-applied-configuration` — estouravam a largura do terminal. O reflow do terminal rasgava a borda lateral `│` e o rodapé `╰───` do box, "quebrando a box inteira".

A causa: `StreamOutput` imprimia cada linha crua, sem nenhum wrap. O rodapé do box (`RenderStreamBoxEnd`) usa a largura medida antes do streaming, então qualquer linha que reflui desalinha tudo.

## Fix

- `StreamOutput` agora mede a largura do terminal e quebra cada linha na largura interna útil do box (descontando borda, ícone e a gutter de 2 colunas já reservada pelo renderer).
- Novo helper `wrapStreamLine`: rune-aware (via `lipgloss.Width`, não corta UTF-8/wide-runes no meio) e preserva a indentação inicial nas continuações, mantendo YAML/JSON legível — diferente de `wrapText`, que colapsa espaços.
- Cada linha visual emitida recebe o prefixo de borda, então a borda nunca mais reflui.

Afeta os dois modos porque ambos passam pelo mesmo loop em `agent_mode.go`.

## Testes

Novo `ui_renderer_stream_wrap_test.go` cobrindo: linha gigante sem espaços, YAML indentado com valor enorme, wide-runes, e linha curta intocada. `go build ./...` e `go test ./cli/agent/` passam.