### PR TITLE
feat(imagegen): Z.AI + MiniMax image backends, model-aware auto, and /model-image

### DIFF
--- a/cli/cli_completer.go
+++ b/cli/cli_completer.go
@@ -43,6 +43,7 @@ var slashPrefixRoutes = []slashPrefixRoute{
 	{"/agent", (*ChatCLI).getAgentSuggestions},
 	{"/switch", (*ChatCLI).getSwitchSuggestions},
 	{"/provider", (*ChatCLI).getProviderSuggestions},
+	{"/model-image", (*ChatCLI).getImageModelSuggestions}, // before "/model" — it shadows this prefix
 	{"/model", (*ChatCLI).getModelSuggestions},
 	{"/max-tokens", (*ChatCLI).getMaxTokensSuggestions},
 	{"/auth", (*ChatCLI).getAuthSuggestions},
@@ -294,6 +295,7 @@ func (cli *ChatCLI) GetInternalCommands() []prompt.Suggest {
 		{Text: "/switch", Description: i18n.T("complete.root.switch")},
 		{Text: "/provider", Description: i18n.T("complete.root.provider")},
 		{Text: "/model", Description: i18n.T("complete.root.model")},
+		{Text: "/model-image", Description: i18n.T("complete.root.model_image")},
 		{Text: "/max-tokens", Description: i18n.T("complete.root.maxtokens")},
 		{Text: "/help", Description: i18n.T("complete.root.help")},
 		{Text: "/menu", Description: i18n.T("complete.root.menu")},

--- a/cli/command_handler.go
+++ b/cli/command_handler.go
@@ -193,6 +193,8 @@ func (ch *CommandHandler) buildRoutes() {
 	ch.routes.prefixes = []prefixRoute{
 		{"/switch", false, func(in string) bool { c.handleSwitchCommand(in); return false }},
 		{"/provider", false, func(in string) bool { c.handleProviderCommand(in); return false }},
+		// Must precede "/model" (raw-prefix) so it isn't shadowed by it.
+		{"/model-image", true, func(in string) bool { c.handleImageModelCommand(in); return false }},
 		{"/model", false, func(in string) bool { c.handleModelCommand(in); return false }},
 		{"/max-tokens", false, func(in string) bool { c.handleMaxTokensCommand(in); return false }},
 		{"/config", true, ch.cmdConfig},

--- a/cli/config_image_mutate.go
+++ b/cli/config_image_mutate.go
@@ -9,12 +9,15 @@
  * default (we never rewrite .env — user territory).
  *
  *   /config image                      # status
- *   /config image provider <name>      # sdwebui|url|openai|responses|google|xai|auto
+ *   /config image provider <name>      # sdwebui|url|openai|responses|google|xai|zai|minimax|bedrock|auto
  *   /config image api images|responses # OpenAI: Images API vs Responses API
  *   /config image model <id>           # CHATCLI_IMAGE_MODEL
  *   /config image url <url>            # CHATCLI_IMAGE_URL (self-hosted/SD WebUI)
  *   /config image models               # list the image-model catalog
  *   /config image reset                # clear the overrides above
+ *
+ * Shorthand: `/model-image [<id>]` mirrors `/config image model` (and lists the
+ * catalog when bare), the @image counterpart to `/model` for text models.
  */
 package cli
 
@@ -59,6 +62,42 @@ func (cli *ChatCLI) routeConfigImage(args []string) {
 		fmt.Println(colorize("  "+i18n.T("cfg.image.unknown_sub", args[0]), ColorYellow))
 		cli.printConfigImageUsage()
 	}
+}
+
+// handleImageModelCommand is the `/model-image [<id>]` shorthand for
+// `/config image model <id>`: it switches only the @image generation model
+// (CHATCLI_IMAGE_MODEL) without the longer /config path, mirroring how `/model`
+// shortcuts the text-model switch. With no argument it prints the image-model
+// catalog (same as `/config image models`). It deliberately does NOT touch the
+// text/chat model — image and text models are separate backends.
+func (cli *ChatCLI) handleImageModelCommand(input string) {
+	rest := strings.TrimSpace(strings.TrimPrefix(input, "/model-image"))
+	if rest == "" {
+		fmt.Println(cli.imageModelsCatalog())
+		return
+	}
+	cli.setImageEnv("CHATCLI_IMAGE_MODEL", []string{rest})
+}
+
+// getImageModelSuggestions autocompletes the `/model-image <id>` shorthand with
+// the image-model catalog — the same source as `/config image model`.
+func (cli *ChatCLI) getImageModelSuggestions(d prompt.Document) []prompt.Suggest {
+	line := d.TextBeforeCursor()
+	args := strings.Fields(line)
+	word := d.GetWordBeforeCursor()
+
+	// Just typed "/model-image" without a trailing space.
+	if len(args) == 1 && !strings.HasSuffix(line, " ") {
+		return []prompt.Suggest{
+			{Text: "/model-image", Description: i18n.T("complete.root.model_image")},
+		}
+	}
+
+	out := make([]prompt.Suggest, 0, len(imagegen.KnownModels()))
+	for _, m := range imagegen.KnownModels() {
+		out = append(out, prompt.Suggest{Text: m.Name, Description: m.Provider + " · " + m.API})
+	}
+	return prompt.FilterHasPrefix(out, word, true)
 }
 
 // setImageEnv applies a single image env override at runtime.
@@ -129,6 +168,8 @@ func (cli *ChatCLI) getConfigImageSuggestions(d prompt.Document) []prompt.Sugges
 				{Text: "responses", Description: i18n.T("complete.configimage.val")},
 				{Text: "google", Description: i18n.T("complete.configimage.val")},
 				{Text: "xai", Description: i18n.T("complete.configimage.val")},
+				{Text: "zai", Description: i18n.T("complete.configimage.val")},
+				{Text: "minimax", Description: i18n.T("complete.configimage.val")},
 				{Text: "bedrock", Description: i18n.T("complete.configimage.val")},
 				{Text: "url", Description: i18n.T("complete.configimage.val")},
 			}, word, true)

--- a/cli/image_model_cmd_test.go
+++ b/cli/image_model_cmd_test.go
@@ -1,0 +1,71 @@
+/*
+ * ChatCLI - /model-image shortcut tests.
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	prompt "github.com/c-bata/go-prompt"
+	"go.uber.org/zap"
+)
+
+func newTestCLI() *ChatCLI { return &ChatCLI{logger: zap.NewNop()} }
+
+// getImageModelSuggestions lists the image-model catalog (not the text models).
+func TestImageModelSuggestionsListCatalog(t *testing.T) {
+	cli := newTestCLI()
+	b := prompt.NewBuffer()
+	b.InsertText("/model-image ", false, true)
+	sugg := cli.getImageModelSuggestions(*b.Document())
+	if len(sugg) == 0 {
+		t.Fatal("expected image-model suggestions")
+	}
+	var foundZAI, foundMiniMax bool
+	for _, s := range sugg {
+		switch s.Text {
+		case "glm-image", "cogview-4-250304":
+			foundZAI = true
+		case "image-01":
+			foundMiniMax = true
+		}
+	}
+	if !foundZAI || !foundMiniMax {
+		t.Errorf("catalog missing new providers: zai=%v minimax=%v", foundZAI, foundMiniMax)
+	}
+
+	// Prefix filtering: typing part of an id narrows the list.
+	b2 := prompt.NewBuffer()
+	b2.InsertText("/model-image cogview", false, true)
+	narrowed := cli.getImageModelSuggestions(*b2.Document())
+	if len(narrowed) == 0 {
+		t.Fatal("expected cogview matches")
+	}
+	for _, s := range narrowed {
+		if !strings.HasPrefix(s.Text, "cogview") {
+			t.Errorf("prefix filter leaked %q", s.Text)
+		}
+	}
+}
+
+// handleImageModelCommand with an id sets CHATCLI_IMAGE_MODEL at runtime.
+func TestHandleImageModelCommandSetsEnv(t *testing.T) {
+	t.Setenv("CHATCLI_IMAGE_MODEL", "")
+	t.Setenv("OPENAI_API_KEY", "") // keep imageModelsCatalog from hitting the network
+	cli := newTestCLI()
+
+	cli.handleImageModelCommand("/model-image image-01")
+	if got := os.Getenv("CHATCLI_IMAGE_MODEL"); got != "image-01" {
+		t.Fatalf("CHATCLI_IMAGE_MODEL = %q, want image-01", got)
+	}
+
+	// Bare form prints the catalog and must not mutate the model.
+	cli.handleImageModelCommand("/model-image")
+	if got := os.Getenv("CHATCLI_IMAGE_MODEL"); got != "image-01" {
+		t.Fatalf("bare form changed the model to %q", got)
+	}
+}

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -2215,6 +2215,7 @@
   "complete.root.quit": "Alias of /exit - Exit ChatCLI",
   "complete.root.switch": "Switch the LLM provider; followed by --model changes the model",
   "complete.root.model": "Shorthand for /switch --model: change the current provider's model",
+  "complete.root.model_image": "Shorthand for /config image model: change the @image generation model",
   "complete.root.maxtokens": "Shorthand for /switch --max-tokens: cap the session's output tokens",
   "complete.maxtokens.default": "0 = use the provider's default",
   "complete.root.help": "Show help",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -2215,6 +2215,7 @@
   "complete.root.quit": "Alias of /exit - Exit ChatCLI",
   "complete.root.switch": "Switch the LLM provider; followed by --model changes the model",
   "complete.root.model": "Shorthand for /switch --model: change the current provider's model",
+  "complete.root.model_image": "Shorthand for /config image model: change the @image generation model",
   "complete.root.maxtokens": "Shorthand for /switch --max-tokens: cap the session's output tokens",
   "complete.maxtokens.default": "0 = use the provider's default",
   "complete.root.help": "Show help",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -2215,6 +2215,7 @@
   "complete.root.quit": "Alias de /exit - Sair do ChatCLI",
   "complete.root.switch": "Trocar o provedor de LLM, seguido por --model troca o modelo",
   "complete.root.model": "Atalho para /switch --model: troca o modelo do provedor atual",
+  "complete.root.model_image": "Atalho para /config image model: troca o modelo de geração de imagem (@image)",
   "complete.root.maxtokens": "Atalho para /switch --max-tokens: limita os tokens de saída da sessão",
   "complete.maxtokens.default": "0 = usar o padrão do provedor",
   "complete.root.help": "Mostrar ajuda",

--- a/llm/imagegen/bedrock.go
+++ b/llm/imagegen/bedrock.go
@@ -3,12 +3,14 @@
  * Copyright (c) 2024 Edilson Freitas
  * License: Apache-2.0
  *
- * Bedrock generates images through its dedicated image models — Amazon Nova
- * Canvas and Amazon Titan Image Generator — via bedrock-runtime InvokeModel
- * (AWS SigV4), NOT through the OpenAI shape and NOT through the chat/gpt models.
- * Nova Canvas and Titan share the TEXT_IMAGE request/response shape, so one
- * backend covers both. Credentials reuse the same chain as the chat provider
- * (llm/bedrock.LoadBedrockRuntime: env / shared profile / IAM role).
+ * Bedrock generates images through its dedicated image models via bedrock-runtime
+ * InvokeModel (AWS SigV4), NOT through the OpenAI shape and NOT through the
+ * chat/gpt models. Two request families are covered: the current Stability AI
+ * models (Stable Image Core/Ultra, SD3.5 Large) use a text-to-image shape, while
+ * the legacy Amazon models (Nova Canvas, Titan Image Generator) share the
+ * TEXT_IMAGE shape. Both return {"images":["<b64>"]}. Credentials reuse the same
+ * chain as the chat provider (llm/bedrock.LoadBedrockRuntime: env / shared
+ * profile / IAM role).
  */
 package imagegen
 
@@ -25,7 +27,10 @@ import (
 	"go.uber.org/zap"
 )
 
-const defaultBedrockImageModel = "amazon.nova-canvas-v1:0"
+// defaultBedrockImageModel is a current (non-legacy) Stability model. Nova
+// Canvas — the previous default — is legacy with an EOL of 2026-09-30, so new
+// users default to Stable Image Core (broadly available, cheapest, fast).
+const defaultBedrockImageModel = "stability.stable-image-core-v1:1"
 
 // Bedrock generates images via bedrock-runtime InvokeModel.
 type Bedrock struct {
@@ -52,7 +57,8 @@ func NewBedrock(ctx context.Context, region, profile, model string, logger *zap.
 // Name returns "bedrock".
 func (*Bedrock) Name() string { return "bedrock" }
 
-// Generate invokes the Nova Canvas / Titan TEXT_IMAGE task.
+// Generate invokes the configured Bedrock image model (Stability text-to-image
+// or the legacy Amazon TEXT_IMAGE task, selected per model family).
 func (b *Bedrock) Generate(ctx context.Context, prompt string, opts Options) ([]Image, error) {
 	if strings.TrimSpace(prompt) == "" {
 		return nil, fmt.Errorf("imagegen: empty prompt")
@@ -101,8 +107,8 @@ func buildBedrockRequest(model, prompt string, opts Options) []byte {
 	return body
 }
 
-// parseBedrockImages decodes the {"images":["<b64>"]} response shared by Nova
-// Canvas and Titan Image Generator.
+// parseBedrockImages decodes the {"images":["<b64>"]} response shared by the
+// Stability text-to-image models and the legacy Amazon Nova Canvas / Titan ones.
 func parseBedrockImages(raw []byte) ([]Image, error) {
 	var out struct {
 		Images []string `json:"images"`

--- a/llm/imagegen/catalog.go
+++ b/llm/imagegen/catalog.go
@@ -36,11 +36,12 @@ type ModelInfo struct {
 func KnownModels() []ModelInfo {
 	return []ModelInfo{
 		// OpenAI Images API (gpt-image family). May require org verification.
-		{Name: "gpt-image-2", Provider: "openai", API: "images", Note: "Newest OpenAI image model (Images API)."},
+		// DALL-E 2/3 were retired (dall-e-3 on 2026-03-04; both shut down
+		// 2026-05-12) — removed, they only error now. Use the gpt-image family.
+		{Name: "gpt-image-2", Provider: "openai", API: "images", Note: "Newest OpenAI image model — adds reasoning (Images API)."},
 		{Name: "gpt-image-1.5", Provider: "openai", API: "images", Note: "OpenAI Images API."},
 		{Name: "gpt-image-1", Provider: "openai", API: "images", Note: "OpenAI Images API (broadly available; default)."},
 		{Name: "gpt-image-1-mini", Provider: "openai", API: "images", Note: "Smaller/cheaper OpenAI image model."},
-		{Name: "dall-e-3", Provider: "openai", API: "images", Note: "Legacy; not on all accounts."},
 		// OpenAI Responses API (a chat model generates via the image_generation tool).
 		{Name: "gpt-5.5", Provider: "openai", API: "responses", Note: "Chat model w/ image_generation tool (Responses API)."},
 		{Name: "gpt-5", Provider: "openai", API: "responses", Note: "gpt-5 and newer support the image_generation tool."},
@@ -49,11 +50,20 @@ func KnownModels() []ModelInfo {
 		// xAI.
 		{Name: "grok-2-image", Provider: "xai", API: "native", Note: "xAI image (OpenAI-shaped /images/generations, no size)."},
 		{Name: "grok-imagine-image-quality", Provider: "xai", API: "imagine", Note: "xAI Imagine quality model (Imagine API)."},
-		// AWS Bedrock (InvokeModel; Nova Canvas / Titan share the TEXT_IMAGE shape).
-		{Name: "amazon.nova-canvas-v1:0", Provider: "bedrock", API: "native", Note: "Bedrock Nova Canvas (TEXT_IMAGE; default)."},
-		{Name: "amazon.titan-image-generator-v2:0", Provider: "bedrock", API: "native", Note: "Bedrock Titan Image v2 (TEXT_IMAGE)."},
-		{Name: "stability.sd3-5-large-v1:0", Provider: "bedrock", API: "stability", Note: "Bedrock Stability SD3.5 (different request shape)."},
-		{Name: "stability.stable-image-ultra-v1:1", Provider: "bedrock", API: "stability", Note: "Bedrock Stability Ultra (different request shape)."},
+		// Z.AI (Zhipu) — OpenAI-shaped /images/generations, returns image URLs.
+		{Name: "glm-image", Provider: "zai", API: "images", Note: "Z.AI GLM-Image (newest; bilingual text-in-image; default)."},
+		{Name: "cogview-4-250304", Provider: "zai", API: "images", Note: "Z.AI CogView-4 flagship (bilingual)."},
+		{Name: "cogview-3-flash", Provider: "zai", API: "images", Note: "Z.AI CogView-3 Flash (free tier)."},
+		// MiniMax (Hailuo) — custom /v1/image_generation endpoint, base64 response.
+		{Name: "image-01", Provider: "minimax", API: "native", Note: "MiniMax Image-01 (text-to-image, up to 9 images)."},
+		// AWS Bedrock (InvokeModel). Current Stability models use the text-to-image
+		// shape; the Amazon TEXT_IMAGE models are legacy (AWS recommends migrating
+		// to Stability Core/Ultra/SD3.5 — Nova Canvas EOL 2026-09-30).
+		{Name: "stability.stable-image-core-v1:1", Provider: "bedrock", API: "stability", Note: "Bedrock Stability Stable Image Core (current; cheapest, fast; default)."},
+		{Name: "stability.stable-image-ultra-v1:1", Provider: "bedrock", API: "stability", Note: "Bedrock Stability Stable Image Ultra (current; highest quality)."},
+		{Name: "stability.sd3-5-large-v1:0", Provider: "bedrock", API: "stability", Note: "Bedrock Stability SD3.5 Large (current; flagship)."},
+		{Name: "amazon.nova-canvas-v1:0", Provider: "bedrock", API: "native", Note: "Bedrock Nova Canvas (TEXT_IMAGE; LEGACY, EOL 2026-09-30)."},
+		{Name: "amazon.titan-image-generator-v2:0", Provider: "bedrock", API: "native", Note: "Bedrock Titan Image v2 (TEXT_IMAGE; legacy)."},
 	}
 }
 

--- a/llm/imagegen/factory.go
+++ b/llm/imagegen/factory.go
@@ -3,7 +3,12 @@
  * Copyright (c) 2024 Edilson Freitas
  * License: Apache-2.0
  *
- * Centralizes env reading. Selection is "local/keyless first":
+ * Centralizes env reading. In `auto` mode (no CHATCLI_IMAGE_PROVIDER) the chosen
+ * CHATCLI_IMAGE_MODEL decides the provider — e.g. `glm-image`/`cogview-*` → Z.AI,
+ * `image-01` → MiniMax, `gpt-image-*` → OpenAI, `stability.*` → Bedrock — so a
+ * user only picks a model (via /model-image) and the right backend + key are
+ * used, no URL or provider env needed. Only an unrecognized/empty model falls
+ * back to the key-presence chain below:
  *
  *   1. CHATCLI_IMAGE_PROVIDER=sdwebui → self-hosted Stable Diffusion WebUI at
  *      CHATCLI_IMAGE_URL (default http://localhost:7860). Keyless.
@@ -12,12 +17,14 @@
  *   3. OPENAI_API_KEY                 → OpenAI images (paid).
  *   4. GOOGLEAI_API_KEY/GEMINI_API_KEY → native Google Imagen.
  *   5. XAI_API_KEY                    → native xAI grok-image.
- *   6. otherwise                      → Null (image generation disabled).
+ *   6. ZAI_API_KEY                    → Z.AI CogView-4 / GLM-Image.
+ *   7. MINIMAX_API_KEY               → MiniMax Image-01.
+ *   8. otherwise                      → Null (image generation disabled).
  *
- * CHATCLI_IMAGE_PROVIDER pins a backend (sdwebui|url|openai|google|xai); a
- * pinned backend whose config is missing degrades to Null rather than silently
- * switching. Beyond these, any provider speaking the OpenAI image shape works
- * by pointing CHATCLI_IMAGE_URL at it.
+ * CHATCLI_IMAGE_PROVIDER pins a backend (sdwebui|url|openai|google|xai|zai|
+ * minimax|bedrock); a pinned backend whose config is missing degrades to Null
+ * rather than silently switching. Beyond these, any provider speaking the
+ * OpenAI image shape works by pointing CHATCLI_IMAGE_URL at it.
  */
 package imagegen
 
@@ -34,6 +41,11 @@ const (
 	openAIBaseURL   = "https://api.openai.com/v1"
 	xaiBaseURL      = "https://api.x.ai/v1"
 	defaultXAIModel = "grok-2-image"
+
+	// Z.AI (Zhipu) CogView / GLM-Image: OpenAI-shaped /images/generations, but
+	// the response carries image URLs and the "n" field is rejected.
+	zaiImageBaseURL      = "https://api.z.ai/api/paas/v4"
+	defaultZAIImageModel = "glm-image"
 )
 
 // NewFromEnv builds the configured provider, falling back to Null when none is
@@ -72,6 +84,10 @@ func NewFromEnvContext(ctx context.Context, logger *zap.Logger) Provider {
 		return googleOrNull(model, logger, "CHATCLI_IMAGE_PROVIDER=google set but no GOOGLEAI_API_KEY/GEMINI_API_KEY")
 	case "xai", "grok":
 		return xaiOrNull(model, logger, "CHATCLI_IMAGE_PROVIDER=xai set but XAI_API_KEY is empty")
+	case "zai", "zhipu", "glm", "cogview", "glm-image":
+		return zaiOrNull(model, logger, "CHATCLI_IMAGE_PROVIDER=zai set but ZAI_API_KEY is empty")
+	case "minimax", "hailuo":
+		return minimaxOrNull(model, logger, "CHATCLI_IMAGE_PROVIDER=minimax set but MINIMAX_API_KEY is empty")
 	case "bedrock", "aws":
 		return bedrockOrNull(ctx, model, logger)
 	case "", "auto":
@@ -84,6 +100,30 @@ func NewFromEnvContext(ctx context.Context, logger *zap.Logger) Provider {
 
 	if url != "" {
 		return selfHostedOrNull(url, model, logger)
+	}
+	// In auto mode the chosen MODEL decides the provider — picking a model is all
+	// the user needs, no CHATCLI_IMAGE_PROVIDER. A recognized model that maps to
+	// a provider whose credential is missing degrades to Null (with a pointed
+	// warning) rather than silently routing the model to a backend that can't
+	// run it. Only an unrecognized/empty model falls through to the key chain.
+	switch providerFromModel(model) {
+	case "openai":
+		return cloudOrNull(openAIBaseURL, os.Getenv("OPENAI_API_KEY"), model, "openai", logger,
+			"image model "+model+" implies OpenAI but OPENAI_API_KEY is empty")
+	case "openai-responses":
+		return responsesOrNull(model, logger,
+			"image model "+model+" implies the OpenAI Responses API but OPENAI_API_KEY is empty")
+	case "google":
+		return googleOrNull(model, logger,
+			"image model "+model+" implies Google but no GOOGLEAI_API_KEY/GEMINI_API_KEY")
+	case "xai":
+		return xaiOrNull(model, logger, "image model "+model+" implies xAI but XAI_API_KEY is empty")
+	case "zai":
+		return zaiOrNull(model, logger, "image model "+model+" implies Z.AI but ZAI_API_KEY is empty")
+	case "minimax":
+		return minimaxOrNull(model, logger, "image model "+model+" implies MiniMax but MINIMAX_API_KEY is empty")
+	case "bedrock":
+		return bedrockOrNull(ctx, model, logger)
 	}
 	// Cloud fallbacks: any provider whose key is present. OpenAI first for
 	// back-compat, then Google (native Imagen) — so @image is not limited to a
@@ -99,6 +139,12 @@ func NewFromEnvContext(ctx context.Context, logger *zap.Logger) Provider {
 	}
 	if strings.TrimSpace(os.Getenv("XAI_API_KEY")) != "" {
 		return xaiOrNull(model, logger, "")
+	}
+	if strings.TrimSpace(os.Getenv("ZAI_API_KEY")) != "" {
+		return zaiOrNull(model, logger, "")
+	}
+	if strings.TrimSpace(os.Getenv("MINIMAX_API_KEY")) != "" {
+		return minimaxOrNull(model, logger, "")
 	}
 	return NewNull()
 }
@@ -162,6 +208,49 @@ func xaiOrNull(model string, logger *zap.Logger, missingMsg string) Provider {
 	return p
 }
 
+// zaiOrNull builds the Z.AI (Zhipu) image backend — CogView-4 / GLM-Image.
+// They speak the OpenAI /images/generations shape, so the shared client serves
+// them, but they return image URLs (downloaded automatically) and reject the
+// "n" field. Reuses the same ZAI_API_KEY as the Z.AI chat provider.
+func zaiOrNull(model string, logger *zap.Logger, missingMsg string) Provider {
+	key := strings.TrimSpace(os.Getenv("ZAI_API_KEY"))
+	if key == "" {
+		if missingMsg != "" {
+			logger.Warn("imagegen: " + missingMsg + "; image generation disabled")
+		}
+		return NewNull()
+	}
+	m := model
+	if m == "" {
+		m = defaultZAIImageModel
+	}
+	p, err := NewOpenAICompatible(zaiImageBaseURL, key, m, "zai", logger)
+	if err != nil {
+		logger.Warn("imagegen: Z.AI init failed; image generation disabled", zap.Error(err))
+		return NewNull()
+	}
+	p.omitN = true
+	return p
+}
+
+// minimaxOrNull builds the MiniMax (Hailuo) Image-01 backend (custom endpoint,
+// base64 response). Reuses the same MINIMAX_API_KEY as the chat provider.
+func minimaxOrNull(model string, logger *zap.Logger, missingMsg string) Provider {
+	key := strings.TrimSpace(os.Getenv("MINIMAX_API_KEY"))
+	if key == "" {
+		if missingMsg != "" {
+			logger.Warn("imagegen: " + missingMsg + "; image generation disabled")
+		}
+		return NewNull()
+	}
+	p, err := NewMiniMax(minimaxImageBaseURL, key, model, logger)
+	if err != nil {
+		logger.Warn("imagegen: MiniMax init failed; image generation disabled", zap.Error(err))
+		return NewNull()
+	}
+	return p
+}
+
 func googleOrNull(model string, logger *zap.Logger, missingMsg string) Provider {
 	key := googleImageKey()
 	if key == "" {
@@ -202,6 +291,46 @@ func selfHostedOrNull(url, model string, logger *zap.Logger) Provider {
 		return NewNull()
 	}
 	return p
+}
+
+// providerFromModel infers the image provider/backend from a model id so `auto`
+// mode routes purely on the chosen model. It first consults the catalog (exact,
+// case-insensitive match) — the self-maintaining source of truth — then falls
+// back to id prefixes so dated/snapshot ids not yet in the catalog still
+// resolve. Returns "" when the model maps to nothing recognizable. The OpenAI
+// Responses-API models resolve to "openai-responses" so the caller picks the
+// right OpenAI path without consulting CHATCLI_IMAGE_API.
+func providerFromModel(model string) string {
+	model = strings.ToLower(strings.TrimSpace(model))
+	if model == "" {
+		return ""
+	}
+	for _, m := range KnownModels() {
+		if strings.ToLower(m.Name) == model {
+			if m.Provider == "openai" && m.API == "responses" {
+				return "openai-responses"
+			}
+			return m.Provider
+		}
+	}
+	switch {
+	case strings.HasPrefix(model, "stability."), strings.HasPrefix(model, "amazon."),
+		strings.Contains(model, "nova-canvas"), strings.Contains(model, "titan-image"):
+		return "bedrock"
+	case strings.HasPrefix(model, "glm-image"), strings.HasPrefix(model, "cogview"), strings.HasPrefix(model, "glm-"):
+		return "zai"
+	case strings.HasPrefix(model, "image-0"), strings.HasPrefix(model, "minimax"), strings.HasPrefix(model, "hailuo"):
+		return "minimax"
+	case strings.HasPrefix(model, "grok"):
+		return "xai"
+	case strings.HasPrefix(model, "imagen"):
+		return "google"
+	case strings.HasPrefix(model, "gpt-image"), strings.HasPrefix(model, "dall-e"):
+		return "openai"
+	case strings.HasPrefix(model, "gpt-5"), strings.HasPrefix(model, "gpt-4"):
+		return "openai-responses"
+	}
+	return ""
 }
 
 func cloudOrNull(baseURL, key, model, label string, logger *zap.Logger, missingMsg string) Provider {

--- a/llm/imagegen/minimax.go
+++ b/llm/imagegen/minimax.go
@@ -1,0 +1,163 @@
+/*
+ * ChatCLI - MiniMax (Hailuo) image generation provider.
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * MiniMax Image-01 is NOT OpenAI-shaped: it POSTs to a dedicated
+ * /v1/image_generation endpoint with an aspect_ratio (not a WxH size) and
+ * returns base64 strings under data.image_base64. Errors arrive in base_resp.
+ * Credentials reuse the same MINIMAX_API_KEY as the MiniMax chat provider.
+ */
+package imagegen
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/diillson/chatcli/utils"
+	"go.uber.org/zap"
+)
+
+const (
+	minimaxImageBaseURL      = "https://api.minimax.io/v1"
+	minimaxImagePath         = "/image_generation"
+	defaultMiniMaxImageModel = "image-01"
+)
+
+// MiniMax generates images via the MiniMax Image-01 endpoint.
+type MiniMax struct {
+	baseURL string
+	apiKey  string
+	model   string
+	client  *http.Client
+}
+
+// NewMiniMax builds the provider. apiKey is required (MiniMax is not keyless);
+// model falls back to image-01.
+func NewMiniMax(baseURL, apiKey, model string, logger *zap.Logger) (*MiniMax, error) {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	if strings.TrimSpace(apiKey) == "" {
+		return nil, fmt.Errorf("imagegen: MiniMax requires MINIMAX_API_KEY")
+	}
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if baseURL == "" {
+		baseURL = minimaxImageBaseURL
+	}
+	if strings.TrimSpace(model) == "" {
+		model = defaultMiniMaxImageModel
+	}
+	return &MiniMax{
+		baseURL: baseURL,
+		apiKey:  strings.TrimSpace(apiKey),
+		model:   model,
+		client:  utils.NewHTTPClient(logger, imageGenTimeout),
+	}, nil
+}
+
+// Name returns "minimax".
+func (*MiniMax) Name() string { return "minimax" }
+
+// Generate posts the prompt and decodes the base64 images MiniMax returns.
+func (m *MiniMax) Generate(ctx context.Context, prompt string, opts Options) ([]Image, error) {
+	if strings.TrimSpace(prompt) == "" {
+		return nil, fmt.Errorf("imagegen: empty prompt")
+	}
+	n := opts.N
+	if n <= 0 {
+		n = 1
+	}
+	w, h := parseSize(opts.Size)
+	payload := map[string]interface{}{
+		"model":           m.model,
+		"prompt":          prompt,
+		"aspect_ratio":    minimaxAspect(w, h),
+		"response_format": "base64",
+		"n":               n,
+	}
+	body, _ := json.Marshal(payload)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, m.baseURL+minimaxImagePath, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+m.apiKey)
+
+	resp, err := m.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("imagegen: MiniMax request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrBody))
+		return nil, fmt.Errorf("imagegen: MiniMax returned %d: %s", resp.StatusCode, strings.TrimSpace(string(snippet)))
+	}
+
+	var out struct {
+		Data struct {
+			ImageBase64 []string `json:"image_base64"`
+		} `json:"data"`
+		BaseResp struct {
+			StatusCode int    `json:"status_code"`
+			StatusMsg  string `json:"status_msg"`
+		} `json:"base_resp"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("imagegen: MiniMax decode: %w", err)
+	}
+	// MiniMax signals logical errors in base_resp even on HTTP 200.
+	if out.BaseResp.StatusCode != 0 {
+		return nil, fmt.Errorf("imagegen: MiniMax: %s (code %d)", out.BaseResp.StatusMsg, out.BaseResp.StatusCode)
+	}
+	images := make([]Image, 0, len(out.Data.ImageBase64))
+	for _, b64 := range out.Data.ImageBase64 {
+		data, derr := base64.StdEncoding.DecodeString(b64)
+		if derr != nil || len(data) == 0 {
+			continue
+		}
+		images = append(images, Image{Data: data, Mime: "image/png", Ext: "png"})
+	}
+	if len(images) == 0 {
+		return nil, fmt.Errorf("imagegen: MiniMax returned no decodable images")
+	}
+	return images, nil
+}
+
+// minimaxAspect maps a width/height to the nearest MiniMax-supported aspect
+// ratio (MiniMax takes aspect_ratio, not explicit pixels). The thresholds are
+// the midpoints between adjacent supported ratios, so each input snaps to its
+// closest neighbor. Supported set and their decimal r=w/h:
+//
+//	21:9=2.333  16:9=1.778  3:2=1.5  4:3=1.333  1:1=1.0
+//	3:4=0.75    2:3=0.667   9:16=0.5625
+func minimaxAspect(w, h int) string {
+	if w <= 0 || h <= 0 || w == h {
+		return "1:1"
+	}
+	r := float64(w) / float64(h)
+	switch {
+	case r >= 2.056: // midpoint(16:9, 21:9)
+		return "21:9"
+	case r >= 1.639: // midpoint(3:2, 16:9)
+		return "16:9"
+	case r >= 1.417: // midpoint(4:3, 3:2)
+		return "3:2"
+	case r >= 1.167: // midpoint(1:1, 4:3)
+		return "4:3"
+	case r <= 0.615: // midpoint(9:16, 2:3)
+		return "9:16"
+	case r <= 0.708: // midpoint(2:3, 3:4)
+		return "2:3"
+	case r <= 0.875: // midpoint(3:4, 1:1)
+		return "3:4"
+	default:
+		return "1:1"
+	}
+}

--- a/llm/imagegen/minimax_zai_test.go
+++ b/llm/imagegen/minimax_zai_test.go
@@ -1,0 +1,286 @@
+/*
+ * ChatCLI - MiniMax + Z.AI image backend tests.
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package imagegen
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// 1x1 transparent PNG, base64 — a valid decodable image payload for tests.
+const tinyPNGB64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+
+func TestMiniMaxGenerate(t *testing.T) {
+	var gotBody map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/image_generation") {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		if auth := r.Header.Get("Authorization"); auth != "Bearer k" {
+			t.Errorf("auth = %q", auth)
+		}
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data":      map[string]interface{}{"image_base64": []string{tinyPNGB64}},
+			"base_resp": map[string]interface{}{"status_code": 0, "status_msg": "success"},
+		})
+	}))
+	defer srv.Close()
+
+	m, err := NewMiniMax(srv.URL, "k", "image-01", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	imgs, err := m.Generate(context.Background(), "a cat", Options{Size: "1920x1080"})
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if len(imgs) != 1 || imgs[0].Ext != "png" {
+		t.Fatalf("imgs = %+v", imgs)
+	}
+	if gotBody["model"] != "image-01" {
+		t.Errorf("model = %v", gotBody["model"])
+	}
+	if gotBody["aspect_ratio"] != "16:9" {
+		t.Errorf("aspect_ratio = %v (want 16:9 for 1920x1080)", gotBody["aspect_ratio"])
+	}
+	if _, hasSize := gotBody["size"]; hasSize {
+		t.Errorf("MiniMax payload must not carry a pixel 'size' field")
+	}
+}
+
+func TestMiniMaxBaseRespError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"base_resp": map[string]interface{}{"status_code": 1008, "status_msg": "insufficient balance"},
+		})
+	}))
+	defer srv.Close()
+
+	m, _ := NewMiniMax(srv.URL, "k", "", nil)
+	_, err := m.Generate(context.Background(), "x", Options{})
+	if err == nil || !strings.Contains(err.Error(), "insufficient balance") {
+		t.Fatalf("expected base_resp error, got %v", err)
+	}
+}
+
+func TestMiniMaxRequiresKey(t *testing.T) {
+	if _, err := NewMiniMax("", "", "", nil); err == nil {
+		t.Fatal("MiniMax should require an API key")
+	}
+}
+
+func TestMiniMaxEmptyPrompt(t *testing.T) {
+	m, _ := NewMiniMax("http://localhost:1", "k", "", nil)
+	if _, err := m.Generate(context.Background(), "   ", Options{}); err == nil {
+		t.Fatal("empty prompt should error")
+	}
+}
+
+func TestMiniMaxHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("upstream boom"))
+	}))
+	defer srv.Close()
+	m, _ := NewMiniMax(srv.URL, "k", "", nil)
+	_, err := m.Generate(context.Background(), "x", Options{})
+	if err == nil || !strings.Contains(err.Error(), "500") {
+		t.Fatalf("expected HTTP 500 error, got %v", err)
+	}
+}
+
+func TestMiniMaxNoDecodableImages(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// status_code 0 but a non-base64 payload -> no decodable images.
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data":      map[string]interface{}{"image_base64": []string{"!!!not-base64!!!"}},
+			"base_resp": map[string]interface{}{"status_code": 0},
+		})
+	}))
+	defer srv.Close()
+	m, _ := NewMiniMax(srv.URL, "k", "", nil)
+	if _, err := m.Generate(context.Background(), "x", Options{}); err == nil {
+		t.Fatal("undecodable payload should error")
+	}
+}
+
+func TestMiniMaxAspect(t *testing.T) {
+	cases := []struct {
+		w, h int
+		want string
+	}{
+		{1024, 1024, "1:1"},
+		{0, 0, "1:1"},
+		{2560, 1080, "21:9"},
+		{1920, 1080, "16:9"},
+		{1500, 1000, "3:2"},
+		{1024, 768, "4:3"},
+		{1080, 1920, "9:16"},
+		{1000, 1500, "2:3"},
+		{768, 1024, "3:4"},
+		{1000, 1100, "1:1"}, // near-square, no specific ratio
+	}
+	for _, c := range cases {
+		if got := minimaxAspect(c.w, c.h); got != c.want {
+			t.Errorf("minimaxAspect(%d,%d) = %q, want %q", c.w, c.h, got, c.want)
+		}
+	}
+}
+
+// Z.AI CogView/GLM-Image: OpenAI-shaped, returns a URL, rejects "n".
+func TestZAIViaOpenAICompatibleURLAndOmitN(t *testing.T) {
+	raw, _ := base64.StdEncoding.DecodeString(tinyPNGB64)
+	imgSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(raw)
+	}))
+	defer imgSrv.Close()
+
+	var gotBody map[string]interface{}
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/images/generations") {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []map[string]interface{}{{"url": imgSrv.URL + "/x.png"}},
+		})
+	}))
+	defer apiSrv.Close()
+
+	p, err := NewOpenAICompatible(apiSrv.URL, "zk", "glm-image", "zai", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.omitN = true
+	imgs, err := p.Generate(context.Background(), "a dog", Options{Size: "1024x1024"})
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if len(imgs) != 1 {
+		t.Fatalf("want 1 image, got %d", len(imgs))
+	}
+	if _, hasN := gotBody["n"]; hasN {
+		t.Errorf("omitN provider must not send 'n'")
+	}
+	if gotBody["model"] != "glm-image" {
+		t.Errorf("model = %v", gotBody["model"])
+	}
+}
+
+func TestProviderFromModel(t *testing.T) {
+	cases := map[string]string{
+		"glm-image":                        "zai",
+		"cogview-4-250304":                 "zai",
+		"cogview-4-250999":                 "zai", // future snapshot, heuristic
+		"image-01":                         "minimax",
+		"gpt-image-1":                      "openai",
+		"gpt-5.5":                          "openai-responses",
+		"grok-2-image":                     "xai",
+		"imagen-3.0-generate-002":          "google",
+		"stability.stable-image-core-v1:1": "bedrock",
+		"amazon.nova-canvas-v1:0":          "bedrock",
+		"":                                 "",
+		"some-unknown-model":               "",
+	}
+	for model, want := range cases {
+		if got := providerFromModel(model); got != want {
+			t.Errorf("providerFromModel(%q) = %q, want %q", model, got, want)
+		}
+	}
+}
+
+// auto mode (no CHATCLI_IMAGE_PROVIDER): the model alone picks the backend.
+func TestFactoryAutoInfersProviderFromModel(t *testing.T) {
+	for _, k := range []string{"CHATCLI_IMAGE_PROVIDER", "CHATCLI_IMAGE_MODEL", "CHATCLI_IMAGE_URL", "CHATCLI_IMAGE_API", "OPENAI_API_KEY", "GOOGLEAI_API_KEY", "GEMINI_API_KEY", "XAI_API_KEY", "ZAI_API_KEY", "MINIMAX_API_KEY"} {
+		t.Setenv(k, "")
+	}
+	// Provider stays unset (auto). Only ZAI_API_KEY present, model = glm-image.
+	t.Setenv("ZAI_API_KEY", "zk")
+	t.Setenv("CHATCLI_IMAGE_MODEL", "glm-image")
+	if p := NewFromEnv(nil); p.Name() != "zai" {
+		t.Errorf("auto+glm-image: got %q, want zai", p.Name())
+	}
+
+	// Model = image-01 but only MINIMAX key -> minimax (not the present ZAI key path).
+	t.Setenv("MINIMAX_API_KEY", "mk")
+	t.Setenv("CHATCLI_IMAGE_MODEL", "image-01")
+	if p := NewFromEnv(nil); p.Name() != "minimax" {
+		t.Errorf("auto+image-01: got %q, want minimax", p.Name())
+	}
+
+	// Recognized model whose key is absent -> Null, does NOT silently use the
+	// other present keys.
+	t.Setenv("CHATCLI_IMAGE_MODEL", "image-01")
+	t.Setenv("MINIMAX_API_KEY", "")
+	if p := NewFromEnv(nil); !IsNull(p) {
+		t.Errorf("auto+image-01 without MINIMAX key should be Null, got %q", p.Name())
+	}
+}
+
+// Exercises the remaining auto-inference branches so a chosen model routes to
+// the matching cloud backend purely from its id.
+func TestFactoryAutoRoutesEachProvider(t *testing.T) {
+	clear := func() {
+		for _, k := range []string{"CHATCLI_IMAGE_PROVIDER", "CHATCLI_IMAGE_MODEL", "CHATCLI_IMAGE_URL", "CHATCLI_IMAGE_API", "OPENAI_API_KEY", "GOOGLEAI_API_KEY", "GEMINI_API_KEY", "XAI_API_KEY", "ZAI_API_KEY", "MINIMAX_API_KEY"} {
+			t.Setenv(k, "")
+		}
+	}
+	cases := []struct {
+		model, keyEnv, keyVal, wantNamePart string
+	}{
+		{"gpt-image-1", "OPENAI_API_KEY", "ok", "openai"},
+		{"gpt-5.5", "OPENAI_API_KEY", "ok", ""}, // responses backend; just must not be Null
+		{"imagen-3.0-generate-002", "GOOGLEAI_API_KEY", "gk", "google"},
+		{"grok-2-image", "XAI_API_KEY", "xk", "xai"},
+	}
+	for _, c := range cases {
+		clear()
+		t.Setenv("CHATCLI_IMAGE_MODEL", c.model)
+		t.Setenv(c.keyEnv, c.keyVal)
+		p := NewFromEnv(nil)
+		if IsNull(p) {
+			t.Errorf("model %s with %s set should route to a backend, got Null", c.model, c.keyEnv)
+			continue
+		}
+		if c.wantNamePart != "" && !strings.Contains(p.Name(), c.wantNamePart) {
+			t.Errorf("model %s routed to %q, want name containing %q", c.model, p.Name(), c.wantNamePart)
+		}
+	}
+}
+
+func TestFactoryZAIAndMiniMaxSelection(t *testing.T) {
+	for _, k := range []string{"CHATCLI_IMAGE_PROVIDER", "CHATCLI_IMAGE_MODEL", "CHATCLI_IMAGE_URL", "OPENAI_API_KEY", "ZAI_API_KEY", "MINIMAX_API_KEY"} {
+		t.Setenv(k, "")
+	}
+
+	t.Setenv("CHATCLI_IMAGE_PROVIDER", "zai")
+	t.Setenv("ZAI_API_KEY", "zk")
+	if p := NewFromEnv(nil); p.Name() != "zai" {
+		t.Errorf("zai provider: got %q", p.Name())
+	}
+
+	t.Setenv("CHATCLI_IMAGE_PROVIDER", "minimax")
+	t.Setenv("MINIMAX_API_KEY", "mk")
+	if p := NewFromEnv(nil); p.Name() != "minimax" {
+		t.Errorf("minimax provider: got %q", p.Name())
+	}
+
+	// Pinned but no key -> degrades to Null, never silently switches.
+	t.Setenv("MINIMAX_API_KEY", "")
+	if p := NewFromEnv(nil); !IsNull(p) {
+		t.Errorf("minimax without key should be Null, got %q", p.Name())
+	}
+}

--- a/llm/imagegen/openai_compatible.go
+++ b/llm/imagegen/openai_compatible.go
@@ -41,6 +41,7 @@ type OpenAICompatible struct {
 	model    string
 	label    string
 	omitSize bool // some servers (xAI grok-image) reject the "size" field
+	omitN    bool // some servers (Z.AI CogView/GLM-Image) reject the "n" field
 	client   *http.Client
 }
 
@@ -96,7 +97,9 @@ func (o *OpenAICompatible) Generate(ctx context.Context, prompt string, opts Opt
 	payload := map[string]interface{}{
 		"model":  o.model,
 		"prompt": prompt,
-		"n":      n,
+	}
+	if !o.omitN {
+		payload["n"] = n
 	}
 	if !o.omitSize {
 		payload["size"] = size

--- a/ui/theme/glamour.go
+++ b/ui/theme/glamour.go
@@ -81,10 +81,14 @@ func (t Theme) GlamourStyleConfig() ansi.StyleConfig {
 		Emph:           ansi.StylePrimitive{Color: hexPtr(p.Text), Italic: boolPtr(true)},
 		Strikethrough:  ansi.StylePrimitive{CrossedOut: boolPtr(true)},
 		HorizontalRule: ansi.StylePrimitive{Color: hexPtr(p.Muted), Format: "\n──────\n"},
-		Item:           ansi.StylePrimitive{Color: hexPtr(p.Text)},
-		Enumeration:    ansi.StylePrimitive{Color: hexPtr(p.Muted)},
-		Link:           ansi.StylePrimitive{Color: hexPtr(p.Secondary), Underline: boolPtr(true)},
-		LinkText:       ansi.StylePrimitive{Color: hexPtr(p.Accent)},
+		// BlockPrefix carries the list marker glamour emits before each item's
+		// text ("• " for bullets, ". " right after the number for ordered lists).
+		// Overriding these styles without it produces "1Foo"/"Foo" — the marker
+		// vanishes. See glamour stock styles + ansi/listitem.go.
+		Item:        ansi.StylePrimitive{Color: hexPtr(p.Text), BlockPrefix: "• "},
+		Enumeration: ansi.StylePrimitive{Color: hexPtr(p.Muted), BlockPrefix: ". "},
+		Link:        ansi.StylePrimitive{Color: hexPtr(p.Secondary), Underline: boolPtr(true)},
+		LinkText:    ansi.StylePrimitive{Color: hexPtr(p.Accent)},
 		// Inline `code`: tinted and padded so it reads as a chip.
 		Code: ansi.StyleBlock{StylePrimitive: ansi.StylePrimitive{
 			Color: hexPtr(p.Warning), Prefix: " ", Suffix: " "}},


### PR DESCRIPTION
## Summary

Image-generation work plus one markdown-rendering fix.

### 🐛 Fix: glued list numbering
Overriding glamour's `Item`/`Enumeration` styles in the theme dropped their `BlockPrefix` — the field that emits the `•` bullet and the `. ` after an ordered-list number. The result was glued output like `1Foo`/`2Bar` across chat, agent and one-shot modes. The prefixes are restored.

### 🎨 Image-model catalog revalidated
- **Bedrock:** the Amazon models are now legacy, so the current Stability models are added (**Stable Image Core**, **Ultra**, **SD3.5 Large**); Nova Canvas (EOL 2026-09-30) and Titan are marked legacy; the **default** moves to Stable Image Core.
- **OpenAI:** `dall-e-3` is removed (retired 2026-05-12); the gpt-image family stays.

### ✨ New backends (reusing the keys their chat providers already use)
- **Z.AI** CogView-4 / GLM-Image — speak the `/images/generations` shape but return image **URLs** and reject the count field; they reuse the shared client with a new omit-count flag and a fixed base URL keyed on `ZAI_API_KEY`. **No image-URL env var required.**
- **MiniMax** Image-01 — a dedicated endpoint with an aspect ratio and a base64 response; standalone backend keyed on `MINIMAX_API_KEY`.

### 🤖 Auto mode now infers the provider from the model
Instead of picking the backend by whichever key happens to be present, `auto` resolves it from `CHATCLI_IMAGE_MODEL` (catalog match plus an id-prefix heuristic). A user just picks a model via `/model-image` and the right backend and key are used — no `CHATCLI_IMAGE_PROVIDER`, no URL. A recognized model whose key is missing degrades to the disabled provider with a pointed warning, rather than silently routing the model to a backend that cannot run it.

### 🔀 `/model-image` shortcut
The image counterpart to `/model`: lists the catalog when bare, switches the image model when given an id. Registered **ahead of** `/model` so the raw-prefix route doesn't shadow it. Wired into dispatch, completion, the root listing and i18n (pt/en).

Claude and Moonshot/Kimi are intentionally not wired — neither generates images.

## Tests
- New httptest-based tests for MiniMax (request/response, `base_resp` error path, key required), Z.AI (URL download + count omission), `providerFromModel` (12 cases incl. a future snapshot id), and factory selection (model-aware auto + degradation to the disabled provider when the key is absent).
- `go build ./...`, `go vet`, and the `llm/imagegen`, `cli`, `ui/theme` suites all pass.