### PR TITLE
docs: fix provider count and stale default models in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <h1 align="center">ChatCLI</h1>
 <p align="center">
   <strong>Plataforma de IA unificada para terminal, servidor gRPC e Kubernetes.</strong><br>
-  <sub>13 provedores · 14 agentes autônomos · pipeline de qualidade em 7 padrões · um único binário.</sub>
+  <sub>14 provedores · 14 agentes autônomos · pipeline de qualidade em 7 padrões · um único binário.</sub>
 </p>
 
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ helm install chatcli oci://ghcr.io/diillson/charts/chatcli \
 |---|---|---|---|---|
 | **OpenAI** | gpt-5.4 | Nativo | Sim | `reasoning_effort` (o-series / gpt-5) |
 | **Anthropic (Claude)** | claude-sonnet-4-6 | Nativo | Sim | Extended thinking com cache |
-| **AWS Bedrock** | claude-sonnet-4-6 | Nativo | Sim | Thinking budget (Anthropic models) |
+| **AWS Bedrock** | claude-sonnet-4-5 | Nativo | Sim | Thinking budget (Anthropic models) |
 | **Google Gemini** | gemini-2.5-flash | Nativo | Sim | — |
 | **xAI (Grok)** | grok-4-1 | XML fallback | — | — |
 | **ZAI (Zhipu AI)** | glm-5 | Nativo | Sim | — |
@@ -272,7 +272,7 @@ helm install chatcli oci://ghcr.io/diillson/charts/chatcli \
 | **GitHub Copilot** | gpt-4o | Nativo | Sim | — |
 | **GitHub Models** | gpt-4o | Nativo | Sim | — |
 | **StackSpot AI** | StackSpotAI | — | — | — |
-| **OpenRouter** | openai/gpt-4o | Nativo | Sim | Passthrough |
+| **OpenRouter** | openai/gpt-5.2 | Nativo | Sim | Passthrough |
 | **Ollama** | (local) | XML fallback | — | Tags `<thinking>` normalizadas |
 | **OpenAI Assistants** | gpt-4o | Assistants API | — | — |
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -7,7 +7,7 @@
 <h1 align="center">ChatCLI</h1>
 <p align="center">
   <strong>Unified AI platform for terminal, gRPC server, and Kubernetes.</strong><br>
-  <sub>13 providers · 14 autonomous agents · 7-pattern quality pipeline · one binary.</sub>
+  <sub>14 providers · 14 autonomous agents · 7-pattern quality pipeline · one binary.</sub>
 </p>
 
 <div align="center">

--- a/README_EN.md
+++ b/README_EN.md
@@ -263,7 +263,7 @@ helm install chatcli oci://ghcr.io/diillson/charts/chatcli \
 |---|---|---|---|---|
 | **OpenAI** | gpt-5.4 | Native | Yes | `reasoning_effort` (o-series / gpt-5) |
 | **Anthropic (Claude)** | claude-sonnet-4-6 | Native | Yes | Extended thinking with cache |
-| **AWS Bedrock** | claude-sonnet-4-6 | Native | Yes | Thinking budget (Anthropic models) |
+| **AWS Bedrock** | claude-sonnet-4-5 | Native | Yes | Thinking budget (Anthropic models) |
 | **Google Gemini** | gemini-2.5-flash | Native | Yes | — |
 | **xAI (Grok)** | grok-4-1 | XML fallback | — | — |
 | **ZAI (Zhipu AI)** | glm-5 | Native | Yes | — |
@@ -272,7 +272,7 @@ helm install chatcli oci://ghcr.io/diillson/charts/chatcli \
 | **GitHub Copilot** | gpt-4o | Native | Yes | — |
 | **GitHub Models** | gpt-4o | Native | Yes | — |
 | **StackSpot AI** | StackSpotAI | — | — | — |
-| **OpenRouter** | openai/gpt-4o | Native | Yes | Passthrough |
+| **OpenRouter** | openai/gpt-5.2 | Native | Yes | Passthrough |
 | **Ollama** | (local) | XML fallback | — | `<thinking>` tag normalization |
 | **OpenAI Assistants** | gpt-4o | Assistants API | — | — |
 


### PR DESCRIPTION
Correções de precisão em `README.md` e `README_EN.md`, validadas contra o código.

## 1. Contagem de providers no hero

O subtítulo dizia **13 providers**, mas o corpo (linha de features e seção "Provedores suportados") já dizia **14**, e a tabela tem 14 linhas. Subtítulo alinhado para 14.

## 2. Modelos default desatualizados na tabela

Cruzado com `config/defaults.go`:

| Provider | Antes | Agora (default real) |
|---|---|---|
| OpenRouter | `openai/gpt-4o` | `openai/gpt-5.2` |
| AWS Bedrock | `claude-sonnet-4-6` | `claude-sonnet-4-5` |

## Validado e correto (sem mudança)

- **14 agentes**: confere com o registry (File, Coder, Shell, Git, Search, Planner, Reviewer, Tester, Refactor, Diagnostics, Formatter, Deps, Refiner, Verifier).
- Demais 12 modelos default da tabela batem com `config/defaults.go`.