### PR TITLE
fix(embedding): rebuild embedding provider on /reload

### DIFF
--- a/cli/cli_config.go
+++ b/cli/cli_config.go
@@ -66,6 +66,7 @@ func (cli *ChatCLI) reloadConfiguration() {
 		"COPILOT_MODEL", "COPILOT_MAX_TOKENS", "GITHUB_COPILOT_TOKEN",
 		"GITHUB_TOKEN", "GH_TOKEN", "GITHUB_MODELS_TOKEN", "GITHUB_MODELS_MODEL",
 		"CHATCLI_WEBFETCH_USER_AGENT", "CHATCLI_WEBFETCH_AUTOSAVE_BYTES",
+		"CHATCLI_EMBED_PROVIDER", "CHATCLI_EMBED_MODEL", "CHATCLI_EMBED_DIMENSIONS",
 	}
 
 	for _, variable := range variablesToUnset {
@@ -84,6 +85,13 @@ func (cli *ChatCLI) reloadConfiguration() {
 	config.Global.Reload(cli.logger)
 
 	cli.reconfigureLogger()
+
+	// Rebuild the embedding provider so a CHATCLI_EMBED_PROVIDER change in
+	// .env takes effect on reload — without this the session keeps the
+	// provider captured at boot until the process restarts.
+	if oldEmb, newEmb := cli.refreshEmbeddingProvider(); oldEmb != newEmb {
+		fmt.Println(i18n.T("status.reload_embed_provider", newEmb))
+	}
 
 	manager, err := manager.NewLLMManager(cli.logger)
 	if err != nil {

--- a/cli/hyde_setup.go
+++ b/cli/hyde_setup.go
@@ -19,28 +19,84 @@ import (
 	"go.uber.org/zap"
 )
 
-// hydeOnce makes sure the embedding provider is constructed once per
-// session — the vector index keeps a stable reference and on-disk
-// state stays consistent across calls.
-var hydeOnce sync.Once
+// hydeMu guards the session-cached embedding provider. The provider is
+// built lazily on first use — the vector index keeps a stable reference
+// and on-disk state stays consistent across calls — and rebuilt by
+// refreshEmbeddingProvider when /config reload re-reads the environment.
+// A plain sync.Once would latch a Null provider for the whole process
+// when CHATCLI_EMBED_PROVIDER only lands in .env after boot.
+var hydeMu sync.Mutex
 var hydeProvider embedding.Provider
+var hydeProviderReady bool
 
 // hydeProviderForSession returns the embedding provider configured
 // via CHATCLI_EMBED_PROVIDER, instantiating it on first use. Returns
 // the null provider when nothing is configured or when construction
-// fails (logged once).
+// fails (logged once per build).
 func (cli *ChatCLI) hydeProviderForSession() embedding.Provider {
-	hydeOnce.Do(func() {
-		p, err := embedding.NewFromEnv()
-		if err != nil {
-			cli.logger.Warn("HyDE: embedding provider construction failed; falling back to null",
-				zap.Error(err))
-			hydeProvider = embedding.NewNull()
-			return
-		}
-		hydeProvider = p
-	})
+	hydeMu.Lock()
+	defer hydeMu.Unlock()
+	if !hydeProviderReady {
+		hydeProvider = cli.buildEmbeddingProviderLocked()
+		hydeProviderReady = true
+	}
 	return hydeProvider
+}
+
+// buildEmbeddingProviderLocked constructs a provider from the current
+// environment. Callers must hold hydeMu.
+func (cli *ChatCLI) buildEmbeddingProviderLocked() embedding.Provider {
+	p, err := embedding.NewFromEnv()
+	if err != nil {
+		cli.logger.Warn("HyDE: embedding provider construction failed; falling back to null",
+			zap.Error(err))
+		return embedding.NewNull()
+	}
+	return p
+}
+
+// refreshEmbeddingProvider rebuilds the embedding provider from the
+// (re-loaded) environment and rewires every consumer that captured the
+// previous instance: /context semantic retrieval and the memory vector
+// index. Called by /config reload so a CHATCLI_EMBED_PROVIDER change
+// takes effect without restarting the process. Returns the previous and
+// current provider names so the caller can surface the transition.
+func (cli *ChatCLI) refreshEmbeddingProvider() (oldName, newName string) {
+	hydeMu.Lock()
+	old := hydeProvider
+	fresh := cli.buildEmbeddingProviderLocked()
+	hydeProvider = fresh
+	hydeProviderReady = true
+	hydeMu.Unlock()
+
+	if cli.contextHandler != nil {
+		if mgr := cli.contextHandler.GetManager(); mgr != nil {
+			mgr.AttachEmbeddingProvider(fresh)
+		}
+	}
+
+	// Swap the memory vector index only when one was already attached: a
+	// fresh index for the new provider (vindex auto-migrates on provider
+	// or dimension change), or a detach when embeddings were turned off.
+	// When none was attached, ensureHyDEVectors lazily attaches on the
+	// next turn and picks up the new provider by itself.
+	if cli.memoryStore != nil && cli.memoryStore.VectorIndex() != nil {
+		if embedding.IsNull(fresh) {
+			cli.memoryStore.AttachVectorIndex(nil)
+		} else if mgr := cli.memoryStore.Manager(); mgr != nil && mgr.MemoryDir() != "" {
+			cli.memoryStore.AttachVectorIndex(memory.NewVectorIndex(mgr.MemoryDir(), fresh, cli.logger))
+		}
+	}
+	return embeddingProviderLabel(old), embeddingProviderLabel(fresh)
+}
+
+// embeddingProviderLabel renders a provider name for status output;
+// nil/Null collapse to "null" so transitions compare cleanly.
+func embeddingProviderLabel(p embedding.Provider) string {
+	if embedding.IsNull(p) {
+		return "null"
+	}
+	return p.Name()
 }
 
 // hydeAugmenter constructs a per-call HyDE augmenter wrapping the
@@ -79,7 +135,7 @@ func (cli *ChatCLI) ensureHyDEVectors(qcfg quality.Config) {
 	provider := cli.hydeProviderForSession()
 	if embedding.IsNull(provider) {
 		cli.logger.Info("HyDE vectors requested but no embedding provider configured; using keyword-only retrieval",
-			zap.String("hint", "set CHATCLI_EMBED_PROVIDER=voyage|openai"))
+			zap.String("hint", "set CHATCLI_EMBED_PROVIDER=voyage|openai|bedrock"))
 		return
 	}
 	memDir := ""

--- a/cli/hyde_setup_test.go
+++ b/cli/hyde_setup_test.go
@@ -1,0 +1,144 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/cli/workspace"
+	"github.com/diillson/chatcli/cli/workspace/memory"
+	"github.com/diillson/chatcli/llm/embedding"
+	"go.uber.org/zap"
+)
+
+// resetHydeProvider clears the session-cached embedding provider and
+// restores whatever was latched once the test finishes, so tests can
+// exercise the lazy-build/refresh cycle without leaking state.
+func resetHydeProvider(t *testing.T) {
+	t.Helper()
+	hydeMu.Lock()
+	prevProvider, prevReady := hydeProvider, hydeProviderReady
+	hydeProvider, hydeProviderReady = nil, false
+	hydeMu.Unlock()
+	t.Cleanup(func() {
+		hydeMu.Lock()
+		hydeProvider, hydeProviderReady = prevProvider, prevReady
+		hydeMu.Unlock()
+	})
+}
+
+func TestHydeProviderForSession_LatchesUntilRefresh(t *testing.T) {
+	resetHydeProvider(t)
+	cli := &ChatCLI{logger: zap.NewNop()}
+
+	// No provider configured at first use → null latched for the session.
+	t.Setenv("CHATCLI_EMBED_PROVIDER", "")
+	if p := cli.hydeProviderForSession(); !embedding.IsNull(p) {
+		t.Fatalf("expected null provider with empty env, got %s", p.Name())
+	}
+
+	// Setting the env afterwards must NOT change the latched provider —
+	// this is exactly the .env-edited-mid-session scenario.
+	t.Setenv("CHATCLI_EMBED_PROVIDER", "bedrock")
+	if p := cli.hydeProviderForSession(); !embedding.IsNull(p) {
+		t.Fatal("provider must stay latched until an explicit refresh")
+	}
+
+	// /reload calls refreshEmbeddingProvider → the new env takes effect.
+	oldName, newName := cli.refreshEmbeddingProvider()
+	if oldName != "null" {
+		t.Errorf("oldName = %q, want null", oldName)
+	}
+	if !strings.HasPrefix(newName, "bedrock:") {
+		t.Errorf("newName = %q, want bedrock:*", newName)
+	}
+	if p := cli.hydeProviderForSession(); embedding.IsNull(p) {
+		t.Fatal("expected a real provider after refresh")
+	} else if !strings.HasPrefix(p.Name(), "bedrock:") {
+		t.Errorf("provider = %q, want bedrock:*", p.Name())
+	}
+}
+
+func TestRefreshEmbeddingProvider_UnknownNameFallsBackToNull(t *testing.T) {
+	resetHydeProvider(t)
+	cli := &ChatCLI{logger: zap.NewNop()}
+
+	t.Setenv("CHATCLI_EMBED_PROVIDER", "does-not-exist")
+	if _, newName := cli.refreshEmbeddingProvider(); newName != "null" {
+		t.Errorf("unknown provider must fall back to null, got %q", newName)
+	}
+	if p := cli.hydeProviderForSession(); !embedding.IsNull(p) {
+		t.Fatal("expected null provider after failed construction")
+	}
+}
+
+func TestRefreshEmbeddingProvider_SwapsMemoryVectorIndex(t *testing.T) {
+	resetHydeProvider(t)
+	ms := workspace.NewMemoryStore(t.TempDir(), zap.NewNop())
+	cli := &ChatCLI{logger: zap.NewNop(), memoryStore: ms}
+
+	// Simulate a session that already attached an index for provider A.
+	t.Setenv("CHATCLI_EMBED_PROVIDER", "voyage")
+	t.Setenv("VOYAGE_API_KEY", "test-key")
+	first := cli.hydeProviderForSession()
+	ms.AttachVectorIndex(memory.NewVectorIndex(ms.Manager().MemoryDir(), first, zap.NewNop()))
+
+	// Provider changes in .env → refresh must swap the attached index.
+	t.Setenv("CHATCLI_EMBED_PROVIDER", "bedrock")
+	if _, newName := cli.refreshEmbeddingProvider(); !strings.HasPrefix(newName, "bedrock:") {
+		t.Fatalf("newName = %q, want bedrock:*", newName)
+	}
+	idx := ms.VectorIndex()
+	if idx == nil {
+		t.Fatal("expected vector index to stay attached after provider swap")
+	}
+	if got := idx.ProviderName(); !strings.HasPrefix(got, "bedrock:") {
+		t.Errorf("vector index provider = %q, want bedrock:*", got)
+	}
+
+	// Embeddings turned off → refresh must detach the index.
+	t.Setenv("CHATCLI_EMBED_PROVIDER", "")
+	if _, newName := cli.refreshEmbeddingProvider(); newName != "null" {
+		t.Fatalf("newName = %q, want null", newName)
+	}
+	if ms.VectorIndex() != nil {
+		t.Error("expected vector index detached when provider is removed")
+	}
+}
+
+func TestRefreshEmbeddingProvider_RewiresContextRetrieval(t *testing.T) {
+	resetHydeProvider(t)
+	ch, err := NewContextHandler(zap.NewNop())
+	if err != nil {
+		t.Skipf("NewContextHandler unavailable in this environment: %v", err)
+	}
+	cli := &ChatCLI{logger: zap.NewNop(), contextHandler: ch}
+
+	t.Setenv("CHATCLI_EMBED_PROVIDER", "bedrock")
+	cli.refreshEmbeddingProvider()
+	if !ch.GetManager().RetrievalEnabled() {
+		t.Fatal("expected /context retrieval enabled after refresh with a real provider")
+	}
+
+	t.Setenv("CHATCLI_EMBED_PROVIDER", "")
+	cli.refreshEmbeddingProvider()
+	if ch.GetManager().RetrievalEnabled() {
+		t.Fatal("expected /context retrieval disabled after provider removal")
+	}
+}
+
+func TestEmbeddingProviderLabel(t *testing.T) {
+	if got := embeddingProviderLabel(nil); got != "null" {
+		t.Errorf("label(nil) = %q, want null", got)
+	}
+	if got := embeddingProviderLabel(embedding.NewNull()); got != "null" {
+		t.Errorf("label(Null) = %q, want null", got)
+	}
+	t.Setenv("CHATCLI_EMBED_PROVIDER", "bedrock")
+	p, err := embedding.NewFromEnv()
+	if err != nil {
+		t.Fatalf("NewFromEnv: %v", err)
+	}
+	if got := embeddingProviderLabel(p); !strings.HasPrefix(got, "bedrock:") {
+		t.Errorf("label = %q, want bedrock:*", got)
+	}
+}

--- a/docs/AGENT_PATTERNS.md
+++ b/docs/AGENT_PATTERNS.md
@@ -109,7 +109,7 @@ Reflexion runs in a background goroutine — never blocks the user-facing turn.
 Long-term memory retrieval with two enhancements:
 
 - **3a — Hypothesis-as-keyword-expansion**: a cheap LLM call generates a 2-4 sentence "hypothetical answer" to the user query; keywords extracted from it widen the retrieval net.
-- **3b — Vector embeddings**: optional. When `CHATCLI_EMBED_PROVIDER=voyage` or `=openai` is set, the user query is embedded and cosine-matched against fact vectors. Lazy backfill: facts get embedded as they surface.
+- **3b — Vector embeddings**: optional. When `CHATCLI_EMBED_PROVIDER=voyage`, `=openai` or `=bedrock` is set, the user query is embedded and cosine-matched against fact vectors. Lazy backfill: facts get embedded as they surface.
 
 Vectors persisted as JSON (`~/.chatcli/memory/vector_index.json`) — pure-Go cosine, no CGO, no external deps.
 
@@ -117,8 +117,8 @@ Vectors persisted as JSON (`~/.chatcli/memory/vector_index.json`) — pure-Go co
 ```bash
 export CHATCLI_QUALITY_HYDE_ENABLED=true
 export CHATCLI_QUALITY_HYDE_USE_VECTORS=true        # optional
-export CHATCLI_EMBED_PROVIDER=voyage                # voyage|openai
-export VOYAGE_API_KEY=...                            # provider-specific
+export CHATCLI_EMBED_PROVIDER=voyage                # voyage|openai|bedrock
+export VOYAGE_API_KEY=...                            # provider-specific (bedrock uses the AWS credential chain)
 ```
 
 ## #5 — Self-Refine

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -147,6 +147,7 @@
   "status.reloading_config": "Reloading configurations...",
   "status.reload_success_preserved": "Configurations reloaded successfully! (current provider/model preserved)",
   "status.reload_fail_preserve": "Failed to preserve provider/model after reload; falling back to .env values",
+  "status.reload_embed_provider": "Embedding provider reconfigured: %s",
   "status.reload_success": "Configurations reloaded successfully!",
   "status.reload_fail_client": "Failed to reconfigure LLM client after reload.",
   "status.operation_canceled": "🛑 Operation canceled successfully!",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -147,6 +147,7 @@
   "status.reloading_config": "Reloading configurations...",
   "status.reload_success_preserved": "Configurations reloaded successfully! (current provider/model preserved)",
   "status.reload_fail_preserve": "Failed to preserve provider/model after reload; falling back to .env values",
+  "status.reload_embed_provider": "Embedding provider reconfigured: %s",
   "status.reload_success": "Configurations reloaded successfully!",
   "status.reload_fail_client": "Failed to reconfigure LLM client after reload.",
   "status.operation_canceled": "🛑 Operation canceled successfully!",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -147,6 +147,7 @@
   "status.reloading_config": "Recarregando configurações...",
   "status.reload_success_preserved": "Configurações recarregadas com sucesso! (provedor/modelo atuais preservados)",
   "status.reload_fail_preserve": "Falha ao preservar provedor/modelo após recarregar; usando valores do .env",
+  "status.reload_embed_provider": "Provider de embeddings reconfigurado: %s",
   "status.reload_success": "Configurações recarregadas com sucesso!",
   "status.reload_fail_client": "Falha ao reconfigurar cliente LLM após recarregar.",
   "status.operation_canceled": "🛑 Operação cancelada com sucesso!",


### PR DESCRIPTION
## Problem

Setting `CHATCLI_EMBED_PROVIDER=bedrock` in `.env` after boot and running `/reload` had no effect — the embedding provider kept the instance captured at startup until the process restarted. Cause: the provider was built behind a package-level `sync.Once` in `cli/hyde_setup.go`, which latched the Null provider for the whole process.

On top of that, the HyDE log hint suggested only `voyage|openai` were valid values, while `bedrock` is fully supported by the embedding factory — misleading users into thinking Bedrock was rejected.

## Changes

- `cli/hyde_setup.go`: replace the `sync.Once` latch with a mutex-guarded cache plus `refreshEmbeddingProvider()`, which rebuilds the provider from the re-loaded env and rewires both consumers that captured the old instance: `/context --rag` semantic retrieval and the memory vector index. The shared vindex layer already auto-migrates on provider/dimension change, so the swap is safe.
- `cli/cli_config.go`: `/reload` now calls the refresh and prints the provider transition when it changes; `CHATCLI_EMBED_PROVIDER`, `CHATCLI_EMBED_MODEL` and `CHATCLI_EMBED_DIMENSIONS` joined the reload unset list, so removing them from `.env` also disables embeddings without a restart.
- HyDE hint updated to `voyage|openai|bedrock`; same in `docs/AGENT_PATTERNS.md`.
- New i18n status line in pt-BR / en / en-US.

## Validation

- `go build ./...` and full `go test ./...` pass.
- Scenario reproduced by the report: edit `.env` with `CHATCLI_EMBED_PROVIDER=bedrock` mid-session, run `/reload` → provider is rebuilt and announced, retrieval works without restarting.