### PR TITLE
chore(deps): bump Go toolchain to 1.26.4 for stdlib security fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # License: MIT
 
 # --- Build stage ---
-FROM golang:1.26.3-alpine AS builder
+FROM golang:1.26.4-alpine AS builder
 
 RUN apk add --no-cache git ca-certificates
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/diillson/chatcli
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.9

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -2,7 +2,7 @@
 # Must be built from the repo root: docker build -f operator/Dockerfile .
 # This is required because go.mod uses: replace github.com/diillson/chatcli => ../
 
-FROM golang:1.26.3 AS builder
+FROM golang:1.26.4 AS builder
 
 WORKDIR /workspace
 

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/diillson/chatcli/operator
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/diillson/chatcli v0.0.0


### PR DESCRIPTION
`govulncheck` now flags three **standard-library** vulnerabilities in **go1.26.3**, reachable from existing code (Discord websocket TLS handshake, k8s log streaming, scheduler x509 verification) — so any PR built on 1.26.3 fails the Go Vulnerability Check:

- **GO-2026-5039** `net/textproto` — unescaped input in errors
- **GO-2026-5038** `mime` — quadratic `WordDecoder.DecodeHeader`
- **GO-2026-5037** `crypto/x509` — inefficient candidate hostname parsing

All three are fixed in **go1.26.4**. This bumps the `go` directive in the root and operator modules. Locally with the 1.26.4 toolchain `govulncheck ./...` reports **no vulnerabilities**; `go build`/`go test` green. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)