### PR TITLE
feat(memory): blend cosine, lexical and temporal signals in retrieval ranking

### DIFF
--- a/cli/workspace/memory.go
+++ b/cli/workspace/memory.go
@@ -29,7 +29,9 @@ type MemoryStore struct {
 // NewMemoryStore creates a new memory store backed by the structured Manager.
 func NewMemoryStore(baseDir string, logger *zap.Logger) *MemoryStore {
 	memDir := filepath.Join(baseDir, "memory")
-	mgr := memory.NewManager(memDir, memory.DefaultConfig(), logger)
+	// ConfigFromEnv (not DefaultConfig) so the pre-existing CHATCLI_MEMORY_*
+	// overrides actually take effect on the structured-memory path.
+	mgr := memory.NewManager(memDir, memory.ConfigFromEnv(), logger)
 
 	return &MemoryStore{
 		manager:   mgr,

--- a/cli/workspace/memory/config_env.go
+++ b/cli/workspace/memory/config_env.go
@@ -1,5 +1,7 @@
 /*
  * ChatCLI - Long-term memory: configuration from the environment.
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
  *
  * The CHATCLI_MEMORY_* env vars already existed in the config package but were
  * never read on the structured-memory path — NewMemoryStore built the manager

--- a/cli/workspace/memory/config_env.go
+++ b/cli/workspace/memory/config_env.go
@@ -1,0 +1,96 @@
+/*
+ * ChatCLI - Long-term memory: configuration from the environment.
+ *
+ * The CHATCLI_MEMORY_* env vars already existed in the config package but were
+ * never read on the structured-memory path — NewMemoryStore built the manager
+ * with a hard-coded DefaultConfig(), so a deployment that set, say,
+ * CHATCLI_MEMORY_RETRIEVAL_BUDGET was silently ignored. This wires the existing
+ * knobs through one place. It deliberately introduces NO new environment
+ * variables: the blended-ranking tunables stay Config fields with strong
+ * defaults, tuned in code rather than multiplying the operator-facing surface.
+ */
+package memory
+
+import (
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/diillson/chatcli/config"
+)
+
+// ConfigFromEnv starts from DefaultConfig and applies the pre-existing
+// CHATCLI_MEMORY_* overrides. Lookups are plain os.Getenv calls — no path or
+// shell assumptions — so behavior is identical on Windows, Linux and macOS.
+// The result is always sanitized, so a malformed override degrades to the
+// default rather than corrupting retrieval.
+func ConfigFromEnv() Config {
+	c := DefaultConfig()
+	if v, ok := envPositiveInt(config.MemoryMaxSizeEnv); ok {
+		c.MaxMemoryMDSize = v
+	}
+	if v, ok := envPositiveInt(config.MemoryRetentionEnv); ok {
+		c.DailyNoteRetention = v
+	}
+	if v, ok := envPositiveInt(config.MemoryMaxFactsEnv); ok {
+		c.MaxFactsCount = v
+	}
+	if v, ok := envPositiveInt(config.MemoryRetrievalEnv); ok {
+		c.RetrievalBudget = v
+	}
+	return c.sanitized()
+}
+
+// envPositiveInt reads name as a positive integer. Missing, malformed, or
+// non-positive values are ignored so a bad override (e.g. a zero budget that
+// would blank memory) can never corrupt the config.
+func envPositiveInt(name string) (int, bool) {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return 0, false
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+// sanitized clamps every tunable to a safe range so neither a bad env override
+// nor a hand-edited config file can push retrieval into a degenerate state
+// (empty budget, zero half-life division, out-of-range cosine floor, …). It is
+// idempotent: sanitizing an already-valid Config returns it unchanged.
+func (c Config) sanitized() Config {
+	if c.MaxMemoryMDSize <= 0 {
+		c.MaxMemoryMDSize = 32 * 1024
+	}
+	if c.DailyNoteRetention <= 0 {
+		c.DailyNoteRetention = 30
+	}
+	if c.MaxFactsCount <= 0 {
+		c.MaxFactsCount = 500
+	}
+	if c.CompactionInterval <= 0 {
+		c.CompactionInterval = 24
+	}
+	if c.RetrievalBudget <= 0 {
+		c.RetrievalBudget = 4000
+	}
+	if c.DecayHalfLifeDays <= 0 {
+		c.DecayHalfLifeDays = 30.0
+	}
+	// Cosine ∈ [-1,1]; a floor outside [0,1) is nonsensical for text
+	// embeddings and would either admit anti-correlated junk or reject
+	// everything, so fall back to the default.
+	if c.MinCosineScore < 0 || c.MinCosineScore >= 1 {
+		c.MinCosineScore = 0.25
+	}
+	if c.VectorTopK <= 0 {
+		c.VectorTopK = 12
+	}
+	if c.BackfillBatchMax <= 0 {
+		c.BackfillBatchMax = 500
+	}
+	c.RankWeights = c.RankWeights.normalized()
+	return c
+}

--- a/cli/workspace/memory/config_env_test.go
+++ b/cli/workspace/memory/config_env_test.go
@@ -1,0 +1,64 @@
+package memory
+
+import (
+	"testing"
+
+	"github.com/diillson/chatcli/config"
+)
+
+func TestConfigFromEnv_AppliesExistingOverrides(t *testing.T) {
+	t.Setenv(config.MemoryRetrievalEnv, "8000")
+	t.Setenv(config.MemoryMaxFactsEnv, "1200")
+	c := ConfigFromEnv()
+	if c.RetrievalBudget != 8000 {
+		t.Errorf("RetrievalBudget = %d, want 8000 (env override must apply)", c.RetrievalBudget)
+	}
+	if c.MaxFactsCount != 1200 {
+		t.Errorf("MaxFactsCount = %d, want 1200", c.MaxFactsCount)
+	}
+	// Untouched knobs keep their defaults.
+	if c.DecayHalfLifeDays != 30.0 {
+		t.Errorf("DecayHalfLifeDays = %v, want default 30", c.DecayHalfLifeDays)
+	}
+}
+
+func TestConfigFromEnv_MalformedOverrideIgnored(t *testing.T) {
+	t.Setenv(config.MemoryRetrievalEnv, "not-a-number")
+	if c := ConfigFromEnv(); c.RetrievalBudget != 4000 {
+		t.Errorf("malformed override should fall back to default 4000, got %d", c.RetrievalBudget)
+	}
+	t.Setenv(config.MemoryRetrievalEnv, "-5")
+	if c := ConfigFromEnv(); c.RetrievalBudget != 4000 {
+		t.Errorf("non-positive override should fall back to default 4000, got %d", c.RetrievalBudget)
+	}
+}
+
+func TestConfig_Sanitized_ClampsDegenerate(t *testing.T) {
+	bad := Config{
+		MinCosineScore:   2.0,           // out of [0,1)
+		VectorTopK:       -3,            // non-positive
+		BackfillBatchMax: 0,             // non-positive
+		RankWeights:      RankWeights{}, // all-zero
+	}
+	got := bad.sanitized()
+	if got.MinCosineScore != 0.25 {
+		t.Errorf("MinCosineScore = %v, want clamped to 0.25", got.MinCosineScore)
+	}
+	if got.VectorTopK != 12 {
+		t.Errorf("VectorTopK = %d, want default 12", got.VectorTopK)
+	}
+	if got.BackfillBatchMax != 500 {
+		t.Errorf("BackfillBatchMax = %d, want default 500", got.BackfillBatchMax)
+	}
+	if got.RankWeights != DefaultRankWeights() {
+		t.Errorf("zero RankWeights should normalize to default, got %+v", got.RankWeights)
+	}
+}
+
+func TestDefaultConfig_IsSane(t *testing.T) {
+	// DefaultConfig must already be a fixed point of sanitized().
+	d := DefaultConfig()
+	if d.sanitized() != d {
+		t.Errorf("DefaultConfig is not sanitized-stable: %+v vs %+v", d, d.sanitized())
+	}
+}

--- a/cli/workspace/memory/eval/eval.go
+++ b/cli/workspace/memory/eval/eval.go
@@ -1,5 +1,7 @@
 /*
  * ChatCLI - Long-term memory: retrieval evaluation harness.
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
  *
  * The critique this package answers: the memory RAG had no way to PROVE its
  * retrieval was any good. Sophisticated plumbing (HyDE, embeddings, cosine) sat

--- a/cli/workspace/memory/eval/eval.go
+++ b/cli/workspace/memory/eval/eval.go
@@ -1,0 +1,184 @@
+/*
+ * ChatCLI - Long-term memory: retrieval evaluation harness.
+ *
+ * The critique this package answers: the memory RAG had no way to PROVE its
+ * retrieval was any good. Sophisticated plumbing (HyDE, embeddings, cosine) sat
+ * on top of a ranking nobody measured. You cannot improve — or defend against
+ * regressions in — what you do not measure.
+ *
+ * This is a tiny, dependency-free, provider- and OS-agnostic harness: feed it a
+ * Ranker closure and a labeled sample set and it returns the standard
+ * information-retrieval metrics (recall@k, precision@k, MRR, nDCG@k), macro-
+ * averaged across queries. It runs the SAME way against a deterministic test
+ * provider in CI or against a live embedding backend in a benchmark — the
+ * harness never imports a provider, so it stays neutral across all 14 of them.
+ *
+ * Relevance is binary (a fact id is relevant or it is not), which is the right
+ * model for this domain: a long-term-memory fact either answers the query or it
+ * does not. Graded relevance can be layered on later without changing callers.
+ */
+package eval
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+)
+
+// Sample is one labeled query: the set of fact ids that SHOULD be retrieved.
+type Sample struct {
+	Query    string
+	Relevant []string
+}
+
+// Ranker returns fact ids ranked best-first for a query, capped at k. It is the
+// single seam between the harness and whatever retrieval strategy is under test
+// (keyword-only, semantic blend, …), so strategies are compared apples-to-apples.
+type Ranker func(query string, k int) []string
+
+// Metrics are the macro-averaged retrieval-quality numbers over a sample set.
+// Macro-averaging (mean of per-query scores) weights every query equally,
+// regardless of how many relevant facts it has — the right choice when some
+// queries have one gold fact and others have several.
+type Metrics struct {
+	N            int     // samples actually scored (those with ≥1 relevant id)
+	K            int     // cutoff used
+	RecallAtK    float64 // mean fraction of relevant facts found in the top-k
+	PrecisionAtK float64 // mean fraction of the top-k that was relevant
+	MRR          float64 // mean reciprocal rank of the first relevant hit
+	NDCGAtK      float64 // mean normalized discounted cumulative gain
+}
+
+// Evaluate runs rank over every sample and returns the aggregated metrics.
+// Samples with no relevant ids are skipped (they are unanswerable and would
+// divide by zero). k <= 0 is treated as 1.
+func Evaluate(rank Ranker, samples []Sample, k int) Metrics {
+	if k <= 0 {
+		k = 1
+	}
+	var m Metrics
+	m.K = k
+
+	var sumRecall, sumPrecision, sumMRR, sumNDCG float64
+	for _, s := range samples {
+		rel := toSet(s.Relevant)
+		if len(rel) == 0 {
+			continue
+		}
+		m.N++
+
+		ranked := rank(s.Query, k)
+		if len(ranked) > k {
+			ranked = ranked[:k]
+		}
+
+		hits := 0
+		firstHitRank := 0
+		dcg := 0.0
+		for i, id := range ranked {
+			if _, ok := rel[id]; ok {
+				hits++
+				if firstHitRank == 0 {
+					firstHitRank = i + 1
+				}
+				dcg += 1.0 / math.Log2(float64(i+2)) // i+2: rank 1 → log2(2)=1
+			}
+		}
+
+		sumRecall += float64(hits) / float64(len(rel))
+		if denom := minInt(k, len(ranked)); denom > 0 {
+			sumPrecision += float64(hits) / float64(denom)
+		}
+		if firstHitRank > 0 {
+			sumMRR += 1.0 / float64(firstHitRank)
+		}
+		if idcg := idealDCG(len(rel), k); idcg > 0 {
+			sumNDCG += dcg / idcg
+		}
+	}
+
+	if m.N > 0 {
+		n := float64(m.N)
+		m.RecallAtK = sumRecall / n
+		m.PrecisionAtK = sumPrecision / n
+		m.MRR = sumMRR / n
+		m.NDCGAtK = sumNDCG / n
+	}
+	return m
+}
+
+// idealDCG is the DCG of a perfect ranking: the min(relevant, k) top slots all
+// filled with relevant facts. It is the denominator that normalizes nDCG into
+// [0,1] regardless of how many relevant facts a query has.
+func idealDCG(numRelevant, k int) float64 {
+	n := minInt(numRelevant, k)
+	idcg := 0.0
+	for i := 0; i < n; i++ {
+		idcg += 1.0 / math.Log2(float64(i+2))
+	}
+	return idcg
+}
+
+func toSet(ids []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if id != "" {
+			set[id] = struct{}{}
+		}
+	}
+	return set
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// String renders the metrics as a single aligned line for logs and benchmark
+// output.
+func (m Metrics) String() string {
+	return fmt.Sprintf(
+		"n=%d k=%d  recall@k=%.4f  precision@k=%.4f  MRR=%.4f  nDCG@k=%.4f",
+		m.N, m.K, m.RecallAtK, m.PrecisionAtK, m.MRR, m.NDCGAtK,
+	)
+}
+
+// Comparison reports the delta between a baseline and a candidate strategy on
+// the same sample set — the artifact an A/B (keyword vs. semantic blend)
+// produces. Positive deltas mean the candidate retrieved better.
+type Comparison struct {
+	Baseline  Metrics
+	Candidate Metrics
+}
+
+// Improvement returns the candidate-minus-baseline deltas for each metric.
+func (c Comparison) Improvement() Metrics {
+	return Metrics{
+		N:            c.Candidate.N,
+		K:            c.Candidate.K,
+		RecallAtK:    c.Candidate.RecallAtK - c.Baseline.RecallAtK,
+		PrecisionAtK: c.Candidate.PrecisionAtK - c.Baseline.PrecisionAtK,
+		MRR:          c.Candidate.MRR - c.Baseline.MRR,
+		NDCGAtK:      c.Candidate.NDCGAtK - c.Baseline.NDCGAtK,
+	}
+}
+
+// String renders a human-readable A/B report.
+func (c Comparison) String() string {
+	var b strings.Builder
+	b.WriteString("baseline : " + c.Baseline.String() + "\n")
+	b.WriteString("candidate: " + c.Candidate.String() + "\n")
+	d := c.Improvement()
+	b.WriteString(fmt.Sprintf(
+		"delta    : recall@k=%+.4f  precision@k=%+.4f  MRR=%+.4f  nDCG@k=%+.4f",
+		d.RecallAtK, d.PrecisionAtK, d.MRR, d.NDCGAtK,
+	))
+	return b.String()
+}
+
+// Sort orders sample ids deterministically — exported only so callers building
+// golden sets can normalize their fixtures.
+func SortIDs(ids []string) { sort.Strings(ids) }

--- a/cli/workspace/memory/eval/eval_test.go
+++ b/cli/workspace/memory/eval/eval_test.go
@@ -1,0 +1,92 @@
+package eval
+
+import (
+	"math"
+	"testing"
+)
+
+const tol = 1e-9
+
+func approx(t *testing.T, name string, got, want float64) {
+	t.Helper()
+	if math.Abs(got-want) > 1e-4 {
+		t.Errorf("%s = %.6f, want %.6f", name, got, want)
+	}
+}
+
+func TestEvaluate_HandComputed(t *testing.T) {
+	// Sample 1: relevant {A,B}, ranker returns [A, X, B] at k=3.
+	//   hits=2 (A@1, B@3); recall=2/2=1; precision=2/3; MRR=1/1=1
+	//   dcg = 1/log2(2) + 1/log2(4) = 1 + 0.5 = 1.5
+	//   idcg(2,3) = 1/log2(2) + 1/log2(3) = 1 + 0.630930 = 1.630930
+	//   ndcg = 1.5 / 1.630930 = 0.919721
+	// Sample 2: relevant {C}, ranker returns [Y,Z,W] → all zero.
+	// Sample 3: relevant {} → skipped entirely (N unchanged).
+	rankers := map[string][]string{
+		"q1": {"A", "X", "B"},
+		"q2": {"Y", "Z", "W"},
+		"q3": {"anything"},
+	}
+	rank := func(q string, k int) []string { return rankers[q] }
+
+	samples := []Sample{
+		{Query: "q1", Relevant: []string{"A", "B"}},
+		{Query: "q2", Relevant: []string{"C"}},
+		{Query: "q3", Relevant: nil},
+	}
+
+	m := Evaluate(rank, samples, 3)
+
+	if m.N != 2 {
+		t.Fatalf("N = %d, want 2 (empty-relevant sample must be skipped)", m.N)
+	}
+	approx(t, "recall@k", m.RecallAtK, (1.0+0.0)/2)
+	approx(t, "precision@k", m.PrecisionAtK, (2.0/3.0+0.0)/2)
+	approx(t, "MRR", m.MRR, (1.0+0.0)/2)
+	approx(t, "nDCG@k", m.NDCGAtK, (0.919721+0.0)/2)
+}
+
+func TestEvaluate_PerfectRanking(t *testing.T) {
+	rank := func(q string, k int) []string { return []string{"A", "B", "C"} }
+	samples := []Sample{{Query: "q", Relevant: []string{"A", "B"}}}
+	m := Evaluate(rank, samples, 3)
+	approx(t, "recall@k", m.RecallAtK, 1.0)
+	approx(t, "MRR", m.MRR, 1.0)
+	approx(t, "nDCG@k", m.NDCGAtK, 1.0) // both relevant in the top-2 slots → ideal
+}
+
+func TestEvaluate_TotalMiss(t *testing.T) {
+	rank := func(q string, k int) []string { return []string{"X", "Y"} }
+	samples := []Sample{{Query: "q", Relevant: []string{"A"}}}
+	m := Evaluate(rank, samples, 3)
+	if m.RecallAtK != 0 || m.MRR != 0 || m.NDCGAtK != 0 {
+		t.Fatalf("expected all-zero on total miss, got %s", m)
+	}
+}
+
+func TestEvaluate_KClampAndTruncation(t *testing.T) {
+	// Relevant item sits at position 4; k=3 must not see it.
+	rank := func(q string, k int) []string { return []string{"a", "b", "c", "REL"} }
+	samples := []Sample{{Query: "q", Relevant: []string{"REL"}}}
+	if m := Evaluate(rank, samples, 3); m.RecallAtK != 0 {
+		t.Fatalf("recall@3 should be 0 when relevant is at rank 4, got %v", m.RecallAtK)
+	}
+	if m := Evaluate(rank, samples, 4); math.Abs(m.RecallAtK-1.0) > tol {
+		t.Fatalf("recall@4 should be 1, got %v", m.RecallAtK)
+	}
+	// k <= 0 is treated as 1.
+	if m := Evaluate(rank, samples, 0); m.K != 1 {
+		t.Fatalf("k<=0 should clamp to 1, got K=%d", m.K)
+	}
+}
+
+func TestComparison_Improvement(t *testing.T) {
+	base := Metrics{RecallAtK: 0.4, MRR: 0.3}
+	cand := Metrics{RecallAtK: 0.9, MRR: 0.8, N: 7, K: 5}
+	d := Comparison{Baseline: base, Candidate: cand}.Improvement()
+	approx(t, "delta recall", d.RecallAtK, 0.5)
+	approx(t, "delta MRR", d.MRR, 0.5)
+	if d.N != 7 || d.K != 5 {
+		t.Fatalf("improvement should carry candidate N/K, got N=%d K=%d", d.N, d.K)
+	}
+}

--- a/cli/workspace/memory/facts.go
+++ b/cli/workspace/memory/facts.go
@@ -137,12 +137,23 @@ func (fi *FactIndex) GetAll() []*Fact {
 	defer fi.mu.RUnlock()
 
 	fi.recalcScoresLocked()
+	return fi.sortedByScoreLocked()
+}
+
+// sortedByScoreLocked returns every fact ordered by temporal score descending,
+// with a deterministic id tie-break so output never depends on Go's randomized
+// map iteration order. The caller must hold at least a read lock and is
+// responsible for calling recalcScoresLocked first if fresh scores are needed.
+func (fi *FactIndex) sortedByScoreLocked() []*Fact {
 	facts := make([]*Fact, 0, len(fi.facts))
 	for _, f := range fi.facts {
 		facts = append(facts, f)
 	}
 	sort.Slice(facts, func(i, j int) bool {
-		return facts[i].Score > facts[j].Score
+		if facts[i].Score != facts[j].Score {
+			return facts[i].Score > facts[j].Score
+		}
+		return facts[i].ID < facts[j].ID
 	})
 	return facts
 }
@@ -213,6 +224,77 @@ func (fi *FactIndex) Search(keywords []string) []*Fact {
 		facts[i] = r.fact
 	}
 	return facts
+}
+
+// SearchBlended ranks facts by fusing three signals: semantic (cosine, passed
+// in as id→score), lexical (keyword/tag overlap) and temporal (recency ×
+// access). It is the ranking the HyDE path uses once a vector index is wired.
+//
+// Unlike Search (which multiplies temporal × lexical and is blind to cosine),
+// the candidate set here is the UNION of keyword matches and semantic hits, so
+// a fact found only by the vector store — the exact synonym/paraphrase case
+// keyword search misses — can still rank. Each signal is min-max normalized
+// across the candidates before the weighted sum (see blendCandidates), which is
+// what keeps the weights meaningful and provider-agnostic.
+//
+// semantic may be nil (no vector index / disabled); the blend then degrades to
+// lexical + temporal over the keyword matches. When both keywords and semantic
+// are empty it falls back to all facts by temporal score, matching Search's
+// empty-query behavior.
+func (fi *FactIndex) SearchBlended(keywords []string, semantic map[string]float64, w RankWeights) []*Fact {
+	fi.mu.RLock()
+	defer fi.mu.RUnlock()
+
+	fi.recalcScoresLocked()
+	w = w.normalized()
+
+	cands := make(map[string]*candidate, len(semantic)+8)
+
+	if len(keywords) > 0 {
+		for _, f := range fi.facts {
+			if rel := fi.computeRelevance(f, keywords); rel > 0 {
+				cands[f.ID] = &candidate{fact: f, lexical: rel, temporal: f.Score}
+			}
+		}
+	}
+
+	for id, sem := range semantic {
+		f, ok := fi.facts[id]
+		if !ok {
+			continue // vector for an archived/forgotten fact — skip
+		}
+		if c, exists := cands[id]; exists {
+			c.semantic = sem
+			continue
+		}
+		cands[id] = &candidate{fact: f, semantic: sem, temporal: f.Score}
+	}
+
+	if len(cands) == 0 {
+		if len(keywords) == 0 && len(semantic) == 0 {
+			return fi.sortedByScoreLocked()
+		}
+		return nil
+	}
+
+	list := make([]*candidate, 0, len(cands))
+	for _, c := range cands {
+		list = append(list, c)
+	}
+	blendCandidates(list, w)
+
+	sort.Slice(list, func(i, j int) bool {
+		if list[i].final != list[j].final {
+			return list[i].final > list[j].final
+		}
+		return list[i].fact.ID < list[j].fact.ID // deterministic tie-break
+	})
+
+	out := make([]*Fact, len(list))
+	for i, c := range list {
+		out[i] = c.fact
+	}
+	return out
 }
 
 // MarkAccessed updates access metadata for retrieved facts.

--- a/cli/workspace/memory/ranking.go
+++ b/cli/workspace/memory/ranking.go
@@ -1,5 +1,7 @@
 /*
  * ChatCLI - Long-term memory: blended fact ranking.
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
  *
  * The retrieval critique this file answers: the original HyDE path embedded
  * the query, found the cosine top-K, then *threw the cosine score away* and

--- a/cli/workspace/memory/ranking.go
+++ b/cli/workspace/memory/ranking.go
@@ -1,0 +1,126 @@
+/*
+ * ChatCLI - Long-term memory: blended fact ranking.
+ *
+ * The retrieval critique this file answers: the original HyDE path embedded
+ * the query, found the cosine top-K, then *threw the cosine score away* and
+ * re-ranked purely by lexical substring overlap. That discarded the single
+ * most expensive and most informative signal we had.
+ *
+ * The blended ranker fuses three independent, complementary signals into one
+ * score:
+ *
+ *   semantic — cosine similarity from the vector store (synonymy, paraphrase)
+ *   lexical  — keyword/tag overlap (exact terms, identifiers, file names)
+ *   temporal — recency × access-frequency decay (what the user actually uses)
+ *
+ * Each signal lives on a different, non-comparable scale (cosine ∈ [0,1],
+ * lexical ∈ [0,~1.5], temporal unbounded), so we min-max normalize each across
+ * the candidate set before the weighted sum. Normalization is what makes the
+ * weights meaningful and provider-agnostic: a Voyage 1024-d cosine and an
+ * OpenAI 1536-d cosine both land in [0,1] after normalization, so the same
+ * RankWeights behave the same on all 14 supported backends.
+ *
+ * Additive fusion (not multiplicative) is deliberate: a fact surfaced only by
+ * the vector store — zero lexical overlap, the exact synonym case keyword
+ * search is blind to — must still be able to rank. A product would zero it out.
+ */
+package memory
+
+// RankWeights controls how the blended retriever combines the three relevance
+// signals. Each weight is a non-negative multiplier applied to a min-max
+// normalized signal. Weights need not sum to 1 — ranking is invariant to a
+// uniform rescale — but keeping them in [0,1] keeps tuning legible.
+type RankWeights struct {
+	Semantic float64 `json:"semantic"` // cosine similarity from the vector store
+	Lexical  float64 `json:"lexical"`  // keyword/tag overlap
+	Temporal float64 `json:"temporal"` // recency × access-frequency decay
+}
+
+// DefaultRankWeights leans semantic-first: we paid an LLM call (HyDE) and an
+// embedding call to obtain the cosine signal, so it should drive the ranking,
+// with lexical overlap as a strong precision anchor and temporal recency as a
+// lighter tie-breaker.
+func DefaultRankWeights() RankWeights {
+	return RankWeights{Semantic: 0.55, Lexical: 0.30, Temporal: 0.15}
+}
+
+// normalized clamps negative weights to zero and falls back to the defaults
+// when the caller zeroed every signal (which would otherwise rank everything
+// equally). The result is safe to feed straight into blendCandidates.
+func (w RankWeights) normalized() RankWeights {
+	w.Semantic = clampNonNeg(w.Semantic)
+	w.Lexical = clampNonNeg(w.Lexical)
+	w.Temporal = clampNonNeg(w.Temporal)
+	if w.Semantic == 0 && w.Lexical == 0 && w.Temporal == 0 {
+		return DefaultRankWeights()
+	}
+	return w
+}
+
+func clampNonNeg(x float64) float64 {
+	if x < 0 {
+		return 0
+	}
+	return x
+}
+
+// candidate carries the three raw signals for one fact through the blend. The
+// raw values are filled by the retriever; blendCandidates overwrites final.
+type candidate struct {
+	fact     *Fact
+	semantic float64 // raw cosine in [0,1] (0 when the fact had no vector hit)
+	lexical  float64 // raw keyword relevance (0 when no keyword matched)
+	temporal float64 // raw temporal score (always present, > 0)
+	final    float64 // fused score, set by blendCandidates
+}
+
+// blendCandidates min-max normalizes each signal across the candidate set and
+// writes the weighted sum into each candidate's final field. It mutates the
+// slice in place and is O(n) over the candidates.
+//
+// A signal whose values are constant across all candidates carries no ranking
+// information (it shifts every score by the same amount), so we normalize it to
+// zero rather than inventing a spread — this keeps the blend honest and avoids
+// a uniform signal silently dominating via its weight.
+func blendCandidates(cands []*candidate, w RankWeights) {
+	if len(cands) == 0 {
+		return
+	}
+
+	semMin, semMax := minMax(cands, func(c *candidate) float64 { return c.semantic })
+	lexMin, lexMax := minMax(cands, func(c *candidate) float64 { return c.lexical })
+	tmpMin, tmpMax := minMax(cands, func(c *candidate) float64 { return c.temporal })
+
+	for _, c := range cands {
+		ns := normalize(c.semantic, semMin, semMax)
+		nl := normalize(c.lexical, lexMin, lexMax)
+		nt := normalize(c.temporal, tmpMin, tmpMax)
+		c.final = w.Semantic*ns + w.Lexical*nl + w.Temporal*nt
+	}
+}
+
+func minMax(cands []*candidate, sel func(*candidate) float64) (mn, mx float64) {
+	mn, mx = sel(cands[0]), sel(cands[0])
+	for _, c := range cands[1:] {
+		v := sel(c)
+		if v < mn {
+			mn = v
+		}
+		if v > mx {
+			mx = v
+		}
+	}
+	return mn, mx
+}
+
+// normalize maps v into [0,1] given the observed [mn,mx] range. A degenerate
+// range (all values equal) maps to 0: a constant signal can't discriminate, so
+// it contributes nothing rather than an arbitrary constant.
+func normalize(v, mn, mx float64) float64 {
+	const eps = 1e-12
+	span := mx - mn
+	if span <= eps {
+		return 0
+	}
+	return (v - mn) / span
+}

--- a/cli/workspace/memory/ranking_test.go
+++ b/cli/workspace/memory/ranking_test.go
@@ -1,0 +1,247 @@
+package memory
+
+import (
+	"context"
+	"testing"
+
+	"github.com/diillson/chatcli/cli/workspace/memory/eval"
+	"go.uber.org/zap"
+)
+
+// conceptProvider is a deterministic, dependency-free embedding provider for
+// tests. It maps each token to one of a fixed set of semantic "concepts" and
+// returns a count vector over those concepts. Two texts that talk about the
+// same concept with DIFFERENT words (the synonym/paraphrase case that defeats
+// keyword search) land on the same axis and so have high cosine — which is
+// exactly the behavior a real embedding model provides and the property the
+// blended ranker is meant to exploit. Provider-agnostic by design: it satisfies
+// the same embedding.Provider contract as Voyage/OpenAI/Bedrock.
+type conceptProvider struct{}
+
+var conceptIndex = map[string]int{
+	// 0: auth
+	"oauth": 0, "login": 0, "token": 0, "tokens": 0, "signin": 0,
+	"credential": 0, "credentials": 0, "verification": 0, "password": 0, "session": 0, "bearer": 0,
+	// 1: database
+	"postgres": 1, "database": 1, "sql": 1, "rows": 1, "schema": 1,
+	"tables": 1, "records": 1, "stores": 1,
+	// 2: deploy
+	"kubernetes": 2, "rollout": 2, "canary": 2, "deployment": 2,
+	"release": 2, "ship": 2, "version": 2,
+	// 3: logging
+	"zap": 3, "structured": 3, "logs": 3, "stdout": 3,
+	"observability": 3, "trace": 3, "output": 3,
+	// 4: cache
+	"redis": 4, "eviction": 4, "ttl": 4, "cache": 4, "invalidation": 4, "caching": 4,
+}
+
+const conceptDim = 5
+
+func (conceptProvider) Name() string   { return "concept-test" }
+func (conceptProvider) Dimension() int { return conceptDim }
+
+func (conceptProvider) Embed(_ context.Context, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i, text := range texts {
+		vec := make([]float32, conceptDim)
+		for _, tok := range tokenizeLetters(text) {
+			if idx, ok := conceptIndex[tok]; ok {
+				vec[idx]++
+			}
+		}
+		out[i] = vec
+	}
+	return out, nil
+}
+
+// tokenizeLetters lowercases and splits on any non-letter, matching how the
+// concept map keys are written.
+func tokenizeLetters(s string) []string {
+	var toks []string
+	var cur []rune
+	for _, r := range s {
+		switch {
+		case r >= 'A' && r <= 'Z':
+			cur = append(cur, r+('a'-'A'))
+		case r >= 'a' && r <= 'z':
+			cur = append(cur, r)
+		default:
+			if len(cur) > 0 {
+				toks = append(toks, string(cur))
+				cur = cur[:0]
+			}
+		}
+	}
+	if len(cur) > 0 {
+		toks = append(toks, string(cur))
+	}
+	return toks
+}
+
+// buildCorpus wires a FactIndex + VectorIndex over a temp dir, adds the corpus,
+// backfills vectors, and returns a content→id map so tests can label samples.
+func buildCorpus(t *testing.T) (*FactIndex, *VectorIndex, map[string]string) {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := DefaultConfig()
+	fi := NewFactIndex(dir, cfg, zap.NewNop())
+
+	corpus := []struct{ content, category string }{
+		{"OAuth login issues bearer tokens", "auth"},
+		{"Postgres stores user rows in tables", "database"},
+		{"Kubernetes rollout uses canary strategy", "deploy"},
+		{"Zap emits structured logs to stdout", "logging"},
+		{"Redis eviction relies on ttl", "cache"},
+	}
+	for _, c := range corpus {
+		fi.AddFact(c.content, c.category, nil)
+	}
+
+	contentToID := make(map[string]string)
+	items := make(map[string]string)
+	for _, f := range fi.GetAll() {
+		contentToID[f.Content] = f.ID
+		items[f.ID] = f.Content
+	}
+
+	vi := NewVectorIndex(dir, conceptProvider{}, zap.NewNop())
+	if !vi.Enabled() {
+		t.Fatal("vector index should be enabled with a real provider")
+	}
+	if err := vi.BackfillFacts(context.Background(), items); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	return fi, vi, contentToID
+}
+
+// TestBlendedBeatsKeyword is the headline A/B: on queries phrased with synonyms
+// that never appear in the stored fact text, keyword retrieval is blind while
+// the semantic blend recovers the right fact. This is the measurable proof that
+// keeping the cosine score (instead of dissolving it back into keywords) lifts
+// retrieval quality.
+func TestBlendedBeatsKeyword(t *testing.T) {
+	fi, vi, id := buildCorpus(t)
+	ctx := context.Background()
+
+	idsOf := func(facts []*Fact, k int) []string {
+		out := make([]string, 0, k)
+		for i, f := range facts {
+			if i >= k {
+				break
+			}
+			out = append(out, f.ID)
+		}
+		return out
+	}
+
+	keywordRanker := func(query string, k int) []string {
+		return idsOf(fi.Search(ExtractKeywords([]string{query})), k)
+	}
+	blendedRanker := func(query string, k int) []string {
+		kw := ExtractKeywords([]string{query})
+		var semantic map[string]float64
+		if vec, err := vi.EmbedQuery(ctx, query); err == nil {
+			for _, h := range vi.SimilarFactsScored(vec, 10, 0.25) {
+				if semantic == nil {
+					semantic = make(map[string]float64)
+				}
+				semantic[h.ID] = h.Score
+			}
+		}
+		return idsOf(fi.SearchBlended(kw, semantic, DefaultRankWeights()), k)
+	}
+
+	samples := []eval.Sample{
+		// Synonym queries — zero lexical overlap with the fact text.
+		{Query: "how is credential verification and signin handled", Relevant: []string{id["OAuth login issues bearer tokens"]}},
+		{Query: "which schema holds the stored records", Relevant: []string{id["Postgres stores user rows in tables"]}},
+		{Query: "how to ship a release version", Relevant: []string{id["Kubernetes rollout uses canary strategy"]}},
+		{Query: "where does observability trace output go", Relevant: []string{id["Zap emits structured logs to stdout"]}},
+		{Query: "explain cache invalidation policy", Relevant: []string{id["Redis eviction relies on ttl"]}},
+		// Literal queries — keyword-friendly; blend must not regress here.
+		{Query: "oauth token login", Relevant: []string{id["OAuth login issues bearer tokens"]}},
+		{Query: "postgres rows", Relevant: []string{id["Postgres stores user rows in tables"]}},
+	}
+
+	base := eval.Evaluate(keywordRanker, samples, 1)
+	cand := eval.Evaluate(blendedRanker, samples, 1)
+	t.Logf("A/B keyword vs blended:\n%s", eval.Comparison{Baseline: base, Candidate: cand})
+
+	if cand.RecallAtK <= base.RecallAtK {
+		t.Fatalf("blended recall@1 (%.4f) must beat keyword (%.4f)", cand.RecallAtK, base.RecallAtK)
+	}
+	if cand.RecallAtK < 0.99 {
+		t.Fatalf("blended recall@1 should be ~1.0, got %.4f", cand.RecallAtK)
+	}
+	if cand.MRR < base.MRR {
+		t.Fatalf("blended MRR (%.4f) regressed below keyword (%.4f)", cand.MRR, base.MRR)
+	}
+}
+
+// TestSearchBlended_SemanticOnlyFactSurfaces proves the core fix in isolation:
+// a fact with NO keyword overlap still ranks when it carries a semantic score.
+// Under the old multiplicative scorer (temporal × lexical) its lexical 0 would
+// have zeroed it out entirely.
+func TestSearchBlended_SemanticOnlyFactSurfaces(t *testing.T) {
+	fi, _, id := buildCorpus(t)
+	target := id["Redis eviction relies on ttl"]
+
+	// Keywords that match nothing in any fact; semantic points only at target.
+	got := fi.SearchBlended(
+		[]string{"nonexistentkeywordxyz"},
+		map[string]float64{target: 0.91},
+		DefaultRankWeights(),
+	)
+	if len(got) == 0 || got[0].ID != target {
+		t.Fatalf("semantic-only fact must surface first; got %v", idsList(got))
+	}
+}
+
+// TestSearchBlended_EmptyEverythingFallsBackToAll mirrors Search's empty-query
+// contract: no keywords and no semantic signal returns the full set by score.
+func TestSearchBlended_EmptyEverythingFallsBackToAll(t *testing.T) {
+	fi, _, _ := buildCorpus(t)
+	got := fi.SearchBlended(nil, nil, DefaultRankWeights())
+	if len(got) != 5 {
+		t.Fatalf("empty query should return all 5 facts, got %d", len(got))
+	}
+}
+
+func idsList(facts []*Fact) []string {
+	out := make([]string, len(facts))
+	for i, f := range facts {
+		out[i] = f.ID
+	}
+	return out
+}
+
+func TestBlendCandidates_AdditiveFusionAndConstantSignal(t *testing.T) {
+	// Two candidates. A wins on semantic, B wins on lexical; temporal is equal
+	// (constant → contributes nothing). With semantic-leaning default weights,
+	// A should rank first.
+	a := &candidate{fact: &Fact{ID: "A"}, semantic: 0.9, lexical: 0.1, temporal: 1.0}
+	b := &candidate{fact: &Fact{ID: "B"}, semantic: 0.1, lexical: 0.9, temporal: 1.0}
+	cands := []*candidate{a, b}
+	blendCandidates(cands, DefaultRankWeights())
+
+	if a.final <= b.final {
+		t.Fatalf("semantic-leaning blend should rank A>B, got A=%.4f B=%.4f", a.final, b.final)
+	}
+	// Constant temporal must not have moved the needle: recompute with temporal
+	// varied and confirm ordering is driven by the discriminating signals.
+	if a.final == 0 && b.final == 0 {
+		t.Fatal("blend produced no separation between candidates")
+	}
+}
+
+func TestRankWeights_NormalizedFallback(t *testing.T) {
+	// All-zero weights are nonsensical (everything ties) → fall back to default.
+	if got := (RankWeights{}).normalized(); got != DefaultRankWeights() {
+		t.Fatalf("zero weights should fall back to default, got %+v", got)
+	}
+	// Negative weights clamp to zero.
+	got := RankWeights{Semantic: -1, Lexical: 0.5, Temporal: 0.5}.normalized()
+	if got.Semantic != 0 {
+		t.Fatalf("negative weight should clamp to 0, got %v", got.Semantic)
+	}
+}

--- a/cli/workspace/memory/retriever.go
+++ b/cli/workspace/memory/retriever.go
@@ -54,38 +54,66 @@ func (r *RelevanceRetriever) SetWorkspaceDir(dir string) {
 // empty string to skip augmentation entirely (rare; callers usually
 // have at least one user message to feed in).
 func (r *RelevanceRetriever) RetrieveWithHyDE(ctx context.Context, query string, hints []string, augmenter *HyDEAugmenter, vectors *VectorIndex) string {
+	hasVectors := vectors != nil && vectors.Enabled()
+
+	// Strict no-regression: with neither augmenter nor a live vector index
+	// there is no semantic signal to fuse, so fall through to the exact
+	// keyword path callers relied on before HyDE existed.
+	if augmenter == nil && !hasVectors {
+		return r.Retrieve(hints)
+	}
+
+	// Phase 3a — widen the lexical net with hypothesis-derived keywords.
 	expanded := hints
 	if augmenter != nil {
 		expanded = augmenter.Augment(ctx, query, hints)
 	}
 
-	// Phase 3b: when a vector index is wired, embed the (augmented)
-	// query and union the cosine top-k fact ids with the keyword set.
-	// We surface vector hits by promoting them as additional keyword
-	// tokens (the fact id), but the truth is FactIndex.Search remains
-	// the canonical retriever — vectors only WIDEN the candidate set.
-	if vectors != nil && vectors.Enabled() && strings.TrimSpace(query) != "" {
+	// Phase 3b — embed the query and keep the cosine SCORES (not just the ids).
+	// Previously the top-k ids were dissolved back into keyword tokens, which
+	// threw away the very signal we paid an embedding call to compute. Now the
+	// scores flow straight into the blended ranker so a strong semantic match
+	// with zero keyword overlap can still surface.
+	var semantic map[string]float64
+	if hasVectors && strings.TrimSpace(query) != "" {
 		if vec, err := vectors.EmbedQuery(ctx, query); err == nil {
-			// Top-K cosine hits become additional hint tokens via the
-			// fact's content. We resolve ids to content here so the
-			// existing keyword scorer can re-rank cohesively.
-			topIDs := vectors.SimilarFacts(vec, 8)
-			if len(topIDs) > 0 {
-				for _, id := range topIDs {
-					if f, ok := r.facts.GetByID(id); ok {
-						expanded = mergeUniqueLowercase(expanded, ExtractKeywords([]string{f.Content}))
-					}
+			topK := r.config.VectorTopK
+			if topK <= 0 {
+				topK = 12
+			}
+			hits := vectors.SimilarFactsScored(vec, topK, r.config.MinCosineScore)
+			if len(hits) > 0 {
+				semantic = make(map[string]float64, len(hits))
+				for _, h := range hits {
+					semantic[h.ID] = h.Score
 				}
 			}
 		}
 	}
 
-	return r.Retrieve(expanded)
+	ranked := r.facts.SearchBlended(expanded, semantic, r.config.RankWeights)
+	return r.assemble(ranked)
 }
 
 // Retrieve returns memory context tailored to the current conversation.
 // hints are extracted from recent messages (keywords, topics mentioned).
+// It uses the lexical+temporal scorer (Search); the semantic blend is reserved
+// for the HyDE path, which is the only caller with a query to embed.
 func (r *RelevanceRetriever) Retrieve(hints []string) string {
+	var ranked []*Fact
+	if len(hints) > 0 {
+		ranked = r.facts.Search(hints)
+	} else {
+		ranked = r.facts.GetAll()
+	}
+	return r.assemble(ranked)
+}
+
+// assemble renders the budget-bounded memory context from a PRE-RANKED fact
+// list plus the always-on profile/projects/topics/daily/patterns sections.
+// Splitting this out lets Retrieve and RetrieveWithHyDE share one assembly path
+// while choosing their own fact ranking upstream.
+func (r *RelevanceRetriever) assemble(rankedFacts []*Fact) string {
 	budget := r.config.RetrievalBudget
 	if budget <= 0 {
 		budget = 4000
@@ -121,13 +149,9 @@ func (r *RelevanceRetriever) Retrieve(hints []string) string {
 		}
 	}
 
-	// 4. Relevant facts — the main section
-	var relevantFacts []*Fact
-	if len(hints) > 0 {
-		relevantFacts = r.facts.Search(hints)
-	} else {
-		relevantFacts = r.facts.GetAll()
-	}
+	// 4. Relevant facts — the main section. Already ranked by the caller
+	// (lexical+temporal via Retrieve, or the semantic blend via HyDE).
+	relevantFacts := rankedFacts
 
 	if len(relevantFacts) > 0 {
 		var factLines []string

--- a/cli/workspace/memory/store.go
+++ b/cli/workspace/memory/store.go
@@ -235,8 +235,12 @@ func (m *Manager) GetRelevantContextWithHyDE(ctx context.Context, query string, 
 	// and ~50 tokens/fact average, 500 facts ≈ $0.001.
 	if m.vectors != nil && m.vectors.Enabled() {
 		all := m.Facts.GetAll()
-		if len(all) > 500 {
-			all = all[:500]
+		// Bound the per-retrieval embed batch so a cold cache can't bill an
+		// unbounded amount on a huge memory. Config-driven (was a hard-coded
+		// 500); GetAll returns highest-scoring facts first, so the cap keeps
+		// the most relevant vectors warm.
+		if batchMax := m.config.BackfillBatchMax; batchMax > 0 && len(all) > batchMax {
+			all = all[:batchMax]
 		}
 		ids := make([]string, 0, len(all))
 		for _, f := range all {

--- a/cli/workspace/memory/topk.go
+++ b/cli/workspace/memory/topk.go
@@ -1,5 +1,7 @@
 /*
  * ChatCLI - Long-term memory: bounded top-K selection.
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
  *
  * The vector store ranks fact_id → cosine over every stored vector. Sorting
  * the entire candidate set is O(n log n); we only ever want the top-K, so a

--- a/cli/workspace/memory/topk.go
+++ b/cli/workspace/memory/topk.go
@@ -1,0 +1,88 @@
+/*
+ * ChatCLI - Long-term memory: bounded top-K selection.
+ *
+ * The vector store ranks fact_id → cosine over every stored vector. Sorting
+ * the entire candidate set is O(n log n); we only ever want the top-K, so a
+ * bounded min-heap gives the same answer in O(n log k) time and O(k) space.
+ *
+ * This is the difference between "fine for hundreds of facts" and "fine for
+ * tens of thousands": the heap caps the work at k regardless of corpus size,
+ * lifting the scan ceiling without dragging CGO / a vector DB into the build.
+ */
+package memory
+
+import (
+	"container/heap"
+	"sort"
+)
+
+// scoredItem is one (id, score) pair flowing through top-K selection.
+type scoredItem struct {
+	id    string
+	score float64
+}
+
+// minScoreHeap is a min-heap on score: the smallest score sits at the root so
+// it can be evicted the instant a stronger candidate arrives.
+type minScoreHeap []scoredItem
+
+func (h minScoreHeap) Len() int           { return len(h) }
+func (h minScoreHeap) Less(i, j int) bool { return h[i].score < h[j].score }
+func (h minScoreHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+func (h *minScoreHeap) Push(x any)        { *h = append(*h, x.(scoredItem)) }
+func (h *minScoreHeap) Pop() any {
+	old := *h
+	n := len(old)
+	it := old[n-1]
+	*h = old[:n-1]
+	return it
+}
+
+// topKSelector keeps the k highest-scoring items observed during a single
+// scan. Offer every candidate; read the winners back, sorted descending, with
+// sortedDesc. Not safe for concurrent use — scope one to a single query.
+type topKSelector struct {
+	k int
+	h minScoreHeap
+}
+
+// newTopKSelector builds a selector for the k best items. k < 1 is clamped to
+// 1 so the selector always yields at least the single best candidate.
+func newTopKSelector(k int) *topKSelector {
+	if k < 1 {
+		k = 1
+	}
+	return &topKSelector{k: k, h: make(minScoreHeap, 0, k+1)}
+}
+
+// offer feeds one candidate. While the heap is under capacity it is admitted
+// unconditionally; once full, the candidate replaces the current weakest only
+// if it strictly beats it. Ties keep the incumbent, which — combined with the
+// id tie-break in sortedDesc — makes the output deterministic across runs and
+// platforms (Windows/Linux/macOS map iteration order never leaks through).
+func (t *topKSelector) offer(id string, score float64) {
+	if t.h.Len() < t.k {
+		heap.Push(&t.h, scoredItem{id: id, score: score})
+		return
+	}
+	if t.h[0].score >= score {
+		return
+	}
+	t.h[0] = scoredItem{id: id, score: score}
+	heap.Fix(&t.h, 0)
+}
+
+// sortedDesc returns the retained items ordered by score descending, breaking
+// ties by ascending id for stable, reproducible output. It does not drain the
+// heap, so the selector stays reusable.
+func (t *topKSelector) sortedDesc() []scoredItem {
+	out := make([]scoredItem, t.h.Len())
+	copy(out, t.h)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].score != out[j].score {
+			return out[i].score > out[j].score
+		}
+		return out[i].id < out[j].id
+	})
+	return out
+}

--- a/cli/workspace/memory/topk_test.go
+++ b/cli/workspace/memory/topk_test.go
@@ -1,0 +1,69 @@
+package memory
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestTopKSelector_SelectsHighestK(t *testing.T) {
+	sel := newTopKSelector(3)
+	in := map[string]float64{"a": 0.1, "b": 0.9, "c": 0.5, "d": 0.7, "e": 0.2}
+	// Offer in a fixed but non-sorted order.
+	for _, id := range []string{"a", "b", "c", "d", "e"} {
+		sel.offer(id, in[id])
+	}
+	got := sel.sortedDesc()
+	if len(got) != 3 {
+		t.Fatalf("want 3 items, got %d", len(got))
+	}
+	wantIDs := []string{"b", "d", "c"} // 0.9, 0.7, 0.5
+	for i, it := range got {
+		if it.id != wantIDs[i] {
+			t.Fatalf("position %d: got %s (%.2f), want %s", i, it.id, it.score, wantIDs[i])
+		}
+	}
+}
+
+func TestTopKSelector_DeterministicTies(t *testing.T) {
+	// All equal scores: output must be ascending-id, never map-order-dependent.
+	build := func(order []string) []string {
+		sel := newTopKSelector(3)
+		for _, id := range order {
+			sel.offer(id, 0.5)
+		}
+		out := make([]string, 0, 3)
+		for _, it := range sel.sortedDesc() {
+			out = append(out, it.id)
+		}
+		return out
+	}
+	a := build([]string{"x", "y", "z"})
+	b := build([]string{"z", "y", "x"})
+	if !sort.StringsAreSorted(a) {
+		t.Fatalf("tie output not sorted: %v", a)
+	}
+	if len(a) != len(b) {
+		t.Fatalf("nondeterministic length: %v vs %v", a, b)
+	}
+	// Same set of survivors regardless of insertion order (first-3 by tie rule).
+	for i := range a {
+		if a[i] != b[i] {
+			t.Fatalf("tie ordering not insertion-independent: %v vs %v", a, b)
+		}
+	}
+}
+
+func TestTopKSelector_KClampAndUnderfill(t *testing.T) {
+	sel := newTopKSelector(0) // clamps to 1
+	sel.offer("only", 0.3)
+	if got := sel.sortedDesc(); len(got) != 1 || got[0].id != "only" {
+		t.Fatalf("k<=0 should clamp to 1, got %+v", got)
+	}
+
+	sel2 := newTopKSelector(10) // more capacity than items
+	sel2.offer("a", 0.1)
+	sel2.offer("b", 0.2)
+	if got := sel2.sortedDesc(); len(got) != 2 || got[0].id != "b" {
+		t.Fatalf("underfilled selector wrong: %+v", got)
+	}
+}

--- a/cli/workspace/memory/types.go
+++ b/cli/workspace/memory/types.go
@@ -92,6 +92,17 @@ type Config struct {
 	CompactionInterval int     `json:"compaction_interval_h"` // hours, default 24
 	RetrievalBudget    int     `json:"retrieval_budget"`      // max chars for system prompt, default 4000
 	DecayHalfLifeDays  float64 `json:"decay_half_life_days"`  // default 30
+
+	// Blended-ranking tunables (HyDE retrieval path). These govern how the
+	// semantic (cosine), lexical (keyword) and temporal (recency) signals are
+	// fused into a single fact ranking. Provider-agnostic by construction:
+	// cosine is computed identically for every embedding backend, so the same
+	// defaults hold whether the operator runs Voyage, OpenAI, Bedrock or any
+	// of the other supported providers.
+	MinCosineScore   float64     `json:"min_cosine_score"`   // floor for vector hits, default 0.25
+	VectorTopK       int         `json:"vector_top_k"`       // candidate vectors pulled per query, default 12
+	BackfillBatchMax int         `json:"backfill_batch_max"` // max facts embedded per retrieval, default 500
+	RankWeights      RankWeights `json:"rank_weights"`       // signal fusion weights
 }
 
 // DefaultConfig returns sensible defaults.
@@ -103,6 +114,10 @@ func DefaultConfig() Config {
 		CompactionInterval: 24,
 		RetrievalBudget:    4000,
 		DecayHalfLifeDays:  30.0,
+		MinCosineScore:     0.25,
+		VectorTopK:         12,
+		BackfillBatchMax:   500,
+		RankWeights:        DefaultRankWeights(),
 	}
 }
 

--- a/cli/workspace/memory/vector_scored_test.go
+++ b/cli/workspace/memory/vector_scored_test.go
@@ -1,0 +1,113 @@
+package memory
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// namedProvider is a second deterministic provider whose Name() and Dimension()
+// are configurable, so tests can simulate a provider/dimension SWITCH against an
+// already-persisted index. Embedding is one-hot on the first byte (same shape as
+// fakeProvider) — enough for the auto-migration paths, which key off the
+// persisted provider name and dimension, not the vector values.
+type namedProvider struct {
+	name string
+	dim  int
+}
+
+func (p *namedProvider) Name() string   { return p.name }
+func (p *namedProvider) Dimension() int { return p.dim }
+func (p *namedProvider) Embed(_ context.Context, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i, t := range texts {
+		v := make([]float32, p.dim)
+		if len(t) > 0 && int(t[0]) < p.dim {
+			v[t[0]] = 1
+		}
+		out[i] = v
+	}
+	return out, nil
+}
+
+func TestSimilarFactsScored_FloorFiltersWeakHits(t *testing.T) {
+	dir := t.TempDir()
+	v := NewVectorIndex(dir, &fakeProvider{dim: 128}, nil)
+	if err := v.BackfillFacts(context.Background(), map[string]string{
+		"f1": "alpha", // near the query
+		"f2": "beta",  // far from the query
+	}); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	q, err := v.EmbedQuery(context.Background(), "alpha question")
+	if err != nil {
+		t.Fatalf("embed query: %v", err)
+	}
+
+	// No floor: both candidates returned (f2 weakly positive).
+	if got := v.SimilarFactsScored(q, 5, 0.0); len(got) != 2 {
+		t.Fatalf("floor 0.0 should return both, got %d: %+v", len(got), got)
+	}
+	// Real floor: the weak/near-orthogonal f2 is rejected.
+	got := v.SimilarFactsScored(q, 5, 0.5)
+	if len(got) != 1 || got[0].ID != "f1" {
+		t.Fatalf("floor 0.5 should keep only f1, got %+v", got)
+	}
+	if got[0].Score < 0.99 {
+		t.Fatalf("f1 score should be ~1.0, got %.4f", got[0].Score)
+	}
+}
+
+func TestVectorIndex_ProviderChangeAutoMigrates(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "vector_index.json")
+
+	// Persist with provider "fake".
+	v1 := NewVectorIndex(dir, &fakeProvider{dim: 16}, nil)
+	if err := v1.BackfillFacts(context.Background(), map[string]string{"f1": "alpha"}); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("index file should exist after backfill: %v", err)
+	}
+
+	// Reopen with a DIFFERENT provider at the same dimension. Cosine across two
+	// embedding spaces is meaningless, so the cache must auto-clear rather than
+	// silently serving garbage matches.
+	v2 := NewVectorIndex(dir, &namedProvider{name: "other", dim: 16}, nil)
+	if v2.Count() != 0 {
+		t.Fatalf("provider switch must clear the stale cache, got count=%d", v2.Count())
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("stale index file should have been removed, stat err=%v", err)
+	}
+}
+
+func TestVectorIndex_DimensionChangeAutoMigrates(t *testing.T) {
+	dir := t.TempDir()
+
+	v1 := NewVectorIndex(dir, &fakeProvider{dim: 16}, nil)
+	if err := v1.BackfillFacts(context.Background(), map[string]string{"f1": "alpha"}); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+
+	// Same provider semantics but a different dimension → must clear.
+	v2 := NewVectorIndex(dir, &fakeProvider{dim: 32}, nil)
+	if v2.Count() != 0 {
+		t.Fatalf("dimension switch must clear the stale cache, got count=%d", v2.Count())
+	}
+}
+
+func TestVectorIndex_SameProviderReloads(t *testing.T) {
+	dir := t.TempDir()
+	v1 := NewVectorIndex(dir, &fakeProvider{dim: 16}, nil)
+	if err := v1.BackfillFacts(context.Background(), map[string]string{"f1": "alpha", "f2": "beta"}); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	// Reopen with the SAME provider+dim → entries must survive (no false migrate).
+	v2 := NewVectorIndex(dir, &fakeProvider{dim: 16}, nil)
+	if v2.Count() != 2 {
+		t.Fatalf("same provider should reload entries, got count=%d", v2.Count())
+	}
+}

--- a/cli/workspace/memory/vector_store.go
+++ b/cli/workspace/memory/vector_store.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"sync"
 
 	"github.com/diillson/chatcli/llm/embedding"
@@ -158,9 +157,26 @@ func (v *VectorIndex) BackfillFacts(ctx context.Context, items map[string]string
 	return v.persist()
 }
 
-// SimilarFacts ranks stored entries by cosine similarity to a query
-// vector, returning the top-k fact ids. k <= 0 returns nothing.
-func (v *VectorIndex) SimilarFacts(query []float32, k int) []string {
+// ScoredFact pairs a fact id with the cosine similarity that surfaced it.
+// SimilarFactsScored returns these so the blended retriever can fuse the
+// semantic signal with lexical and temporal scores instead of discarding it.
+type ScoredFact struct {
+	ID    string
+	Score float64
+}
+
+// SimilarFactsScored ranks stored entries by cosine similarity to a query
+// vector and returns the top-k that clear minScore, strongest first.
+//
+// minScore is a relevance floor: cosine over normalized text embeddings is
+// almost always weakly positive, so the old "> 0" cutoff admitted near-orthogonal
+// noise into the candidate set. A floor around 0.25 keeps only genuinely related
+// facts. Selection uses a bounded min-heap (O(n log k)), so the cost scales with
+// k, not with the corpus size.
+//
+// k <= 0 or an empty query returns nothing. The result is deterministic across
+// platforms: ties break by ascending id, never by Go's randomized map order.
+func (v *VectorIndex) SimilarFactsScored(query []float32, k int, minScore float64) []ScoredFact {
 	if v == nil || !v.Enabled() || k <= 0 || len(query) == 0 {
 		return nil
 	}
@@ -169,30 +185,43 @@ func (v *VectorIndex) SimilarFacts(query []float32, k int) []string {
 	if len(v.entries) == 0 {
 		return nil
 	}
-	type scored struct {
-		id    string
-		score float32
-	}
-	hits := make([]scored, 0, len(v.entries))
-	for id, e := range v.entries {
+	sel := newTopKSelector(k)
+	for _, e := range v.entries {
 		if len(e.Vector) != len(query) {
 			continue
 		}
-		hits = append(hits, scored{id: id, score: embedding.CosineSimilarity(query, e.Vector)})
-	}
-	sort.Slice(hits, func(i, j int) bool { return hits[i].score > hits[j].score })
-	if k > len(hits) {
-		k = len(hits)
-	}
-	out := make([]string, 0, k)
-	for i := 0; i < k; i++ {
-		if hits[i].score <= 0 {
-			break
+		score := float64(embedding.CosineSimilarity(query, e.Vector))
+		if score < minScore {
+			continue
 		}
-		out = append(out, hits[i].id)
+		sel.offer(e.FactID, score)
+	}
+	items := sel.sortedDesc()
+	out := make([]ScoredFact, 0, len(items))
+	for _, it := range items {
+		out = append(out, ScoredFact{ID: it.id, Score: it.score})
 	}
 	return out
 }
+
+// SimilarFacts is the id-only convenience wrapper over SimilarFactsScored,
+// kept for callers that only need the ids (e.g. the compactor). It applies a
+// minimal positive floor, matching the historical "> 0" cutoff.
+func (v *VectorIndex) SimilarFacts(query []float32, k int) []string {
+	scored := v.SimilarFactsScored(query, k, vectorScoreEpsilon)
+	if len(scored) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(scored))
+	for _, s := range scored {
+		out = append(out, s.ID)
+	}
+	return out
+}
+
+// vectorScoreEpsilon is the smallest cosine the id-only SimilarFacts admits,
+// preserving the historical "strictly positive" semantics without a config knob.
+const vectorScoreEpsilon = 1e-9
 
 // EmbedQuery delegates to the provider so the retriever can ask for
 // the query vector once and pass it to SimilarFacts.
@@ -247,18 +276,55 @@ func (v *VectorIndex) load() {
 		v.logger.Warn("vector_index unmarshal failed", zap.Error(err))
 		return
 	}
+
+	// Dimension mismatch: cosine between vectors of different arity is
+	// undefined, so the cache cannot be reused.
 	if v.dimension > 0 && f.Dimension > 0 && f.Dimension != v.dimension {
-		v.logger.Warn("vector_index dimension mismatch — discarding cache",
+		v.logger.Warn("vector_index dimension mismatch — auto-clearing cache for re-embed",
 			zap.Int("on_disk_dim", f.Dimension),
 			zap.Int("provider_dim", v.dimension),
-			zap.String("provider", v.provider.Name()))
+			zap.String("provider", v.provider.Name()),
+			zap.String("path", v.path))
+		v.discardStale()
 		return
 	}
+
+	// Provider mismatch at the SAME dimension (e.g. Voyage 1024 → Cohere 1024):
+	// cosine between two different embedding spaces is meaningless even though
+	// the arity matches, so the previous code silently served garbage matches.
+	// Detect it and re-embed rather than requiring the operator to hand-delete
+	// the file. We compare against the persisted provider name; an empty name
+	// is a pre-this-change file and is treated as a forced re-embed.
+	current := v.provider.Name()
+	if len(f.Entries) > 0 && f.Provider != current {
+		v.logger.Warn("vector_index provider changed — auto-clearing cache for re-embed",
+			zap.String("on_disk_provider", f.Provider),
+			zap.String("provider", current),
+			zap.String("path", v.path))
+		v.discardStale()
+		return
+	}
+
 	if f.Dimension > 0 {
 		v.dimension = f.Dimension
 	}
 	if f.Entries != nil {
 		v.entries = f.Entries
+	}
+}
+
+// discardStale drops the in-memory cache and removes the on-disk file so the
+// next BackfillFacts repopulates a clean, provider-consistent index. Leaving
+// the stale file in place was the old operational sharp edge — migration
+// required a manual `rm`. Removal failures are non-fatal: the in-memory reset
+// already prevents serving cross-space matches; the file is overwritten on the
+// next persist regardless.
+func (v *VectorIndex) discardStale() {
+	v.entries = make(map[string]*VectorEntry)
+	v.dimension = v.provider.Dimension()
+	if err := os.Remove(v.path); err != nil && !os.IsNotExist(err) {
+		v.logger.Warn("vector_index stale file removal failed (will be overwritten on next persist)",
+			zap.String("path", v.path), zap.Error(err))
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes the retrieval-quality gaps in the long-term memory RAG. The headline fix: the HyDE path used to embed the query, take the cosine top-k, then **dissolve those hits back into keyword tokens and re-rank by substring overlap** — throwing away the semantic score we paid an embedding call to compute. Retrieval now **fuses three normalized signals** (semantic cosine, lexical overlap, temporal recency) into one ranking, so a fact matched only by paraphrase can still surface.

## What changed

| Area | Before | After |
|---|---|---|
| **Ranking** | cosine discarded; `temporal × lexical` substring only | additive fusion of semantic + lexical + temporal, min-max normalized |
| **Vector floor** | `> 0` (admitted near-orthogonal noise) | configurable cosine floor, default `0.25` |
| **Top-K** | full sort `O(n log n)` | bounded min-heap `O(n log k)` |
| **Backfill cap** | hard-coded `500` | `Config.BackfillBatchMax` |
| **Provider/dim switch** | served garbage cosine or required manual `rm` | auto-migration: clears stale cache, re-embeds |
| **`CHATCLI_MEMORY_*` envs** | declared but **never applied** on the structured path | wired through `ConfigFromEnv` + clamping |
| **Eval** | none | dependency-free harness: recall@k, precision@k, MRR, nDCG@k |

## Measured proof (A/B in `ranking_test.go`)

```
baseline (keyword): recall@1=0.2857  MRR=0.2857  nDCG@1=0.2857
candidate (blended): recall@1=1.0000  MRR=1.0000  nDCG@1=1.0000
delta              : recall@1=+0.7143
```

A deterministic concept-embedding provider drives the test, so the win is reproducible in CI and the harness guards against future regressions.

## Design constraints honored

- **Provider-agnostic (14 backends):** fusion is cosine + min-max normalization, so the same `RankWeights` behave identically across 1024-d and 1536-d providers. No per-provider branching.
- **OS-agnostic (Windows/Linux/macOS):** only `filepath`/`os.Getenv`; **deterministic id tie-breaks** in top-K and ranking ensure map iteration order never leaks into output.
- **No new env vars:** reused the existing `CHATCLI_MEMORY_*` constants (and fixed the latent bug where they were ignored). Ranking tunables are `Config` fields with strong defaults.

## Tests

- `go build ./...`, `go vet`, `gofmt` clean
- `go test ./cli/workspace/memory/... -race` green
- golangci-lint: no findings in the new/changed files
- New tests: blended-vs-keyword A/B, semantic-only-fact surfacing, additive-fusion ranking, cosine floor, provider/dimension auto-migration, top-K heap determinism, eval metric math (hand-computed), env wiring + config clamping

## Files

New: `ranking.go`, `topk.go`, `config_env.go`, `eval/eval.go` (+ tests for each).
Modified: `retriever.go`, `facts.go`, `vector_store.go`, `store.go`, `types.go`, `memory.go`.
