### PR TITLE
fix(gateway): list stop in the /gateway usage hint

### DIFF
--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -197,7 +197,7 @@
   "lsp.no_response": "No diagnostics received within the timeout.",
   "lsp.header": "Diagnostics for %s",
   "lsp.clean": "No problems found.",
-  "gateway.usage": "Usage: /gateway [start|status]",
+  "gateway.usage": "Usage: /gateway [start|status|stop]",
   "gateway.no_platforms": "No messaging platform configured. Set e.g. CHATCLI_TELEGRAM_BOT_TOKEN.",
   "gateway.registered": "Registered platforms:",
   "gateway.configured": "Configured (ready) adapters:",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -197,7 +197,7 @@
   "lsp.no_response": "No diagnostics received within the timeout.",
   "lsp.header": "Diagnostics for %s",
   "lsp.clean": "No problems found.",
-  "gateway.usage": "Usage: /gateway [start|status]",
+  "gateway.usage": "Usage: /gateway [start|status|stop]",
   "gateway.no_platforms": "No messaging platform configured. Set e.g. CHATCLI_TELEGRAM_BOT_TOKEN.",
   "gateway.registered": "Registered platforms:",
   "gateway.configured": "Configured (ready) adapters:",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -197,7 +197,7 @@
   "lsp.no_response": "Nenhum diagnóstico recebido dentro do tempo limite.",
   "lsp.header": "Diagnósticos de %s",
   "lsp.clean": "Nenhum problema encontrado.",
-  "gateway.usage": "Uso: /gateway [start|status]",
+  "gateway.usage": "Uso: /gateway [start|status|stop]",
   "gateway.no_platforms": "Nenhuma plataforma de mensageria configurada. Defina ex. CHATCLI_TELEGRAM_BOT_TOKEN.",
   "gateway.registered": "Plataformas registradas:",
   "gateway.configured": "Adapters configurados (prontos):",


### PR DESCRIPTION
## What changes

The `/gateway` handler accepts `start`, `status` and `stop` (`cli/gateway_command.go`), and the autocomplete already suggests all three — but the usage hint shown on an unknown subcommand still read `/gateway [start|status]`, omitting `stop`.

Update `gateway.usage` to `/gateway [start|status|stop]` across all three locales so the hint matches the handler, the autocomplete, and the docs.

## Validation
- `go build ./...` clean
- all three locale JSONs valid