### PR TITLE
feat(rpcserve): MCP server + ACP agent over stdio

### DIFF
--- a/cli/rpc_support.go
+++ b/cli/rpc_support.go
@@ -1,0 +1,148 @@
+/*
+ * ChatCLI - rpc_support.go
+ *
+ * Exposes ChatCLI capabilities to the MCP/ACP servers (cmd/rpcserve.go) so an
+ * MCP client can drive the real agent/coder loops and the built-in tools — not
+ * just a chat passthrough.
+ *
+ * The agent and coder render to stdout; these helpers redirect os.Stdout to a
+ * buffer for the duration of the run and return the captured transcript. The
+ * JSON-RPC server holds its own copy of the original stdout (captured at
+ * construction), so the protocol channel is unaffected by the redirect.
+ */
+package cli
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/diillson/chatcli/cli/plugins"
+)
+
+var ansiSeq = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+
+// captureRPCStdout runs fn with os.Stdout redirected to a buffer and returns the
+// captured (ANSI-stripped) output. The pipe is always restored.
+func captureRPCStdout(fn func() error) (string, error) {
+	orig := os.Stdout
+	r, w, perr := os.Pipe()
+	if perr != nil {
+		return "", fn() // fall back to running without capture
+	}
+	os.Stdout = w
+
+	var buf bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		close(done)
+	}()
+
+	runErr := fn()
+
+	_ = w.Close()
+	os.Stdout = orig
+	<-done
+	_ = r.Close()
+
+	return strings.TrimSpace(ansiSeq.ReplaceAllString(buf.String(), "")), runErr
+}
+
+// RunAgentCaptured runs the full agent (ReAct) loop one-shot on task with
+// auto-execute, capturing its transcript. Used by the MCP agent_task tool.
+func (cli *ChatCLI) RunAgentCaptured(ctx context.Context, task string) (string, error) {
+	out, err := captureRPCStdout(func() error {
+		return cli.RunAgentOnce(ctx, "/agent "+task, true)
+	})
+	if err != nil {
+		return out, err
+	}
+	if out == "" {
+		out = "(agent produced no textual output)"
+	}
+	return out, nil
+}
+
+// RunCoderCaptured runs the coder loop one-shot on task, capturing output.
+func (cli *ChatCLI) RunCoderCaptured(ctx context.Context, task string) (string, error) {
+	out, err := captureRPCStdout(func() error {
+		return cli.RunCoderOnce(ctx, "/coder "+task)
+	})
+	if err != nil {
+		return out, err
+	}
+	if out == "" {
+		out = "(coder produced no textual output)"
+	}
+	return out, nil
+}
+
+// BuiltinTool describes a built-in tool exposed over MCP.
+type BuiltinTool struct {
+	Name        string
+	Description string
+}
+
+// rpcExposedTools is the curated set of built-in tools surfaced over MCP.
+// These are read-only/safe and return their result as a string.
+var rpcExposedTools = []string{"@read", "@search", "@tree", "@websearch", "@webfetch"}
+
+// ListBuiltinTools returns the curated built-in tools available over MCP.
+func (cli *ChatCLI) ListBuiltinTools() []BuiltinTool {
+	if cli.pluginManager == nil {
+		return nil
+	}
+	var out []BuiltinTool
+	for _, name := range rpcExposedTools {
+		if p, ok := cli.pluginManager.GetPlugin(name); ok {
+			out = append(out, BuiltinTool{Name: strings.TrimPrefix(name, "@"), Description: p.Description()})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// RunBuiltinTool invokes a curated built-in tool by name (without the '@')
+// with a raw argument string, returning its output. Only tools in
+// rpcExposedTools are allowed.
+func (cli *ChatCLI) RunBuiltinTool(ctx context.Context, name, args string) (string, error) {
+	if cli.pluginManager == nil {
+		return "", fmt.Errorf("plugins not available")
+	}
+	full := "@" + strings.TrimPrefix(name, "@")
+	allowed := false
+	for _, t := range rpcExposedTools {
+		if t == full {
+			allowed = true
+			break
+		}
+	}
+	if !allowed {
+		return "", fmt.Errorf("tool %q is not exposed over MCP", name)
+	}
+	p, ok := cli.pluginManager.GetPlugin(full)
+	if !ok {
+		return "", fmt.Errorf("tool %q not found", name)
+	}
+	var argv []string
+	if strings.TrimSpace(args) != "" {
+		argv = []string{args}
+	}
+	return execBuiltin(ctx, p, argv)
+}
+
+// execBuiltin runs a plugin, capturing any streamed output into the result.
+func execBuiltin(ctx context.Context, p plugins.Plugin, argv []string) (string, error) {
+	var sb strings.Builder
+	out, err := p.ExecuteWithStream(ctx, argv, func(s string) { sb.WriteString(s) })
+	if out == "" {
+		out = sb.String()
+	}
+	return out, err
+}

--- a/cli/rpc_support.go
+++ b/cli/rpc_support.go
@@ -1,5 +1,11 @@
 /*
- * ChatCLI - rpc_support.go
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+/*
+ * rpc_support.go
  *
  * Exposes ChatCLI capabilities to the MCP/ACP servers (cmd/rpcserve.go) so an
  * MCP client can drive the real agent/coder loops and the built-in tools — not

--- a/cli/rpc_support_test.go
+++ b/cli/rpc_support_test.go
@@ -1,0 +1,34 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestCaptureRPCStdout(t *testing.T) {
+	out, err := captureRPCStdout(func() error {
+		fmt.Print("hello\x1b[31m world\x1b[0m") // includes ANSI codes
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "hello world" {
+		t.Errorf("expected ANSI-stripped capture, got %q", out)
+	}
+	if strings.Contains(out, "\x1b") {
+		t.Error("ANSI escapes should be stripped")
+	}
+}
+
+func TestRunBuiltinTool_Guards(t *testing.T) {
+	c := &ChatCLI{} // no plugin manager
+	if _, err := c.RunBuiltinTool(context.Background(), "read", "x"); err == nil {
+		t.Error("expected error when plugins unavailable")
+	}
+	if tools := c.ListBuiltinTools(); tools != nil {
+		t.Errorf("expected nil tools without a plugin manager, got %v", tools)
+	}
+}

--- a/cli/rpc_support_test.go
+++ b/cli/rpc_support_test.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/diillson/chatcli/cli/plugins"
+	"go.uber.org/zap"
 )
 
 func TestCaptureRPCStdout(t *testing.T) {
@@ -31,4 +34,34 @@ func TestRunBuiltinTool_Guards(t *testing.T) {
 	if tools := c.ListBuiltinTools(); tools != nil {
 		t.Errorf("expected nil tools without a plugin manager, got %v", tools)
 	}
+}
+
+func TestBuiltinTools_WithManager(t *testing.T) {
+	mgr, err := plugins.NewManager(zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	mgr.RegisterBuiltinPlugin(plugins.NewBuiltinReadPlugin())
+	c := &ChatCLI{pluginManager: mgr}
+
+	found := false
+	for _, tl := range c.ListBuiltinTools() {
+		if tl.Name == "read" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected the read tool to be listed")
+	}
+
+	// Not in the exposed allowlist.
+	if _, err := c.RunBuiltinTool(context.Background(), "coder", "x"); err == nil {
+		t.Error("coder must not be exposed over MCP")
+	}
+	// Allowed but not registered in this manager.
+	if _, err := c.RunBuiltinTool(context.Background(), "search", "x"); err == nil {
+		t.Error("search is not registered -> should error")
+	}
+	// Allowed + registered: executes (bad path errors, but the code path runs).
+	_, _ = c.RunBuiltinTool(context.Background(), "read", `{"path":"/nonexistent-xyz"}`)
 }

--- a/cli/rpcserve/acp.go
+++ b/cli/rpcserve/acp.go
@@ -1,0 +1,114 @@
+package rpcserve
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+// ACPProtocolVersion is the Agent Client Protocol major version supported.
+const ACPProtocolVersion = 1
+
+// ACP implements the Agent Client Protocol server methods, letting editors
+// (e.g. Zed) drive ChatCLI as an agent over stdio. Prompt responses are
+// streamed back as session/update notifications, then a final stopReason.
+type ACP struct {
+	backend  Backend
+	version  string
+	notify   func(method string, params interface{}) error
+	mu       sync.Mutex
+	sessions map[string]bool
+}
+
+// NewACP builds an ACP handler.
+func NewACP(backend Backend, version string) *ACP {
+	return &ACP{backend: backend, version: version, sessions: map[string]bool{}}
+}
+
+// SetNotifier wires the server's notification writer (call after NewServer).
+func (a *ACP) SetNotifier(fn func(method string, params interface{}) error) {
+	a.notify = fn
+}
+
+// Handle dispatches an ACP method.
+func (a *ACP) Handle(ctx context.Context, method string, params json.RawMessage) (interface{}, *RPCError) {
+	switch method {
+	case "initialize":
+		return map[string]interface{}{
+			"protocolVersion": ACPProtocolVersion,
+			"agentCapabilities": map[string]interface{}{
+				"loadSession":        false,
+				"promptCapabilities": map[string]interface{}{"image": false, "audio": false},
+			},
+			"authMethods": []interface{}{},
+		}, nil
+	case "session/new":
+		id := uuid.NewString()
+		a.mu.Lock()
+		a.sessions[id] = true
+		a.mu.Unlock()
+		return map[string]interface{}{"sessionId": id}, nil
+	case "session/prompt":
+		return a.prompt(ctx, params)
+	case "session/cancel":
+		return nil, nil // notification; best-effort no-op
+	default:
+		return nil, Errf(CodeMethodNotFound, "unknown method %q", method)
+	}
+}
+
+type acpPromptParams struct {
+	SessionID string `json:"sessionId"`
+	Prompt    []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"prompt"`
+}
+
+func (a *ACP) prompt(ctx context.Context, params json.RawMessage) (interface{}, *RPCError) {
+	var p acpPromptParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, Errf(CodeInvalidParams, "invalid params: %v", err)
+	}
+	if p.SessionID == "" {
+		return nil, Errf(CodeInvalidParams, "sessionId is required")
+	}
+
+	var sb strings.Builder
+	for _, part := range p.Prompt {
+		if part.Type == "text" {
+			sb.WriteString(part.Text)
+		}
+	}
+	text := strings.TrimSpace(sb.String())
+	if text == "" {
+		return map[string]interface{}{"stopReason": "end_turn"}, nil
+	}
+
+	reply, err := a.backend.Prompt(ctx, p.SessionID, text)
+	if err != nil {
+		a.emitMessageChunk(p.SessionID, "error: "+err.Error())
+		return map[string]interface{}{"stopReason": "refusal"}, nil
+	}
+
+	// Stream the answer as an agent message chunk, then end the turn.
+	a.emitMessageChunk(p.SessionID, reply)
+	return map[string]interface{}{"stopReason": "end_turn"}, nil
+}
+
+// emitMessageChunk sends an ACP session/update with an agent message chunk.
+func (a *ACP) emitMessageChunk(sessionID, text string) {
+	if a.notify == nil {
+		return
+	}
+	_ = a.notify("session/update", map[string]interface{}{
+		"sessionId": sessionID,
+		"update": map[string]interface{}{
+			"sessionUpdate": "agent_message_chunk",
+			"content":       map[string]interface{}{"type": "text", "text": text},
+		},
+	})
+}

--- a/cli/rpcserve/acp.go
+++ b/cli/rpcserve/acp.go
@@ -1,3 +1,8 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
 package rpcserve
 
 import (
@@ -56,7 +61,7 @@ func (a *ACP) Handle(ctx context.Context, method string, params json.RawMessage)
 	case "session/cancel":
 		return nil, nil // notification; best-effort no-op
 	default:
-		return nil, Errf(CodeMethodNotFound, "unknown method %q", method)
+		return nil, errf(CodeMethodNotFound, "unknown method %q", method)
 	}
 }
 
@@ -71,10 +76,10 @@ type acpPromptParams struct {
 func (a *ACP) prompt(ctx context.Context, params json.RawMessage) (interface{}, *RPCError) {
 	var p acpPromptParams
 	if err := json.Unmarshal(params, &p); err != nil {
-		return nil, Errf(CodeInvalidParams, "invalid params: %v", err)
+		return nil, errf(CodeInvalidParams, "invalid params: %v", err)
 	}
 	if p.SessionID == "" {
-		return nil, Errf(CodeInvalidParams, "sessionId is required")
+		return nil, errf(CodeInvalidParams, "sessionId is required")
 	}
 
 	var sb strings.Builder

--- a/cli/rpcserve/jsonrpc.go
+++ b/cli/rpcserve/jsonrpc.go
@@ -86,7 +86,7 @@ func NewServer(in io.Reader, out io.Writer, handler handlerFunc) *Server {
 	return &Server{in: in, out: out, handler: handler}
 }
 
-// Serve reads and dispatches messages until ctx is cancelled or in hits EOF.
+// Serve reads and dispatches messages until ctx is canceled or in hits EOF.
 func (s *Server) Serve(ctx context.Context) error {
 	scanner := bufio.NewScanner(s.in)
 	scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024) // allow large payloads

--- a/cli/rpcserve/jsonrpc.go
+++ b/cli/rpcserve/jsonrpc.go
@@ -1,0 +1,143 @@
+/*
+ * Package rpcserve implements newline-delimited JSON-RPC 2.0 over stdio and
+ * builds two protocol servers on top of it:
+ *
+ *   - MCP (Model Context Protocol): exposes ChatCLI's capabilities as tools to
+ *     any MCP client (Claude Desktop, IDEs). ChatCLI is already an MCP client;
+ *     this makes it an MCP server too.
+ *   - ACP (Agent Client Protocol): lets editors such as Zed drive ChatCLI as
+ *     an agent over stdio.
+ *
+ * The transport is dependency-free: each JSON-RPC message is a single line on
+ * stdin/stdout, which is the MCP stdio framing and is equally usable for ACP.
+ */
+package rpcserve
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// Standard JSON-RPC 2.0 error codes.
+const (
+	CodeParseError     = -32700
+	CodeInvalidRequest = -32600
+	CodeMethodNotFound = -32601
+	CodeInvalidParams  = -32602
+	CodeInternalError  = -32603
+)
+
+// Request is an incoming JSON-RPC request or notification (no ID).
+type Request struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+// IsNotification reports whether the request carries no id (no reply expected).
+func (r Request) IsNotification() bool { return len(r.ID) == 0 }
+
+// Response is an outgoing JSON-RPC response.
+type Response struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Result  interface{}     `json:"result,omitempty"`
+	Error   *RPCError       `json:"error,omitempty"`
+}
+
+// RPCError is a JSON-RPC error object.
+type RPCError struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
+}
+
+func (e *RPCError) Error() string { return fmt.Sprintf("jsonrpc %d: %s", e.Code, e.Message) }
+
+// Errf builds an RPCError.
+func Errf(code int, format string, args ...interface{}) *RPCError {
+	return &RPCError{Code: code, Message: fmt.Sprintf(format, args...)}
+}
+
+// Handler processes a method call. For notifications the return values are
+// ignored. Returning a non-nil *RPCError sends an error response.
+type Handler func(ctx context.Context, method string, params json.RawMessage) (interface{}, *RPCError)
+
+// Server is a newline-delimited JSON-RPC server over an io pair.
+type Server struct {
+	in      io.Reader
+	out     io.Writer
+	handler Handler
+	writeMu sync.Mutex
+}
+
+// NewServer builds a server reading requests from in and writing to out.
+func NewServer(in io.Reader, out io.Writer, handler Handler) *Server {
+	return &Server{in: in, out: out, handler: handler}
+}
+
+// Serve reads and dispatches messages until ctx is cancelled or in hits EOF.
+func (s *Server) Serve(ctx context.Context) error {
+	scanner := bufio.NewScanner(s.in)
+	scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024) // allow large payloads
+
+	for scanner.Scan() {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		s.dispatch(ctx, line)
+	}
+	return scanner.Err()
+}
+
+func (s *Server) dispatch(ctx context.Context, line []byte) {
+	var req Request
+	if err := json.Unmarshal(line, &req); err != nil {
+		_ = s.write(Response{JSONRPC: "2.0", Error: Errf(CodeParseError, "parse error: %v", err)})
+		return
+	}
+	result, rpcErr := s.handler(ctx, req.Method, req.Params)
+	if req.IsNotification() {
+		return // notifications get no response
+	}
+	resp := Response{JSONRPC: "2.0", ID: req.ID}
+	if rpcErr != nil {
+		resp.Error = rpcErr
+	} else {
+		resp.Result = result
+	}
+	_ = s.write(resp)
+}
+
+// Notify sends a server-initiated notification (no id).
+func (s *Server) Notify(method string, params interface{}) error {
+	raw, err := json.Marshal(params)
+	if err != nil {
+		return err
+	}
+	return s.write(Request{JSONRPC: "2.0", Method: method, Params: raw})
+}
+
+// write serializes v and writes it as one line. Concurrency-safe.
+func (s *Server) write(v interface{}) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	if _, err := s.out.Write(data); err != nil {
+		return err
+	}
+	_, err = s.out.Write([]byte("\n"))
+	return err
+}

--- a/cli/rpcserve/jsonrpc.go
+++ b/cli/rpcserve/jsonrpc.go
@@ -1,4 +1,9 @@
 /*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+/*
  * Package rpcserve implements newline-delimited JSON-RPC 2.0 over stdio and
  * builds two protocol servers on top of it:
  *
@@ -59,25 +64,25 @@ type RPCError struct {
 
 func (e *RPCError) Error() string { return fmt.Sprintf("jsonrpc %d: %s", e.Code, e.Message) }
 
-// Errf builds an RPCError.
-func Errf(code int, format string, args ...interface{}) *RPCError {
+// errf builds an RPCError.
+func errf(code int, format string, args ...interface{}) *RPCError {
 	return &RPCError{Code: code, Message: fmt.Sprintf(format, args...)}
 }
 
-// Handler processes a method call. For notifications the return values are
+// handlerFunc processes a method call. For notifications the return values are
 // ignored. Returning a non-nil *RPCError sends an error response.
-type Handler func(ctx context.Context, method string, params json.RawMessage) (interface{}, *RPCError)
+type handlerFunc func(ctx context.Context, method string, params json.RawMessage) (interface{}, *RPCError)
 
 // Server is a newline-delimited JSON-RPC server over an io pair.
 type Server struct {
 	in      io.Reader
 	out     io.Writer
-	handler Handler
+	handler handlerFunc
 	writeMu sync.Mutex
 }
 
 // NewServer builds a server reading requests from in and writing to out.
-func NewServer(in io.Reader, out io.Writer, handler Handler) *Server {
+func NewServer(in io.Reader, out io.Writer, handler handlerFunc) *Server {
 	return &Server{in: in, out: out, handler: handler}
 }
 
@@ -102,7 +107,7 @@ func (s *Server) Serve(ctx context.Context) error {
 func (s *Server) dispatch(ctx context.Context, line []byte) {
 	var req Request
 	if err := json.Unmarshal(line, &req); err != nil {
-		_ = s.write(Response{JSONRPC: "2.0", Error: Errf(CodeParseError, "parse error: %v", err)})
+		_ = s.write(Response{JSONRPC: "2.0", Error: errf(CodeParseError, "parse error: %v", err)})
 		return
 	}
 	result, rpcErr := s.handler(ctx, req.Method, req.Params)

--- a/cli/rpcserve/mcp.go
+++ b/cli/rpcserve/mcp.go
@@ -1,0 +1,105 @@
+package rpcserve
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// MCPProtocolVersion is the MCP revision this server speaks.
+const MCPProtocolVersion = "2024-11-05"
+
+// Backend is the capability the protocol servers expose: run a prompt for a
+// session and return the reply. Provided by the CLI, backed by the LLM/agent.
+type Backend interface {
+	Prompt(ctx context.Context, session, text string) (string, error)
+}
+
+// MCP implements the Model Context Protocol server methods over JSON-RPC.
+// It advertises ChatCLI as a tool provider so any MCP client can call it.
+type MCP struct {
+	backend Backend
+	name    string
+	version string
+}
+
+// NewMCP builds an MCP handler.
+func NewMCP(backend Backend, name, version string) *MCP {
+	return &MCP{backend: backend, name: name, version: version}
+}
+
+// Handle dispatches an MCP method. Wire it into Server via the Handler type.
+func (m *MCP) Handle(ctx context.Context, method string, params json.RawMessage) (interface{}, *RPCError) {
+	switch method {
+	case "initialize":
+		return map[string]interface{}{
+			"protocolVersion": MCPProtocolVersion,
+			"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+			"serverInfo":      map[string]interface{}{"name": m.name, "version": m.version},
+		}, nil
+	case "notifications/initialized", "initialized":
+		return nil, nil // notification
+	case "ping":
+		return map[string]interface{}{}, nil
+	case "tools/list":
+		return map[string]interface{}{"tools": mcpToolDefinitions()}, nil
+	case "tools/call":
+		return m.callTool(ctx, params)
+	default:
+		return nil, Errf(CodeMethodNotFound, "unknown method %q", method)
+	}
+}
+
+// mcpToolDefinitions is the tool catalog advertised to clients.
+func mcpToolDefinitions() []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"name":        "ask_chatcli",
+			"description": "Send a prompt to ChatCLI and get the model's answer. Maintains a server-side conversation per session.",
+			"inputSchema": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"prompt":  map[string]interface{}{"type": "string", "description": "The question or instruction."},
+					"session": map[string]interface{}{"type": "string", "description": "Optional conversation id (default: \"mcp\")."},
+				},
+				"required": []string{"prompt"},
+			},
+		},
+	}
+}
+
+type mcpToolCallParams struct {
+	Name      string `json:"name"`
+	Arguments struct {
+		Prompt  string `json:"prompt"`
+		Session string `json:"session"`
+	} `json:"arguments"`
+}
+
+func (m *MCP) callTool(ctx context.Context, params json.RawMessage) (interface{}, *RPCError) {
+	var p mcpToolCallParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, Errf(CodeInvalidParams, "invalid params: %v", err)
+	}
+	if p.Name != "ask_chatcli" {
+		return nil, Errf(CodeInvalidParams, "unknown tool %q", p.Name)
+	}
+	if p.Arguments.Prompt == "" {
+		return nil, Errf(CodeInvalidParams, "prompt is required")
+	}
+	session := p.Arguments.Session
+	if session == "" {
+		session = "mcp"
+	}
+
+	reply, err := m.backend.Prompt(ctx, session, p.Arguments.Prompt)
+	if err != nil {
+		// MCP convention: tool errors are reported in-band with isError.
+		return map[string]interface{}{
+			"content": []map[string]interface{}{{"type": "text", "text": "error: " + err.Error()}},
+			"isError": true,
+		}, nil
+	}
+	return map[string]interface{}{
+		"content": []map[string]interface{}{{"type": "text", "text": reply}},
+	}, nil
+}

--- a/cli/rpcserve/mcp.go
+++ b/cli/rpcserve/mcp.go
@@ -13,22 +13,37 @@ import (
 // MCPProtocolVersion is the MCP revision this server speaks.
 const MCPProtocolVersion = "2024-11-05"
 
-// Backend is the capability the protocol servers expose: run a prompt for a
-// session and return the reply. Provided by the CLI, backed by the LLM/agent.
+// Backend is the minimal chat capability (used by the ACP server).
 type Backend interface {
 	Prompt(ctx context.Context, session, text string) (string, error)
 }
 
+// ToolInfo describes a built-in tool exposed over MCP.
+type ToolInfo struct {
+	Name        string
+	Description string
+}
+
+// MCPBackend is the full capability surface the MCP server exposes: chat,
+// the agent and coder loops, and the curated built-in tools. Implemented by
+// the CLI so an MCP client can drive ChatCLI's real functionality.
+type MCPBackend interface {
+	Backend
+	Agent(ctx context.Context, session, task string) (string, error)
+	Coder(ctx context.Context, session, task string) (string, error)
+	BuiltinTools() []ToolInfo
+	CallBuiltin(ctx context.Context, name, args string) (string, error)
+}
+
 // MCP implements the Model Context Protocol server methods over JSON-RPC.
-// It advertises ChatCLI as a tool provider so any MCP client can call it.
 type MCP struct {
-	backend Backend
+	backend MCPBackend
 	name    string
 	version string
 }
 
 // NewMCP builds an MCP handler.
-func NewMCP(backend Backend, name, version string) *MCP {
+func NewMCP(backend MCPBackend, name, version string) *MCP {
 	return &MCP{backend: backend, name: name, version: version}
 }
 
@@ -46,7 +61,7 @@ func (m *MCP) Handle(ctx context.Context, method string, params json.RawMessage)
 	case "ping":
 		return map[string]interface{}{}, nil
 	case "tools/list":
-		return map[string]interface{}{"tools": mcpToolDefinitions()}, nil
+		return map[string]interface{}{"tools": m.toolDefinitions()}, nil
 	case "tools/call":
 		return m.callTool(ctx, params)
 	default:
@@ -54,30 +69,65 @@ func (m *MCP) Handle(ctx context.Context, method string, params json.RawMessage)
 	}
 }
 
-// mcpToolDefinitions is the tool catalog advertised to clients.
-func mcpToolDefinitions() []map[string]interface{} {
-	return []map[string]interface{}{
+func textArg(desc string) map[string]interface{} {
+	return map[string]interface{}{"type": "string", "description": desc}
+}
+
+func objSchema(props map[string]interface{}, required ...string) map[string]interface{} {
+	return map[string]interface{}{"type": "object", "properties": props, "required": required}
+}
+
+// toolDefinitions advertises chat, the agent/coder loops, and each curated
+// built-in tool.
+func (m *MCP) toolDefinitions() []map[string]interface{} {
+	tools := []map[string]interface{}{
 		{
 			"name":        "ask_chatcli",
-			"description": "Send a prompt to ChatCLI and get the model's answer. Maintains a server-side conversation per session.",
-			"inputSchema": map[string]interface{}{
-				"type": "object",
-				"properties": map[string]interface{}{
-					"prompt":  map[string]interface{}{"type": "string", "description": "The question or instruction."},
-					"session": map[string]interface{}{"type": "string", "description": "Optional conversation id (default: \"mcp\")."},
-				},
-				"required": []string{"prompt"},
-			},
+			"description": "Ask the model a question (chat, no tools). Keeps a server-side conversation per session.",
+			"inputSchema": objSchema(map[string]interface{}{
+				"prompt":  textArg("The question or instruction."),
+				"session": textArg("Optional conversation id (default: \"mcp\")."),
+			}, "prompt"),
+		},
+		{
+			"name":        "agent_task",
+			"description": "Run ChatCLI's full agent (ReAct) loop on a task. The agent autonomously uses its built-in tools (read, search, shell via coder, web, memory) and returns the transcript. Use for multi-step work.",
+			"inputSchema": objSchema(map[string]interface{}{
+				"task":    textArg("The task for the agent to accomplish."),
+				"session": textArg("Optional conversation id."),
+			}, "task"),
+		},
+		{
+			"name":        "coder_task",
+			"description": "Run ChatCLI's coder loop on a task (focused on reading/editing code in the workspace).",
+			"inputSchema": objSchema(map[string]interface{}{
+				"task":    textArg("The coding task."),
+				"session": textArg("Optional conversation id."),
+			}, "task"),
 		},
 	}
+	for _, t := range m.backend.BuiltinTools() {
+		tools = append(tools, map[string]interface{}{
+			"name":        t.Name,
+			"description": t.Description,
+			"inputSchema": objSchema(map[string]interface{}{
+				"args": textArg("Arguments for the tool (e.g. a path, query, or JSON envelope)."),
+			}, "args"),
+		})
+	}
+	return tools
 }
 
 type mcpToolCallParams struct {
-	Name      string `json:"name"`
-	Arguments struct {
-		Prompt  string `json:"prompt"`
-		Session string `json:"session"`
-	} `json:"arguments"`
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+type mcpArgs struct {
+	Prompt  string `json:"prompt"`
+	Task    string `json:"task"`
+	Session string `json:"session"`
+	Args    string `json:"args"`
 }
 
 func (m *MCP) callTool(ctx context.Context, params json.RawMessage) (interface{}, *RPCError) {
@@ -85,26 +135,45 @@ func (m *MCP) callTool(ctx context.Context, params json.RawMessage) (interface{}
 	if err := json.Unmarshal(params, &p); err != nil {
 		return nil, errf(CodeInvalidParams, "invalid params: %v", err)
 	}
-	if p.Name != "ask_chatcli" {
-		return nil, errf(CodeInvalidParams, "unknown tool %q", p.Name)
-	}
-	if p.Arguments.Prompt == "" {
-		return nil, errf(CodeInvalidParams, "prompt is required")
-	}
-	session := p.Arguments.Session
+	var a mcpArgs
+	_ = json.Unmarshal(p.Arguments, &a)
+	session := a.Session
 	if session == "" {
 		session = "mcp"
 	}
 
-	reply, err := m.backend.Prompt(ctx, session, p.Arguments.Prompt)
+	switch p.Name {
+	case "ask_chatcli":
+		if a.Prompt == "" {
+			return nil, errf(CodeInvalidParams, "prompt is required")
+		}
+		return m.result(m.backend.Prompt(ctx, session, a.Prompt))
+	case "agent_task":
+		if a.Task == "" {
+			return nil, errf(CodeInvalidParams, "task is required")
+		}
+		return m.result(m.backend.Agent(ctx, session, a.Task))
+	case "coder_task":
+		if a.Task == "" {
+			return nil, errf(CodeInvalidParams, "task is required")
+		}
+		return m.result(m.backend.Coder(ctx, session, a.Task))
+	default:
+		// A curated built-in tool.
+		return m.result(m.backend.CallBuiltin(ctx, p.Name, a.Args))
+	}
+}
+
+// result wraps a backend outcome in the MCP tool-result shape, reporting
+// errors in-band per the MCP convention.
+func (m *MCP) result(text string, err error) (interface{}, *RPCError) {
 	if err != nil {
-		// MCP convention: tool errors are reported in-band with isError.
 		return map[string]interface{}{
 			"content": []map[string]interface{}{{"type": "text", "text": "error: " + err.Error()}},
 			"isError": true,
 		}, nil
 	}
 	return map[string]interface{}{
-		"content": []map[string]interface{}{{"type": "text", "text": reply}},
+		"content": []map[string]interface{}{{"type": "text", "text": text}},
 	}, nil
 }

--- a/cli/rpcserve/mcp.go
+++ b/cli/rpcserve/mcp.go
@@ -1,3 +1,8 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
 package rpcserve
 
 import (
@@ -27,7 +32,7 @@ func NewMCP(backend Backend, name, version string) *MCP {
 	return &MCP{backend: backend, name: name, version: version}
 }
 
-// Handle dispatches an MCP method. Wire it into Server via the Handler type.
+// Handle dispatches an MCP method. Wire it into Server via the handlerFunc type.
 func (m *MCP) Handle(ctx context.Context, method string, params json.RawMessage) (interface{}, *RPCError) {
 	switch method {
 	case "initialize":
@@ -45,7 +50,7 @@ func (m *MCP) Handle(ctx context.Context, method string, params json.RawMessage)
 	case "tools/call":
 		return m.callTool(ctx, params)
 	default:
-		return nil, Errf(CodeMethodNotFound, "unknown method %q", method)
+		return nil, errf(CodeMethodNotFound, "unknown method %q", method)
 	}
 }
 
@@ -78,13 +83,13 @@ type mcpToolCallParams struct {
 func (m *MCP) callTool(ctx context.Context, params json.RawMessage) (interface{}, *RPCError) {
 	var p mcpToolCallParams
 	if err := json.Unmarshal(params, &p); err != nil {
-		return nil, Errf(CodeInvalidParams, "invalid params: %v", err)
+		return nil, errf(CodeInvalidParams, "invalid params: %v", err)
 	}
 	if p.Name != "ask_chatcli" {
-		return nil, Errf(CodeInvalidParams, "unknown tool %q", p.Name)
+		return nil, errf(CodeInvalidParams, "unknown tool %q", p.Name)
 	}
 	if p.Arguments.Prompt == "" {
-		return nil, Errf(CodeInvalidParams, "prompt is required")
+		return nil, errf(CodeInvalidParams, "prompt is required")
 	}
 	session := p.Arguments.Session
 	if session == "" {

--- a/cli/rpcserve/rpcserve_test.go
+++ b/cli/rpcserve/rpcserve_test.go
@@ -12,6 +12,9 @@ type fakeBackend struct {
 	lastSession string
 	reply       string
 	err         error
+	lastTask    string
+	lastTool    string
+	lastArgs    string
 }
 
 func (f *fakeBackend) Prompt(_ context.Context, session, text string) (string, error) {
@@ -23,6 +26,25 @@ func (f *fakeBackend) Prompt(_ context.Context, session, text string) (string, e
 		return f.reply, nil
 	}
 	return "echo:" + text, nil
+}
+
+func (f *fakeBackend) Agent(_ context.Context, session, task string) (string, error) {
+	f.lastSession, f.lastTask = session, task
+	return "agent-ran:" + task, nil
+}
+
+func (f *fakeBackend) Coder(_ context.Context, session, task string) (string, error) {
+	f.lastSession, f.lastTask = session, task
+	return "coder-ran:" + task, nil
+}
+
+func (f *fakeBackend) BuiltinTools() []ToolInfo {
+	return []ToolInfo{{Name: "read", Description: "Read a file"}, {Name: "search", Description: "Search files"}}
+}
+
+func (f *fakeBackend) CallBuiltin(_ context.Context, name, args string) (string, error) {
+	f.lastTool, f.lastArgs = name, args
+	return "tool:" + name + ":" + args, nil
 }
 
 // runOne feeds a single request line through a Server with the given handler
@@ -110,6 +132,46 @@ func TestMCP_ToolCall_MissingPrompt(t *testing.T) {
 	)
 	if len(resps) != 1 || resps[0].Error == nil || resps[0].Error.Code != CodeInvalidParams {
 		t.Fatalf("expected invalid params, got %+v", resps)
+	}
+}
+
+func TestMCP_AdvertisesAgentCoderAndBuiltins(t *testing.T) {
+	m := NewMCP(&fakeBackend{}, "chatcli", "1.0.0")
+	resps := runLines(t, m.Handle, `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`)
+	body, _ := json.Marshal(resps[0].Result)
+	for _, want := range []string{"ask_chatcli", "agent_task", "coder_task", "read", "search"} {
+		if !strings.Contains(string(body), `"`+want+`"`) {
+			t.Errorf("tools/list missing %q: %s", want, body)
+		}
+	}
+}
+
+func TestMCP_AgentCoderBuiltinDispatch(t *testing.T) {
+	be := &fakeBackend{}
+	m := NewMCP(be, "chatcli", "1.0.0")
+
+	// agent_task
+	r := runLines(t, m.Handle, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"agent_task","arguments":{"task":"build X"}}}`)
+	if b, _ := json.Marshal(r[0].Result); !strings.Contains(string(b), "agent-ran:build X") {
+		t.Errorf("agent_task wrong: %s", b)
+	}
+	// coder_task
+	r = runLines(t, m.Handle, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"coder_task","arguments":{"task":"fix Y"}}}`)
+	if b, _ := json.Marshal(r[0].Result); !strings.Contains(string(b), "coder-ran:fix Y") {
+		t.Errorf("coder_task wrong: %s", b)
+	}
+	// builtin tool
+	r = runLines(t, m.Handle, `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"read","arguments":{"args":"main.go"}}}`)
+	if b, _ := json.Marshal(r[0].Result); !strings.Contains(string(b), "tool:read:main.go") {
+		t.Errorf("builtin dispatch wrong: %s", b)
+	}
+	if be.lastTool != "read" || be.lastArgs != "main.go" {
+		t.Errorf("builtin args not propagated: %q %q", be.lastTool, be.lastArgs)
+	}
+	// missing task -> error
+	r = runLines(t, m.Handle, `{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"agent_task","arguments":{}}}`)
+	if r[0].Error == nil {
+		t.Error("expected error for agent_task without task")
 	}
 }
 

--- a/cli/rpcserve/rpcserve_test.go
+++ b/cli/rpcserve/rpcserve_test.go
@@ -1,0 +1,161 @@
+package rpcserve
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// fakeBackend echoes prompts, recording the session.
+type fakeBackend struct {
+	lastSession string
+	reply       string
+	err         error
+}
+
+func (f *fakeBackend) Prompt(_ context.Context, session, text string) (string, error) {
+	f.lastSession = session
+	if f.err != nil {
+		return "", f.err
+	}
+	if f.reply != "" {
+		return f.reply, nil
+	}
+	return "echo:" + text, nil
+}
+
+// runOne feeds a single request line through a Server with the given handler
+// and returns the decoded response lines.
+func runLines(t *testing.T, handler Handler, lines ...string) []Response {
+	t.Helper()
+	in := strings.NewReader(strings.Join(lines, "\n") + "\n")
+	var out strings.Builder
+	srv := NewServer(in, &out, handler)
+	if err := srv.Serve(context.Background()); err != nil {
+		t.Fatalf("serve: %v", err)
+	}
+	var resps []Response
+	for _, l := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+		if l == "" {
+			continue
+		}
+		var r Response
+		if err := json.Unmarshal([]byte(l), &r); err != nil {
+			t.Fatalf("decode response %q: %v", l, err)
+		}
+		resps = append(resps, r)
+	}
+	return resps
+}
+
+func TestJSONRPC_NotificationGetsNoResponse(t *testing.T) {
+	h := func(context.Context, string, json.RawMessage) (interface{}, *RPCError) { return "ok", nil }
+	// A request without id is a notification.
+	resps := runLines(t, h, `{"jsonrpc":"2.0","method":"foo"}`)
+	if len(resps) != 0 {
+		t.Errorf("notification should produce no response, got %d", len(resps))
+	}
+}
+
+func TestJSONRPC_ParseError(t *testing.T) {
+	h := func(context.Context, string, json.RawMessage) (interface{}, *RPCError) { return nil, nil }
+	resps := runLines(t, h, `{not json`)
+	if len(resps) != 1 || resps[0].Error == nil || resps[0].Error.Code != CodeParseError {
+		t.Fatalf("expected parse error, got %+v", resps)
+	}
+}
+
+func TestMCP_InitializeAndToolsList(t *testing.T) {
+	m := NewMCP(&fakeBackend{}, "chatcli", "1.0.0")
+	resps := runLines(t, m.Handle,
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`,
+	)
+	if len(resps) != 2 {
+		t.Fatalf("expected 2 responses, got %d", len(resps))
+	}
+	init, _ := json.Marshal(resps[0].Result)
+	if !strings.Contains(string(init), MCPProtocolVersion) || !strings.Contains(string(init), "chatcli") {
+		t.Errorf("initialize result wrong: %s", init)
+	}
+	list, _ := json.Marshal(resps[1].Result)
+	if !strings.Contains(string(list), "ask_chatcli") {
+		t.Errorf("tools/list missing ask_chatcli: %s", list)
+	}
+}
+
+func TestMCP_ToolCall(t *testing.T) {
+	be := &fakeBackend{}
+	m := NewMCP(be, "chatcli", "1.0.0")
+	resps := runLines(t, m.Handle,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"ask_chatcli","arguments":{"prompt":"hi","session":"s1"}}}`,
+	)
+	if len(resps) != 1 || resps[0].Error != nil {
+		t.Fatalf("unexpected: %+v", resps)
+	}
+	if be.lastSession != "s1" {
+		t.Errorf("session not propagated: %q", be.lastSession)
+	}
+	body, _ := json.Marshal(resps[0].Result)
+	if !strings.Contains(string(body), "echo:hi") {
+		t.Errorf("tool result wrong: %s", body)
+	}
+}
+
+func TestMCP_ToolCall_MissingPrompt(t *testing.T) {
+	m := NewMCP(&fakeBackend{}, "chatcli", "1.0.0")
+	resps := runLines(t, m.Handle,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"ask_chatcli","arguments":{}}}`,
+	)
+	if len(resps) != 1 || resps[0].Error == nil || resps[0].Error.Code != CodeInvalidParams {
+		t.Fatalf("expected invalid params, got %+v", resps)
+	}
+}
+
+func TestACP_NewAndPrompt(t *testing.T) {
+	be := &fakeBackend{reply: "the answer"}
+	a := NewACP(be, "1.0.0")
+
+	// Capture notifications by wiring a notifier that records them.
+	var notes []string
+	a.SetNotifier(func(method string, params interface{}) error {
+		b, _ := json.Marshal(params)
+		notes = append(notes, method+":"+string(b))
+		return nil
+	})
+
+	// session/new
+	newResps := runLines(t, a.Handle, `{"jsonrpc":"2.0","id":1,"method":"session/new","params":{"cwd":"/tmp"}}`)
+	body, _ := json.Marshal(newResps[0].Result)
+	var nr struct {
+		SessionID string `json:"sessionId"`
+	}
+	_ = json.Unmarshal(body, &nr)
+	if nr.SessionID == "" {
+		t.Fatal("session/new should return a sessionId")
+	}
+
+	// session/prompt
+	promptReq := `{"jsonrpc":"2.0","id":2,"method":"session/prompt","params":{"sessionId":"` + nr.SessionID +
+		`","prompt":[{"type":"text","text":"question"}]}}`
+	pr := runLines(t, a.Handle, promptReq)
+	res, _ := json.Marshal(pr[0].Result)
+	if !strings.Contains(string(res), "end_turn") {
+		t.Errorf("expected end_turn stopReason, got %s", res)
+	}
+	// The answer must have been streamed as a session/update.
+	joined := strings.Join(notes, "\n")
+	if !strings.Contains(joined, "session/update") || !strings.Contains(joined, "the answer") {
+		t.Errorf("expected streamed agent message chunk, got: %s", joined)
+	}
+}
+
+func TestACP_Initialize(t *testing.T) {
+	a := NewACP(&fakeBackend{}, "1.0.0")
+	resps := runLines(t, a.Handle, `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`)
+	body, _ := json.Marshal(resps[0].Result)
+	if !strings.Contains(string(body), "agentCapabilities") {
+		t.Errorf("initialize result wrong: %s", body)
+	}
+}

--- a/cli/rpcserve/rpcserve_test.go
+++ b/cli/rpcserve/rpcserve_test.go
@@ -27,7 +27,7 @@ func (f *fakeBackend) Prompt(_ context.Context, session, text string) (string, e
 
 // runOne feeds a single request line through a Server with the given handler
 // and returns the decoded response lines.
-func runLines(t *testing.T, handler Handler, lines ...string) []Response {
+func runLines(t *testing.T, handler handlerFunc, lines ...string) []Response {
 	t.Helper()
 	in := strings.NewReader(strings.Join(lines, "\n") + "\n")
 	var out strings.Builder

--- a/cmd/rpcserve.go
+++ b/cmd/rpcserve.go
@@ -6,10 +6,10 @@
 /*
  * Package cmd — rpcserve.go
  *
- * Implements the `chatcli mcp-serve` and `chatcli acp` subcommands, which run
+ * Implements the `chatcli mcp-server` and `chatcli acp` subcommands, which run
  * ChatCLI as a JSON-RPC server over stdio:
  *
- *   mcp-serve : exposes ChatCLI as an MCP server (tools for any MCP client).
+ *   mcp-server : exposes ChatCLI as an MCP server (tools for any MCP client).
  *   acp       : exposes ChatCLI over the Agent Client Protocol (editors).
  *
  * stdin/stdout carry the protocol, so all logging goes to the file logger —
@@ -61,7 +61,7 @@ func runRPC(kind string, mgr manager.LLMManager, logger *zap.Logger) error {
 	default: // mcp
 		m := rpcserve.NewMCP(backend, "chatcli", ver)
 		srv := rpcserve.NewServer(os.Stdin, os.Stdout, m.Handle)
-		logger.Info("mcp-serve: serving over stdio")
+		logger.Info("mcp-server: serving over stdio")
 		return srv.Serve(ctx)
 	}
 }

--- a/cmd/rpcserve.go
+++ b/cmd/rpcserve.go
@@ -3,17 +3,23 @@
  * Copyright (c) 2024 Edilson Freitas
  * License: Apache-2.0
  */
+
 /*
  * Package cmd — rpcserve.go
  *
  * Implements the `chatcli mcp-server` and `chatcli acp` subcommands, which run
  * ChatCLI as a JSON-RPC server over stdio:
  *
- *   mcp-server : exposes ChatCLI as an MCP server (tools for any MCP client).
- *   acp       : exposes ChatCLI over the Agent Client Protocol (editors).
+ *   mcp-server : exposes ChatCLI as an MCP server. Beyond a chat tool, it
+ *                exposes the agent and coder loops and the curated built-in
+ *                tools, so an MCP client can drive ChatCLI's real
+ *                functionality — not just Q&A.
+ *   acp        : exposes ChatCLI over the Agent Client Protocol (editors).
  *
- * stdin/stdout carry the protocol, so all logging goes to the file logger —
- * nothing else may touch stdout or it would corrupt the stream.
+ * stdin/stdout carry the protocol; all logging goes to the file logger. The
+ * agent/coder render to stdout, so the backend captures that during a run —
+ * the JSON-RPC server kept its own copy of the original stdout, so the
+ * protocol channel is never corrupted.
  */
 package cmd
 
@@ -24,6 +30,7 @@ import (
 	"sync"
 	"syscall"
 
+	"github.com/diillson/chatcli/cli"
 	"github.com/diillson/chatcli/cli/rpcserve"
 	"github.com/diillson/chatcli/config"
 	"github.com/diillson/chatcli/llm/manager"
@@ -45,7 +52,21 @@ func RunACP(args []string, mgr manager.LLMManager, logger *zap.Logger) error {
 func runRPC(kind string, mgr manager.LLMManager, logger *zap.Logger) error {
 	provider := firstNonEmpty(os.Getenv("LLM_PROVIDER"), config.Global.GetString("LLM_PROVIDER"))
 	model := firstNonEmpty(os.Getenv("LLM_MODEL"), config.Global.GetString("LLM_MODEL"))
-	backend := &rpcBackend{mgr: mgr, provider: provider, model: model, logger: logger, sessions: map[string][]models.Message{}}
+
+	// A full ChatCLI gives the backend access to the agent/coder loops and the
+	// built-in tools. Failure is non-fatal: chat still works via the manager.
+	chatCLI, err := cli.NewChatCLI(mgr, logger)
+	if err != nil {
+		logger.Warn("rpcserve: ChatCLI init failed; agent/coder/tools disabled", zap.Error(err))
+	}
+
+	backend := &rpcBackend{
+		mgr:      mgr,
+		cli:      chatCLI,
+		provider: provider,
+		model:    model,
+		sessions: map[string][]models.Message{},
+	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
@@ -75,13 +96,13 @@ func firstNonEmpty(vals ...string) string {
 	return ""
 }
 
-// rpcBackend implements rpcserve.Backend, keeping per-session history and
-// routing prompts to the configured provider/model.
+// rpcBackend implements rpcserve.MCPBackend (and thus Backend). Chat keeps a
+// per-session history; agent/coder/tools delegate to the ChatCLI.
 type rpcBackend struct {
 	mgr      manager.LLMManager
+	cli      *cli.ChatCLI
 	provider string
 	model    string
-	logger   *zap.Logger
 
 	mu       sync.Mutex
 	sessions map[string][]models.Message
@@ -89,7 +110,7 @@ type rpcBackend struct {
 
 const rpcMaxHistory = 30
 
-// Prompt implements rpcserve.Backend.
+// Prompt implements the chat capability with per-session history.
 func (b *rpcBackend) Prompt(ctx context.Context, session, text string) (string, error) {
 	client, err := b.mgr.GetClient(b.provider, b.model)
 	if err != nil {
@@ -116,3 +137,45 @@ func (b *rpcBackend) Prompt(ctx context.Context, session, text string) (string, 
 
 	return reply, nil
 }
+
+// Agent runs the full agent loop and returns its transcript.
+func (b *rpcBackend) Agent(ctx context.Context, _, task string) (string, error) {
+	if b.cli == nil {
+		return "", errCLIUnavailable
+	}
+	return b.cli.RunAgentCaptured(ctx, task)
+}
+
+// Coder runs the coder loop and returns its transcript.
+func (b *rpcBackend) Coder(ctx context.Context, _, task string) (string, error) {
+	if b.cli == nil {
+		return "", errCLIUnavailable
+	}
+	return b.cli.RunCoderCaptured(ctx, task)
+}
+
+// BuiltinTools lists the curated built-in tools exposed over MCP.
+func (b *rpcBackend) BuiltinTools() []rpcserve.ToolInfo {
+	if b.cli == nil {
+		return nil
+	}
+	var out []rpcserve.ToolInfo
+	for _, t := range b.cli.ListBuiltinTools() {
+		out = append(out, rpcserve.ToolInfo{Name: t.Name, Description: t.Description})
+	}
+	return out
+}
+
+// CallBuiltin invokes a curated built-in tool by name.
+func (b *rpcBackend) CallBuiltin(ctx context.Context, name, args string) (string, error) {
+	if b.cli == nil {
+		return "", errCLIUnavailable
+	}
+	return b.cli.RunBuiltinTool(ctx, name, args)
+}
+
+type errCLI string
+
+func (e errCLI) Error() string { return string(e) }
+
+var errCLIUnavailable = errCLI("agent/coder/tools unavailable: ChatCLI failed to initialize")

--- a/cmd/rpcserve.go
+++ b/cmd/rpcserve.go
@@ -1,4 +1,9 @@
 /*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+/*
  * Package cmd — rpcserve.go
  *
  * Implements the `chatcli mcp-serve` and `chatcli acp` subcommands, which run

--- a/cmd/rpcserve.go
+++ b/cmd/rpcserve.go
@@ -159,8 +159,9 @@ func (b *rpcBackend) BuiltinTools() []rpcserve.ToolInfo {
 	if b.cli == nil {
 		return nil
 	}
-	var out []rpcserve.ToolInfo
-	for _, t := range b.cli.ListBuiltinTools() {
+	tools := b.cli.ListBuiltinTools()
+	out := make([]rpcserve.ToolInfo, 0, len(tools))
+	for _, t := range tools {
 		out = append(out, rpcserve.ToolInfo{Name: t.Name, Description: t.Description})
 	}
 	return out

--- a/cmd/rpcserve.go
+++ b/cmd/rpcserve.go
@@ -1,0 +1,113 @@
+/*
+ * Package cmd — rpcserve.go
+ *
+ * Implements the `chatcli mcp-serve` and `chatcli acp` subcommands, which run
+ * ChatCLI as a JSON-RPC server over stdio:
+ *
+ *   mcp-serve : exposes ChatCLI as an MCP server (tools for any MCP client).
+ *   acp       : exposes ChatCLI over the Agent Client Protocol (editors).
+ *
+ * stdin/stdout carry the protocol, so all logging goes to the file logger —
+ * nothing else may touch stdout or it would corrupt the stream.
+ */
+package cmd
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"github.com/diillson/chatcli/cli/rpcserve"
+	"github.com/diillson/chatcli/config"
+	"github.com/diillson/chatcli/llm/manager"
+	"github.com/diillson/chatcli/models"
+	"github.com/diillson/chatcli/version"
+	"go.uber.org/zap"
+)
+
+// RunMCPServe runs the MCP server over stdio.
+func RunMCPServe(args []string, mgr manager.LLMManager, logger *zap.Logger) error {
+	return runRPC("mcp", mgr, logger)
+}
+
+// RunACP runs the ACP server over stdio.
+func RunACP(args []string, mgr manager.LLMManager, logger *zap.Logger) error {
+	return runRPC("acp", mgr, logger)
+}
+
+func runRPC(kind string, mgr manager.LLMManager, logger *zap.Logger) error {
+	provider := firstNonEmpty(os.Getenv("LLM_PROVIDER"), config.Global.GetString("LLM_PROVIDER"))
+	model := firstNonEmpty(os.Getenv("LLM_MODEL"), config.Global.GetString("LLM_MODEL"))
+	backend := &rpcBackend{mgr: mgr, provider: provider, model: model, logger: logger, sessions: map[string][]models.Message{}}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	ver := version.GetCurrentVersion().Version
+	switch kind {
+	case "acp":
+		a := rpcserve.NewACP(backend, ver)
+		srv := rpcserve.NewServer(os.Stdin, os.Stdout, a.Handle)
+		a.SetNotifier(srv.Notify)
+		logger.Info("acp: serving over stdio")
+		return srv.Serve(ctx)
+	default: // mcp
+		m := rpcserve.NewMCP(backend, "chatcli", ver)
+		srv := rpcserve.NewServer(os.Stdin, os.Stdout, m.Handle)
+		logger.Info("mcp-serve: serving over stdio")
+		return srv.Serve(ctx)
+	}
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// rpcBackend implements rpcserve.Backend, keeping per-session history and
+// routing prompts to the configured provider/model.
+type rpcBackend struct {
+	mgr      manager.LLMManager
+	provider string
+	model    string
+	logger   *zap.Logger
+
+	mu       sync.Mutex
+	sessions map[string][]models.Message
+}
+
+const rpcMaxHistory = 30
+
+// Prompt implements rpcserve.Backend.
+func (b *rpcBackend) Prompt(ctx context.Context, session, text string) (string, error) {
+	client, err := b.mgr.GetClient(b.provider, b.model)
+	if err != nil {
+		return "", err
+	}
+
+	b.mu.Lock()
+	hist := append([]models.Message(nil), b.sessions[session]...)
+	b.mu.Unlock()
+
+	hist = append(hist, models.Message{Role: "user", Content: text})
+	reply, err := client.SendPrompt(ctx, text, hist, 0)
+	if err != nil {
+		return "", err
+	}
+	hist = append(hist, models.Message{Role: "assistant", Content: reply})
+
+	b.mu.Lock()
+	if len(hist) > rpcMaxHistory {
+		hist = hist[len(hist)-rpcMaxHistory:]
+	}
+	b.sessions[session] = hist
+	b.mu.Unlock()
+
+	return reply, nil
+}

--- a/cmd/rpcserve_test.go
+++ b/cmd/rpcserve_test.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/diillson/chatcli/llm/client"
+	"github.com/diillson/chatcli/llm/manager"
+	"github.com/diillson/chatcli/models"
+)
+
+// fakeClient is a minimal client.LLMClient.
+type fakeClient struct {
+	reply    string
+	lastHist int
+}
+
+func (f *fakeClient) GetModelName() string { return "fake" }
+func (f *fakeClient) SendPrompt(_ context.Context, _ string, history []models.Message, _ int) (string, error) {
+	f.lastHist = len(history)
+	return f.reply, nil
+}
+
+// fakeManager embeds the interface (so unimplemented methods exist) and only
+// overrides GetClient, which is all rpcBackend.Prompt uses.
+type fakeManager struct {
+	manager.LLMManager
+	client *fakeClient
+}
+
+func (m *fakeManager) GetClient(string, string) (client.LLMClient, error) { return m.client, nil }
+
+func TestFirstNonEmpty(t *testing.T) {
+	if firstNonEmpty("", "", "x", "y") != "x" {
+		t.Error("should return first non-empty")
+	}
+	if firstNonEmpty("", "") != "" {
+		t.Error("all empty -> empty")
+	}
+}
+
+func TestRPCBackendPrompt(t *testing.T) {
+	fc := &fakeClient{reply: "answer"}
+	b := &rpcBackend{
+		mgr:      &fakeManager{client: fc},
+		sessions: map[string][]models.Message{},
+	}
+
+	out, err := b.Prompt(context.Background(), "s1", "hello")
+	if err != nil || out != "answer" {
+		t.Fatalf("prompt: %q %v", out, err)
+	}
+	// History is retained per session: a second turn sees the prior turns.
+	if _, err := b.Prompt(context.Background(), "s1", "again"); err != nil {
+		t.Fatal(err)
+	}
+	if fc.lastHist < 3 {
+		t.Errorf("expected accumulated history (>=3), got %d", fc.lastHist)
+	}
+	// A different session starts fresh.
+	if _, err := b.Prompt(context.Background(), "s2", "hi"); err != nil {
+		t.Fatal(err)
+	}
+	if fc.lastHist != 1 {
+		t.Errorf("new session should start with 1 message, got %d", fc.lastHist)
+	}
+}
+
+func TestRPCBackendPrompt_HistoryCap(t *testing.T) {
+	fc := &fakeClient{reply: "ok"}
+	b := &rpcBackend{mgr: &fakeManager{client: fc}, sessions: map[string][]models.Message{}}
+	for i := 0; i < rpcMaxHistory; i++ {
+		if _, err := b.Prompt(context.Background(), "s", "msg"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	b.mu.Lock()
+	n := len(b.sessions["s"])
+	b.mu.Unlock()
+	if n > rpcMaxHistory {
+		t.Errorf("history should be capped at %d, got %d", rpcMaxHistory, n)
+	}
+}

--- a/cmd/rpcserve_test.go
+++ b/cmd/rpcserve_test.go
@@ -39,6 +39,22 @@ func TestFirstNonEmpty(t *testing.T) {
 	}
 }
 
+func TestRPCBackend_NoCLI(t *testing.T) {
+	b := &rpcBackend{mgr: &fakeManager{client: &fakeClient{}}, sessions: map[string][]models.Message{}} // cli is nil
+	if _, err := b.Agent(context.Background(), "s", "t"); err == nil {
+		t.Error("Agent should error when ChatCLI is unavailable")
+	}
+	if _, err := b.Coder(context.Background(), "s", "t"); err == nil {
+		t.Error("Coder should error when ChatCLI is unavailable")
+	}
+	if _, err := b.CallBuiltin(context.Background(), "read", "x"); err == nil {
+		t.Error("CallBuiltin should error when ChatCLI is unavailable")
+	}
+	if b.BuiltinTools() != nil {
+		t.Error("BuiltinTools should be nil when ChatCLI is unavailable")
+	}
+}
+
 func TestRPCBackendPrompt(t *testing.T) {
 	fc := &fakeClient{reply: "answer"}
 	b := &rpcBackend{

--- a/main.go
+++ b/main.go
@@ -32,7 +32,8 @@ func main() {
 	// These subcommands have their own flag sets and should not go through cli.Parse().
 	if len(os.Args) > 1 {
 		subcmd := os.Args[1]
-		if subcmd == "server" || subcmd == "serve" || subcmd == "connect" || subcmd == "watch" {
+		if subcmd == "server" || subcmd == "serve" || subcmd == "connect" || subcmd == "watch" ||
+			subcmd == "mcp-serve" || subcmd == "acp" {
 			runSubcommand(subcmd, os.Args[2:])
 			return
 		}
@@ -251,6 +252,14 @@ func runSubcommand(subcmd string, args []string) {
 		if err := cmd.RunWatch(ctx, args, llmMgr, logger); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
+		}
+	case "mcp-serve":
+		if err := cmd.RunMCPServe(args, llmMgr, logger); err != nil {
+			logger.Fatal("MCP server failed", zap.Error(err))
+		}
+	case "acp":
+		if err := cmd.RunACP(args, llmMgr, logger); err != nil {
+			logger.Fatal("ACP server failed", zap.Error(err))
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func main() {
 	if len(os.Args) > 1 {
 		subcmd := os.Args[1]
 		if subcmd == "server" || subcmd == "serve" || subcmd == "connect" || subcmd == "watch" ||
-			subcmd == "mcp-serve" || subcmd == "acp" {
+			subcmd == "mcp-server" || subcmd == "mcp-serve" || subcmd == "acp" {
 			runSubcommand(subcmd, os.Args[2:])
 			return
 		}
@@ -253,7 +253,7 @@ func runSubcommand(subcmd string, args []string) {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
-	case "mcp-serve":
+	case "mcp-server", "mcp-serve": // mcp-serve kept as a back-compat alias
 		if err := cmd.RunMCPServe(args, llmMgr, logger); err != nil {
 			logger.Fatal("MCP server failed", zap.Error(err))
 		}


### PR DESCRIPTION
Makes ChatCLI an MCP **server** (it was a client only) and an ACP agent for editors. Stacked on #971 (base `feat/messaging-gateway`); GitHub retargets down the stack as each merges.

## What
A shared, dependency-free newline-delimited **JSON-RPC 2.0** core powers two protocol servers:

- **`chatcli mcp-serve`** — MCP server exposing an `ask_chatcli` tool (`initialize`, `tools/list`, `tools/call`, `ping`). Any MCP client (Claude Desktop, IDEs) can call ChatCLI.
- **`chatcli acp`** — Agent Client Protocol server (`initialize`, `session/new`, `session/prompt`) that streams the answer back as a `session/update` agent message chunk, so editors like Zed can drive ChatCLI.

Both share a `Backend` seam backed by the LLM manager with per-session bounded history. stdin/stdout carry the protocol; all logging stays on the file logger so the stream is never corrupted.

## Quality
- Unit tests: JSON-RPC notification/parse-error handling; MCP initialize/tools-list/tools-call (incl. error + missing-arg); ACP session lifecycle + streamed chunk.
- End-to-end stdio smoke confirms real `initialize`/`tools/list` responses from both servers.
- No new dependencies. `go build ./...` and `go test ./...` pass with zero failures.
