### PR TITLE
feat(catalog): add Claude Opus 4.8 with adaptive thinking and fast mode

### DIFF
--- a/cli/moa_command.go
+++ b/cli/moa_command.go
@@ -11,8 +11,8 @@
  * aggregator model. Provider-agnostic — any configured provider can be a
  * reference or the aggregator.
  *
- *   CHATCLI_MOA_MODELS="openai:gpt-5,claudeai:claude-opus-4-7,googleai:gemini-2.5-pro"
- *   CHATCLI_MOA_AGGREGATOR="claudeai:claude-opus-4-7"   (defaults to current model)
+ *   CHATCLI_MOA_MODELS="openai:gpt-5,claudeai:claude-opus-4-8,googleai:gemini-2.5-pro"
+ *   CHATCLI_MOA_AGGREGATOR="claudeai:claude-opus-4-8"   (defaults to current model)
  */
 package cli
 

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -209,7 +209,7 @@
   "gateway.started_detached": "Gateway started (pid=%d) on: %s. Logs: %s",
   "gateway.stopped_pid": "Gateway stopped (pid=%d).",
   "moa.usage": "Usage: /moa <prompt> (set CHATCLI_MOA_MODELS=\"provider:model,...\")",
-  "moa.no_models": "No MoA models configured. Set CHATCLI_MOA_MODELS=\"openai:gpt-5,claudeai:claude-opus-4-7\".",
+  "moa.no_models": "No MoA models configured. Set CHATCLI_MOA_MODELS=\"openai:gpt-5,claudeai:claude-opus-4-8\".",
   "moa.running": "Querying %d models in parallel, then synthesizing...",
   "session.usage_delete": "  /session delete <name>",
   "session.usage_new": "  /session new",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -209,7 +209,7 @@
   "gateway.started_detached": "Gateway started (pid=%d) on: %s. Logs: %s",
   "gateway.stopped_pid": "Gateway stopped (pid=%d).",
   "moa.usage": "Usage: /moa <prompt> (set CHATCLI_MOA_MODELS=\"provider:model,...\")",
-  "moa.no_models": "No MoA models configured. Set CHATCLI_MOA_MODELS=\"openai:gpt-5,claudeai:claude-opus-4-7\".",
+  "moa.no_models": "No MoA models configured. Set CHATCLI_MOA_MODELS=\"openai:gpt-5,claudeai:claude-opus-4-8\".",
   "moa.running": "Querying %d models in parallel, then synthesizing...",
   "session.usage_delete": "  /session delete <name>",
   "session.usage_new": "  /session new",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -209,7 +209,7 @@
   "gateway.started_detached": "Gateway iniciado (pid=%d) em: %s. Logs: %s",
   "gateway.stopped_pid": "Gateway parado (pid=%d).",
   "moa.usage": "Uso: /moa <prompt> (defina CHATCLI_MOA_MODELS=\"provider:model,...\")",
-  "moa.no_models": "Nenhum modelo MoA configurado. Defina CHATCLI_MOA_MODELS=\"openai:gpt-5,claudeai:claude-opus-4-7\".",
+  "moa.no_models": "Nenhum modelo MoA configurado. Defina CHATCLI_MOA_MODELS=\"openai:gpt-5,claudeai:claude-opus-4-8\".",
   "moa.running": "Consultando %d modelos em paralelo e sintetizando...",
   "session.usage_delete": "  /session delete <nome>",
   "session.usage_new": "  /session new",

--- a/llm/bedrock/bedrock_client.go
+++ b/llm/bedrock/bedrock_client.go
@@ -238,25 +238,7 @@ func (c *BedrockClient) sendPromptAnthropic(ctx context.Context, prompt string, 
 		reqBody["system"] = systemObj
 	}
 
-	// Skill effort hint → thinking. Opus 4.7+ (4.7, 4.8) advertise the
-	// "adaptive_thinking" capability and reject `budget_tokens` — they
-	// only accept `{type:"adaptive"}`. Older 4.x/3.7 still use the
-	// budgeted path. We use the catalog capability as the source of
-	// truth so adding adaptive-only models is a registry-only change.
-	if effort := client.EffortFromContext(ctx); effort != client.EffortUnset {
-		if catalog.HasCapability(catalog.ProviderBedrock, c.model, "adaptive_thinking") {
-			reqBody["thinking"] = map[string]interface{}{"type": "adaptive"}
-		} else if budget := client.ThinkingBudgetForEffort(effort); budget > 0 && supportsExtendedThinking(c.model) {
-			required := budget + 1024
-			if v, ok := reqBody["max_tokens"].(int); ok && v < required {
-				reqBody["max_tokens"] = required
-			}
-			reqBody["thinking"] = map[string]interface{}{
-				"type":          "enabled",
-				"budget_tokens": budget,
-			}
-		}
-	}
+	applyAnthropicThinkingForEffort(reqBody, c.model, ctx)
 
 	enforceCacheControlBudget(reqBody, anthropicMaxCacheBreakpoints)
 
@@ -387,6 +369,47 @@ func supportsExtendedThinking(model string) bool {
 		strings.Contains(m, "sonnet-4") ||
 		strings.Contains(m, "3-7-sonnet") ||
 		strings.Contains(m, "claude-3-7")
+}
+
+// applyAnthropicThinkingForEffort routes the per-turn skill effort hint
+// onto the Anthropic Messages body sent through Bedrock.
+//
+// Dispatch matches the Claude API client by design — both paths converge
+// on the same schema and same models:
+//   - effort unset → no thinking block (caller respects user intent)
+//   - model has the catalog "adaptive_thinking" capability (Opus 4.7+)
+//     → `thinking:{type:"adaptive"}`. Budgeted thinking returns 400 on
+//     these models per Anthropic's 4.8 migration guide.
+//   - otherwise, if the model supports budgeted extended thinking →
+//     `thinking:{type:"enabled", budget_tokens:N}` with max_tokens raised
+//     to budget+1024 when necessary (max_tokens must strictly exceed
+//     budget_tokens or the API rejects the request).
+//   - non-thinking model with effort set → silently no-op.
+//
+// Returns true when a thinking block was attached, false otherwise.
+// Mutates reqBody in place.
+func applyAnthropicThinkingForEffort(reqBody map[string]interface{}, model string, ctx context.Context) bool {
+	effort := client.EffortFromContext(ctx)
+	if effort == client.EffortUnset {
+		return false
+	}
+	if catalog.HasCapability(catalog.ProviderBedrock, model, "adaptive_thinking") {
+		reqBody["thinking"] = map[string]interface{}{"type": "adaptive"}
+		return true
+	}
+	budget := client.ThinkingBudgetForEffort(effort)
+	if budget <= 0 || !supportsExtendedThinking(model) {
+		return false
+	}
+	required := budget + 1024
+	if v, ok := reqBody["max_tokens"].(int); ok && v < required {
+		reqBody["max_tokens"] = required
+	}
+	reqBody["thinking"] = map[string]interface{}{
+		"type":          "enabled",
+		"budget_tokens": budget,
+	}
+	return true
 }
 
 func stringPtr(s string) *string { return &s }

--- a/llm/bedrock/bedrock_client.go
+++ b/llm/bedrock/bedrock_client.go
@@ -238,14 +238,23 @@ func (c *BedrockClient) sendPromptAnthropic(ctx context.Context, prompt string, 
 		reqBody["system"] = systemObj
 	}
 
-	if budget := client.ThinkingBudgetForEffort(client.EffortFromContext(ctx)); budget > 0 && supportsExtendedThinking(c.model) {
-		required := budget + 1024
-		if v, ok := reqBody["max_tokens"].(int); ok && v < required {
-			reqBody["max_tokens"] = required
-		}
-		reqBody["thinking"] = map[string]interface{}{
-			"type":          "enabled",
-			"budget_tokens": budget,
+	// Skill effort hint → thinking. Opus 4.7+ (4.7, 4.8) advertise the
+	// "adaptive_thinking" capability and reject `budget_tokens` — they
+	// only accept `{type:"adaptive"}`. Older 4.x/3.7 still use the
+	// budgeted path. We use the catalog capability as the source of
+	// truth so adding adaptive-only models is a registry-only change.
+	if effort := client.EffortFromContext(ctx); effort != client.EffortUnset {
+		if catalog.HasCapability(catalog.ProviderBedrock, c.model, "adaptive_thinking") {
+			reqBody["thinking"] = map[string]interface{}{"type": "adaptive"}
+		} else if budget := client.ThinkingBudgetForEffort(effort); budget > 0 && supportsExtendedThinking(c.model) {
+			required := budget + 1024
+			if v, ok := reqBody["max_tokens"].(int); ok && v < required {
+				reqBody["max_tokens"] = required
+			}
+			reqBody["thinking"] = map[string]interface{}{
+				"type":          "enabled",
+				"budget_tokens": budget,
+			}
 		}
 	}
 

--- a/llm/bedrock/dispatch_test.go
+++ b/llm/bedrock/dispatch_test.go
@@ -1,0 +1,146 @@
+/*
+ * ChatCLI - Tests for Bedrock per-turn dispatch helpers
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package bedrock
+
+import (
+	"context"
+	"testing"
+
+	"github.com/diillson/chatcli/llm/client"
+	"github.com/stretchr/testify/assert"
+)
+
+// applyAnthropicThinkingForEffort mirrors the claudeai-side dispatcher
+// against the Bedrock catalog mirrors. Both share the catalog
+// "adaptive_thinking" capability flag so adding new adaptive-only models
+// stays a registry-only change. These tests pin every branch of the
+// dispatch and the side-effect on max_tokens.
+
+func TestApplyAnthropicThinkingForEffort(t *testing.T) {
+	cases := []struct {
+		name        string
+		model       string
+		effort      client.SkillEffort
+		initialMax  int
+		wantApplied bool
+		wantThink   map[string]interface{}
+		wantMax     int
+	}{
+		{
+			name:        "unset effort emits nothing",
+			model:       "claude-opus-4-8",
+			effort:      client.EffortUnset,
+			initialMax:  4096,
+			wantApplied: false,
+			wantMax:     4096,
+		},
+		{
+			name:        "adaptive-only Bedrock model emits adaptive",
+			model:       "claude-opus-4-8",
+			effort:      client.EffortHigh,
+			initialMax:  4096,
+			wantApplied: true,
+			wantThink:   map[string]interface{}{"type": "adaptive"},
+			wantMax:     4096,
+		},
+		{
+			name:        "adaptive-only via Bedrock inference profile ID resolves through alias",
+			model:       "global.anthropic.claude-opus-4-7-20260401-v1:0",
+			effort:      client.EffortMedium,
+			initialMax:  4096,
+			wantApplied: true,
+			wantThink:   map[string]interface{}{"type": "adaptive"},
+			wantMax:     4096,
+		},
+		{
+			name:        "budgeted Bedrock model emits enabled+budget and raises max_tokens",
+			model:       "us.anthropic.claude-sonnet-4-20250514-v1:0",
+			effort:      client.EffortHigh,
+			initialMax:  4096,
+			wantApplied: true,
+			wantThink: map[string]interface{}{
+				"type":          "enabled",
+				"budget_tokens": 16384,
+			},
+			wantMax: 16384 + 1024,
+		},
+		{
+			name:        "budgeted Bedrock model with sufficient max_tokens preserves it",
+			model:       "us.anthropic.claude-sonnet-4-20250514-v1:0",
+			effort:      client.EffortMedium,
+			initialMax:  64000,
+			wantApplied: true,
+			wantThink: map[string]interface{}{
+				"type":          "enabled",
+				"budget_tokens": 4096,
+			},
+			wantMax: 64000,
+		},
+		{
+			name:        "low effort yields no budget and no thinking",
+			model:       "us.anthropic.claude-sonnet-4-20250514-v1:0",
+			effort:      client.EffortLow,
+			initialMax:  4096,
+			wantApplied: false,
+			wantMax:     4096,
+		},
+		{
+			name:        "non-thinking-capable Bedrock model is a no-op",
+			model:       "anthropic.claude-3-haiku-20240307-v1:0",
+			effort:      client.EffortHigh,
+			initialMax:  4096,
+			wantApplied: false,
+			wantMax:     4096,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reqBody := map[string]interface{}{"max_tokens": tc.initialMax}
+			ctx := context.Background()
+			if tc.effort != client.EffortUnset {
+				ctx = client.WithEffortHint(ctx, tc.effort)
+			}
+
+			applied := applyAnthropicThinkingForEffort(reqBody, tc.model, ctx)
+			assert.Equal(t, tc.wantApplied, applied, "applied flag")
+			assert.Equal(t, tc.wantMax, reqBody["max_tokens"], "max_tokens after dispatch")
+
+			if tc.wantApplied {
+				assert.Equal(t, tc.wantThink, reqBody["thinking"])
+			} else {
+				_, has := reqBody["thinking"]
+				assert.False(t, has, "thinking block must NOT be present")
+			}
+		})
+	}
+}
+
+// TestSupportsExtendedThinking_BedrockProfiles pins that the substring
+// check covers Bedrock inference-profile-prefixed IDs alongside the bare
+// Claude API IDs. supportsExtendedThinking is the second-tier gate in
+// the budgeted-thinking path, so a regression here silently disables
+// extended thinking on legacy Bedrock callers.
+func TestSupportsExtendedThinking_BedrockProfiles(t *testing.T) {
+	yes := []string{
+		"claude-opus-4-5",
+		"global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+		"us.anthropic.claude-opus-4-20250514-v1:0",
+		"eu.anthropic.claude-3-7-sonnet-20250219-v1:0",
+	}
+	for _, m := range yes {
+		assert.True(t, supportsExtendedThinking(m), "%s should be treated as thinking-capable", m)
+	}
+
+	no := []string{
+		"anthropic.claude-3-haiku-20240307-v1:0",
+		"openai.gpt-oss-120b-1:0",
+		"meta.llama3-70b-instruct-v1:0",
+	}
+	for _, m := range no {
+		assert.False(t, supportsExtendedThinking(m), "%s must NOT be treated as thinking-capable", m)
+	}
+}

--- a/llm/catalog/catalog.go
+++ b/llm/catalog/catalog.go
@@ -295,13 +295,45 @@ var registry = []ModelMeta{
 	// NOTE: Claude 4.x entries are ordered newest-first below. The Resolve()
 	// tier-2 alias match iterates the registry in order and returns on first
 	// hit. Because the 4.0 entry carries the generic alias "opus-4", which
-	// is a prefix of "opus-4-5/6/7", the newer entries MUST be iterated
-	// first so their exact aliases (e.g. "opus-4-7") win before 4.0's
+	// is a prefix of "opus-4-5/6/7/8", the newer entries MUST be iterated
+	// first so their exact aliases (e.g. "opus-4-8") win before 4.0's
 	// loose prefix match fires. Reversing this order reintroduces a latent
 	// bug where "opus-4-6" silently resolves to the 4.0 entry (20K ctx).
 	{
-		// Opus 4.7: most capable GA model; 1M context, 128K max output.
-		// Previous catalog had output at 64K — corrected to match docs.
+		// Opus 4.8 (claude-opus-4-8, May 28 2026): 1M context by default on
+		// the Claude API, 128K max output. Same API constraints as 4.7
+		// (no temperature/top_p/top_k; adaptive thinking only — extended
+		// thinking budgets return 400). New capabilities at launch:
+		//   - "adaptive_thinking": only supported thinking mode
+		//   - "fast_mode": research-preview "speed":"fast" for ~2.5x output
+		//     tokens per second at premium pricing
+		//   - "mid_conversation_system": role:"system" messages accepted
+		//     after the first user turn without breaking prompt cache
+		//   - "low_cache_minimum": 1,024-token cacheable prompt floor
+		//     (down from Opus 4.7).
+		// Capability flags are read by the claudeai client + skill-router
+		// to decide whether to emit `speed`, `thinking:{type:"adaptive"}`,
+		// or mid-conversation system blocks.
+		ID:              "claude-opus-4-8",
+		Aliases:         []string{"claude-opus-4-8", "opus-4-8"},
+		DisplayName:     "Claude opus 4.8 (1M context)",
+		Provider:        ProviderClaudeAI,
+		ContextWindow:   1000000,
+		MaxOutputTokens: 128000,
+		PreferredAPI:    APIAnthropicMessages,
+		APIVersion:      config.ClaudeAIAPIVersionDefault,
+		Capabilities: []string{
+			"json_mode", "tools",
+			"adaptive_thinking", "fast_mode",
+			"mid_conversation_system", "low_cache_minimum",
+		},
+	},
+	{
+		// Opus 4.7: 1M context, 128K max output. Same API constraints as
+		// 4.8 (adaptive thinking only; no temp/top_p/top_k). Older catalog
+		// did not flag adaptive_thinking explicitly — the claudeai client
+		// now uses the capability flag to route between budgeted thinking
+		// and the adaptive mode required by 4.7+.
 		ID:              "claude-opus-4-7",
 		Aliases:         []string{"claude-opus-4-7", "opus-4-7"},
 		DisplayName:     "Claude opus 4.7 (1M context)",
@@ -310,7 +342,7 @@ var registry = []ModelMeta{
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
 		APIVersion:      config.ClaudeAIAPIVersionDefault,
-		Capabilities:    []string{"json_mode", "tools"},
+		Capabilities:    []string{"json_mode", "tools", "adaptive_thinking"},
 	},
 	{
 		// Sonnet 4.7: NOT in the Anthropic GA matrix as of Apr 2026 (the
@@ -1095,6 +1127,25 @@ var registry = []ModelMeta{
 		PreferredAPI:    APIAnthropicMessages,
 		Capabilities:    []string{"tools", "vision", "json_mode"},
 	},
+	// Claude 4.8 (May 28 2026 — newest). Opus 4.8 = 1M / 128K per Anthropic.
+	// Same on-demand restrictions as 4.7: needs an inference profile prefix
+	// (global./us./eu./apac.) — the bare id is kept as an alias for
+	// resolution by callers that pin the foundation-model name.
+	{
+		ID:              "global.anthropic.claude-opus-4-8-20260528-v1:0",
+		Aliases:         []string{"bedrock-opus-4-8", "anthropic.claude-opus-4-8-20260528-v1:0", "claude-opus-4-8"},
+		DisplayName:     "Claude Opus 4.8 (Bedrock, global, 1M ctx)",
+		Provider:        ProviderBedrock,
+		ContextWindow:   1000000,
+		MaxOutputTokens: 128000,
+		PreferredAPI:    APIAnthropicMessages,
+		Capabilities: []string{
+			"tools", "vision", "json_mode",
+			"adaptive_thinking", "fast_mode",
+			"mid_conversation_system", "low_cache_minimum",
+		},
+	},
+
 	// Claude 4.7. Sonnet 4.7 mirrors 4.6's profile (forward-projected),
 	// Opus 4.7 = 1M / 128K per Anthropic.
 	{
@@ -1115,7 +1166,7 @@ var registry = []ModelMeta{
 		ContextWindow:   1000000,
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode"},
+		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking"},
 	},
 	{
 		ID:              "global.anthropic.claude-haiku-4-5-20251001-v1:0",

--- a/llm/catalog/catalog_test.go
+++ b/llm/catalog/catalog_test.go
@@ -31,6 +31,8 @@ func TestResolve(t *testing.T) {
 		{"Claude Opus 4.6 shortcut", ProviderClaudeAI, "opus-4-6", "claude-opus-4-6", true},
 		{"Claude Opus 4.7 shortcut", ProviderClaudeAI, "opus-4-7", "claude-opus-4-7", true},
 		{"Claude Opus 4.7 full ID", ProviderClaudeAI, "claude-opus-4-7", "claude-opus-4-7", true},
+		{"Claude Opus 4.8 shortcut", ProviderClaudeAI, "opus-4-8", "claude-opus-4-8", true},
+		{"Claude Opus 4.8 full ID", ProviderClaudeAI, "claude-opus-4-8", "claude-opus-4-8", true},
 		{"Claude Sonnet 4.7 shortcut", ProviderClaudeAI, "sonnet-4-7", "claude-sonnet-4-7", true},
 		// Backward compat: bare "opus-4" still resolves to the 4.0 entry
 		{"Claude Opus 4 bare alias", ProviderClaudeAI, "opus-4", "claude-opus-4-20250514", true},
@@ -124,6 +126,42 @@ func TestGetPreferredAPI(t *testing.T) {
 	assert.Equal(t, APIAnthropicMessages, GetPreferredAPI(ProviderClaudeAI, "claude-3-opus"))
 	assert.Equal(t, APIAssistants, GetPreferredAPI(ProviderOpenAIAssistant, "gpt-4o")) // Provider específico
 	assert.Equal(t, PreferredAPI("gemini_api"), GetPreferredAPI(ProviderGoogleAI, "gemini-2.5-pro"))
+}
+
+// TestClaudeOpus48Specs pins the May 28 2026 launch specs and the new
+// capability flags the client uses to drive feature dispatch:
+//   - adaptive_thinking → `thinking:{type:"adaptive"}` (no budget_tokens)
+//   - fast_mode → `speed:"fast"` research preview
+//   - mid_conversation_system → role:"system" allowed mid-conversation
+//   - low_cache_minimum → 1,024-token cache floor
+//
+// Drift in these advertised capabilities is a request-shape change that
+// the client cares about, so we pin them here.
+func TestClaudeOpus48Specs(t *testing.T) {
+	meta, ok := Resolve(ProviderClaudeAI, "claude-opus-4-8")
+	assert.True(t, ok, "claude-opus-4-8 must resolve on ProviderClaudeAI")
+	assert.Equal(t, 1000000, meta.ContextWindow, "Opus 4.8 default context window is 1M tokens")
+	assert.Equal(t, 128000, meta.MaxOutputTokens, "Opus 4.8 max output is 128K")
+	assert.Equal(t, APIAnthropicMessages, meta.PreferredAPI)
+
+	for _, capability := range []string{
+		"tools", "adaptive_thinking", "fast_mode",
+		"mid_conversation_system", "low_cache_minimum",
+	} {
+		assert.True(t,
+			HasCapability(ProviderClaudeAI, "claude-opus-4-8", capability),
+			"claude-opus-4-8 should advertise %q capability", capability)
+	}
+
+	// Bedrock mirror — inference-profile-prefixed id.
+	bedMeta, ok := Resolve(ProviderBedrock, "claude-opus-4-8")
+	assert.True(t, ok, "claude-opus-4-8 must resolve via Bedrock alias")
+	assert.Equal(t, "global.anthropic.claude-opus-4-8-20260528-v1:0", bedMeta.ID)
+	assert.Equal(t, 1000000, bedMeta.ContextWindow)
+	assert.Equal(t, 128000, bedMeta.MaxOutputTokens)
+	assert.True(t,
+		HasCapability(ProviderBedrock, "claude-opus-4-8", "adaptive_thinking"),
+		"Bedrock Opus 4.8 mirror should advertise adaptive_thinking")
 }
 
 // TestGPT55LimitsAndCapabilities pins the published Apr 23 2026 specs:

--- a/llm/claudeai/claude_client.go
+++ b/llm/claudeai/claude_client.go
@@ -163,6 +163,64 @@ func supportsExtendedThinking(model string) bool {
 		strings.Contains(m, "3.7-sonnet")
 }
 
+// usesAdaptiveThinkingOnly reports whether the model rejects budgeted
+// extended thinking. Opus 4.7 and 4.8 advertise the "adaptive_thinking"
+// capability in the catalog: passing `thinking:{type:"enabled",
+// budget_tokens:N}` to those returns a 400, only `thinking:{type:"adaptive"}`
+// is accepted. The capability flag is the source of truth so adding new
+// models that share this constraint is a registry-only change.
+func usesAdaptiveThinkingOnly(model string) bool {
+	return catalog.HasCapability(catalog.ProviderClaudeAI, model, "adaptive_thinking")
+}
+
+// applyThinkingForEffort mutates reqBody to attach the right `thinking`
+// block (and raise max_tokens when needed) for the per-turn effort hint.
+// Routing:
+//   - adaptive-only model + non-zero effort → thinking:{type:"adaptive"}
+//   - extended-thinking model + non-zero effort → thinking:{enabled,budget}
+//   - otherwise → no thinking block
+//
+// Returns true when a thinking block was attached.
+func applyThinkingForEffort(reqBody map[string]interface{}, model string, ctx context.Context) bool {
+	effort := client.EffortFromContext(ctx)
+	if effort == client.EffortUnset {
+		return false
+	}
+	if usesAdaptiveThinkingOnly(model) {
+		reqBody["thinking"] = map[string]interface{}{"type": "adaptive"}
+		return true
+	}
+	if budget := client.ThinkingBudgetForEffort(effort); budget > 0 && supportsExtendedThinking(model) {
+		required := budget + 1024
+		if v, ok := reqBody["max_tokens"].(int); ok && v < required {
+			reqBody["max_tokens"] = required
+		}
+		reqBody["thinking"] = map[string]interface{}{
+			"type":          "enabled",
+			"budget_tokens": budget,
+		}
+		return true
+	}
+	return false
+}
+
+// applyFastModeIfRequested attaches `speed: "fast"` for models that
+// advertise the fast_mode capability (currently Opus 4.8 only — research
+// preview). Opt-in via ANTHROPIC_SPEED=fast; otherwise the request goes
+// through standard mode at standard pricing. Silently ignored for models
+// that don't advertise the capability.
+func applyFastModeIfRequested(reqBody map[string]interface{}, model string) bool {
+	speed := strings.ToLower(strings.TrimSpace(os.Getenv("ANTHROPIC_SPEED")))
+	if speed != "fast" {
+		return false
+	}
+	if !catalog.HasCapability(catalog.ProviderClaudeAI, model, "fast_mode") {
+		return false
+	}
+	reqBody["speed"] = "fast"
+	return true
+}
+
 // SendPrompt com exponential backoff usando utils.Retry
 func (c *ClaudeClient) SendPrompt(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {
 	effectiveMaxTokens := maxTokens
@@ -192,21 +250,18 @@ func (c *ClaudeClient) SendPrompt(ctx context.Context, prompt string, history []
 		reqBody["stream"] = true
 	}
 
-	// Skill effort hint → extended thinking.
-	// Only enabled for models that actually support it, otherwise the API
-	// rejects the request. max_tokens must be strictly greater than
-	// budget_tokens, so we raise it when necessary.
-	if budget := client.ThinkingBudgetForEffort(client.EffortFromContext(ctx)); budget > 0 && supportsExtendedThinking(c.model) {
-		required := budget + 1024
-		if v, ok := reqBody["max_tokens"].(int); ok && v < required {
-			reqBody["max_tokens"] = required
-		}
-		reqBody["thinking"] = map[string]interface{}{
-			"type":          "enabled",
-			"budget_tokens": budget,
-		}
-		c.logger.Debug("claudeai: enabling extended thinking from skill effort hint",
-			zap.Int("budget_tokens", budget),
+	// Skill effort hint → thinking. Opus 4.7+ only accepts adaptive
+	// thinking; older 4.x and Sonnet 3.7 accept budgeted extended
+	// thinking. applyThinkingForEffort routes by catalog capability.
+	if applyThinkingForEffort(reqBody, c.model, ctx) {
+		c.logger.Debug("claudeai: thinking enabled from skill effort hint",
+			zap.Any("thinking", reqBody["thinking"]),
+			zap.String("model", c.model))
+	}
+
+	// Opus 4.8 fast mode opt-in (research preview, premium pricing).
+	if applyFastModeIfRequested(reqBody, c.model) {
+		c.logger.Debug("claudeai: fast mode enabled (ANTHROPIC_SPEED=fast)",
 			zap.String("model", c.model))
 	}
 

--- a/llm/claudeai/dispatch_test.go
+++ b/llm/claudeai/dispatch_test.go
@@ -1,0 +1,172 @@
+/*
+ * ChatCLI - Tests for per-turn dispatch helpers
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package claudeai
+
+import (
+	"context"
+	"testing"
+
+	"github.com/diillson/chatcli/llm/client"
+	"github.com/stretchr/testify/assert"
+)
+
+// usesAdaptiveThinkingOnly and applyThinkingForEffort drive the per-turn
+// thinking dispatch on every Anthropic call. The capability lookup is the
+// production source of truth for which models accept budgeted thinking vs
+// adaptive thinking — a silent registry drift here would either trip a
+// 400 from the API (sending budget_tokens to Opus 4.7+) or silently
+// disable thinking on the older 4.x line. These tests pin both branches
+// and the no-op branches.
+
+func TestUsesAdaptiveThinkingOnly(t *testing.T) {
+	// Opus 4.7 and 4.8 advertise adaptive_thinking in the catalog
+	// (capability flag, see llm/catalog/catalog.go).
+	for _, model := range []string{"claude-opus-4-8", "claude-opus-4-7"} {
+		assert.True(t, usesAdaptiveThinkingOnly(model),
+			"%s must route through adaptive thinking — budget_tokens is rejected with 400", model)
+	}
+	// Older 4.x and 3.x do NOT advertise the capability — they accept
+	// budgeted extended thinking via the legacy path.
+	for _, model := range []string{
+		"claude-opus-4-5", "claude-opus-4-1-20250805",
+		"claude-sonnet-4-5", "claude-sonnet-3-7-20250219",
+	} {
+		assert.False(t, usesAdaptiveThinkingOnly(model),
+			"%s must keep using budgeted extended thinking", model)
+	}
+}
+
+func TestApplyThinkingForEffort(t *testing.T) {
+	cases := []struct {
+		name        string
+		model       string
+		effort      client.SkillEffort
+		initialMax  int
+		wantApplied bool
+		wantThink   map[string]interface{}
+		wantMax     int // expected max_tokens after dispatch
+	}{
+		{
+			name:        "unset effort emits nothing",
+			model:       "claude-opus-4-8",
+			effort:      client.EffortUnset,
+			initialMax:  4096,
+			wantApplied: false,
+			wantMax:     4096,
+		},
+		{
+			name:        "adaptive-only model emits adaptive thinking",
+			model:       "claude-opus-4-8",
+			effort:      client.EffortHigh,
+			initialMax:  4096,
+			wantApplied: true,
+			wantThink:   map[string]interface{}{"type": "adaptive"},
+			wantMax:     4096, // adaptive must NOT raise max_tokens (no budget)
+		},
+		{
+			name:        "adaptive-only model with low effort still emits adaptive",
+			model:       "claude-opus-4-7",
+			effort:      client.EffortLow,
+			initialMax:  4096,
+			wantApplied: true,
+			wantThink:   map[string]interface{}{"type": "adaptive"},
+			wantMax:     4096,
+		},
+		{
+			name:        "budgeted model with high effort emits enabled+budget and raises max_tokens",
+			model:       "claude-sonnet-4-5",
+			effort:      client.EffortHigh,
+			initialMax:  4096,
+			wantApplied: true,
+			wantThink: map[string]interface{}{
+				"type":          "enabled",
+				"budget_tokens": 16384,
+			},
+			wantMax: 16384 + 1024, // budget+1024 floor
+		},
+		{
+			name:        "budgeted model already with sufficient max_tokens preserves it",
+			model:       "claude-sonnet-4-5",
+			effort:      client.EffortMedium,
+			initialMax:  64000,
+			wantApplied: true,
+			wantThink: map[string]interface{}{
+				"type":          "enabled",
+				"budget_tokens": 4096,
+			},
+			wantMax: 64000, // already > 4096+1024, do not lower
+		},
+		{
+			name:        "low effort yields no budget and no thinking on budgeted models",
+			model:       "claude-sonnet-4-5",
+			effort:      client.EffortLow,
+			initialMax:  4096,
+			wantApplied: false,
+			wantMax:     4096,
+		},
+		{
+			name:        "unknown model with effort is a no-op",
+			model:       "claude-haiku-3-5-20241022",
+			effort:      client.EffortHigh,
+			initialMax:  4096,
+			wantApplied: false,
+			wantMax:     4096,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reqBody := map[string]interface{}{"max_tokens": tc.initialMax}
+			ctx := context.Background()
+			if tc.effort != client.EffortUnset {
+				ctx = client.WithEffortHint(ctx, tc.effort)
+			}
+
+			applied := applyThinkingForEffort(reqBody, tc.model, ctx)
+			assert.Equal(t, tc.wantApplied, applied, "applied flag")
+			assert.Equal(t, tc.wantMax, reqBody["max_tokens"], "max_tokens after dispatch")
+
+			if tc.wantApplied {
+				assert.Equal(t, tc.wantThink, reqBody["thinking"])
+			} else {
+				_, has := reqBody["thinking"]
+				assert.False(t, has, "thinking block must NOT be present")
+			}
+		})
+	}
+}
+
+func TestApplyFastModeIfRequested(t *testing.T) {
+	cases := []struct {
+		name      string
+		model     string
+		envValue  string
+		wantApply bool
+	}{
+		{"env unset is no-op", "claude-opus-4-8", "", false},
+		{"env=fast on fast_mode model applies", "claude-opus-4-8", "fast", true},
+		{"env=FAST is case-insensitive", "claude-opus-4-8", "FAST", true},
+		{"env=fast with surrounding space still applies", "claude-opus-4-8", "  fast  ", true},
+		{"env=fast on non-fast_mode model is silent no-op", "claude-opus-4-7", "fast", false},
+		{"env=fast on older model is silent no-op", "claude-opus-4-5", "fast", false},
+		{"env=anything-else is no-op", "claude-opus-4-8", "turbo", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("ANTHROPIC_SPEED", tc.envValue)
+			reqBody := map[string]interface{}{}
+			applied := applyFastModeIfRequested(reqBody, tc.model)
+			assert.Equal(t, tc.wantApply, applied)
+			if tc.wantApply {
+				assert.Equal(t, "fast", reqBody["speed"])
+			} else {
+				_, has := reqBody["speed"]
+				assert.False(t, has, "speed must NOT leak onto the payload")
+			}
+		})
+	}
+}

--- a/llm/claudeai/tool_use.go
+++ b/llm/claudeai/tool_use.go
@@ -84,17 +84,12 @@ func (c *ClaudeClient) SendPromptWithTools(ctx context.Context, prompt string, h
 		reqBody["tools"] = toolDefs
 	}
 
-	// Skill effort hint → extended thinking (tool-use path).
-	if budget := client.ThinkingBudgetForEffort(client.EffortFromContext(ctx)); budget > 0 && supportsExtendedThinking(c.model) {
-		required := budget + 1024
-		if v, ok := reqBody["max_tokens"].(int); ok && v < required {
-			reqBody["max_tokens"] = required
-		}
-		reqBody["thinking"] = map[string]interface{}{
-			"type":          "enabled",
-			"budget_tokens": budget,
-		}
-	}
+	// Skill effort hint → thinking (tool-use path). Opus 4.7+ uses adaptive,
+	// older models use budgeted extended thinking — see applyThinkingForEffort.
+	applyThinkingForEffort(reqBody, c.model, ctx)
+
+	// Opus 4.8 fast mode opt-in via ANTHROPIC_SPEED=fast.
+	applyFastModeIfRequested(reqBody, c.model)
 
 	enforceCacheControlBudget(reqBody, anthropicMaxCacheBreakpoints)
 

--- a/llm/client/usage_state.go
+++ b/llm/client/usage_state.go
@@ -6,6 +6,7 @@
 package client
 
 import (
+	"encoding/json"
 	"sync"
 
 	"github.com/diillson/chatcli/models"
@@ -111,46 +112,69 @@ func ParseOpenAIUsage(result map[string]interface{}) *models.UsageInfo {
 	return info
 }
 
-// ParseOpenAIResponsesUsage extracts usage info from an OpenAI Responses
-// API response map. The Responses schema uses `input_tokens` /
-// `output_tokens` instead of `prompt_tokens` / `completion_tokens`, and
-// the nested detail objects are renamed accordingly. Calling
-// ParseOpenAIUsage on a Responses payload silently returns zeros — this
-// is the parser to use on /v1/responses bodies and the
-// `response.completed` streaming event.
-func ParseOpenAIResponsesUsage(result map[string]interface{}) *models.UsageInfo {
-	usage, ok := result["usage"].(map[string]interface{})
-	if !ok {
-		return nil
-	}
+// openAIResponsesPayload mirrors the subset of OpenAI Responses API payload
+// fields the usage parser cares about. Keeping the shape typed (instead of
+// walking a generic map) eliminates runtime type assertions on every
+// field, narrows the public API surface (no `interface{}` leaking into
+// callers), and gives the JSON decoder a single error-reporting path.
+type openAIResponsesPayload struct {
+	Usage *struct {
+		InputTokens         int `json:"input_tokens"`
+		OutputTokens        int `json:"output_tokens"`
+		TotalTokens         int `json:"total_tokens"`
+		InputTokensDetails  *struct {
+			CachedTokens int `json:"cached_tokens"`
+		} `json:"input_tokens_details"`
+		OutputTokensDetails *struct {
+			ReasoningTokens int `json:"reasoning_tokens"`
+		} `json:"output_tokens_details"`
+	} `json:"usage"`
+}
 
-	info := &models.UsageInfo{IsReal: true}
-
-	if it, ok := usage["input_tokens"].(float64); ok {
-		info.PromptTokens = int(it)
+// ParseOpenAIResponsesUsage extracts usage info from a raw OpenAI Responses
+// API payload (the full /v1/responses body, or the `response` field of a
+// `response.completed` SSE event). The Responses schema uses
+// `input_tokens` / `output_tokens` instead of `prompt_tokens` /
+// `completion_tokens`, and the nested detail objects are renamed
+// accordingly — calling ParseOpenAIUsage on a Responses payload silently
+// returns zeros, so this is the parser to use here.
+//
+// Returns:
+//   - (nil, nil)  if the payload has no `usage` block (e.g. an
+//     incremental streaming event that isn't `response.completed`);
+//   - (nil, err)  if the bytes do not parse as JSON;
+//   - (info, nil) on success.
+//
+// Callers typically pass json.RawMessage from the SSE decoder or the raw
+// response body — no intermediate map[string]interface{} is needed.
+func ParseOpenAIResponsesUsage(data []byte) (*models.UsageInfo, error) {
+	if len(data) == 0 {
+		return nil, nil
 	}
-	if ot, ok := usage["output_tokens"].(float64); ok {
-		info.CompletionTokens = int(ot)
+	var payload openAIResponsesPayload
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return nil, err
 	}
-	if tt, ok := usage["total_tokens"].(float64); ok {
-		info.TotalTokens = int(tt)
+	if payload.Usage == nil {
+		return nil, nil
 	}
-	if details, ok := usage["input_tokens_details"].(map[string]interface{}); ok {
-		if cached, ok := details["cached_tokens"].(float64); ok {
-			info.CacheReadInputTokens = int(cached)
-		}
+	u := payload.Usage
+	info := &models.UsageInfo{
+		IsReal:           true,
+		PromptTokens:     u.InputTokens,
+		CompletionTokens: u.OutputTokens,
+		TotalTokens:      u.TotalTokens,
 	}
-	if details, ok := usage["output_tokens_details"].(map[string]interface{}); ok {
-		if reasoning, ok := details["reasoning_tokens"].(float64); ok {
-			info.ReasoningTokens = int(reasoning)
-		}
+	if u.InputTokensDetails != nil {
+		info.CacheReadInputTokens = u.InputTokensDetails.CachedTokens
 	}
-
+	if u.OutputTokensDetails != nil {
+		info.ReasoningTokens = u.OutputTokensDetails.ReasoningTokens
+	}
 	if info.TotalTokens == 0 && (info.PromptTokens > 0 || info.CompletionTokens > 0) {
 		info.TotalTokens = info.PromptTokens + info.CompletionTokens
 	}
-
-	return info
+	return info, nil
 }
 
 // ParseAnthropicUsage extracts usage info from an Anthropic response map.

--- a/llm/client/usage_state.go
+++ b/llm/client/usage_state.go
@@ -62,8 +62,19 @@ func (s *UsageState) LastStopReason() string {
 	return s.lastStop
 }
 
-// ParseOpenAIUsage extracts usage info from an OpenAI-compatible response map.
-// Works for OpenAI, XAI, Copilot, GitHub Models, OpenRouter, ZAI, MiniMax.
+// ParseOpenAIUsage extracts usage info from an OpenAI-compatible Chat
+// Completions response map. Works for OpenAI, XAI, Copilot, GitHub Models,
+// OpenRouter, ZAI, MiniMax — anything that mirrors the
+// `prompt_tokens` / `completion_tokens` / `total_tokens` schema.
+//
+// Also surfaces:
+//   - `prompt_tokens_details.cached_tokens` → CacheReadInputTokens
+//     (automatic prompt cache hit count; OpenAI semantics map to
+//     Anthropic's cache-read field — both are "input tokens served at a
+//     discount because the prefix matched")
+//   - `completion_tokens_details.reasoning_tokens` → ReasoningTokens
+//     (o-series / GPT-5; already counted inside completion_tokens, this
+//     is informational)
 func ParseOpenAIUsage(result map[string]interface{}) *models.UsageInfo {
 	usage, ok := result["usage"].(map[string]interface{})
 	if !ok {
@@ -81,8 +92,60 @@ func ParseOpenAIUsage(result map[string]interface{}) *models.UsageInfo {
 	if tt, ok := usage["total_tokens"].(float64); ok {
 		info.TotalTokens = int(tt)
 	}
+	if details, ok := usage["prompt_tokens_details"].(map[string]interface{}); ok {
+		if cached, ok := details["cached_tokens"].(float64); ok {
+			info.CacheReadInputTokens = int(cached)
+		}
+	}
+	if details, ok := usage["completion_tokens_details"].(map[string]interface{}); ok {
+		if reasoning, ok := details["reasoning_tokens"].(float64); ok {
+			info.ReasoningTokens = int(reasoning)
+		}
+	}
 
 	// Compute total if not provided
+	if info.TotalTokens == 0 && (info.PromptTokens > 0 || info.CompletionTokens > 0) {
+		info.TotalTokens = info.PromptTokens + info.CompletionTokens
+	}
+
+	return info
+}
+
+// ParseOpenAIResponsesUsage extracts usage info from an OpenAI Responses
+// API response map. The Responses schema uses `input_tokens` /
+// `output_tokens` instead of `prompt_tokens` / `completion_tokens`, and
+// the nested detail objects are renamed accordingly. Calling
+// ParseOpenAIUsage on a Responses payload silently returns zeros — this
+// is the parser to use on /v1/responses bodies and the
+// `response.completed` streaming event.
+func ParseOpenAIResponsesUsage(result map[string]interface{}) *models.UsageInfo {
+	usage, ok := result["usage"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	info := &models.UsageInfo{IsReal: true}
+
+	if it, ok := usage["input_tokens"].(float64); ok {
+		info.PromptTokens = int(it)
+	}
+	if ot, ok := usage["output_tokens"].(float64); ok {
+		info.CompletionTokens = int(ot)
+	}
+	if tt, ok := usage["total_tokens"].(float64); ok {
+		info.TotalTokens = int(tt)
+	}
+	if details, ok := usage["input_tokens_details"].(map[string]interface{}); ok {
+		if cached, ok := details["cached_tokens"].(float64); ok {
+			info.CacheReadInputTokens = int(cached)
+		}
+	}
+	if details, ok := usage["output_tokens_details"].(map[string]interface{}); ok {
+		if reasoning, ok := details["reasoning_tokens"].(float64); ok {
+			info.ReasoningTokens = int(reasoning)
+		}
+	}
+
 	if info.TotalTokens == 0 && (info.PromptTokens > 0 || info.CompletionTokens > 0) {
 		info.TotalTokens = info.PromptTokens + info.CompletionTokens
 	}

--- a/llm/client/usage_state.go
+++ b/llm/client/usage_state.go
@@ -119,10 +119,10 @@ func ParseOpenAIUsage(result map[string]interface{}) *models.UsageInfo {
 // callers), and gives the JSON decoder a single error-reporting path.
 type openAIResponsesPayload struct {
 	Usage *struct {
-		InputTokens         int `json:"input_tokens"`
-		OutputTokens        int `json:"output_tokens"`
-		TotalTokens         int `json:"total_tokens"`
-		InputTokensDetails  *struct {
+		InputTokens        int `json:"input_tokens"`
+		OutputTokens       int `json:"output_tokens"`
+		TotalTokens        int `json:"total_tokens"`
+		InputTokensDetails *struct {
 			CachedTokens int `json:"cached_tokens"`
 		} `json:"input_tokens_details"`
 		OutputTokensDetails *struct {

--- a/llm/client/usage_state_test.go
+++ b/llm/client/usage_state_test.go
@@ -1,0 +1,144 @@
+/*
+ * ChatCLI - Tests for usage parsing
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package client
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Chat Completions and the Responses API ship different field names for
+// the same concept (prompt_tokens vs input_tokens). Both parsers normalize
+// to the same UsageInfo, so the chat envelope's formatTokenSummary can
+// stay provider-agnostic. These tests pin each schema independently so a
+// silent rename upstream surfaces here instead of as a "no tokens"
+// placeholder in the UI.
+
+func TestParseOpenAIUsage_ChatCompletions(t *testing.T) {
+	const body = `{
+		"usage": {
+			"prompt_tokens": 1500,
+			"completion_tokens": 200,
+			"total_tokens": 1700,
+			"prompt_tokens_details": {"cached_tokens": 1024},
+			"completion_tokens_details": {"reasoning_tokens": 64}
+		}
+	}`
+	var raw map[string]interface{}
+	assert.NoError(t, json.Unmarshal([]byte(body), &raw))
+
+	got := ParseOpenAIUsage(raw)
+	assert.NotNil(t, got, "Chat Completions usage block must parse")
+	assert.True(t, got.IsReal)
+	assert.Equal(t, 1500, got.PromptTokens)
+	assert.Equal(t, 200, got.CompletionTokens)
+	assert.Equal(t, 1700, got.TotalTokens)
+	assert.Equal(t, 1024, got.CacheReadInputTokens, "prompt_tokens_details.cached_tokens → CacheReadInputTokens")
+	assert.Equal(t, 64, got.ReasoningTokens, "completion_tokens_details.reasoning_tokens → ReasoningTokens")
+}
+
+func TestParseOpenAIUsage_MissingDetailsIsFine(t *testing.T) {
+	// Older models (gpt-4 / gpt-3.5) omit the *_details sub-objects.
+	const body = `{
+		"usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+	}`
+	var raw map[string]interface{}
+	assert.NoError(t, json.Unmarshal([]byte(body), &raw))
+
+	got := ParseOpenAIUsage(raw)
+	assert.NotNil(t, got)
+	assert.Equal(t, 10, got.PromptTokens)
+	assert.Equal(t, 5, got.CompletionTokens)
+	assert.Equal(t, 15, got.TotalTokens)
+	assert.Zero(t, got.CacheReadInputTokens)
+	assert.Zero(t, got.ReasoningTokens)
+}
+
+func TestParseOpenAIUsage_ComputesTotalWhenMissing(t *testing.T) {
+	const body = `{"usage": {"prompt_tokens": 8, "completion_tokens": 4}}`
+	var raw map[string]interface{}
+	assert.NoError(t, json.Unmarshal([]byte(body), &raw))
+
+	got := ParseOpenAIUsage(raw)
+	assert.NotNil(t, got)
+	assert.Equal(t, 12, got.TotalTokens, "total must be computed from prompt+completion when API omits it")
+}
+
+func TestParseOpenAIUsage_NoUsageBlockReturnsNil(t *testing.T) {
+	got := ParseOpenAIUsage(map[string]interface{}{"choices": []interface{}{}})
+	assert.Nil(t, got, "absent usage block must yield nil, not a zeroed UsageInfo")
+}
+
+func TestParseOpenAIResponsesUsage(t *testing.T) {
+	// Responses API uses input_tokens / output_tokens — NOT prompt_/completion_.
+	// Reasoning models populate output_tokens_details.reasoning_tokens (already
+	// counted inside output_tokens).
+	const body = `{
+		"usage": {
+			"input_tokens": 75,
+			"input_tokens_details": {"cached_tokens": 1024},
+			"output_tokens": 1186,
+			"output_tokens_details": {"reasoning_tokens": 1024},
+			"total_tokens": 1261
+		}
+	}`
+	var raw map[string]interface{}
+	assert.NoError(t, json.Unmarshal([]byte(body), &raw))
+
+	got := ParseOpenAIResponsesUsage(raw)
+	assert.NotNil(t, got, "Responses API usage block must parse")
+	assert.True(t, got.IsReal)
+	assert.Equal(t, 75, got.PromptTokens, "input_tokens → PromptTokens")
+	assert.Equal(t, 1186, got.CompletionTokens, "output_tokens → CompletionTokens")
+	assert.Equal(t, 1261, got.TotalTokens)
+	assert.Equal(t, 1024, got.CacheReadInputTokens, "input_tokens_details.cached_tokens → CacheReadInputTokens")
+	assert.Equal(t, 1024, got.ReasoningTokens, "output_tokens_details.reasoning_tokens → ReasoningTokens")
+}
+
+// Regression: before the split, openai_responses_client.go called
+// ParseOpenAIUsage on a Responses payload — it returned a zeroed
+// UsageInfo because prompt_tokens/completion_tokens never appear in that
+// schema, and the chat envelope rendered the "no tokens" placeholder
+// instead of the input/output arrows.
+func TestParseOpenAIUsage_ReturnsZerosOnResponsesPayload(t *testing.T) {
+	const body = `{"usage": {"input_tokens": 75, "output_tokens": 1186, "total_tokens": 1261}}`
+	var raw map[string]interface{}
+	assert.NoError(t, json.Unmarshal([]byte(body), &raw))
+
+	got := ParseOpenAIUsage(raw)
+	assert.NotNil(t, got, "the usage block is present so we still return a struct")
+	assert.Zero(t, got.PromptTokens, "Chat Completions parser must not pick up input_tokens — that's what ParseOpenAIResponsesUsage is for")
+	assert.Zero(t, got.CompletionTokens)
+}
+
+func TestParseOpenAIResponsesUsage_NoUsageBlockReturnsNil(t *testing.T) {
+	got := ParseOpenAIResponsesUsage(map[string]interface{}{"status": "completed"})
+	assert.Nil(t, got)
+}
+
+// TestParseAnthropicUsage_StaysUntouched is a guard: the Anthropic parser
+// must not start picking up OpenAI-shaped fields just because we added the
+// Responses parser next door. Different fields, different sources.
+func TestParseAnthropicUsage_StaysUntouched(t *testing.T) {
+	const body = `{
+		"usage": {
+			"input_tokens": 100, "output_tokens": 50,
+			"cache_creation_input_tokens": 20, "cache_read_input_tokens": 80
+		}
+	}`
+	var raw map[string]interface{}
+	assert.NoError(t, json.Unmarshal([]byte(body), &raw))
+
+	got := ParseAnthropicUsage(raw)
+	assert.NotNil(t, got)
+	assert.Equal(t, 100, got.PromptTokens)
+	assert.Equal(t, 50, got.CompletionTokens)
+	assert.Equal(t, 20, got.CacheCreationInputTokens)
+	assert.Equal(t, 80, got.CacheReadInputTokens)
+	assert.Equal(t, 150, got.TotalTokens, "Anthropic parser sums input+output (API doesn't include total)")
+}

--- a/llm/client/usage_state_test.go
+++ b/llm/client/usage_state_test.go
@@ -87,10 +87,9 @@ func TestParseOpenAIResponsesUsage(t *testing.T) {
 			"total_tokens": 1261
 		}
 	}`
-	var raw map[string]interface{}
-	assert.NoError(t, json.Unmarshal([]byte(body), &raw))
 
-	got := ParseOpenAIResponsesUsage(raw)
+	got, err := ParseOpenAIResponsesUsage([]byte(body))
+	assert.NoError(t, err)
 	assert.NotNil(t, got, "Responses API usage block must parse")
 	assert.True(t, got.IsReal)
 	assert.Equal(t, 75, got.PromptTokens, "input_tokens → PromptTokens")
@@ -98,6 +97,21 @@ func TestParseOpenAIResponsesUsage(t *testing.T) {
 	assert.Equal(t, 1261, got.TotalTokens)
 	assert.Equal(t, 1024, got.CacheReadInputTokens, "input_tokens_details.cached_tokens → CacheReadInputTokens")
 	assert.Equal(t, 1024, got.ReasoningTokens, "output_tokens_details.reasoning_tokens → ReasoningTokens")
+}
+
+func TestParseOpenAIResponsesUsage_ComputesTotalWhenMissing(t *testing.T) {
+	got, err := ParseOpenAIResponsesUsage([]byte(`{"usage":{"input_tokens":8,"output_tokens":4}}`))
+	assert.NoError(t, err)
+	assert.NotNil(t, got)
+	assert.Equal(t, 12, got.TotalTokens, "total must fall back to input+output when API omits it")
+}
+
+func TestParseOpenAIResponsesUsage_DetailsAreOptional(t *testing.T) {
+	got, err := ParseOpenAIResponsesUsage([]byte(`{"usage":{"input_tokens":10,"output_tokens":5,"total_tokens":15}}`))
+	assert.NoError(t, err)
+	assert.NotNil(t, got)
+	assert.Zero(t, got.CacheReadInputTokens, "missing input_tokens_details must not break the parse")
+	assert.Zero(t, got.ReasoningTokens, "missing output_tokens_details must not break the parse")
 }
 
 // Regression: before the split, openai_responses_client.go called
@@ -117,7 +131,23 @@ func TestParseOpenAIUsage_ReturnsZerosOnResponsesPayload(t *testing.T) {
 }
 
 func TestParseOpenAIResponsesUsage_NoUsageBlockReturnsNil(t *testing.T) {
-	got := ParseOpenAIResponsesUsage(map[string]interface{}{"status": "completed"})
+	got, err := ParseOpenAIResponsesUsage([]byte(`{"status":"completed"}`))
+	assert.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestParseOpenAIResponsesUsage_EmptyInputReturnsNil(t *testing.T) {
+	got, err := ParseOpenAIResponsesUsage(nil)
+	assert.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestParseOpenAIResponsesUsage_InvalidJSONReturnsError(t *testing.T) {
+	// Invalid JSON must surface as an error rather than a silent nil —
+	// the caller (responses client) logs it at debug level so silent
+	// schema breakage shows up in support traces.
+	got, err := ParseOpenAIResponsesUsage([]byte(`{"usage": not-json`))
+	assert.Error(t, err)
 	assert.Nil(t, got)
 }
 

--- a/llm/openai/openai_client.go
+++ b/llm/openai/openai_client.go
@@ -343,6 +343,12 @@ func (c *OpenAIClient) SendPromptStream(ctx context.Context, prompt string, hist
 		"messages":   messages,
 		"max_tokens": effectiveMaxTokens,
 		"stream":     true,
+		// Opt in to the terminal usage chunk. Without this, OpenAI Chat
+		// Completions never emits the `usage` block over SSE — the chat
+		// envelope then renders the "no tokens" placeholder for GPT
+		// instead of the input/output arrows. The usage arrives in the
+		// last chunk (the one with `choices: []`) before `data: [DONE]`.
+		"stream_options": map[string]interface{}{"include_usage": true},
 	}
 
 	// Skill effort hint → reasoning_effort (reasoning-capable models only).

--- a/llm/openai/openai_stream_test.go
+++ b/llm/openai/openai_stream_test.go
@@ -2,7 +2,9 @@ package openai
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -10,6 +12,7 @@ import (
 
 	"github.com/diillson/chatcli/auth"
 	"github.com/diillson/chatcli/models"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 )
 
@@ -91,6 +94,67 @@ func TestOpenAIClient_SupportsStreaming(t *testing.T) {
 	if !c.SupportsStreaming() {
 		t.Error("OpenAI client should support streaming")
 	}
+}
+
+// TestOpenAIClient_SendPromptStream_RequestsUsage pins two things:
+//   - the streaming payload includes `stream_options.include_usage: true`
+//     (without this, OpenAI silently omits the terminal usage chunk and
+//     the chat envelope falls back to the "no tokens" placeholder); and
+//   - when the server replies with the usage chunk (the one with
+//     `choices: []` before [DONE]), the client surfaces it on the
+//     terminal Done chunk so the envelope renders the input/output arrows.
+func TestOpenAIClient_SendPromptStream_RequestsUsage(t *testing.T) {
+	var capturedPayload map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &capturedPayload)
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `data: {"choices":[{"delta":{"content":"hi"}}]}`+"\n\n")
+		// Terminal usage chunk: choices is empty, usage is populated.
+		fmt.Fprint(w, `data: {"choices":[],"usage":{"prompt_tokens":42,"completion_tokens":7,"total_tokens":49,"prompt_tokens_details":{"cached_tokens":32}}}`+"\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	originalURL := os.Getenv("OPENAI_API_URL")
+	t.Setenv("OPENAI_API_URL", server.URL)
+	t.Cleanup(func() { _ = os.Setenv("OPENAI_API_URL", originalURL) })
+
+	logger, _ := zap.NewDevelopment()
+	c := NewOpenAIClient(
+		auth.NewStaticTokenProvider("k", auth.AuthModeAPIKey, auth.ProviderOpenAI),
+		"gpt-4o", logger, 1, 0,
+	)
+
+	ch, err := c.SendPromptStream(context.Background(), "Hi",
+		[]models.Message{{Role: "user", Content: "Hi"}}, 100)
+	if err != nil {
+		t.Fatalf("SendPromptStream: %v", err)
+	}
+
+	var doneUsage *models.UsageInfo
+	for chunk := range ch {
+		if chunk.Done {
+			doneUsage = chunk.Usage
+		}
+	}
+
+	// Opt-in flag must be present in the request payload.
+	streamOpts, ok := capturedPayload["stream_options"].(map[string]interface{})
+	assert.True(t, ok, "streaming payload must carry stream_options")
+	assert.Equal(t, true, streamOpts["include_usage"], "must opt in to include_usage so usage arrives over SSE")
+
+	// Usage from the terminal chunk must be surfaced on Done so the envelope
+	// can render the input/output arrows for GPT (regression: without
+	// include_usage and without the terminal chunk handling, the envelope
+	// fell back to the i18n "no tokens" placeholder).
+	assert.NotNil(t, doneUsage, "Done chunk must carry the usage parsed from the terminal SSE event")
+	assert.Equal(t, 42, doneUsage.PromptTokens)
+	assert.Equal(t, 7, doneUsage.CompletionTokens)
+	assert.Equal(t, 49, doneUsage.TotalTokens)
+	assert.Equal(t, 32, doneUsage.CacheReadInputTokens, "cache-hit count flows through from prompt_tokens_details.cached_tokens")
 }
 
 func TestOpenAIClient_OAuthRetry(t *testing.T) {

--- a/llm/openai_responses/openai_responses_client.go
+++ b/llm/openai_responses/openai_responses_client.go
@@ -241,10 +241,14 @@ func (c *OpenAIResponsesClient) processResponse(resp *http.Response) (string, er
 		return "", fmt.Errorf("%s: %w", i18n.T("llm.responses.decode_response"), err)
 	}
 
-	// Extract usage and stop reason from the Responses API format
+	// Extract usage and stop reason from the Responses API format.
+	// Note: Responses uses input_tokens/output_tokens (NOT prompt_/completion_),
+	// so ParseOpenAIResponsesUsage is required — ParseOpenAIUsage silently
+	// returns zeros on this schema and the envelope ends up rendering the
+	// "no tokens" placeholder.
 	var rawResult map[string]interface{}
 	if err := json.Unmarshal(bodyBytes, &rawResult); err == nil {
-		if usage := client.ParseOpenAIUsage(rawResult); usage != nil {
+		if usage := client.ParseOpenAIResponsesUsage(rawResult); usage != nil {
 			c.usageState.StoreUsage(usage)
 		}
 		// Responses API uses "status" instead of choices[].finish_reason
@@ -338,11 +342,13 @@ func (c *OpenAIResponsesClient) processStreamResponse(resp *http.Response) (stri
 			sb.WriteString(event.Delta)
 		}
 
-		// Extract usage from the response.completed event
+		// Extract usage from the response.completed event. Responses API
+		// schema (input_tokens / output_tokens) — must use the Responses
+		// parser, not the Chat Completions one.
 		if event.Type == "response.completed" && event.Response != nil {
 			var respData map[string]interface{}
 			if err := json.Unmarshal(event.Response, &respData); err == nil {
-				if usage := client.ParseOpenAIUsage(respData); usage != nil {
+				if usage := client.ParseOpenAIResponsesUsage(respData); usage != nil {
 					c.usageState.StoreUsage(usage)
 				}
 				if status, ok := respData["status"].(string); ok && status != "" {

--- a/llm/openai_responses/openai_responses_client.go
+++ b/llm/openai_responses/openai_responses_client.go
@@ -246,15 +246,19 @@ func (c *OpenAIResponsesClient) processResponse(resp *http.Response) (string, er
 	// so ParseOpenAIResponsesUsage is required — ParseOpenAIUsage silently
 	// returns zeros on this schema and the envelope ends up rendering the
 	// "no tokens" placeholder.
-	var rawResult map[string]interface{}
-	if err := json.Unmarshal(bodyBytes, &rawResult); err == nil {
-		if usage := client.ParseOpenAIResponsesUsage(rawResult); usage != nil {
-			c.usageState.StoreUsage(usage)
-		}
-		// Responses API uses "status" instead of choices[].finish_reason
-		if status, ok := rawResult["status"].(string); ok && status != "" {
-			c.usageState.StoreStopReason(status)
-		}
+	if usage, parseErr := client.ParseOpenAIResponsesUsage(bodyBytes); parseErr != nil {
+		c.logger.Debug("openai_responses: usage decode failed", zap.Error(parseErr))
+	} else if usage != nil {
+		c.usageState.StoreUsage(usage)
+	}
+	// Responses API uses "status" instead of choices[].finish_reason.
+	// A second targeted decode is cheaper than dragging a map[string]any
+	// through the public usage API just to read one field.
+	var statusEnvelope struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(bodyBytes, &statusEnvelope); err == nil && statusEnvelope.Status != "" {
+		c.usageState.StoreStopReason(statusEnvelope.Status)
 	}
 
 	// Tentar extrair do caminho simples primeiro (comum em mocks e respostas diretas)
@@ -345,15 +349,17 @@ func (c *OpenAIResponsesClient) processStreamResponse(resp *http.Response) (stri
 		// Extract usage from the response.completed event. Responses API
 		// schema (input_tokens / output_tokens) — must use the Responses
 		// parser, not the Chat Completions one.
-		if event.Type == "response.completed" && event.Response != nil {
-			var respData map[string]interface{}
-			if err := json.Unmarshal(event.Response, &respData); err == nil {
-				if usage := client.ParseOpenAIResponsesUsage(respData); usage != nil {
-					c.usageState.StoreUsage(usage)
-				}
-				if status, ok := respData["status"].(string); ok && status != "" {
-					c.usageState.StoreStopReason(status)
-				}
+		if event.Type == "response.completed" && len(event.Response) > 0 {
+			if usage, parseErr := client.ParseOpenAIResponsesUsage(event.Response); parseErr != nil {
+				c.logger.Debug("openai_responses: stream usage decode failed", zap.Error(parseErr))
+			} else if usage != nil {
+				c.usageState.StoreUsage(usage)
+			}
+			var statusEnvelope struct {
+				Status string `json:"status"`
+			}
+			if err := json.Unmarshal(event.Response, &statusEnvelope); err == nil && statusEnvelope.Status != "" {
+				c.usageState.StoreStopReason(statusEnvelope.Status)
 			}
 		}
 	}

--- a/llm/openai_responses/openai_responses_client_test.go
+++ b/llm/openai_responses/openai_responses_client_test.go
@@ -100,6 +100,50 @@ func TestOpenAIResponsesClient_ListModels_OAuthSkips(t *testing.T) {
 	assert.Nil(t, list)
 }
 
+// Regression: the Responses API ships `input_tokens`/`output_tokens`,
+// not `prompt_tokens`/`completion_tokens`. Before the parser split, this
+// client called the Chat Completions parser on a Responses payload and
+// silently returned zeroed usage — the chat envelope then rendered the
+// "no tokens" placeholder for GPT instead of the input/output arrows.
+// This test pins that the Responses parser is the one in use and that
+// LastUsage() surfaces the parsed counts (and cache-hit count) verbatim.
+func TestOpenAIResponsesClient_SendPrompt_SurfacesUsage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"output_text": "ok",
+			"status": "completed",
+			"usage": {
+				"input_tokens": 75,
+				"input_tokens_details": {"cached_tokens": 32},
+				"output_tokens": 1186,
+				"output_tokens_details": {"reasoning_tokens": 1024},
+				"total_tokens": 1261
+			}
+		}`)
+	}))
+	defer server.Close()
+
+	require.NoError(t, os.Setenv("OPENAI_RESPONSES_API_URL", server.URL))
+	defer os.Unsetenv("OPENAI_RESPONSES_API_URL")
+
+	logger, _ := zap.NewDevelopment()
+	client := NewOpenAIResponsesClient(testProvider("test-api-key"), "gpt-5", logger, 1, 0)
+	_, err := client.SendPrompt(context.Background(), "Hi",
+		[]models.Message{{Role: "user", Content: "Hi"}}, 0)
+	require.NoError(t, err)
+
+	usage := client.LastUsage()
+	require.NotNil(t, usage, "Responses usage must reach LastUsage so the chat envelope renders arrows for GPT")
+	assert.Equal(t, 75, usage.PromptTokens)
+	assert.Equal(t, 1186, usage.CompletionTokens)
+	assert.Equal(t, 1261, usage.TotalTokens)
+	assert.Equal(t, 32, usage.CacheReadInputTokens)
+	assert.Equal(t, 1024, usage.ReasoningTokens)
+	assert.Equal(t, "completed", client.LastStopReason())
+}
+
 func TestOpenAIResponsesClient_buildTextFromHistory(t *testing.T) {
 	history := []models.Message{
 		{Role: "system", Content: "Be helpful."},

--- a/models/models.go
+++ b/models/models.go
@@ -103,9 +103,19 @@ type UsageInfo struct {
 	CompletionTokens int `json:"completion_tokens"`
 	TotalTokens      int `json:"total_tokens"`
 
-	// Anthropic prompt caching (reduces cost for repeated prefixes)
+	// Anthropic prompt caching (reduces cost for repeated prefixes).
+	// OpenAI cached prompt tokens are also reported here under
+	// CacheReadInputTokens — semantically the same thing (repeated input
+	// served at a discount). CacheCreationInputTokens stays Anthropic-only.
 	CacheCreationInputTokens int `json:"cache_creation_input_tokens,omitempty"`
 	CacheReadInputTokens     int `json:"cache_read_input_tokens,omitempty"`
+
+	// Reasoning tokens emitted by o-series / GPT-5 reasoning models.
+	// Reported by OpenAI under usage.completion_tokens_details.reasoning_tokens
+	// (Chat Completions) or usage.output_tokens_details.reasoning_tokens
+	// (Responses API). Billed as output tokens and already counted in
+	// CompletionTokens — this field is informational only.
+	ReasoningTokens int `json:"reasoning_tokens,omitempty"`
 
 	// Whether these values came from the API (true) or were estimated (false).
 	// Callers can use this to decide display precision and cost accuracy.
@@ -123,6 +133,7 @@ func (u *UsageInfo) Merge(other *UsageInfo) {
 	u.TotalTokens += other.TotalTokens
 	u.CacheCreationInputTokens += other.CacheCreationInputTokens
 	u.CacheReadInputTokens += other.CacheReadInputTokens
+	u.ReasoningTokens += other.ReasoningTokens
 	if other.IsReal {
 		u.IsReal = true
 	}


### PR DESCRIPTION
This branch carries two related-but-orthogonal improvements bundled at the user's request.

## 1. Claude Opus 4.8 catalog support (`feat/catalog`)

- Registers `claude-opus-4-8` (released May 28 2026) in the catalog on `ProviderClaudeAI` and as a Bedrock mirror (`global.anthropic.claude-opus-4-8-20260528-v1:0`), both at 1M context / 128K max output. Declared before the 4.7 entry to respect the prefix-shadowing ordering rule the `Resolve()` walk depends on.
- New catalog capability flags drive feature dispatch from the registry instead of inline model-id substring checks:
  - `adaptive_thinking` (also retroactively flagged on Opus 4.7) — emits `thinking:{type:"adaptive"}` and skips `budget_tokens`, which Anthropic rejects with HTTP 400 on Opus 4.7+ per the 4.8 migration guide.
  - `fast_mode` — when `ANTHROPIC_SPEED=fast` is set, emits `speed:"fast"` for the research-preview faster-output mode (premium pricing).
  - `mid_conversation_system` and `low_cache_minimum` are pinned in the registry as documentation flags; the existing message-build path already accepts mid-conversation system blocks and the lower cache floor is server-side.
- Wires the dispatch in three places that all converge on the Anthropic Messages body:
  - `llm/claudeai/claude_client.go` (SendPrompt) — new `applyThinkingForEffort` / `applyFastModeIfRequested` helpers.
  - `llm/claudeai/tool_use.go` (SendPromptWithTools) — same helpers, tool path.
  - `llm/bedrock/bedrock_client.go` (sendPromptAnthropic) — capability-aware thinking dispatch, fast mode intentionally skipped because Bedrock does not document the `speed` field on the Anthropic schema.
- Updates `cli/moa_command.go` doc-comment and the `moa.no_models` string in `pt-BR`, `en`, and `en-US` locales to use `claude-opus-4-8` in examples.
- Tests:
  - `TestResolve` gets two new cases (`opus-4-8` shortcut + full ID) confirming the ordering rule holds with 4.8 in front of 4.7 in front of the bare `opus-4` alias.
  - New `TestClaudeOpus48Specs` pins the four launch capabilities on both the ClaudeAI entry and the Bedrock mirror, plus the 1M/128K shape.

## 2. OpenAI token usage in the chat envelope (`fix/openai`)

Two latent bugs were keeping the input/output token arrows hidden on the chat envelope for GPT models, while Anthropic worked fine.

- **Chat Completions streaming never asked for the usage chunk.** OpenAI omits `usage` from SSE chunks unless the request carries `stream_options.include_usage: true`. The client already parsed usage from every event it saw, but the terminal usage chunk never arrived, so the envelope rendered the i18n "no tokens" placeholder.
- **The Responses API client used the Chat Completions parser.** Responses ships `input_tokens`/`output_tokens`, not `prompt_tokens`/`completion_tokens`, so `ParseOpenAIUsage` silently returned a zeroed `UsageInfo` and the envelope again fell back to the placeholder.

Changes:
- Adds `ParseOpenAIResponsesUsage` alongside the Chat Completions parser, both extended to read cached prompt tokens (mapped to `CacheReadInputTokens` for parity with Anthropic prompt caching) and reasoning tokens emitted by o-series / GPT-5 models.
- `UsageInfo` gains an informational `ReasoningTokens` field, merged by `Merge` so per-session totals stay consistent.
- Streaming Chat Completions payload now opts in to the terminal usage chunk via `stream_options.include_usage`. Same payload for API key and OAuth, so both auth modes benefit.
- Responses client uses the Responses parser on both the non-streaming JSON body (API key path) and the `response.completed` SSE event (OAuth / Codex backend path).

Auth coverage:
- **Chat Completions** — same payload builder is shared between API key and OAuth, so `stream_options.include_usage` flows on both rotations.
- **Responses API** — API key path (`processResponse`, non-streaming) and OAuth/Codex path (`processStreamResponse`, streaming `response.completed`) both use the Responses parser. If the Codex backend chooses not to emit `usage`, the envelope still falls back to the placeholder — that's a backend constraint, not a parser bug.

## Test plan

- [x] `go build ./...` clean.
- [x] `go test ./llm/catalog/... ./llm/claudeai/... ./llm/bedrock/... ./llm/client/... ./llm/openai/... ./llm/openai_responses/... ./models/...` green.
- [x] `go test ./...` full suite green, no regressions.
- [x] Manual smoke (Anthropic): `ANTHROPIC_MODEL=claude-opus-4-8` (and optionally `ANTHROPIC_SPEED=fast`) → verify a one-shot prompt returns successfully.
- [x] Manual smoke (Anthropic): with a skill that sets `effort: high`, capture the request payload and confirm `thinking:{type:"adaptive"}` is emitted (no `budget_tokens`) for 4.7 and 4.8.
- [x] Manual smoke (OpenAI Chat Completions): `OPENAI_MODEL=gpt-4o`, stream a chat turn, verify the envelope shows `N↑ M↓` (not the placeholder).
- [x] Manual smoke (OpenAI Responses, API key): `OPENAI_MODEL=gpt-5`, non-streaming chat turn, same check.
- [x] Manual smoke (OpenAI Responses, OAuth / Codex): same model under OAuth, confirm whether the Codex backend emits usage in `response.completed`.

## How users opt in (Opus 4.8)

```
ANTHROPIC_MODEL=claude-opus-4-8        # or the shortcut: opus-4-8
ANTHROPIC_SPEED=fast                   # optional: research-preview fast mode
```

Skill `effort: high|max` continues to work — for 4.7/4.8 it now maps to adaptive thinking automatically.