### PR TITLE
fix(webfetch): authenticate through corporate proxies with special-char credentials

### DIFF
--- a/cli/cli_config.go
+++ b/cli/cli_config.go
@@ -387,6 +387,18 @@ func presence(v string) string {
 	return "[SET]"
 }
 
+// firstNonEmptyEnvVal returns the value of the first set, non-blank env var
+// among names. Used to surface a setting that may be spelled upper- or
+// lower-case (e.g. HTTPS_PROXY / https_proxy) under one config line.
+func firstNonEmptyEnvVal(names ...string) string {
+	for _, n := range names {
+		if v := strings.TrimSpace(os.Getenv(n)); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
 // getEnvFilePath retorna o caminho do arquivo .env configurado (expandido).
 func (cli *ChatCLI) getEnvFilePath() string {
 	envFilePath := os.Getenv("CHATCLI_DOTENV")

--- a/cli/config_sections.go
+++ b/cli/config_sections.go
@@ -740,6 +740,9 @@ func (cli *ChatCLI) showConfigResilience() {
 	kv(p, "NO_PROXY", envOr("NO_PROXY"))
 	// Escape hatch for non-Basic proxy auth (Negotiate/NTLM/Kerberos/Bearer).
 	kv(p, "CHATCLI_PROXY_AUTH", presence(os.Getenv("CHATCLI_PROXY_AUTH")))
+	// SSRF guard: metadata/link-local is always blocked; private/loopback only
+	// when this is enabled (web tools legitimately fetch internal services).
+	kv(p, "CHATCLI_WEBFETCH_BLOCK_PRIVATE", envBool("CHATCLI_WEBFETCH_BLOCK_PRIVATE"))
 
 	fmt.Println(p)
 	subheader(p, "cfg.sub.resil.session_state")

--- a/cli/config_sections.go
+++ b/cli/config_sections.go
@@ -731,6 +731,17 @@ func (cli *ChatCLI) showConfigResilience() {
 	kv(p, "AWS_EC2_METADATA_DISABLED", envOr("AWS_EC2_METADATA_DISABLED"))
 
 	fmt.Println(p)
+	subheader(p, "cfg.sub.resil.web_proxy")
+	// Standard proxy vars. A login:senha embedded in the URL is honored and
+	// parsed tolerantly (domain users / special-char passwords included), so we
+	// mask the value — it carries a secret.
+	kv(p, "HTTPS_PROXY", presence(firstNonEmptyEnvVal("HTTPS_PROXY", "https_proxy")))
+	kv(p, "HTTP_PROXY", presence(firstNonEmptyEnvVal("HTTP_PROXY", "http_proxy")))
+	kv(p, "NO_PROXY", envOr("NO_PROXY"))
+	// Escape hatch for non-Basic proxy auth (Negotiate/NTLM/Kerberos/Bearer).
+	kv(p, "CHATCLI_PROXY_AUTH", presence(os.Getenv("CHATCLI_PROXY_AUTH")))
+
+	fmt.Println(p)
 	subheader(p, "cfg.sub.resil.session_state")
 	kv(p, i18n.T("cfg.kv.history_messages"), fmt.Sprintf("%d", len(cli.history)))
 	historyChars := 0

--- a/cli/plugins/builtin_osv.go
+++ b/cli/plugins/builtin_osv.go
@@ -32,7 +32,9 @@ import (
 var osvBaseURL = "https://api.osv.dev"
 
 // osvHTTPClient is the HTTP client used for OSV queries. Overridable in tests.
-var osvHTTPClient = &http.Client{Timeout: 30 * time.Second}
+// It shares the proxy-aware transport so OSV lookups authenticate against a
+// corporate proxy just like @webfetch/@websearch (see builtin_web_httpclient.go).
+var osvHTTPClient = &http.Client{Timeout: 30 * time.Second, Transport: &proxyAuthTransport{base: newWebTransport()}}
 
 // BuiltinOsvPlugin is the @osv tool.
 type BuiltinOsvPlugin struct{}

--- a/cli/plugins/builtin_web_httpclient.go
+++ b/cli/plugins/builtin_web_httpclient.go
@@ -61,6 +61,9 @@ func webHTTPClient() *http.Client {
 	webClientOnce.Do(func() {
 		webClient = &http.Client{
 			Transport: &proxyAuthTransport{base: newWebTransport()},
+			// Re-validate every redirect hop so a 302 to an internal URL can't
+			// launder past the initial SSRF check.
+			CheckRedirect: validateRedirect,
 		}
 	})
 	return webClient
@@ -87,6 +90,9 @@ func newWebTransport() *http.Transport {
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
+			// Airtight SSRF enforcement: runs after DNS resolution on every
+			// connection (initial + each redirect hop), closing DNS-rebinding.
+			Control: ssrfDialControl,
 		}).DialContext,
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          100,
@@ -126,7 +132,15 @@ func (t *proxyAuthTransport) RoundTrip(req *http.Request) (*http.Response, error
 // so a domain login or a password with special characters still authenticates
 // instead of silently disabling the proxy.
 func webProxyForRequest(req *http.Request) (*url.URL, error) {
-	raw := rawProxyForScheme(req.URL.Scheme)
+	return webProxyForURL(req.URL)
+}
+
+// webProxyForURL is the URL-level core of webProxyForRequest, also used by the
+// SSRF guard to decide whether a target is reached through a proxy (in which
+// case the proxy is the egress control point and local IP resolution is both
+// ineffective and prone to false positives).
+func webProxyForURL(target *url.URL) (*url.URL, error) {
+	raw := rawProxyForScheme(target.Scheme)
 	if raw == "" {
 		return nil, nil
 	}
@@ -139,7 +153,7 @@ func webProxyForRequest(req *http.Request) (*url.URL, error) {
 	// Apply NO_PROXY using the standard matcher. We feed it a credential-
 	// stripped copy (which always parses cleanly) purely for the include/
 	// exclude decision, then return our credential-bearing URL.
-	if !proxyAppliesForHost(req.URL, proxyURL) {
+	if !proxyAppliesForHost(target, proxyURL) {
 		return nil, nil
 	}
 	return proxyURL, nil

--- a/cli/plugins/builtin_web_httpclient.go
+++ b/cli/plugins/builtin_web_httpclient.go
@@ -1,0 +1,245 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package plugins
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/net/http/httpproxy"
+)
+
+// Corporate-proxy support shared by the @webfetch / @websearch / @osv builtins.
+//
+// These tools used to issue requests via http.DefaultClient. Its transport
+// reads the standard HTTP_PROXY/HTTPS_PROXY/NO_PROXY variables and DOES inject
+// Proxy-Authorization — BUT only when the proxy URL's userinfo parses cleanly
+// with net/url. Corporate credentials routinely break that: a Windows-domain
+// user (`DOMAIN\jdoe`) or a password containing `%`, `#`, or a space is not a
+// valid percent-encoded userinfo, so url.Parse returns an error. The real trap
+// is what http.ProxyFromEnvironment does with that error — it SWALLOWS it and
+// returns a nil proxy, so Go silently bypasses the proxy and connects directly.
+// Whatever sits in that path then answers 401/407. curl works in the same
+// shell only because it parses the credentials tolerantly.
+//
+// So the fix is NOT a new set of chatcli-specific variables: it is to honor the
+// SAME standard variables the user already sets (HTTP_PROXY/HTTPS_PROXY/
+// ALL_PROXY/NO_PROXY, including embedded login:senha) and parse the credentials
+// tolerantly, re-encoding them so Go emits Proxy-Authorization on both the
+// plain-HTTP request path and the HTTPS CONNECT tunnel.
+//
+// CHATCLI_PROXY_AUTH is the one additive knob: a ready-to-send
+// Proxy-Authorization header value for proxies that need a NON-Basic scheme
+// (Negotiate/NTLM/Kerberos/Bearer), which a login:senha URL cannot express.
+const envProxyAuth = "CHATCLI_PROXY_AUTH"
+
+var (
+	webClientOnce sync.Once
+	webClient     *http.Client
+)
+
+// webHTTPClient returns the shared, proxy-aware HTTP client used by the
+// @webfetch / @websearch / @osv builtins. It mirrors http.DefaultClient's
+// "no client-level timeout" contract (every caller already scopes its request
+// with a context deadline) while adding the corporate-proxy authentication the
+// default transport drops on the floor.
+//
+// The client is built once, but every proxy decision is re-read from the
+// environment per request, so runtime changes — and t.Setenv in tests — take
+// effect without a rebuild.
+func webHTTPClient() *http.Client {
+	webClientOnce.Do(func() {
+		webClient = &http.Client{
+			Transport: &proxyAuthTransport{base: newWebTransport()},
+		}
+	})
+	return webClient
+}
+
+// newWebTransport builds the proxy-aware transport. The connection settings
+// mirror utils.NewHTTPClient so behavior is consistent with the LLM providers.
+func newWebTransport() *http.Transport {
+	return &http.Transport{
+		Proxy: webProxyForRequest,
+		// GetProxyConnectHeader injects a raw (non-Basic) Proxy-Authorization
+		// on the HTTPS CONNECT request. Basic credentials carried in the proxy
+		// userinfo are handled by the transport itself, so we only step in when
+		// the URL has none and CHATCLI_PROXY_AUTH is set.
+		GetProxyConnectHeader: func(_ context.Context, proxyURL *url.URL, _ string) (http.Header, error) {
+			if proxyURL != nil && proxyURL.User != nil {
+				return nil, nil
+			}
+			if auth := proxyAuthRawHeader(); auth != "" {
+				return http.Header{"Proxy-Authorization": {auth}}, nil
+			}
+			return nil, nil
+		},
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+}
+
+// proxyAuthTransport wraps the base transport to cover the one path Go won't
+// handle on its own: a raw (non-Basic) Proxy-Authorization header for a
+// plain-HTTP target. For such targets the request is forwarded to the proxy
+// verbatim, so the header must be set on the request. HTTPS targets are left
+// untouched here — their CONNECT header is supplied via GetProxyConnectHeader.
+type proxyAuthTransport struct {
+	base *http.Transport
+}
+
+func (t *proxyAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.Scheme == "http" && req.Header.Get("Proxy-Authorization") == "" {
+		if auth := proxyAuthRawHeader(); auth != "" {
+			// Attach only when a proxy actually applies AND it carries no Basic
+			// userinfo of its own — so we never double up, and never leak the
+			// credential on a direct (NO_PROXY) connection.
+			if p, _ := webProxyForRequest(req); p != nil && p.User == nil {
+				req = req.Clone(req.Context())
+				req.Header.Set("Proxy-Authorization", auth)
+			}
+		}
+	}
+	return t.base.RoundTrip(req)
+}
+
+// webProxyForRequest resolves the proxy URL for req using the STANDARD
+// environment variables (HTTPS_PROXY/HTTP_PROXY/ALL_PROXY, gated by NO_PROXY).
+// Unlike http.ProxyFromEnvironment, it parses the proxy credentials tolerantly
+// so a domain login or a password with special characters still authenticates
+// instead of silently disabling the proxy.
+func webProxyForRequest(req *http.Request) (*url.URL, error) {
+	raw := rawProxyForScheme(req.URL.Scheme)
+	if raw == "" {
+		return nil, nil
+	}
+
+	proxyURL, err := parseProxyURLTolerant(raw)
+	if err != nil || proxyURL == nil {
+		return proxyURL, err
+	}
+
+	// Apply NO_PROXY using the standard matcher. We feed it a credential-
+	// stripped copy (which always parses cleanly) purely for the include/
+	// exclude decision, then return our credential-bearing URL.
+	if !proxyAppliesForHost(req.URL, proxyURL) {
+		return nil, nil
+	}
+	return proxyURL, nil
+}
+
+// rawProxyForScheme returns the raw proxy string that applies to the target
+// scheme, honoring both upper- and lower-case forms and falling back to
+// ALL_PROXY (a curl-ism the standard library ignores, included here so behavior
+// matches the curl the user is comparing against).
+func rawProxyForScheme(scheme string) string {
+	if strings.EqualFold(scheme, "https") {
+		return firstNonEmptyEnv("HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy")
+	}
+	return firstNonEmptyEnv("HTTP_PROXY", "http_proxy", "ALL_PROXY", "all_proxy")
+}
+
+// parseProxyURLTolerant parses a proxy URL, recovering credentials that
+// net/url rejects when they are not percent-encoded (e.g. `DOMAIN\user`, or a
+// password containing `%`, `#`, or a space). It first tries the strict path;
+// on failure it splits scheme / userinfo / host by hand and re-wraps the
+// credentials with url.UserPassword, which percent-encodes them correctly so
+// Go's transport can emit a valid Basic Proxy-Authorization.
+func parseProxyURLTolerant(raw string) (*url.URL, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+
+	// Strict path: a clean, already-encoded URL is used verbatim (its decoded
+	// credentials round-trip correctly through Go's transport).
+	if u, err := url.Parse(raw); err == nil && u.Host != "" {
+		return u, nil
+	}
+
+	// Tolerant path. Peel an explicit scheme; default to http like the proxy
+	// env conventions do.
+	scheme := "http"
+	work := raw
+	if i := strings.Index(work, "://"); i >= 0 {
+		scheme = work[:i]
+		work = work[i+len("://"):]
+	}
+
+	// Split userinfo from host on the LAST '@' so an '@' inside the password is
+	// kept with the credentials, not mistaken for the host delimiter.
+	var userinfo, hostpart string
+	if at := strings.LastIndex(work, "@"); at >= 0 {
+		userinfo, hostpart = work[:at], work[at+1:]
+	} else {
+		hostpart = work
+	}
+	hostpart = strings.TrimRight(hostpart, "/")
+	if hostpart == "" {
+		return nil, fmt.Errorf("proxy URL %q has no host", raw)
+	}
+
+	u := &url.URL{Scheme: scheme, Host: hostpart}
+	if userinfo != "" {
+		// First ':' splits user from password; everything after it (including
+		// further ':' or '@') is the password.
+		if c := strings.IndexByte(userinfo, ':'); c >= 0 {
+			u.User = url.UserPassword(userinfo[:c], userinfo[c+1:])
+		} else {
+			u.User = url.User(userinfo)
+		}
+	}
+	return u, nil
+}
+
+// proxyAppliesForHost reports whether the proxy should be used for reqURL given
+// NO_PROXY, reusing the standard library matcher on a credential-stripped copy
+// of the proxy (so the matcher never trips over the very credentials we are
+// trying to preserve).
+func proxyAppliesForHost(reqURL *url.URL, proxyURL *url.URL) bool {
+	stripped := *proxyURL
+	stripped.User = nil
+	cfg := &httpproxy.Config{
+		HTTPProxy:  stripped.String(),
+		HTTPSProxy: stripped.String(),
+		NoProxy:    firstNonEmptyEnv("NO_PROXY", "no_proxy"),
+	}
+	u, err := cfg.ProxyFunc()(reqURL)
+	return err == nil && u != nil
+}
+
+// proxyAuthRawHeader returns the explicit Proxy-Authorization header value
+// (CHATCLI_PROXY_AUTH), or "" when none is configured. This is the escape hatch
+// for non-Basic proxy schemes; Basic credentials flow through the proxy URL
+// userinfo instead, so Go handles them uniformly across HTTP and CONNECT.
+func proxyAuthRawHeader() string {
+	return strings.TrimSpace(os.Getenv(envProxyAuth))
+}
+
+// firstNonEmptyEnv returns the trimmed value of the first set, non-blank env
+// var among names.
+func firstNonEmptyEnv(names ...string) string {
+	for _, n := range names {
+		if v := strings.TrimSpace(os.Getenv(n)); v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/cli/plugins/builtin_web_httpclient_test.go
+++ b/cli/plugins/builtin_web_httpclient_test.go
@@ -243,10 +243,11 @@ func TestProxyAuthTransport_NoLeakWithoutProxy(t *testing.T) {
 }
 
 func TestWebHTTPClient_Singleton(t *testing.T) {
-	if c := webHTTPClient(); c == nil {
+	first := webHTTPClient()
+	if first == nil {
 		t.Fatal("expected non-nil client")
 	}
-	if webHTTPClient() != webHTTPClient() {
+	if second := webHTTPClient(); second != first {
 		t.Fatal("expected a stable singleton")
 	}
 }

--- a/cli/plugins/builtin_web_httpclient_test.go
+++ b/cli/plugins/builtin_web_httpclient_test.go
@@ -1,0 +1,252 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package plugins
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func basicB64(user, pass string) string {
+	return base64.StdEncoding.EncodeToString([]byte(user + ":" + pass))
+}
+
+func newProxyReq(t *testing.T, target string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, target, nil)
+	if err != nil {
+		t.Fatalf("building request: %v", err)
+	}
+	return req
+}
+
+func clearProxyEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{
+		"HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY",
+		"http_proxy", "https_proxy", "all_proxy", "no_proxy",
+		envProxyAuth,
+	} {
+		t.Setenv(k, "")
+	}
+}
+
+func TestWebProxyForRequest_NoProxy(t *testing.T) {
+	clearProxyEnv(t)
+	got, err := webProxyForRequest(newProxyReq(t, "https://example.com"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected no proxy, got %v", got)
+	}
+}
+
+func TestWebProxyForRequest_PlainCreds(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("HTTPS_PROXY", "http://alice:s3cr3t@proxy.corp:8080")
+
+	got, err := webProxyForRequest(newProxyReq(t, "https://example.com"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil || got.Host != "proxy.corp:8080" || got.User == nil {
+		t.Fatalf("expected proxy with creds, got %v", got)
+	}
+	if u := got.User.Username(); u != "alice" {
+		t.Fatalf("expected user alice, got %q", u)
+	}
+	if p, _ := got.User.Password(); p != "s3cr3t" {
+		t.Fatalf("expected pass s3cr3t, got %q", p)
+	}
+}
+
+// THE FIX: credentials that net/url rejects (domain backslash, '%', '#',
+// space) must still be recovered so Proxy-Authorization is emitted, instead of
+// http.ProxyFromEnvironment silently dropping the proxy.
+func TestWebProxyForRequest_TolerantSpecialChars(t *testing.T) {
+	cases := []struct {
+		name, raw, wantUser, wantPass string
+	}{
+		{"domain-backslash", `http://CORP\jdoe:s3cr3t@proxy.corp:8080`, `CORP\jdoe`, "s3cr3t"},
+		{"percent", "http://alice:pa%ss@proxy.corp:8080", "alice", "pa%ss"},
+		{"hash", "http://alice:pa#ss@proxy.corp:8080", "alice", "pa#ss"},
+		{"space", "http://alice:pa ss@proxy.corp:8080", "alice", "pa ss"},
+		{"at-in-pass", "http://alice:p@ss@proxy.corp:8080", "alice", "p@ss"},
+		{"no-scheme", "alice:s3cr3t@proxy.corp:8080", "alice", "s3cr3t"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clearProxyEnv(t)
+			t.Setenv("HTTPS_PROXY", tc.raw)
+
+			got, err := webProxyForRequest(newProxyReq(t, "https://example.com"))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got == nil || got.User == nil {
+				t.Fatalf("expected proxy with recovered creds, got %v", got)
+			}
+			if u := got.User.Username(); u != tc.wantUser {
+				t.Fatalf("user: want %q got %q", tc.wantUser, u)
+			}
+			if p, _ := got.User.Password(); p != tc.wantPass {
+				t.Fatalf("pass: want %q got %q", tc.wantPass, p)
+			}
+			if got.Host != "proxy.corp:8080" {
+				t.Fatalf("host: want proxy.corp:8080 got %q", got.Host)
+			}
+			// And crucially the re-encoded URL must produce a parseable,
+			// credential-bearing URL string (what Go base64-encodes for auth).
+			if reparsed, perr := url.Parse(got.String()); perr != nil || reparsed.User == nil {
+				t.Fatalf("re-encoded URL not clean: %q err=%v", got.String(), perr)
+			}
+		})
+	}
+}
+
+func TestWebProxyForRequest_RespectsNoProxy(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("HTTPS_PROXY", "http://alice:s3cr3t@proxy.corp:8080")
+	t.Setenv("NO_PROXY", "example.com")
+
+	got, err := webProxyForRequest(newProxyReq(t, "https://example.com"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected direct connection for NO_PROXY host, got %v", got)
+	}
+}
+
+func TestWebProxyForRequest_SchemeSelection(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("HTTP_PROXY", "http://httponly:9090")
+	t.Setenv("HTTPS_PROXY", "http://httpsonly:9443")
+
+	httpGot, _ := webProxyForRequest(newProxyReq(t, "http://example.com"))
+	if httpGot == nil || httpGot.Host != "httponly:9090" {
+		t.Fatalf("http target: want httponly:9090, got %v", httpGot)
+	}
+	httpsGot, _ := webProxyForRequest(newProxyReq(t, "https://example.com"))
+	if httpsGot == nil || httpsGot.Host != "httpsonly:9443" {
+		t.Fatalf("https target: want httpsonly:9443, got %v", httpsGot)
+	}
+}
+
+func TestWebProxyForRequest_AllProxyFallback(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("ALL_PROXY", "http://allproxy:1080")
+
+	got, _ := webProxyForRequest(newProxyReq(t, "https://example.com"))
+	if got == nil || got.Host != "allproxy:1080" {
+		t.Fatalf("expected ALL_PROXY fallback allproxy:1080, got %v", got)
+	}
+}
+
+func TestProxyAuthRawHeader(t *testing.T) {
+	clearProxyEnv(t)
+	if got := proxyAuthRawHeader(); got != "" {
+		t.Fatalf("expected empty, got %q", got)
+	}
+	t.Setenv(envProxyAuth, "  Negotiate abc  ")
+	if got := proxyAuthRawHeader(); got != "Negotiate abc" {
+		t.Fatalf("expected trimmed 'Negotiate abc', got %q", got)
+	}
+}
+
+// End-to-end: a plain-HTTP target routed through a stub proxy must arrive with
+// the raw Proxy-Authorization header injected by the RoundTripper wrapper.
+func TestProxyAuthTransport_InjectsRawHeaderOnHTTPTarget(t *testing.T) {
+	clearProxyEnv(t)
+
+	var gotAuth string
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Proxy-Authorization")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer proxy.Close()
+
+	t.Setenv("HTTP_PROXY", proxy.URL) // no creds in URL → raw header path
+	t.Setenv(envProxyAuth, "Negotiate TOKEN123")
+
+	client := &http.Client{Transport: &proxyAuthTransport{base: newWebTransport()}}
+	resp, err := client.Get("http://target.internal/page")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if gotAuth != "Negotiate TOKEN123" {
+		t.Fatalf("proxy did not receive injected Proxy-Authorization, got %q", gotAuth)
+	}
+}
+
+// Basic creds in the proxy URL must reach the proxy too (Go injects them); the
+// raw-header wrapper must stay out of the way.
+func TestProxyAuthTransport_BasicFromURLOnHTTPTarget(t *testing.T) {
+	clearProxyEnv(t)
+
+	var gotAuth string
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Proxy-Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer proxy.Close()
+
+	u, _ := url.Parse(proxy.URL)
+	t.Setenv("HTTP_PROXY", "http://alice:s3cr3t@"+u.Host)
+
+	client := &http.Client{Transport: &proxyAuthTransport{base: newWebTransport()}}
+	resp, err := client.Get("http://target.internal/page")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// alice:s3cr3t -> base64
+	if gotAuth != "Basic "+basicB64("alice", "s3cr3t") {
+		t.Fatalf("expected Basic auth from URL, got %q", gotAuth)
+	}
+}
+
+// The wrapper must NOT attach Proxy-Authorization when no proxy applies —
+// otherwise we'd leak the corporate credential to origins on a direct call.
+func TestProxyAuthTransport_NoLeakWithoutProxy(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv(envProxyAuth, "Negotiate TOKEN123")
+
+	var gotAuth string
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Proxy-Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer origin.Close()
+
+	client := &http.Client{Transport: &proxyAuthTransport{base: newWebTransport()}}
+	resp, err := client.Get(origin.URL)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if gotAuth != "" {
+		t.Fatalf("Proxy-Authorization leaked on direct connection: %q", gotAuth)
+	}
+}
+
+func TestWebHTTPClient_Singleton(t *testing.T) {
+	if c := webHTTPClient(); c == nil {
+		t.Fatal("expected non-nil client")
+	}
+	if webHTTPClient() != webHTTPClient() {
+		t.Fatal("expected a stable singleton")
+	}
+}

--- a/cli/plugins/builtin_webfetch.go
+++ b/cli/plugins/builtin_webfetch.go
@@ -129,7 +129,15 @@ func (p *BuiltinWebFetchPlugin) ExecuteWithStream(ctx context.Context, args []st
 	reqCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(reqCtx, "GET", parsed.URL, nil)
+	// SSRF guard: validate (and canonicalize) the target before it reaches the
+	// HTTP client. Blocks cloud-metadata/link-local always; private/loopback
+	// only when CHATCLI_WEBFETCH_BLOCK_PRIVATE is set.
+	safeURL, err := validateWebTarget(parsed.URL)
+	if err != nil {
+		return "", fmt.Errorf("refusing to fetch %q: %w", parsed.URL, err)
+	}
+
+	req, err := http.NewRequestWithContext(reqCtx, "GET", safeURL, nil)
 	if err != nil {
 		return "", fmt.Errorf("creating request: %w", err)
 	}

--- a/cli/plugins/builtin_webfetch.go
+++ b/cli/plugins/builtin_webfetch.go
@@ -137,7 +137,7 @@ func (p *BuiltinWebFetchPlugin) ExecuteWithStream(ctx context.Context, args []st
 	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
 	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := webHTTPClient().Do(req)
 	if err != nil {
 		return "", fmt.Errorf("fetching URL: %w", err)
 	}

--- a/cli/plugins/builtin_websearch.go
+++ b/cli/plugins/builtin_websearch.go
@@ -329,7 +329,14 @@ func searchSearxNG(ctx context.Context, query string, maxResults int, baseURL st
 
 	endpoint := baseURL + "/search?" + params.Encode()
 
-	req, err := http.NewRequestWithContext(reqCtx, "GET", endpoint, nil)
+	// SSRF guard: the SearxNG base URL is operator-supplied; validate and
+	// canonicalize it before it reaches the HTTP client.
+	safeEndpoint, err := validateWebTarget(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("refusing to query SearxNG endpoint: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(reqCtx, "GET", safeEndpoint, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating SearxNG request: %w", err)
 	}
@@ -390,7 +397,13 @@ func searchDuckDuckGo(ctx context.Context, query string, maxResults int) ([]sear
 
 	searchURL := "https://html.duckduckgo.com/html/?q=" + url.QueryEscape(query)
 
-	req, err := http.NewRequestWithContext(reqCtx, "GET", searchURL, nil)
+	// SSRF guard (defense in depth — host is a fixed public endpoint).
+	safeURL, err := validateWebTarget(searchURL)
+	if err != nil {
+		return nil, fmt.Errorf("refusing to query DuckDuckGo: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(reqCtx, "GET", safeURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}

--- a/cli/plugins/builtin_websearch.go
+++ b/cli/plugins/builtin_websearch.go
@@ -336,7 +336,7 @@ func searchSearxNG(ctx context.Context, query string, maxResults int, baseURL st
 	req.Header.Set("User-Agent", browserUA())
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := webHTTPClient().Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("SearxNG request failed: %w", err)
 	}
@@ -398,7 +398,7 @@ func searchDuckDuckGo(ctx context.Context, query string, maxResults int) ([]sear
 	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
 	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := webHTTPClient().Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("search request failed: %w", err)
 	}

--- a/cli/plugins/web_ssrf_guard.go
+++ b/cli/plugins/web_ssrf_guard.go
@@ -83,7 +83,7 @@ func validateWebTarget(rawURL string) (string, error) {
 
 	host := parsed.Hostname()
 	if host == "" {
-		return "", fmt.Errorf("URL has no host")
+		return "", fmt.Errorf("missing host in URL")
 	}
 
 	if isMetadataHostname(host) {

--- a/cli/plugins/web_ssrf_guard.go
+++ b/cli/plugins/web_ssrf_guard.go
@@ -1,0 +1,177 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package plugins
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"syscall"
+)
+
+// SSRF guard for the web tools (@webfetch / @websearch / @osv).
+//
+// These tools fetch URLs that originate from the LLM, from tool arguments, or
+// from operator config. A prompt-injected model can try to point them at
+// internal infrastructure — most dangerously the cloud metadata endpoint
+// (169.254.169.254 / metadata.google.internal), which hands out short-lived
+// cloud credentials.
+//
+// The defense is enforced in DEPTH, at three layers, because upfront URL
+// validation alone is bypassable:
+//
+//  1. validateWebTarget — fast, upfront checks on the requested URL: scheme
+//     must be http/https, cloud-metadata hostnames are refused, and a literal
+//     IP in the URL is range-checked. Gives an early, clear error.
+//  2. ssrfDialControl — a net.Dialer.Control hook that runs AFTER DNS
+//     resolution, on EVERY connection attempt, and re-checks the concrete IP
+//     being dialed. This is the airtight layer: it closes DNS-rebinding /
+//     TOCTOU (a hostname that resolved "safe" during validation but flips to a
+//     metadata IP at dial time) and it covers every redirect hop, since each
+//     hop dials anew.
+//  3. validateRedirect — re-runs the upfront checks on every redirect target
+//     and strips credentials on cross-host hops, so a 302 to an internal URL
+//     cannot launder past the initial validation.
+//
+// Policy:
+//   - Scheme must be http or https.
+//   - Cloud-metadata / link-local targets are ALWAYS blocked. There is no
+//     legitimate reason for these tools to reach them, and that is the SSRF
+//     vector worth closing unconditionally.
+//   - Private / loopback ranges are ALLOWED BY DEFAULT, because fetching an
+//     internal service (e.g. http://svc/metrics) is a documented use case.
+//     Set CHATCLI_WEBFETCH_BLOCK_PRIVATE=true to deny them in hardened
+//     deployments.
+//   - When the request travels through a corporate proxy, the dial targets the
+//     PROXY (the egress control point), so ssrfDialControl validates the proxy
+//     address; the proxy itself enforces egress to the final target. Link-local
+//     is still refused even for a proxy address.
+
+// maxWebRedirects caps redirect chains for the web tools.
+const maxWebRedirects = 10
+
+// metadataHostnames are well-known cloud metadata DNS names blocked regardless
+// of how they resolve.
+var metadataHostnames = []string{
+	"metadata.google.internal",
+	"metadata.goog",
+	"instance-data",
+}
+
+// validateWebTarget validates rawURL against the SSRF policy and returns a
+// canonical, re-encoded URL string safe to hand to the HTTP client. Hostname
+// targets are only checked for scheme/metadata here; their resolved IP is
+// enforced at dial time by ssrfDialControl (rebinding-proof).
+func validateWebTarget(rawURL string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return "", fmt.Errorf("invalid URL: %w", err)
+	}
+
+	switch parsed.Scheme {
+	case "http", "https":
+		// allowed
+	default:
+		return "", fmt.Errorf("unsupported URL scheme %q (only http/https are allowed)", parsed.Scheme)
+	}
+
+	host := parsed.Hostname()
+	if host == "" {
+		return "", fmt.Errorf("URL has no host")
+	}
+
+	if isMetadataHostname(host) {
+		return "", fmt.Errorf("blocked cloud metadata hostname %q", host)
+	}
+
+	// A literal IP is checked immediately (no DNS needed). Hostnames are
+	// enforced at dial time.
+	if ip := net.ParseIP(host); ip != nil {
+		if err := checkWebIP(ip, webBlockPrivate(), host); err != nil {
+			return "", err
+		}
+	}
+
+	return parsed.String(), nil
+}
+
+// ssrfDialControl is installed as net.Dialer.Control on the web transport. It
+// runs after DNS resolution with the concrete address about to be dialed,
+// making it the authoritative, rebinding-proof SSRF enforcement point.
+func ssrfDialControl(_, address string, _ syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		host = address
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		// Post-resolution dials always carry a literal IP; if we somehow can't
+		// parse it, fail closed for the always-blocked classes is impossible,
+		// so allow and let the upper layers handle it.
+		return nil
+	}
+	return checkWebIP(ip, webBlockPrivate(), host)
+}
+
+// validateRedirect is installed as http.Client.CheckRedirect. It re-validates
+// every redirect target and strips sensitive headers on cross-host hops.
+func validateRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= maxWebRedirects {
+		return fmt.Errorf("stopped after %d redirects", maxWebRedirects)
+	}
+	if _, err := validateWebTarget(req.URL.String()); err != nil {
+		return fmt.Errorf("refusing redirect to %q: %w", req.URL.Redacted(), err)
+	}
+	if len(via) > 0 && req.URL.Host != via[0].URL.Host {
+		req.Header.Del("Authorization")
+		req.Header.Del("Proxy-Authorization")
+		req.Header.Del("Cookie")
+		req.Header.Del("Api-Key")
+		req.Header.Del("X-Api-Key")
+	}
+	return nil
+}
+
+// checkWebIP enforces the always-blocked (metadata/link-local) set and the
+// opt-in private/loopback block.
+func checkWebIP(ip net.IP, blockPrivate bool, host string) error {
+	if ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+		return fmt.Errorf("blocked metadata/link-local address %s (host %q)", ip, host)
+	}
+	if blockPrivate && (ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified()) {
+		return fmt.Errorf("blocked private address %s (host %q); unset CHATCLI_WEBFETCH_BLOCK_PRIVATE to allow", ip, host)
+	}
+	return nil
+}
+
+// isMetadataHostname reports whether host is (a subdomain of) a known cloud
+// metadata hostname.
+func isMetadataHostname(host string) bool {
+	lower := strings.ToLower(host)
+	for _, bh := range metadataHostnames {
+		if lower == bh || strings.HasSuffix(lower, "."+bh) {
+			return true
+		}
+	}
+	return false
+}
+
+// webBlockPrivate reports whether private/loopback ranges should be denied.
+func webBlockPrivate() bool {
+	return boolEnvTrue("CHATCLI_WEBFETCH_BLOCK_PRIVATE")
+}
+
+// boolEnvTrue reports whether env var name is set to a truthy value.
+func boolEnvTrue(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(name))) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
+}

--- a/cli/plugins/web_ssrf_guard_test.go
+++ b/cli/plugins/web_ssrf_guard_test.go
@@ -25,7 +25,7 @@ func TestValidateWebTarget_SchemeAndHost(t *testing.T) {
 		{"file blocked", "file:///etc/passwd", "scheme"},
 		{"gopher blocked", "gopher://evil/", "scheme"},
 		{"ftp blocked", "ftp://host/", "scheme"},
-		{"no host", "https://", "no host"},
+		{"no host", "https://", "missing host"},
 		{"metadata hostname", "http://metadata.google.internal/computeMetadata/v1/", "metadata"},
 		{"instance-data", "http://instance-data/latest/", "metadata"},
 		{"literal metadata ip", "http://169.254.169.254/latest/meta-data/", "metadata/link-local"},

--- a/cli/plugins/web_ssrf_guard_test.go
+++ b/cli/plugins/web_ssrf_guard_test.go
@@ -1,0 +1,184 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package plugins
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestValidateWebTarget_SchemeAndHost(t *testing.T) {
+	t.Setenv("CHATCLI_WEBFETCH_BLOCK_PRIVATE", "")
+	cases := []struct {
+		name    string
+		url     string
+		wantErr string // substring; "" means must succeed
+	}{
+		{"https ok", "https://example.com/path", ""},
+		{"http ok", "http://example.com", ""},
+		{"file blocked", "file:///etc/passwd", "scheme"},
+		{"gopher blocked", "gopher://evil/", "scheme"},
+		{"ftp blocked", "ftp://host/", "scheme"},
+		{"no host", "https://", "no host"},
+		{"metadata hostname", "http://metadata.google.internal/computeMetadata/v1/", "metadata"},
+		{"instance-data", "http://instance-data/latest/", "metadata"},
+		{"literal metadata ip", "http://169.254.169.254/latest/meta-data/", "metadata/link-local"},
+		{"public literal ip", "http://1.1.1.1/", ""},
+		{"private literal ip default-allowed", "http://10.0.0.5/metrics", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := validateWebTarget(tc.url)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected success, got %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("want error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestValidateWebTarget_BlockPrivateOptIn(t *testing.T) {
+	t.Setenv("CHATCLI_WEBFETCH_BLOCK_PRIVATE", "true")
+	for _, raw := range []string{"http://10.0.0.5/", "http://127.0.0.1/", "http://192.168.1.1/"} {
+		if _, err := validateWebTarget(raw); err == nil {
+			t.Fatalf("expected %s to be blocked when BLOCK_PRIVATE=true", raw)
+		}
+	}
+	// Public still allowed.
+	if _, err := validateWebTarget("http://1.1.1.1/"); err != nil {
+		t.Fatalf("public IP must remain allowed: %v", err)
+	}
+	// Metadata still blocked regardless.
+	if _, err := validateWebTarget("http://169.254.169.254/"); err == nil {
+		t.Fatal("metadata must always be blocked")
+	}
+}
+
+func TestSSRFDialControl(t *testing.T) {
+	t.Setenv("CHATCLI_WEBFETCH_BLOCK_PRIVATE", "")
+	// Link-local/metadata is always refused at dial time.
+	if err := ssrfDialControl("tcp", "169.254.169.254:80", nil); err == nil {
+		t.Fatal("dial control must block metadata IP")
+	}
+	// Public allowed.
+	if err := ssrfDialControl("tcp", "1.1.1.1:443", nil); err != nil {
+		t.Fatalf("dial control must allow public IP: %v", err)
+	}
+	// Private allowed by default.
+	if err := ssrfDialControl("tcp", "10.0.0.5:80", nil); err != nil {
+		t.Fatalf("private must be allowed by default: %v", err)
+	}
+}
+
+func TestSSRFDialControl_BlockPrivate(t *testing.T) {
+	t.Setenv("CHATCLI_WEBFETCH_BLOCK_PRIVATE", "true")
+	for _, addr := range []string{"10.0.0.5:80", "127.0.0.1:8080", "192.168.0.2:443"} {
+		if err := ssrfDialControl("tcp", addr, nil); err == nil {
+			t.Fatalf("dial control must block %s when BLOCK_PRIVATE=true", addr)
+		}
+	}
+}
+
+func TestCheckWebIP_IPv6(t *testing.T) {
+	// IPv6 link-local must be blocked always.
+	if err := checkWebIP(net.ParseIP("fe80::1"), false, "h"); err == nil {
+		t.Fatal("IPv6 link-local must be blocked")
+	}
+	// IPv4-mapped metadata must be blocked.
+	if err := checkWebIP(net.ParseIP("::ffff:169.254.169.254"), false, "h"); err == nil {
+		t.Fatal("IPv4-mapped metadata must be blocked")
+	}
+	// IPv6 ULA blocked only when private is blocked.
+	if err := checkWebIP(net.ParseIP("fc00::1"), false, "h"); err != nil {
+		t.Fatalf("ULA allowed by default: %v", err)
+	}
+	if err := checkWebIP(net.ParseIP("fc00::1"), true, "h"); err == nil {
+		t.Fatal("ULA must be blocked when private blocked")
+	}
+}
+
+// validateRedirect must refuse a hop to a metadata/internal URL and cap chains.
+func TestValidateRedirect(t *testing.T) {
+	t.Setenv("CHATCLI_WEBFETCH_BLOCK_PRIVATE", "")
+	mkReq := func(u string) *http.Request {
+		r, _ := http.NewRequest(http.MethodGet, u, nil)
+		return r
+	}
+	orig := mkReq("https://example.com/")
+
+	// Redirect to metadata → refused.
+	if err := validateRedirect(mkReq("http://169.254.169.254/"), []*http.Request{orig}); err == nil {
+		t.Fatal("redirect to metadata must be refused")
+	}
+	// Redirect to file scheme → refused.
+	if err := validateRedirect(mkReq("file:///etc/passwd"), []*http.Request{orig}); err == nil {
+		t.Fatal("redirect to file scheme must be refused")
+	}
+	// Normal redirect → allowed, and cross-host strips auth.
+	next := mkReq("https://other.example/")
+	next.Header.Set("Authorization", "Bearer secret")
+	if err := validateRedirect(next, []*http.Request{orig}); err != nil {
+		t.Fatalf("normal redirect should be allowed: %v", err)
+	}
+	if next.Header.Get("Authorization") != "" {
+		t.Fatal("Authorization must be stripped on cross-host redirect")
+	}
+	// Too many hops → refused.
+	chain := make([]*http.Request, maxWebRedirects)
+	for i := range chain {
+		chain[i] = orig
+	}
+	if err := validateRedirect(mkReq("https://example.com/"), chain); err == nil {
+		t.Fatal("redirect chain over the cap must be refused")
+	}
+}
+
+// End-to-end: the shared client must refuse to follow a redirect that points at
+// the cloud metadata endpoint — the canonical SSRF bypass.
+func TestWebHTTPClient_RefusesRedirectToMetadata(t *testing.T) {
+	t.Setenv("CHATCLI_WEBFETCH_BLOCK_PRIVATE", "")
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://169.254.169.254/latest/meta-data/", http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	resp, err := webHTTPClient().Get(redirector.URL)
+	if err == nil {
+		resp.Body.Close()
+		t.Fatal("expected the client to refuse the metadata redirect")
+	}
+	if !strings.Contains(err.Error(), "metadata") && !strings.Contains(err.Error(), "refusing redirect") {
+		t.Fatalf("error should mention the blocked redirect, got: %v", err)
+	}
+}
+
+// End-to-end: a direct fetch to a loopback httptest server works by default
+// (private allowed), proving the guard doesn't break legitimate internal use.
+func TestWebHTTPClient_AllowsLoopbackByDefault(t *testing.T) {
+	t.Setenv("CHATCLI_WEBFETCH_BLOCK_PRIVATE", "")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	resp, err := webHTTPClient().Get(srv.URL)
+	if err != nil {
+		t.Fatalf("loopback fetch should succeed by default: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -1834,6 +1834,7 @@
   "cfg.sub.resil.streaming": "── Streaming",
   "cfg.sub.resil.compaction": "── Compaction",
   "cfg.sub.resil.bedrock_proxy": "── Bedrock corporate proxy",
+  "cfg.sub.resil.web_proxy": "── Web tools corporate proxy (webfetch/websearch/osv)",
   "cfg.sub.resil.session_state": "── Session state",
   "cfg.sub.session.cost": "── Cost & budget",
   "cfg.sub.session.attached": "── Attached contexts",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1834,6 +1834,7 @@
   "cfg.sub.resil.streaming": "── Streaming",
   "cfg.sub.resil.compaction": "── Compaction",
   "cfg.sub.resil.bedrock_proxy": "── Bedrock corporate proxy",
+  "cfg.sub.resil.web_proxy": "── Web tools corporate proxy (webfetch/websearch/osv)",
   "cfg.sub.resil.session_state": "── Session state",
   "cfg.sub.session.cost": "── Cost & budget",
   "cfg.sub.session.attached": "── Attached contexts",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -1834,6 +1834,7 @@
   "cfg.sub.resil.streaming": "── Streaming",
   "cfg.sub.resil.compaction": "── Compactação",
   "cfg.sub.resil.bedrock_proxy": "── Proxy corporativo do Bedrock",
+  "cfg.sub.resil.web_proxy": "── Proxy corporativo das ferramentas web (webfetch/websearch/osv)",
   "cfg.sub.resil.session_state": "── Estado da sessão",
   "cfg.sub.session.cost": "── Custo & budget",
   "cfg.sub.session.attached": "── Contextos anexados",


### PR DESCRIPTION
## Problema

`@webfetch`/`@websearch` falhavam com **401** atrás de proxy corporativo mesmo com `HTTPS_PROXY=http://login:senha@proxy:8080`, enquanto `curl` funcionava.

**Causa raiz:** os web tools usavam `http.DefaultClient`. Ele injeta `Proxy-Authorization` **só quando o userinfo do proxy parseia limpo no `net/url`**. Credenciais corporativas quebram isso (login de domínio `DOMAIN\user`, ou senha com `%`, `#`, espaço não são userinfo percent-encoded válido). `url.Parse` erra e `http.ProxyFromEnvironment` **engole o erro e devolve proxy `nil`** → o Go ignora o proxy e o gateway responde 401. `curl` parseia a credencial de forma tolerante.

## Correção (proxy)

Transport proxy-aware compartilhado (webfetch/websearch/osv) que:
- Honra as **vars padrão** já usadas (`HTTPS_PROXY`/`HTTP_PROXY`/`ALL_PROXY`/`NO_PROXY` com login:senha). Sem var nova obrigatória.
- **Parseia credenciais de forma tolerante**: separa `scheme://userinfo@host` na mão (split no último `@`) e re-encoda via `url.UserPassword`, recuperando `DOMAIN\user`, `%`, `#`, espaço, `@`. Injeta `Proxy-Authorization` no CONNECT (HTTPS) e na request (HTTP).
- Respeita `NO_PROXY` via matcher da stdlib.
- `CHATCLI_PROXY_AUTH` opcional para esquemas não-Basic (Negotiate/NTLM/Kerberos/Bearer).

## Hardening de SSRF (defense-in-depth, 3 camadas)

Como os web tools buscam URLs vindas do LLM/config, adicionei um guard SSRF à prova de bypass:
1. **Validação upfront** — esquema http/https, hostnames de cloud metadata e IPs literais de metadata/link-local recusados.
2. **`net.Dialer.Control`** — re-checa o IP resolvido em **toda** conexão, depois do DNS → fecha **DNS rebinding/TOCTOU** e cobre todo hop de redirect.
3. **`CheckRedirect`** — re-valida cada redirect (bloqueia `302 → http://169.254.169.254`) e remove headers sensíveis em cross-host.

Política: **metadata/link-local sempre bloqueado**; private/loopback permitido por padrão (busca a serviço interno é uso legítimo), bloqueável via `CHATCLI_WEBFETCH_BLOCK_PRIVATE`. Exposto em `/config proxy`.

## Nota sobre o alerta gosec G704 (websearch SearxNG)

A linha do SearxNG usa `os.Getenv("SEARXNG_URL")` → request, que o gosec G704 marca como SSRF. Lendo a fonte do analyzer (`taint` + `analyzers/ssrf.go`): o G704 **não tem sanitizer por design** — só URL constante passa; qualquer `os.Getenv → request` dispara, mesmo com validação. É **falso-positivo**: `SEARXNG_URL` é config do operador, não input de atacante, e o egresso é validado pelo guard SSRF acima. Tratado via dismiss documentado no Code Scanning (não com `#nosec`, que ocultaria no código).

## Testes

Cobertura para credenciais com caracteres especiais, seleção http/https, `ALL_PROXY`, `NO_PROXY`, não-vazamento de credencial em conexão direta; e SSRF: bloqueio de file/gopher, metadata por hostname e IP, IPv6 link-local, IPv4-mapped, opt-in de private, e **end-to-end recusando redirect para a metadata**. `go build ./...` / `go test ./cli/plugins/` verdes.