### PR TITLE
fix(operator): resolve all 82 open gosec findings

### DIFF
--- a/operator/api/rest/middleware.go
+++ b/operator/api/rest/middleware.go
@@ -224,7 +224,10 @@ func loggingMiddleware(next http.Handler) http.Handler {
 		if role == "" {
 			role = "-"
 		}
-		log.Printf("[REST] %s %s %d %s role=%s",
+		// %q on the request-controlled fields escapes control characters so
+		// a crafted path cannot forge extra log lines. gosec's taint pass
+		// has no sanitizer model for fmt quoting, hence the annotation.
+		log.Printf("[REST] %q %q %d %s role=%s", // #nosec G706 -- method and path are %q-escaped above
 			r.Method, r.URL.Path, sc.statusCode, duration.Round(time.Microsecond), role)
 	})
 }

--- a/operator/api/rest/middleware_logging_test.go
+++ b/operator/api/rest/middleware_logging_test.go
@@ -1,0 +1,46 @@
+/*
+ * ChatCLI - Kubernetes Operator
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package rest
+
+import (
+	"bytes"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestLoggingMiddleware_EscapesRequestControlledFields(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	h := loggingMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)
+	// A crafted path with an embedded newline would forge a second log
+	// line if the middleware printed it raw.
+	req.URL.Path = "/api/v1/status\n[REST] FORGED 200"
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	out := buf.String()
+	if strings.Contains(out, "\n[REST] FORGED") {
+		t.Errorf("raw newline leaked into the access log:\n%s", out)
+	}
+	if !strings.Contains(out, `\n[REST] FORGED`) {
+		t.Errorf("expected %%q-escaped path in the access log, got:\n%s", out)
+	}
+	if !strings.Contains(out, "418") {
+		t.Errorf("expected captured status code 418 in the access log, got:\n%s", out)
+	}
+	if !strings.Contains(out, "role=-") {
+		t.Errorf("expected placeholder role for unauthenticated request, got:\n%s", out)
+	}
+}

--- a/operator/api/rest/server.go
+++ b/operator/api/rest/server.go
@@ -90,12 +90,16 @@ type APIServer struct {
 	watcherBridge WatcherDedupInvalidator // optional, for dedup invalidation on manual resolve
 }
 
+// authHeaderName is the HTTP header clients use to present their API key.
+// This is the header NAME, not a credential.
+const authHeaderName = "X-API-Key"
+
 // NewAPIServer creates a new APIServer.
 func NewAPIServer(c client.Client, addr string) *APIServer {
 	return &APIServer{
 		client:       c,
 		listenAddr:   addr,
-		apiKeyHeader: "X-API-Key",
+		apiKeyHeader: authHeaderName,
 		apiKeys:      make(map[string]string),
 		limiter:      newRateLimiter(30), // Security (M3): 30 requests/minute (reduced from 100)
 		corsOrigin:   "",                 // Security (H6): deny-all CORS by default
@@ -166,7 +170,9 @@ func (s *APIServer) Start(ctx context.Context) error {
 	// Graceful shutdown.
 	go func() {
 		<-ctx.Done()
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		// The lifecycle ctx is already canceled here; WithoutCancel keeps
+		// its values while giving the shutdown its own fresh deadline.
+		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 		defer cancel()
 		if err := server.Shutdown(shutdownCtx); err != nil {
 			log.Printf("[REST] shutdown error: %v", err)

--- a/operator/api/rest/server_lifecycle_test.go
+++ b/operator/api/rest/server_lifecycle_test.go
@@ -1,0 +1,42 @@
+/*
+ * ChatCLI - Kubernetes Operator
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package rest
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestNewAPIServer_UsesAuthHeaderConstant(t *testing.T) {
+	s := NewAPIServer(nil, "127.0.0.1:0")
+	if s.apiKeyHeader != authHeaderName {
+		t.Errorf("apiKeyHeader = %q, want %q", s.apiKeyHeader, authHeaderName)
+	}
+}
+
+func TestAPIServerStart_ShutsDownOnContextCancel(t *testing.T) {
+	t.Setenv("CHATCLI_AIOPS_TLS_CERT", "")
+	t.Setenv("CHATCLI_AIOPS_TLS_KEY", "")
+
+	s := NewAPIServer(nil, "127.0.0.1:0")
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- s.Start(ctx) }()
+
+	// Give ListenAndServe a moment to bind before triggering shutdown.
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start returned error on graceful shutdown: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("server did not shut down after context cancellation")
+	}
+}

--- a/operator/controllers/approval_controller.go
+++ b/operator/controllers/approval_controller.go
@@ -553,7 +553,7 @@ func (r *ApprovalReconciler) isWithinChangeWindow(cw *platformv1alpha1.ChangeWin
 	}
 
 	// Check if current hour is within window
-	currentHour := int32(now.Hour())
+	currentHour := clampInt32(now.Hour())
 	if cw.StartHour <= cw.EndHour {
 		// Same day window: e.g., 09-17
 		return currentHour >= cw.StartHour && currentHour < cw.EndHour, nil

--- a/operator/controllers/approval_integration.go
+++ b/operator/controllers/approval_integration.go
@@ -250,7 +250,7 @@ func CalculateBlastRadius(
 			); err != nil {
 				return nil, fmt.Errorf("listing pods: %w", err)
 			}
-			affectedPods = int32(len(podList.Items))
+			affectedPods = clampInt32(len(podList.Items))
 
 			// Find services that select these pods
 			var serviceList corev1.ServiceList

--- a/operator/controllers/audit_logger.go
+++ b/operator/controllers/audit_logger.go
@@ -150,12 +150,14 @@ func (al *OperatorAuditLogger) LogAPIAccess(method, path, clientIP, role, result
 	})
 }
 
-// Close shuts down the file writer. The flush error is reported so
-// callers can surface a truncated audit trail instead of silently
-// losing the tail of the log.
-func (al *OperatorAuditLogger) Close() error {
+// Close shuts down the file writer. A flush failure is logged so a
+// truncated audit trail is surfaced instead of silently losing the
+// tail of the log.
+func (al *OperatorAuditLogger) Close() {
 	if al.fileWriter == nil {
-		return nil
+		return
 	}
-	return al.fileWriter.Close()
+	if err := al.fileWriter.Close(); err != nil {
+		al.zapLogger.Error("failed to close operator audit log file", zap.Error(err))
+	}
 }

--- a/operator/controllers/audit_logger.go
+++ b/operator/controllers/audit_logger.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -46,7 +47,14 @@ func NewOperatorAuditLogger(zapLogger *zap.Logger) *OperatorAuditLogger {
 	}
 
 	if path := os.Getenv("CHATCLI_AUDIT_LOG_PATH"); path != "" {
-		f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+		// Operator-config path: canonicalize and require absolute so a
+		// relative value cannot traverse out of the intended log location.
+		path = filepath.Clean(path)
+		if !filepath.IsAbs(path) {
+			zapLogger.Error("CHATCLI_AUDIT_LOG_PATH must be an absolute path", zap.String("path", path))
+			return al
+		}
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600) // #nosec G304 G703 -- operator-supplied absolute path, cleaned above
 		if err != nil {
 			zapLogger.Error("failed to open operator audit log file", zap.String("path", path), zap.Error(err))
 		} else {
@@ -142,9 +150,12 @@ func (al *OperatorAuditLogger) LogAPIAccess(method, path, clientIP, role, result
 	})
 }
 
-// Close shuts down the file writer.
-func (al *OperatorAuditLogger) Close() {
-	if al.fileWriter != nil {
-		al.fileWriter.Close()
+// Close shuts down the file writer. The flush error is reported so
+// callers can surface a truncated audit trail instead of silently
+// losing the tail of the log.
+func (al *OperatorAuditLogger) Close() error {
+	if al.fileWriter == nil {
+		return nil
 	}
+	return al.fileWriter.Close()
 }

--- a/operator/controllers/audit_logger_test.go
+++ b/operator/controllers/audit_logger_test.go
@@ -1,0 +1,108 @@
+/*
+ * ChatCLI - Kubernetes Operator
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package controllers
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestNewOperatorAuditLogger_RelativePathRejected(t *testing.T) {
+	t.Setenv("CHATCLI_AUDIT_LOG_PATH", filepath.Join("relative", "audit.log"))
+
+	core, logs := observer.New(zapcore.ErrorLevel)
+	al := NewOperatorAuditLogger(zap.New(core))
+
+	if al.fileWriter != nil || al.encoder != nil {
+		t.Error("relative path must not open a file writer")
+	}
+	if logs.FilterMessageSnippet("must be an absolute path").Len() != 1 {
+		t.Errorf("expected rejection to be logged, got %v", logs.All())
+	}
+	// The logger itself must stay usable for the zap sink.
+	al.Log(OperatorAuditEntry{Action: "noop", Resource: "r", Result: "success"})
+	al.Close()
+}
+
+func TestNewOperatorAuditLogger_AbsolutePathWritesEntries(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.log")
+	t.Setenv("CHATCLI_AUDIT_LOG_PATH", path)
+
+	al := NewOperatorAuditLogger(zap.NewNop())
+	if al.fileWriter == nil || al.encoder == nil {
+		t.Fatal("absolute path must enable the file writer")
+	}
+
+	al.Log(OperatorAuditEntry{
+		Actor:    "controller",
+		Action:   "scale_deployment",
+		Resource: "default/web",
+		Result:   "success",
+	})
+	al.Close()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read audit log: %v", err)
+	}
+	var entry OperatorAuditEntry
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(data))), &entry); err != nil {
+		t.Fatalf("audit log is not JSON-lines: %v\n%s", err, data)
+	}
+	if entry.Action != "scale_deployment" || entry.Timestamp == "" {
+		t.Errorf("unexpected entry: %+v", entry)
+	}
+}
+
+func TestNewOperatorAuditLogger_OpenFailureIsNonFatal(t *testing.T) {
+	// Absolute path inside a directory that does not exist: OpenFile
+	// fails, but the constructor must still return a usable logger.
+	t.Setenv("CHATCLI_AUDIT_LOG_PATH", filepath.Join(t.TempDir(), "missing", "audit.log"))
+
+	core, logs := observer.New(zapcore.ErrorLevel)
+	al := NewOperatorAuditLogger(zap.New(core))
+
+	if al.fileWriter != nil {
+		t.Error("open failure must leave the file writer unset")
+	}
+	if logs.FilterMessageSnippet("failed to open").Len() != 1 {
+		t.Errorf("expected open failure to be logged, got %v", logs.All())
+	}
+}
+
+func TestOperatorAuditLoggerClose_NoWriter(t *testing.T) {
+	t.Setenv("CHATCLI_AUDIT_LOG_PATH", "")
+	al := NewOperatorAuditLogger(zap.NewNop())
+	// Must be a no-op, not a nil dereference.
+	al.Close()
+}
+
+type failingWriteCloser struct{}
+
+func (failingWriteCloser) Write(p []byte) (int, error) { return len(p), nil }
+func (failingWriteCloser) Close() error                { return fmt.Errorf("disk gone") }
+
+func TestOperatorAuditLoggerClose_FlushErrorIsLogged(t *testing.T) {
+	core, logs := observer.New(zapcore.ErrorLevel)
+	al := &OperatorAuditLogger{
+		zapLogger:  zap.New(core),
+		fileWriter: failingWriteCloser{},
+	}
+
+	al.Close()
+
+	if logs.FilterMessageSnippet("failed to close operator audit log file").Len() != 1 {
+		t.Errorf("expected close error to be logged, got %v", logs.All())
+	}
+}

--- a/operator/controllers/blast_radius.go
+++ b/operator/controllers/blast_radius.go
@@ -191,8 +191,12 @@ func (bp *BlastRadiusPredictor) predictScaleImpact(ctx context.Context, resource
 	if !ok {
 		return
 	}
-	var target int32
-	fmt.Sscanf(replicasStr, "%d", &target)
+	target, err := parseInt32(replicasStr)
+	if err != nil {
+		prediction.Warnings = append(prediction.Warnings,
+			fmt.Sprintf("unparseable replicas %q; scale impact not predicted", replicasStr))
+		return
+	}
 
 	var deploy appsv1.Deployment
 	if err := bp.client.Get(ctx, types.NamespacedName{Name: resource.Name, Namespace: resource.Namespace}, &deploy); err != nil {
@@ -291,8 +295,12 @@ func (bp *BlastRadiusPredictor) predictScaleStatefulSetImpact(ctx context.Contex
 	if !ok {
 		return
 	}
-	var target int32
-	fmt.Sscanf(replicasStr, "%d", &target)
+	target, err := parseInt32(replicasStr)
+	if err != nil {
+		prediction.Warnings = append(prediction.Warnings,
+			fmt.Sprintf("unparseable replicas %q; scale impact not predicted", replicasStr))
+		return
+	}
 
 	var sts appsv1.StatefulSet
 	if err := bp.client.Get(ctx, types.NamespacedName{Name: resource.Name, Namespace: resource.Namespace}, &sts); err != nil {
@@ -414,10 +422,13 @@ func (bp *BlastRadiusPredictor) predictNodeImpact(ctx context.Context, res platf
 
 func (bp *BlastRadiusPredictor) predictHPAAdjustImpact(ctx context.Context, resource platformv1alpha1.ResourceRef, params map[string]string, prediction *BlastRadiusPrediction) {
 	if maxStr, ok := params["maxReplicas"]; ok {
-		var max int32
-		fmt.Sscanf(maxStr, "%d", &max)
-		prediction.Warnings = append(prediction.Warnings,
-			fmt.Sprintf("Adjusting HPA maxReplicas to %d — ensure cluster has capacity", max))
+		if max, err := parseInt32(maxStr); err == nil {
+			prediction.Warnings = append(prediction.Warnings,
+				fmt.Sprintf("Adjusting HPA maxReplicas to %d — ensure cluster has capacity", max))
+		} else {
+			prediction.Warnings = append(prediction.Warnings,
+				fmt.Sprintf("unparseable maxReplicas %q; capacity impact unknown", maxStr))
+		}
 	}
 }
 

--- a/operator/controllers/blast_radius.go
+++ b/operator/controllers/blast_radius.go
@@ -422,9 +422,9 @@ func (bp *BlastRadiusPredictor) predictNodeImpact(ctx context.Context, res platf
 
 func (bp *BlastRadiusPredictor) predictHPAAdjustImpact(ctx context.Context, resource platformv1alpha1.ResourceRef, params map[string]string, prediction *BlastRadiusPrediction) {
 	if maxStr, ok := params["maxReplicas"]; ok {
-		if max, err := parseInt32(maxStr); err == nil {
+		if maxReplicas, err := parseInt32(maxStr); err == nil {
 			prediction.Warnings = append(prediction.Warnings,
-				fmt.Sprintf("Adjusting HPA maxReplicas to %d — ensure cluster has capacity", max))
+				fmt.Sprintf("Adjusting HPA maxReplicas to %d — ensure cluster has capacity", maxReplicas))
 		} else {
 			prediction.Warnings = append(prediction.Warnings,
 				fmt.Sprintf("unparseable maxReplicas %q; capacity impact unknown", maxStr))

--- a/operator/controllers/blast_radius_params_test.go
+++ b/operator/controllers/blast_radius_params_test.go
@@ -1,0 +1,163 @@
+/*
+ * ChatCLI - Kubernetes Operator
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package controllers
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	platformv1alpha1 "github.com/diillson/chatcli/operator/api/v1alpha1"
+)
+
+func newTestBlastRadiusPredictor(objs ...client.Object) *BlastRadiusPredictor {
+	cb := fake.NewClientBuilder().WithScheme(newScheme())
+	if len(objs) > 0 {
+		cb = cb.WithObjects(objs...)
+	}
+	return NewBlastRadiusPredictor(cb.Build())
+}
+
+func warningsContain(warnings []string, substr string) bool {
+	for _, w := range warnings {
+		if strings.Contains(w, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestPredictScaleImpact_ReplicasParsing(t *testing.T) {
+	resource := platformv1alpha1.ResourceRef{Kind: "Deployment", Name: "web", Namespace: "default"}
+
+	tests := []struct {
+		name        string
+		replicas    string
+		wantWarning string
+	}{
+		{name: "non-numeric replicas", replicas: "not-a-number", wantWarning: "unparseable replicas"},
+		// 2^32+1 wraps to 1 with a bare int32 cast; parseInt32 must
+		// refuse it instead of predicting a harmless scale-to-1.
+		{name: "int32 overflow", replicas: "4294967297", wantWarning: "unparseable replicas"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bp := newTestBlastRadiusPredictor(newDeployment("web", "default", 5))
+			prediction := &BlastRadiusPrediction{Safe: true, RiskLevel: "low"}
+			bp.predictScaleImpact(context.Background(), resource, map[string]string{"replicas": tt.replicas}, prediction)
+
+			if !warningsContain(prediction.Warnings, tt.wantWarning) {
+				t.Errorf("expected warning containing %q, got %v", tt.wantWarning, prediction.Warnings)
+			}
+			if !prediction.Safe || len(prediction.Blockers) != 0 {
+				t.Errorf("unparseable input must not flip safety, got safe=%v blockers=%v", prediction.Safe, prediction.Blockers)
+			}
+		})
+	}
+
+	t.Run("scale to zero is blocked", func(t *testing.T) {
+		bp := newTestBlastRadiusPredictor(newDeployment("web", "default", 5))
+		prediction := &BlastRadiusPrediction{Safe: true, RiskLevel: "low"}
+		bp.predictScaleImpact(context.Background(), resource, map[string]string{"replicas": "0"}, prediction)
+
+		if prediction.Safe || len(prediction.Blockers) == 0 {
+			t.Errorf("scale to 0 must be blocked, got safe=%v blockers=%v", prediction.Safe, prediction.Blockers)
+		}
+	})
+
+	t.Run("missing deployment short-circuits", func(t *testing.T) {
+		bp := newTestBlastRadiusPredictor()
+		prediction := &BlastRadiusPrediction{Safe: true, RiskLevel: "low"}
+		bp.predictScaleImpact(context.Background(), resource, map[string]string{"replicas": "3"}, prediction)
+
+		if len(prediction.Warnings) != 0 || len(prediction.Blockers) != 0 {
+			t.Errorf("expected no findings when the deployment is absent, got %+v", prediction)
+		}
+	})
+}
+
+func TestPredictScaleStatefulSetImpact_ReplicasParsing(t *testing.T) {
+	resource := platformv1alpha1.ResourceRef{Kind: "StatefulSet", Name: "db", Namespace: "default"}
+
+	t.Run("unparseable replicas produce a warning and stop", func(t *testing.T) {
+		bp := newTestBlastRadiusPredictor(newStatefulSet("db", "default", 3))
+		prediction := &BlastRadiusPrediction{Safe: true, RiskLevel: "low"}
+		bp.predictScaleStatefulSetImpact(context.Background(), resource, map[string]string{"replicas": "5x"}, prediction)
+
+		if !warningsContain(prediction.Warnings, "unparseable replicas") {
+			t.Errorf("expected unparseable warning, got %v", prediction.Warnings)
+		}
+		if !prediction.Safe {
+			t.Error("unparseable input must not flip safety")
+		}
+	})
+
+	t.Run("scale down warns about ordinal removal", func(t *testing.T) {
+		bp := newTestBlastRadiusPredictor(newStatefulSet("db", "default", 3))
+		prediction := &BlastRadiusPrediction{Safe: true, RiskLevel: "low"}
+		bp.predictScaleStatefulSetImpact(context.Background(), resource, map[string]string{"replicas": "1"}, prediction)
+
+		if !warningsContain(prediction.Warnings, "highest ordinal") {
+			t.Errorf("expected scale-down warning, got %v", prediction.Warnings)
+		}
+	})
+
+	t.Run("scale to zero is blocked", func(t *testing.T) {
+		bp := newTestBlastRadiusPredictor(newStatefulSet("db", "default", 3))
+		prediction := &BlastRadiusPrediction{Safe: true, RiskLevel: "low"}
+		bp.predictScaleStatefulSetImpact(context.Background(), resource, map[string]string{"replicas": "0"}, prediction)
+
+		if prediction.Safe || len(prediction.Blockers) == 0 {
+			t.Errorf("scale to 0 must be blocked, got safe=%v blockers=%v", prediction.Safe, prediction.Blockers)
+		}
+	})
+}
+
+func TestPredictHPAAdjustImpact(t *testing.T) {
+	resource := platformv1alpha1.ResourceRef{Kind: "HorizontalPodAutoscaler", Name: "web-hpa", Namespace: "default"}
+
+	tests := []struct {
+		name        string
+		params      map[string]string
+		wantWarning string
+	}{
+		{
+			name:        "valid maxReplicas warns about capacity",
+			params:      map[string]string{"maxReplicas": "10"},
+			wantWarning: "maxReplicas to 10",
+		},
+		{
+			name:        "unparseable maxReplicas is reported",
+			params:      map[string]string{"maxReplicas": "1e3"},
+			wantWarning: "unparseable maxReplicas",
+		},
+		{
+			name:   "absent maxReplicas adds nothing",
+			params: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bp := newTestBlastRadiusPredictor()
+			prediction := &BlastRadiusPrediction{Safe: true, RiskLevel: "low"}
+			bp.predictHPAAdjustImpact(context.Background(), resource, tt.params, prediction)
+
+			if tt.wantWarning == "" {
+				if len(prediction.Warnings) != 0 {
+					t.Errorf("expected no warnings, got %v", prediction.Warnings)
+				}
+				return
+			}
+			if !warningsContain(prediction.Warnings, tt.wantWarning) {
+				t.Errorf("expected warning containing %q, got %v", tt.wantWarning, prediction.Warnings)
+			}
+		})
+	}
+}

--- a/operator/controllers/chaos_controller.go
+++ b/operator/controllers/chaos_controller.go
@@ -147,7 +147,7 @@ func (r *ChaosReconciler) reconcilePending(ctx context.Context, exp *platformv1a
 			return ctrl.Result{}, fmt.Errorf("counting healthy pods: %w", err)
 		}
 		killCount := r.getParamInt(exp.Spec.Parameters, "count", 1)
-		remainingHealthy := healthyPods - int32(killCount)
+		remainingHealthy := healthyPods - clampInt32(killCount)
 		if remainingHealthy < exp.Spec.SafetyChecks.MinHealthyPods {
 			return r.transitionToFailed(ctx, exp, fmt.Sprintf(
 				"safety check failed: killing %d pods would leave %d healthy (min required: %d, total: %d)",
@@ -316,7 +316,7 @@ func (r *ChaosReconciler) executePodKill(ctx context.Context, exp *platformv1alp
 		}
 	}
 
-	exp.Status.PodsAffected = int32(len(selected))
+	exp.Status.PodsAffected = clampInt32(len(selected))
 	chaosPodsAffectedTotal.WithLabelValues(string(platformv1alpha1.ChaosTypePodKill)).Add(float64(len(selected)))
 	return nil
 }
@@ -347,7 +347,7 @@ func (r *ChaosReconciler) executePodFailure(ctx context.Context, exp *platformv1
 		}
 	}
 
-	exp.Status.PodsAffected = int32(len(selected))
+	exp.Status.PodsAffected = clampInt32(len(selected))
 	chaosPodsAffectedTotal.WithLabelValues(string(platformv1alpha1.ChaosTypePodFailure)).Add(float64(len(selected)))
 	return nil
 }
@@ -437,7 +437,7 @@ func (r *ChaosReconciler) executeNetworkDelay(ctx context.Context, exp *platform
 		logger.Info("annotated pod for network delay", "pod", pod.Name, "latency", latencyMs+"ms")
 	}
 
-	exp.Status.PodsAffected = int32(len(pods))
+	exp.Status.PodsAffected = clampInt32(len(pods))
 	chaosPodsAffectedTotal.WithLabelValues(string(platformv1alpha1.ChaosTypeNetworkDelay)).Add(float64(len(pods)))
 	return nil
 }
@@ -473,7 +473,7 @@ func (r *ChaosReconciler) executeNetworkLoss(ctx context.Context, exp *platformv
 		logger.Info("annotated pod for network loss", "pod", pod.Name, "percent", percent+"%")
 	}
 
-	exp.Status.PodsAffected = int32(len(pods))
+	exp.Status.PodsAffected = clampInt32(len(pods))
 	chaosPodsAffectedTotal.WithLabelValues(string(platformv1alpha1.ChaosTypeNetworkLoss)).Add(float64(len(pods)))
 	return nil
 }
@@ -948,7 +948,7 @@ func (r *ChaosReconciler) countHealthyPods(ctx context.Context, target platformv
 			healthy++
 		}
 	}
-	return healthy, int32(len(pods)), nil
+	return healthy, clampInt32(len(pods)), nil
 }
 
 // chaosPodReady checks if a pod has the Ready condition set to True.

--- a/operator/controllers/federation_controller.go
+++ b/operator/controllers/federation_controller.go
@@ -173,8 +173,8 @@ func (r *FederationReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	cr.Status.Connected = true
 	cr.Status.LastHealthCheck = &now
 	cr.Status.KubernetesVersion = kubeVersion
-	cr.Status.NodeCount = int32(len(nodeList.Items))
-	cr.Status.NamespaceCount = int32(len(nsList.Items))
+	cr.Status.NodeCount = clampInt32(len(nodeList.Items))
+	cr.Status.NamespaceCount = clampInt32(len(nsList.Items))
 	cr.Status.ActiveIssues = activeIssues
 	cr.Status.ActiveRemediations = activeRemediations
 

--- a/operator/controllers/gitops_detector.go
+++ b/operator/controllers/gitops_detector.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -138,7 +139,7 @@ func (g *GitOpsDetector) detectHelmRelease(ctx context.Context, resource platfor
 
 		rev := 0
 		if revStr, ok := s.Labels["version"]; ok {
-			fmt.Sscanf(revStr, "%d", &rev)
+			rev = leadingInt(revStr)
 		}
 
 		candidates = append(candidates, releaseEntry{
@@ -419,7 +420,9 @@ func (g *GitOpsDetector) ExecuteHelmRollback(ctx context.Context, resource platf
 
 	targetRevision := release.PreviousRevision
 	if rev, ok := params["revision"]; ok {
-		fmt.Sscanf(rev, "%d", &targetRevision)
+		if v, err := strconv.Atoi(strings.TrimSpace(rev)); err == nil {
+			targetRevision = v
+		}
 	}
 
 	// Find the target revision secret

--- a/operator/controllers/grpc_client.go
+++ b/operator/controllers/grpc_client.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -50,7 +51,9 @@ func (sc *ServerClient) Connect(address string, opts ConnectionOpts) error {
 	defer sc.mu.Unlock()
 
 	if sc.conn != nil {
-		sc.conn.Close()
+		// Best-effort teardown of the previous connection before dialing a
+		// new one; a close error on a stale conn is not actionable here.
+		_ = sc.conn.Close()
 	}
 
 	var dialOpts []grpc.DialOption
@@ -70,7 +73,13 @@ func (sc *ServerClient) Connect(address string, opts ConnectionOpts) error {
 		}
 		tlsCfg.RootCAs = certPool
 	} else if caCertPath := os.Getenv("CHATCLI_GRPC_TLS_CA"); caCertPath != "" {
-		caCert, err := os.ReadFile(caCertPath)
+		// Operator-config path: canonicalize and require absolute so a
+		// relative value cannot resolve against an unexpected working dir.
+		caCertPath = filepath.Clean(caCertPath)
+		if !filepath.IsAbs(caCertPath) {
+			return fmt.Errorf("CHATCLI_GRPC_TLS_CA must be an absolute path, got %q", caCertPath)
+		}
+		caCert, err := os.ReadFile(caCertPath) // #nosec G304 G703 -- operator-supplied absolute path, cleaned above
 		if err != nil {
 			return fmt.Errorf("failed to read CA cert from %s: %w", caCertPath, err)
 		}

--- a/operator/controllers/grpc_client_test.go
+++ b/operator/controllers/grpc_client_test.go
@@ -1,0 +1,122 @@
+/*
+ * ChatCLI - Kubernetes Operator
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package controllers
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// writeTestCACert writes a self-signed CA certificate PEM to dir and
+// returns its path.
+func writeTestCACert(t *testing.T, dir string) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "chatcli-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	path := filepath.Join(dir, "ca.pem")
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	if err := os.WriteFile(path, pemBytes, 0o600); err != nil {
+		t.Fatalf("write CA cert: %v", err)
+	}
+	return path
+}
+
+// clearGRPCTLSEnv isolates each test from ambient TLS configuration.
+func clearGRPCTLSEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("CHATCLI_GRPC_TLS_CA", "")
+	t.Setenv("CHATCLI_GRPC_TLS_CERT", "")
+	t.Setenv("CHATCLI_GRPC_TLS_KEY", "")
+}
+
+func TestServerClientConnect_RelativeCAPathRejected(t *testing.T) {
+	clearGRPCTLSEnv(t)
+	t.Setenv("CHATCLI_GRPC_TLS_CA", filepath.Join("relative", "ca.pem"))
+
+	sc := NewServerClient(zap.NewNop())
+	err := sc.Connect("localhost:19999", ConnectionOpts{})
+	if err == nil || !strings.Contains(err.Error(), "must be an absolute path") {
+		t.Fatalf("expected absolute-path error, got %v", err)
+	}
+}
+
+func TestServerClientConnect_MissingCAFile(t *testing.T) {
+	clearGRPCTLSEnv(t)
+	t.Setenv("CHATCLI_GRPC_TLS_CA", filepath.Join(t.TempDir(), "absent.pem"))
+
+	sc := NewServerClient(zap.NewNop())
+	err := sc.Connect("localhost:19999", ConnectionOpts{})
+	if err == nil || !strings.Contains(err.Error(), "failed to read CA cert") {
+		t.Fatalf("expected read error, got %v", err)
+	}
+}
+
+func TestServerClientConnect_InvalidCAContents(t *testing.T) {
+	clearGRPCTLSEnv(t)
+	path := filepath.Join(t.TempDir(), "garbage.pem")
+	if err := os.WriteFile(path, []byte("not a certificate"), 0o600); err != nil {
+		t.Fatalf("write garbage CA: %v", err)
+	}
+	t.Setenv("CHATCLI_GRPC_TLS_CA", path)
+
+	sc := NewServerClient(zap.NewNop())
+	err := sc.Connect("localhost:19999", ConnectionOpts{})
+	if err == nil || !strings.Contains(err.Error(), "failed to parse CA certificate") {
+		t.Fatalf("expected parse error, got %v", err)
+	}
+}
+
+func TestServerClientConnect_ValidCAAndReconnect(t *testing.T) {
+	clearGRPCTLSEnv(t)
+	t.Setenv("CHATCLI_GRPC_TLS_CA", writeTestCACert(t, t.TempDir()))
+
+	sc := NewServerClient(zap.NewNop())
+	// grpc.NewClient is lazy, so a successful Connect only requires the
+	// TLS material to load — no listening server needed.
+	if err := sc.Connect("localhost:19999", ConnectionOpts{Token: "tok"}); err != nil {
+		t.Fatalf("first Connect: %v", err)
+	}
+	if sc.conn == nil || sc.client == nil {
+		t.Fatal("Connect must populate conn and client")
+	}
+
+	// A second Connect must tear down the previous connection and
+	// succeed again.
+	if err := sc.Connect("localhost:19998", ConnectionOpts{}); err != nil {
+		t.Fatalf("reconnect: %v", err)
+	}
+	if sc.conn == nil {
+		t.Fatal("reconnect must leave an active connection")
+	}
+	t.Cleanup(func() { _ = sc.conn.Close() })
+}

--- a/operator/controllers/issue_controller.go
+++ b/operator/controllers/issue_controller.go
@@ -1192,7 +1192,9 @@ func (r *IssueReconciler) handleEscalated(ctx context.Context, issue *platformv1
 	r.invalidateDedup(issue)
 
 	if r.AuditRecorder != nil {
-		r.AuditRecorder.RecordIssueResolved(ctx, issue)
+		if err := r.AuditRecorder.RecordIssueResolved(ctx, issue); err != nil {
+			log.Error(err, "Failed to record issue resolution in audit trail", "name", issue.Name)
+		}
 	}
 
 	issuesTotal.WithLabelValues(string(issue.Spec.Severity), string(platformv1alpha1.IssueStateResolved)).Inc()
@@ -1440,7 +1442,7 @@ func planActionTimestamp(plan *platformv1alpha1.RemediationPlan, now metav1.Time
 // planActionOutcome returns (result, detail) for a plan action by index.
 func planActionOutcome(action platformv1alpha1.RemediationAction, idx int, plan *platformv1alpha1.RemediationPlan) (string, string) {
 	for _, cp := range plan.Status.ActionCheckpoints {
-		if cp.ActionIndex == int32(idx) && !cp.Success {
+		if cp.ActionIndex == clampInt32(idx) && !cp.Success {
 			return "failed", fmt.Sprintf("Action %s failed", action.Type)
 		}
 	}
@@ -1769,7 +1771,7 @@ func (r *IssueReconciler) buildTrendingInfo(ctx context.Context, issue *platform
 	}
 
 	return &platformv1alpha1.TrendingInfo{
-		OccurrenceCount:    int32(len(related)) + 1, // +1 for current
+		OccurrenceCount:    clampInt32(len(related)) + 1, // +1 for current
 		WindowDays:         windowDays,
 		RelatedPostMortems: related,
 		Pattern:            fmt.Sprintf("Recurring %s on %s/%s (%d occurrences in %d days)", issue.Spec.SignalType, issue.Spec.Resource.Kind, issue.Spec.Resource.Name, len(related)+1, windowDays),

--- a/operator/controllers/k8s_context.go
+++ b/operator/controllers/k8s_context.go
@@ -615,7 +615,7 @@ func (b *KubernetesContextBuilder) buildRevisionHistory(ctx context.Context, res
 			if ref.Kind == "Deployment" && ref.Name == resource.Name {
 				rev := 0
 				if revStr, ok := rs.Annotations["deployment.kubernetes.io/revision"]; ok {
-					fmt.Sscanf(revStr, "%d", &rev)
+					rev = leadingInt(revStr)
 				}
 				owned = append(owned, rsInfo{revision: rev, rs: *rs})
 				break

--- a/operator/controllers/metrics_collector.go
+++ b/operator/controllers/metrics_collector.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -250,9 +251,8 @@ func (mc *MetricsCollector) queryRange(ctx context.Context, query string, start,
 				ts, ok1 := val[0].(float64)
 				valStr, ok2 := val[1].(string)
 				if ok1 && ok2 {
-					var v float64
-					fmt.Sscanf(valStr, "%f", &v)
-					if !math.IsNaN(v) && !math.IsInf(v, 0) {
+					v, err := strconv.ParseFloat(strings.TrimSpace(valStr), 64)
+					if err == nil && !math.IsNaN(v) && !math.IsInf(v, 0) {
 						series.DataPoints = append(series.DataPoints, MetricDataPoint{
 							Timestamp: time.Unix(int64(ts), 0),
 							Value:     v,

--- a/operator/controllers/notification_controller.go
+++ b/operator/controllers/notification_controller.go
@@ -729,7 +729,7 @@ func (r *NotificationReconciler) handleEscalationTimer(ctx context.Context, issu
 	r.sendEscalationNotification(ctx, issue, &policy, nextLevel)
 
 	// Update active escalation on the policy status.
-	if err := r.recordActiveEscalation(ctx, &policy, issue, int32(nextLevel)); err != nil {
+	if err := r.recordActiveEscalation(ctx, &policy, issue, clampInt32(nextLevel)); err != nil {
 		logger.Error(err, "failed to record active escalation")
 	}
 

--- a/operator/controllers/rca_enrichment.go
+++ b/operator/controllers/rca_enrichment.go
@@ -114,7 +114,7 @@ func (e *RCAEnricher) findDeploymentChanges(ctx context.Context, resource platfo
 			if ref.Kind == "Deployment" && ref.Name == resource.Name {
 				rev := 0
 				if revStr, ok := rs.Annotations["deployment.kubernetes.io/revision"]; ok {
-					fmt.Sscanf(revStr, "%d", &rev)
+					rev = leadingInt(revStr)
 				}
 				owned = append(owned, rsInfo{revision: rev, rs: *rs})
 				break

--- a/operator/controllers/remediation_actions_extended.go
+++ b/operator/controllers/remediation_actions_extended.go
@@ -259,32 +259,30 @@ func (r *RemediationReconciler) executeAdjustHPA(ctx context.Context, resource p
 	modified := false
 
 	if minStr, ok := params["minReplicas"]; ok {
-		min, err := strconv.Atoi(minStr)
+		min32, err := parseInt32(minStr)
 		if err != nil {
 			return fmt.Errorf("invalid minReplicas %q: %w", minStr, err)
 		}
-		min32 := int32(min)
 		targetHPA.Spec.MinReplicas = &min32
 		modified = true
-		logger.Info("Adjusting HPA minReplicas", "hpa", targetHPA.Name, "min", min)
+		logger.Info("Adjusting HPA minReplicas", "hpa", targetHPA.Name, "min", min32)
 	}
 
 	if maxStr, ok := params["maxReplicas"]; ok {
-		max, err := strconv.Atoi(maxStr)
+		max32, err := parseInt32(maxStr)
 		if err != nil {
 			return fmt.Errorf("invalid maxReplicas %q: %w", maxStr, err)
 		}
-		targetHPA.Spec.MaxReplicas = int32(max)
+		targetHPA.Spec.MaxReplicas = max32
 		modified = true
-		logger.Info("Adjusting HPA maxReplicas", "hpa", targetHPA.Name, "max", max)
+		logger.Info("Adjusting HPA maxReplicas", "hpa", targetHPA.Name, "max", max32)
 	}
 
 	if targetStr, ok := params["targetCPUUtilization"]; ok {
-		target, err := strconv.Atoi(targetStr)
+		target32, err := parseInt32(targetStr)
 		if err != nil {
 			return fmt.Errorf("invalid targetCPUUtilization %q: %w", targetStr, err)
 		}
-		target32 := int32(target)
 		// Find or create CPU metric
 		found := false
 		for i := range targetHPA.Spec.Metrics {
@@ -671,11 +669,10 @@ func (r *RemediationReconciler) executeUpdateIngress(ctx context.Context, resour
 
 	// Update backend port
 	if portStr, ok := params["backendPort"]; ok {
-		port, err := strconv.Atoi(portStr)
+		port32, err := parseInt32(portStr)
 		if err != nil {
 			return fmt.Errorf("invalid backendPort %q: %w", portStr, err)
 		}
-		port32 := int32(port)
 		for i := range ingress.Spec.Rules {
 			if ingress.Spec.Rules[i].HTTP != nil {
 				for j := range ingress.Spec.Rules[i].HTTP.Paths {
@@ -734,7 +731,7 @@ func (r *RemediationReconciler) executePatchNetworkPolicy(ctx context.Context, r
 
 	// Allow adding specific ports
 	if portStr, ok := params["allowPort"]; ok {
-		port, err := strconv.Atoi(portStr)
+		portVal, err := parseInt32(portStr)
 		if err != nil {
 			return fmt.Errorf("invalid port %q: %w", portStr, err)
 		}
@@ -744,7 +741,6 @@ func (r *RemediationReconciler) executePatchNetworkPolicy(ctx context.Context, r
 			protocol = corev1.ProtocolUDP
 		}
 
-		portVal := int32(port)
 		newPort := networkingv1.NetworkPolicyPort{
 			Protocol: &protocol,
 			Port:     &intstr.IntOrString{IntVal: portVal},
@@ -971,7 +967,7 @@ func (r *RemediationReconciler) executeScaleStatefulSet(ctx context.Context, res
 	if !ok {
 		return fmt.Errorf("missing 'replicas' param")
 	}
-	replicas, err := strconv.Atoi(replicasStr)
+	r32, err := parseInt32(replicasStr)
 	if err != nil {
 		return fmt.Errorf("invalid replicas value %q: %w", replicasStr, err)
 	}
@@ -981,7 +977,6 @@ func (r *RemediationReconciler) executeScaleStatefulSet(ctx context.Context, res
 		return fmt.Errorf("failed to get StatefulSet %s/%s: %w", resource.Namespace, resource.Name, err)
 	}
 
-	r32 := int32(replicas)
 	sts.Spec.Replicas = &r32
 	return r.Update(ctx, &sts)
 }
@@ -1148,7 +1143,7 @@ func (r *RemediationReconciler) executePartitionStatefulSetUpdate(ctx context.Co
 	if !ok {
 		return fmt.Errorf("missing 'partition' param")
 	}
-	partition, err := strconv.Atoi(partitionStr)
+	p32, err := parseInt32(partitionStr)
 	if err != nil {
 		return fmt.Errorf("invalid partition value %q: %w", partitionStr, err)
 	}
@@ -1163,14 +1158,13 @@ func (r *RemediationReconciler) executePartitionStatefulSetUpdate(ctx context.Co
 	if sts.Spec.Replicas != nil {
 		desired = *sts.Spec.Replicas
 	}
-	if int32(partition) < 0 || int32(partition) >= desired {
-		return fmt.Errorf("partition (%d) must be >= 0 and < replicas (%d)", partition, desired)
+	if p32 < 0 || p32 >= desired {
+		return fmt.Errorf("partition (%d) must be >= 0 and < replicas (%d)", p32, desired)
 	}
 
 	if sts.Spec.UpdateStrategy.RollingUpdate == nil {
 		sts.Spec.UpdateStrategy.RollingUpdate = &appsv1.RollingUpdateStatefulSetStrategy{}
 	}
-	p32 := int32(partition)
 	sts.Spec.UpdateStrategy.RollingUpdate.Partition = &p32
 	sts.Spec.UpdateStrategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
 
@@ -1471,8 +1465,8 @@ func (r *RemediationReconciler) executeAdjustJobParallelism(ctx context.Context,
 	if !ok {
 		return fmt.Errorf("missing 'parallelism' param")
 	}
-	p, err := strconv.Atoi(pStr)
-	if err != nil || p < 1 {
+	p32, err := parseInt32(pStr)
+	if err != nil || p32 < 1 {
 		return fmt.Errorf("invalid parallelism %q: must be >= 1", pStr)
 	}
 
@@ -1481,7 +1475,6 @@ func (r *RemediationReconciler) executeAdjustJobParallelism(ctx context.Context,
 		return fmt.Errorf("failed to get Job: %w", err)
 	}
 
-	p32 := int32(p)
 	job.Spec.Parallelism = &p32
 	return r.Update(ctx, &job)
 }
@@ -1510,8 +1503,8 @@ func (r *RemediationReconciler) executeAdjustJobBackoffLimit(ctx context.Context
 	if !ok {
 		return fmt.Errorf("missing 'backoffLimit' param")
 	}
-	b, err := strconv.Atoi(bStr)
-	if err != nil || b < 0 {
+	b32, err := parseInt32(bStr)
+	if err != nil || b32 < 0 {
 		return fmt.Errorf("invalid backoffLimit %q: must be >= 0", bStr)
 	}
 
@@ -1520,7 +1513,6 @@ func (r *RemediationReconciler) executeAdjustJobBackoffLimit(ctx context.Context
 		return fmt.Errorf("failed to get Job: %w", err)
 	}
 
-	b32 := int32(b)
 	job.Spec.BackoffLimit = &b32
 	return r.Update(ctx, &job)
 }
@@ -1676,20 +1668,18 @@ func (r *RemediationReconciler) executeAdjustCronJobHistory(ctx context.Context,
 
 	modified := false
 	if sStr, ok := params["successfulJobsHistoryLimit"]; ok {
-		s, err := strconv.Atoi(sStr)
-		if err != nil || s < 0 {
+		s32, err := parseInt32(sStr)
+		if err != nil || s32 < 0 {
 			return fmt.Errorf("invalid successfulJobsHistoryLimit %q: must be >= 0", sStr)
 		}
-		s32 := int32(s)
 		cj.Spec.SuccessfulJobsHistoryLimit = &s32
 		modified = true
 	}
 	if fStr, ok := params["failedJobsHistoryLimit"]; ok {
-		f, err := strconv.Atoi(fStr)
-		if err != nil || f < 0 {
+		f32, err := parseInt32(fStr)
+		if err != nil || f32 < 0 {
 			return fmt.Errorf("invalid failedJobsHistoryLimit %q: must be >= 0", fStr)
 		}
-		f32 := int32(f)
 		cj.Spec.FailedJobsHistoryLimit = &f32
 		modified = true
 	}

--- a/operator/controllers/remediation_controller.go
+++ b/operator/controllers/remediation_controller.go
@@ -638,7 +638,7 @@ func (r *RemediationReconciler) handleAgenticExecuting(ctx context.Context, plan
 	if maxSteps == 0 {
 		maxSteps = defaultAgenticMaxSteps
 	}
-	currentStep := int32(len(plan.Spec.AgenticHistory)) + 1
+	currentStep := clampInt32(len(plan.Spec.AgenticHistory)) + 1
 
 	if res, terminal, err := r.applyAgenticSafetyGuards(ctx, plan, maxSteps, currentStep); terminal {
 		return res, err
@@ -819,7 +819,7 @@ func (r *RemediationReconciler) handleAgenticResolved(ctx context.Context, plan 
 	now := metav1.Now()
 	plan.Status.State = platformv1alpha1.RemediationStateVerifying
 	plan.Status.ActionsCompletedAt = &now
-	plan.Status.AgenticStepCount = int32(len(plan.Spec.AgenticHistory))
+	plan.Status.AgenticStepCount = clampInt32(len(plan.Spec.AgenticHistory))
 	return ctrl.Result{RequeueAfter: 10 * time.Second}, r.Status().Update(ctx, plan)
 }
 
@@ -890,7 +890,7 @@ func (r *RemediationReconciler) runAgenticAction(ctx context.Context, resource p
 // AgenticStartedAt are set AFTER the spec write. Returns a non-zero Requeue
 // on conflict so the controller manager retries.
 func (r *RemediationReconciler) persistAgenticStep(ctx context.Context, plan *platformv1alpha1.RemediationPlan) (ctrl.Result, error) {
-	agenticStepCount := int32(len(plan.Spec.AgenticHistory))
+	agenticStepCount := clampInt32(len(plan.Spec.AgenticHistory))
 	needStartedAt := plan.Status.AgenticStartedAt == nil
 
 	if err := r.Update(ctx, plan); err != nil {
@@ -969,7 +969,7 @@ func (r *RemediationReconciler) rejectDivergentAgenticAction(ctx context.Context
 		Timestamp:   metav1.Now(),
 	})
 
-	agenticStepCount := int32(len(plan.Spec.AgenticHistory))
+	agenticStepCount := clampInt32(len(plan.Spec.AgenticHistory))
 	needStartedAt := plan.Status.AgenticStartedAt == nil
 	if err := r.Update(ctx, plan); err != nil {
 		if errors.IsConflict(err) {
@@ -994,7 +994,7 @@ func (r *RemediationReconciler) executeScaleDeployment(ctx context.Context, reso
 	if !ok {
 		return fmt.Errorf("missing 'replicas' param")
 	}
-	replicas, err := strconv.Atoi(replicasStr)
+	r32, err := parseInt32(replicasStr)
 	if err != nil {
 		return fmt.Errorf("invalid replicas value %q: %w", replicasStr, err)
 	}
@@ -1004,7 +1004,6 @@ func (r *RemediationReconciler) executeScaleDeployment(ctx context.Context, reso
 		return fmt.Errorf("failed to get deployment %s/%s: %w", resource.Namespace, resource.Name, err)
 	}
 
-	r32 := int32(replicas)
 	deploy.Spec.Replicas = &r32
 	return r.Update(ctx, &deploy)
 }
@@ -1037,7 +1036,7 @@ func (r *RemediationReconciler) executeRollbackDeployment(ctx context.Context, r
 			if ref.Kind == "Deployment" && ref.Name == resource.Name {
 				rev := 0
 				if revStr, ok := rs.Annotations["deployment.kubernetes.io/revision"]; ok {
-					fmt.Sscanf(revStr, "%d", &rev)
+					rev = leadingInt(revStr)
 				}
 				owned = append(owned, rsInfo{revision: rev, rs: *rs})
 				break

--- a/operator/controllers/safecast.go
+++ b/operator/controllers/safecast.go
@@ -1,0 +1,69 @@
+/*
+ * ChatCLI Operator - bounded numeric conversions.
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Kubernetes APIs are int32-typed (replicas, ports, thresholds) while Go
+ * code naturally works with int and string parameters. Bare int32(x)
+ * conversions silently wrap on overflow — a malformed or malicious
+ * parameter like "4294967297" would become replicas=1. These helpers make
+ * every narrowing conversion explicit: parse failures surface as errors
+ * and count conversions clamp at the int32 range bounds.
+ */
+package controllers
+
+import (
+	"math"
+	"strconv"
+	"strings"
+)
+
+// parseInt32 parses a decimal string into an int32, failing on values
+// that do not fit in 32 bits instead of silently wrapping.
+func parseInt32(s string) (int32, error) {
+	v, err := strconv.ParseInt(s, 10, 32)
+	if err != nil {
+		return 0, err
+	}
+	return int32(v), nil
+}
+
+// clampInt32 converts an int to int32, clamping at the int32 range
+// bounds. Use for counts and sizes where saturation is the correct
+// behavior on out-of-range values.
+func clampInt32(n int) int32 {
+	if n > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	if n < math.MinInt32 {
+		return math.MinInt32
+	}
+	return int32(n)
+}
+
+// leadingInt parses the leading decimal integer of s, returning 0 when s
+// carries no number. It mirrors the tolerance of fmt.Sscanf("%d") for
+// trailing junk ("123)" → 123) so it can replace the unchecked Sscanf
+// calls used on optional labels, annotations and stack-frame fragments
+// where the zero value is the documented fallback.
+func leadingInt(s string) int {
+	s = strings.TrimSpace(s)
+	start := 0
+	if start < len(s) && (s[start] == '-' || s[start] == '+') {
+		start++
+	}
+	end := start
+	for end < len(s) && s[end] >= '0' && s[end] <= '9' {
+		end++
+	}
+	if end == start {
+		return 0
+	}
+	v, err := strconv.Atoi(s[:end])
+	if err != nil {
+		// Overflowing digit runs fall back to the zero default, same as
+		// an absent value.
+		return 0
+	}
+	return v
+}

--- a/operator/controllers/safecast_test.go
+++ b/operator/controllers/safecast_test.go
@@ -1,0 +1,108 @@
+package controllers
+
+import (
+	"math"
+	"testing"
+)
+
+func TestParseInt32(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    int32
+		wantErr bool
+	}{
+		{"0", 0, false},
+		{"3", 3, false},
+		{"-12", -12, false},
+		{"2147483647", math.MaxInt32, false},
+		{"-2147483648", math.MinInt32, false},
+		{"2147483648", 0, true},  // one past MaxInt32 → error, not wrap
+		{"-2147483649", 0, true}, // one past MinInt32 → error, not wrap
+		{"4294967297", 0, true},  // would silently become 1 with int32(Atoi)
+		{"not-a-number", 0, true},
+		{"", 0, true},
+	}
+	for _, tc := range cases {
+		got, err := parseInt32(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("parseInt32(%q) expected error, got %d", tc.in, got)
+			}
+			continue
+		}
+		if err != nil || got != tc.want {
+			t.Errorf("parseInt32(%q) = %d, %v; want %d", tc.in, got, err, tc.want)
+		}
+	}
+}
+
+func TestLeadingInt(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"42", 42},
+		{"  42  ", 42},
+		{"123)", 123},    // Sscanf-style tolerance for trailing junk
+		{"123:456", 123}, // stack-frame fragment
+		{"-7", -7},
+		{"+9", 9},
+		{"", 0},
+		{"abc", 0},
+		{"-", 0},
+		{"99999999999999999999", 0}, // overflow → zero fallback
+	}
+	for _, tc := range cases {
+		if got := leadingInt(tc.in); got != tc.want {
+			t.Errorf("leadingInt(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestValidateGitInputs(t *testing.T) {
+	valid := []struct{ url, branch string }{
+		{"https://github.com/org/repo.git", "main"},
+		{"ssh://git@host/org/repo.git", "release/1.2"},
+		{"git@github.com:org/repo.git", "feature_x.y"},
+		{"https://github.com/org/repo.git", ""}, // empty branch = default
+	}
+	for _, tc := range valid {
+		if err := validateGitInputs(tc.url, tc.branch); err != nil {
+			t.Errorf("validateGitInputs(%q, %q) unexpected error: %v", tc.url, tc.branch, err)
+		}
+	}
+
+	invalid := []struct{ url, branch, reason string }{
+		{"--upload-pack=/bin/sh", "main", "option-injection URL"},
+		{"ext::sh -c id", "main", "ext transport"},
+		{"file:///etc", "main", "non-allowlisted scheme"},
+		{"https://github.com/org/repo.git", "-Bevil", "option-injection branch"},
+		{"https://github.com/org/repo.git", "br anch", "whitespace in branch"},
+		{"https://github.com/org/repo.git", "br;rm -rf", "shell metachars in branch"},
+	}
+	for _, tc := range invalid {
+		if err := validateGitInputs(tc.url, tc.branch); err == nil {
+			t.Errorf("validateGitInputs(%q, %q) must fail: %s", tc.url, tc.branch, tc.reason)
+		}
+	}
+}
+
+func TestClampInt32(t *testing.T) {
+	cases := []struct {
+		in   int
+		want int32
+	}{
+		{0, 0},
+		{42, 42},
+		{-42, -42},
+		{math.MaxInt32, math.MaxInt32},
+		{math.MinInt32, math.MinInt32},
+		{math.MaxInt32 + 1, math.MaxInt32},
+		{math.MinInt32 - 1, math.MinInt32},
+	}
+	for _, tc := range cases {
+		if got := clampInt32(tc.in); got != tc.want {
+			t.Errorf("clampInt32(%d) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}

--- a/operator/controllers/source_controller.go
+++ b/operator/controllers/source_controller.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -49,7 +50,9 @@ func (r *SourceRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		if errors.IsNotFound(err) {
 			// Clean up local clone if the CR was deleted
 			localPath := filepath.Join(sourceRepoBaseDir, req.Namespace, req.Name)
-			os.RemoveAll(localPath)
+			if rmErr := os.RemoveAll(localPath); rmErr != nil {
+				logger.Error(rmErr, "Failed to remove local clone of deleted repository", "path", localPath)
+			}
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
@@ -149,7 +152,9 @@ func (r *SourceRepositoryReconciler) resolveAuth(ctx context.Context, repo *plat
 		}
 		// Write SSH key to temp file
 		keyFile := filepath.Join(sourceRepoBaseDir, ".ssh", repo.Name)
-		os.MkdirAll(filepath.Dir(keyFile), 0700)
+		if err := os.MkdirAll(filepath.Dir(keyFile), 0700); err != nil {
+			return nil, fmt.Errorf("creating SSH key dir: %w", err)
+		}
 		if err := os.WriteFile(keyFile, sshKey, 0600); err != nil {
 			return nil, fmt.Errorf("writing SSH key: %w", err)
 		}
@@ -167,18 +172,44 @@ func (r *SourceRepositoryReconciler) resolveAuth(ctx context.Context, repo *plat
 	return env, nil
 }
 
+// gitBranchPattern allows the conservative charset git branch names use in
+// practice; crucially it rejects a leading "-", which git would otherwise
+// parse as an option (e.g. --upload-pack=cmd runs an arbitrary binary).
+var gitBranchPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._/-]*$`)
+
+// validateGitInputs guards the git invocations against argument injection.
+// SourceRepository objects are namespace-scoped and may be authored by
+// tenants, so the URL and branch are treated as untrusted input.
+func validateGitInputs(repoURL, branch string) error {
+	if strings.HasPrefix(repoURL, "-") || strings.Contains(repoURL, "ext::") {
+		return fmt.Errorf("unsupported repository URL %q", repoURL)
+	}
+	if !strings.HasPrefix(repoURL, "https://") && !strings.HasPrefix(repoURL, "ssh://") && !strings.HasPrefix(repoURL, "git@") {
+		return fmt.Errorf("repository URL must use https://, ssh:// or git@ form, got %q", repoURL)
+	}
+	if branch != "" && !gitBranchPattern.MatchString(branch) {
+		return fmt.Errorf("invalid branch name %q", branch)
+	}
+	return nil
+}
+
 // cloneRepo performs a shallow clone of the repository.
 func (r *SourceRepositoryReconciler) cloneRepo(ctx context.Context, repo *platformv1alpha1.SourceRepository, localPath string, authEnv []string) error {
-	os.MkdirAll(filepath.Dir(localPath), 0755)
+	if err := os.MkdirAll(filepath.Dir(localPath), 0750); err != nil {
+		return fmt.Errorf("creating clone parent dir: %w", err)
+	}
 
 	branch := repo.Spec.Branch
 	if branch == "" {
 		branch = "main"
 	}
+	if err := validateGitInputs(repo.Spec.URL, branch); err != nil {
+		return err
+	}
 
 	args := []string{"clone", "--depth", "50", "--single-branch", "--branch", branch, repo.Spec.URL, localPath}
 
-	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd := exec.CommandContext(ctx, "git", args...) // #nosec G204 -- fixed git binary; URL/branch validated by validateGitInputs, localPath derived from k8s object names
 	cmd.Env = append(os.Environ(), authEnv...)
 
 	// Apply token auth for HTTPS
@@ -214,31 +245,34 @@ func (r *SourceRepositoryReconciler) applyTokenAuth(ctx context.Context, repoURL
 				newArgs[i] = authedURL
 			}
 		}
-		cmd := exec.CommandContext(ctx, "git", newArgs...)
+		cmd := exec.CommandContext(ctx, "git", newArgs...) // #nosec G204 -- fixed git binary; caller validated URL/branch via validateGitInputs
 		cmd.Env = os.Environ()
 		return cmd
 	}
 
-	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd := exec.CommandContext(ctx, "git", args...) // #nosec G204 -- fixed git binary; caller validated URL/branch via validateGitInputs
 	cmd.Env = append(os.Environ(), authEnv...)
 	return cmd
 }
 
 // pullRepo fetches latest changes.
 func (r *SourceRepositoryReconciler) pullRepo(ctx context.Context, repo *platformv1alpha1.SourceRepository, localPath string, authEnv []string) error {
-	cmd := exec.CommandContext(ctx, "git", "-C", localPath, "fetch", "--depth", "50", "origin")
+	branch := repo.Spec.Branch
+	if branch == "" {
+		branch = "main"
+	}
+	if err := validateGitInputs(repo.Spec.URL, branch); err != nil {
+		return err
+	}
+
+	cmd := exec.CommandContext(ctx, "git", "-C", localPath, "fetch", "--depth", "50", "origin") // #nosec G204 -- fixed git binary; localPath derived from k8s object names
 	cmd.Env = append(os.Environ(), authEnv...)
 
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git fetch: %s: %w", string(output), err)
 	}
 
-	branch := repo.Spec.Branch
-	if branch == "" {
-		branch = "main"
-	}
-
-	cmd = exec.CommandContext(ctx, "git", "-C", localPath, "reset", "--hard", fmt.Sprintf("origin/%s", branch))
+	cmd = exec.CommandContext(ctx, "git", "-C", localPath, "reset", "--hard", fmt.Sprintf("origin/%s", branch)) // #nosec G204 -- fixed git binary; branch validated by validateGitInputs
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git reset: %s: %w", string(output), err)
 	}
@@ -273,7 +307,7 @@ func (r *SourceRepositoryReconciler) indexRepo(ctx context.Context, repo *platfo
 // getRecentCommits retrieves the last N commits with file change info.
 func (r *SourceRepositoryReconciler) getRecentCommits(ctx context.Context, localPath string) ([]platformv1alpha1.GitCommitInfo, error) {
 	// git log with format: SHA|author|timestamp|message
-	cmd := exec.CommandContext(ctx, "git", "-C", localPath, "log",
+	cmd := exec.CommandContext(ctx, "git", "-C", localPath, "log", // #nosec G204 -- fixed git binary and flags; localPath derived from k8s object names
 		fmt.Sprintf("-%d", maxRecentCommits),
 		"--format=%H|%an|%aI|%s",
 		"--name-only")
@@ -343,7 +377,9 @@ func detectLanguages(localPath string) []string {
 	}
 
 	langCount := make(map[string]int)
-	filepath.Walk(localPath, func(path string, info os.FileInfo, err error) error {
+	// Walk errors mean a partially indexed tree — acceptable for language
+	// detection, which is advisory.
+	_ = filepath.Walk(localPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil || info.IsDir() {
 			// Skip hidden directories and vendor/node_modules
 			if info != nil && info.IsDir() {
@@ -601,7 +637,7 @@ func extractRelevantCode(localPath string, relevantPaths []string, stackTraces [
 			}
 
 			// Read the file and extract context around the line
-			content, err := readLinesAround(fullPath, lineNum, 5)
+			content, err := readLinesAround(localPath, fullPath, lineNum, 5)
 			if err != nil {
 				continue
 			}
@@ -634,9 +670,7 @@ func parseStackFrame(frame, language string) (string, int) {
 		// format: package/file.go:123
 		if idx := strings.LastIndex(frame, ":"); idx > 0 {
 			path := frame[:idx]
-			var line int
-			fmt.Sscanf(frame[idx+1:], "%d", &line)
-			return path, line
+			return path, leadingInt(frame[idx+1:])
 		}
 
 	case "java":
@@ -647,9 +681,7 @@ func parseStackFrame(frame, language string) (string, int) {
 				fileInfo := frame[start+1 : end]
 				parts := strings.SplitN(fileInfo, ":", 2)
 				if len(parts) == 2 {
-					var line int
-					fmt.Sscanf(parts[1], "%d", &line)
-					return parts[0], line
+					return parts[0], leadingInt(parts[1])
 				}
 			}
 		}
@@ -662,7 +694,7 @@ func parseStackFrame(frame, language string) (string, int) {
 				path := parts[1]
 				var line int
 				if lineIdx := strings.Index(frame, "line "); lineIdx > 0 {
-					fmt.Sscanf(frame[lineIdx+5:], "%d", &line)
+					line = leadingInt(frame[lineIdx+5:])
 				}
 				return path, line
 			}
@@ -677,9 +709,7 @@ func parseStackFrame(frame, language string) (string, int) {
 		frame = strings.TrimSuffix(frame, ")")
 		parts := strings.SplitN(frame, ":", 3)
 		if len(parts) >= 2 {
-			var line int
-			fmt.Sscanf(parts[1], "%d", &line)
-			return parts[0], line
+			return parts[0], leadingInt(parts[1])
 		}
 	}
 
@@ -705,7 +735,9 @@ func findFileInRepo(localPath, fileName string, relevantPaths []string) string {
 	// Try finding just the filename
 	baseName := filepath.Base(fileName)
 	var found string
-	filepath.Walk(localPath, func(path string, info os.FileInfo, err error) error {
+	// Walk errors mean some subtrees were unreadable; an empty result is
+	// the documented "not found" answer in that case.
+	_ = filepath.Walk(localPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil || info.IsDir() {
 			if info != nil && info.IsDir() {
 				base := filepath.Base(path)
@@ -725,13 +757,25 @@ func findFileInRepo(localPath, fileName string, relevantPaths []string) string {
 	return found
 }
 
-// readLinesAround reads lines around a target line number.
-func readLinesAround(filePath string, targetLine, contextLines int) (string, error) {
-	f, err := os.Open(filePath)
+// readLinesAround reads lines around a target line number. filePath is
+// resolved against rootDir through os.Root, so a stack-frame path crafted
+// to traverse or symlink outside the repository clone cannot escape it —
+// stack traces arrive on Issue objects and are untrusted input.
+func readLinesAround(rootDir, filePath string, targetLine, contextLines int) (string, error) {
+	rel, err := filepath.Rel(rootDir, filePath)
 	if err != nil {
 		return "", err
 	}
-	defer f.Close()
+	root, err := os.OpenRoot(rootDir)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = root.Close() }()
+	f, err := root.Open(rel)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
 
 	startLine := targetLine - contextLines
 	if startLine < 1 {
@@ -777,7 +821,12 @@ func readConfigFiles(localPath string, configFiles []string) []ConfigFileContent
 		}
 
 		fullPath := filepath.Join(localPath, cf)
-		data, err := os.ReadFile(fullPath)
+		// Confinement: config paths come from our own index, but re-check
+		// that the join did not escape the clone root before reading.
+		if !strings.HasPrefix(filepath.Clean(fullPath)+string(os.PathSeparator), filepath.Clean(localPath)+string(os.PathSeparator)) {
+			continue
+		}
+		data, err := os.ReadFile(fullPath) // #nosec G304 -- path confined to the repo clone root above
 		if err != nil {
 			continue
 		}

--- a/operator/controllers/source_controller_test.go
+++ b/operator/controllers/source_controller_test.go
@@ -1,0 +1,502 @@
+/*
+ * ChatCLI - Kubernetes Operator
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package controllers
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	platformv1alpha1 "github.com/diillson/chatcli/operator/api/v1alpha1"
+)
+
+// --- readLinesAround ---
+
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestReadLinesAround_HappyPath(t *testing.T) {
+	root := t.TempDir()
+	var sb strings.Builder
+	for i := 1; i <= 10; i++ {
+		sb.WriteString("line ")
+		sb.WriteString(string(rune('0' + i%10)))
+		sb.WriteString("\n")
+	}
+	writeTestFile(t, filepath.Join(root, "src", "main.go"), sb.String())
+
+	out, err := readLinesAround(root, filepath.Join(root, "src", "main.go"), 5, 2)
+	if err != nil {
+		t.Fatalf("readLinesAround: %v", err)
+	}
+	if !strings.Contains(out, ">>    5 |") {
+		t.Errorf("output missing target-line marker, got:\n%s", out)
+	}
+	if !strings.Contains(out, "   3 |") || !strings.Contains(out, "   7 |") {
+		t.Errorf("output missing context lines 3 and 7, got:\n%s", out)
+	}
+	if strings.Contains(out, "   1 |") || strings.Contains(out, "   9 |") {
+		t.Errorf("output includes lines outside the context window, got:\n%s", out)
+	}
+}
+
+func TestReadLinesAround_RejectsTraversal(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "repo")
+	writeTestFile(t, filepath.Join(base, "secret", "creds.txt"), "top secret\n")
+	if err := os.MkdirAll(root, 0o750); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+
+	_, err := readLinesAround(root, filepath.Join(base, "secret", "creds.txt"), 1, 1)
+	if err == nil {
+		t.Fatal("expected traversal outside the clone root to be rejected")
+	}
+}
+
+func TestReadLinesAround_RejectsSymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires privileges on Windows")
+	}
+	base := t.TempDir()
+	root := filepath.Join(base, "repo")
+	if err := os.MkdirAll(root, 0o750); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+	writeTestFile(t, filepath.Join(base, "outside.txt"), "outside\n")
+	if err := os.Symlink(filepath.Join(base, "outside.txt"), filepath.Join(root, "link.txt")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	_, err := readLinesAround(root, filepath.Join(root, "link.txt"), 1, 1)
+	if err == nil {
+		t.Fatal("expected symlink escaping the clone root to be rejected")
+	}
+}
+
+func TestReadLinesAround_MissingRoot(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	_, err := readLinesAround(missing, filepath.Join(missing, "f.go"), 1, 1)
+	if err == nil {
+		t.Fatal("expected error for a missing root directory")
+	}
+}
+
+func TestReadLinesAround_UnrelatablePaths(t *testing.T) {
+	// A relative root and an absolute file path cannot be made relative to
+	// each other; readLinesAround must surface that instead of guessing.
+	_, err := readLinesAround("relative-root", filepath.Join(t.TempDir(), "f.go"), 1, 1)
+	if err == nil {
+		t.Fatal("expected error when the file path cannot be made root-relative")
+	}
+}
+
+// --- parseStackFrame ---
+
+func TestParseStackFrame(t *testing.T) {
+	tests := []struct {
+		name     string
+		frame    string
+		language string
+		wantPath string
+		wantLine int
+	}{
+		{name: "go frame", frame: "pkg/server/main.go:42", language: "go", wantPath: "pkg/server/main.go", wantLine: 42},
+		{name: "go frame with trailing junk", frame: "main.go:42 +0x1b", language: "go", wantPath: "main.go", wantLine: 42},
+		{name: "go frame without line", frame: "nocolonhere", language: "go", wantPath: "", wantLine: 0},
+		{name: "java frame", frame: "at com.example.MyClass.method(MyClass.java:87)", language: "java", wantPath: "MyClass.java", wantLine: 87},
+		{name: "python frame", frame: `File "/app/handlers/views.py", line 7, in handler`, language: "python", wantPath: "/app/handlers/views.py", wantLine: 7},
+		{name: "nodejs frame", frame: "at handleRequest (/app/server.js:42:10)", language: "nodejs", wantPath: "/app/server.js", wantLine: 42},
+		{name: "unknown language", frame: "main.go:42", language: "rust", wantPath: "", wantLine: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, line := parseStackFrame(tt.frame, tt.language)
+			if path != tt.wantPath || line != tt.wantLine {
+				t.Errorf("parseStackFrame(%q, %q) = (%q, %d), want (%q, %d)",
+					tt.frame, tt.language, path, line, tt.wantPath, tt.wantLine)
+			}
+		})
+	}
+}
+
+// --- findFileInRepo ---
+
+func TestFindFileInRepo(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "pkg", "util.go"), "package util\n")
+	writeTestFile(t, filepath.Join(root, "src", "app.py"), "print('hi')\n")
+	writeTestFile(t, filepath.Join(root, "a", "b", "c", "deep.go"), "package c\n")
+	writeTestFile(t, filepath.Join(root, "vendor", "dep", "hidden.go"), "package dep\n")
+
+	t.Run("direct relative match", func(t *testing.T) {
+		got := findFileInRepo(root, filepath.Join("pkg", "util.go"), nil)
+		if got != filepath.Join(root, "pkg", "util.go") {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("match within relevant paths", func(t *testing.T) {
+		got := findFileInRepo(root, "app.py", []string{"src"})
+		if got != filepath.Join(root, "src", "app.py") {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("basename walk fallback", func(t *testing.T) {
+		got := findFileInRepo(root, filepath.Join("wrong", "prefix", "deep.go"), nil)
+		if got != filepath.Join(root, "a", "b", "c", "deep.go") {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("vendor is skipped by the walk", func(t *testing.T) {
+		if got := findFileInRepo(root, "hidden.go", nil); got != "" {
+			t.Errorf("expected vendor/ to be skipped, got %q", got)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		if got := findFileInRepo(root, "nope.go", nil); got != "" {
+			t.Errorf("expected empty result, got %q", got)
+		}
+	})
+}
+
+// --- readConfigFiles ---
+
+func TestReadConfigFiles(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "Dockerfile"), "FROM scratch\n")
+
+	configs := readConfigFiles(root, []string{
+		"Dockerfile", // important, readable
+		filepath.Join("..", "escape", "Dockerfile"), // important, escapes the root
+		filepath.Join("missing", "values.yaml"),     // important, does not exist
+		"README.md",                                 // not important
+	})
+
+	if len(configs) != 1 {
+		t.Fatalf("expected exactly 1 config, got %d: %+v", len(configs), configs)
+	}
+	if configs[0].FilePath != "Dockerfile" || !strings.Contains(configs[0].Content, "FROM scratch") {
+		t.Errorf("unexpected config: %+v", configs[0])
+	}
+}
+
+// --- detectLanguages ---
+
+func TestDetectLanguages(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "main.go"), "package main\n")
+	writeTestFile(t, filepath.Join(root, "util.go"), "package main\n")
+	writeTestFile(t, filepath.Join(root, "script.py"), "print('hi')\n")
+	writeTestFile(t, filepath.Join(root, "vendor", "dep.go"), "package dep\n")
+	writeTestFile(t, filepath.Join(root, ".hidden", "x.go"), "package x\n")
+
+	langs := detectLanguages(root)
+	if len(langs) != 2 {
+		t.Fatalf("expected 2 languages, got %v", langs)
+	}
+	// Go has 2 files vs Python's 1 (vendor/ and .hidden/ are skipped),
+	// so Go must sort first.
+	if langs[0] != "Go" || langs[1] != "Python" {
+		t.Errorf("expected [Go Python], got %v", langs)
+	}
+}
+
+// --- extractRelevantCode ---
+
+func TestExtractRelevantCode(t *testing.T) {
+	root := t.TempDir()
+	var sb strings.Builder
+	for i := 0; i < 10; i++ {
+		sb.WriteString("package main // filler\n")
+	}
+	writeTestFile(t, filepath.Join(root, "main.go"), sb.String())
+
+	traces := []StackTrace{
+		{
+			Language:      "go",
+			ExceptionType: "panic",
+			Frames:        []string{"main.go:5", "not-a-frame"},
+		},
+	}
+
+	snippets := extractRelevantCode(root, nil, traces)
+	if len(snippets) != 1 {
+		t.Fatalf("expected 1 snippet, got %d", len(snippets))
+	}
+	if snippets[0].FilePath != "main.go" {
+		t.Errorf("FilePath = %q, want main.go", snippets[0].FilePath)
+	}
+	if !strings.Contains(snippets[0].Content, ">>") {
+		t.Errorf("snippet content missing target-line marker:\n%s", snippets[0].Content)
+	}
+}
+
+// --- git-backed helpers ---
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	full := append([]string{
+		"-C", dir,
+		"-c", "user.name=test",
+		"-c", "user.email=test@example.com",
+		"-c", "protocol.file.allow=always",
+	}, args...)
+	cmd := exec.Command("git", full...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+// newLocalGitRepo creates a repo with one commit on branch main and
+// returns its path.
+func newLocalGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGit(t, dir, "-c", "init.defaultBranch=main", "init")
+	writeTestFile(t, filepath.Join(dir, "main.go"), "package main\n")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "feat: initial commit")
+	return dir
+}
+
+func newSourceRepo(url, branch string) *platformv1alpha1.SourceRepository {
+	return &platformv1alpha1.SourceRepository{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-repo", Namespace: "default"},
+		Spec: platformv1alpha1.SourceRepositorySpec{
+			URL:    url,
+			Branch: branch,
+		},
+	}
+}
+
+func TestGetRecentCommits(t *testing.T) {
+	origin := newLocalGitRepo(t)
+	r := &SourceRepositoryReconciler{}
+
+	commits, err := r.getRecentCommits(context.Background(), origin)
+	if err != nil {
+		t.Fatalf("getRecentCommits: %v", err)
+	}
+	if len(commits) != 1 {
+		t.Fatalf("expected 1 commit, got %d", len(commits))
+	}
+	c := commits[0]
+	if len(c.SHA) != 40 {
+		t.Errorf("SHA length = %d, want 40", len(c.SHA))
+	}
+	if c.Message != "feat: initial commit" || c.Author != "test" {
+		t.Errorf("unexpected commit metadata: %+v", c)
+	}
+	if c.Timestamp.IsZero() {
+		t.Error("commit timestamp was not parsed")
+	}
+}
+
+func TestPullRepo(t *testing.T) {
+	r := &SourceRepositoryReconciler{}
+	ctx := context.Background()
+
+	t.Run("rejects invalid url before touching git", func(t *testing.T) {
+		err := r.pullRepo(ctx, newSourceRepo("file:///etc", ""), t.TempDir(), nil)
+		if err == nil || !strings.Contains(err.Error(), "repository URL must use") {
+			t.Fatalf("expected URL validation error, got %v", err)
+		}
+	})
+
+	t.Run("fetch failure on a non-repo directory", func(t *testing.T) {
+		err := r.pullRepo(ctx, newSourceRepo("https://example.com/repo.git", "main"), t.TempDir(), nil)
+		if err == nil || !strings.Contains(err.Error(), "git fetch") {
+			t.Fatalf("expected git fetch error, got %v", err)
+		}
+	})
+
+	t.Run("fetches and resets from origin", func(t *testing.T) {
+		origin := newLocalGitRepo(t)
+		work := t.TempDir()
+		runGit(t, work, "-c", "init.defaultBranch=main", "init")
+		// file:// (instead of a bare path) forces the smart transport,
+		// which supports the shallow fetch pullRepo performs.
+		runGit(t, work, "remote", "add", "origin", "file://"+origin)
+
+		// Branch defaulting: empty Spec.Branch must resolve to main.
+		repo := newSourceRepo("https://example.com/repo.git", "")
+		if err := r.pullRepo(ctx, repo, work, nil); err != nil {
+			t.Fatalf("pullRepo: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(work, "main.go")); err != nil {
+			t.Errorf("expected main.go after reset --hard origin/main: %v", err)
+		}
+	})
+}
+
+func TestCloneRepo(t *testing.T) {
+	r := &SourceRepositoryReconciler{}
+	ctx := context.Background()
+
+	t.Run("rejects invalid url before running git", func(t *testing.T) {
+		err := r.cloneRepo(ctx, newSourceRepo("-oProxyCommand=evil", "main"), filepath.Join(t.TempDir(), "clone"), nil)
+		if err == nil || !strings.Contains(err.Error(), "unsupported repository URL") {
+			t.Fatalf("expected URL validation error, got %v", err)
+		}
+	})
+
+	t.Run("surfaces parent dir creation failure", func(t *testing.T) {
+		blocker := filepath.Join(t.TempDir(), "blocker")
+		writeTestFile(t, blocker, "not a directory\n")
+		err := r.cloneRepo(ctx, newSourceRepo("https://example.com/repo.git", "main"),
+			filepath.Join(blocker, "sub", "clone"), nil)
+		if err == nil || !strings.Contains(err.Error(), "creating clone parent dir") {
+			t.Fatalf("expected mkdir error, got %v", err)
+		}
+	})
+
+	t.Run("surfaces git clone failure", func(t *testing.T) {
+		cloneCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		// Port 1 is reserved and never listening: the clone fails fast
+		// with a connection error instead of touching the network.
+		err := r.cloneRepo(cloneCtx, newSourceRepo("https://127.0.0.1:1/repo.git", "main"),
+			filepath.Join(t.TempDir(), "clone"), nil)
+		if err == nil || !strings.Contains(err.Error(), "git clone failed") {
+			t.Fatalf("expected git clone error, got %v", err)
+		}
+	})
+}
+
+func TestApplyTokenAuth(t *testing.T) {
+	r := &SourceRepositoryReconciler{}
+	ctx := context.Background()
+	repoURL := "https://github.com/org/repo.git"
+	args := []string{"clone", repoURL, "/dest"}
+
+	t.Run("token is injected into the https url", func(t *testing.T) {
+		cmd := r.applyTokenAuth(ctx, repoURL, []string{"GIT_TOKEN=tok123"}, args)
+		joined := strings.Join(cmd.Args, " ")
+		if !strings.Contains(joined, "https://x-access-token:tok123@github.com/org/repo.git") {
+			t.Errorf("token not injected, args: %v", cmd.Args)
+		}
+	})
+
+	t.Run("without token the args are untouched", func(t *testing.T) {
+		cmd := r.applyTokenAuth(ctx, repoURL, nil, args)
+		joined := strings.Join(cmd.Args, " ")
+		if !strings.Contains(joined, repoURL) || strings.Contains(joined, "x-access-token") {
+			t.Errorf("unexpected args: %v", cmd.Args)
+		}
+	})
+}
+
+// --- resolveAuth ---
+
+func TestResolveAuth_SSHKey(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "git-creds", Namespace: "default"},
+		Data:       map[string][]byte{"ssh-key": []byte("fake-key-material")},
+	}
+	c := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(secret).Build()
+	r := &SourceRepositoryReconciler{Client: c}
+
+	repo := newSourceRepo("git@github.com:org/repo.git", "main")
+	repo.Name = "ssh-auth-test-repo"
+	repo.Spec.AuthType = platformv1alpha1.SourceRepoAuthSSH
+	repo.Spec.SecretRef = "git-creds"
+	keyFile := filepath.Join(sourceRepoBaseDir, ".ssh", repo.Name)
+	t.Cleanup(func() { _ = os.Remove(keyFile) })
+
+	env, err := r.resolveAuth(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("resolveAuth: %v", err)
+	}
+	found := false
+	for _, e := range env {
+		if strings.HasPrefix(e, "GIT_SSH_COMMAND=") && strings.Contains(e, keyFile) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("GIT_SSH_COMMAND with key file not present in env: %v", env)
+	}
+	data, err := os.ReadFile(keyFile)
+	if err != nil || string(data) != "fake-key-material" {
+		t.Errorf("key file not written correctly: %v / %q", err, data)
+	}
+}
+
+// --- Reconcile cleanup path ---
+
+func TestSourceRepositoryReconcile_NotFoundRemovesClone(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(newScheme()).Build()
+	r := &SourceRepositoryReconciler{Client: c, Scheme: newScheme()}
+
+	ns, name := "srcrepo-test-ns", "deleted-repo"
+	localPath := filepath.Join(sourceRepoBaseDir, ns, name)
+	writeTestFile(t, filepath.Join(localPath, "main.go"), "package main\n")
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(sourceRepoBaseDir, ns)) })
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: ns, Name: name},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Errorf("expected no requeue for a deleted CR, got %+v", res)
+	}
+	if _, statErr := os.Stat(localPath); !os.IsNotExist(statErr) {
+		t.Errorf("expected local clone to be removed, stat err: %v", statErr)
+	}
+}
+
+func TestSourceRepositoryReconcile_NotFoundCleanupFailureIsNonFatal(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permission bits do not block removal on Windows")
+	}
+	c := fake.NewClientBuilder().WithScheme(newScheme()).Build()
+	r := &SourceRepositoryReconciler{Client: c, Scheme: newScheme()}
+
+	ns, name := "srcrepo-test-ns-ro", "stuck-repo"
+	localPath := filepath.Join(sourceRepoBaseDir, ns, name)
+	writeTestFile(t, filepath.Join(localPath, "main.go"), "package main\n")
+	// Removing the write bit makes RemoveAll fail on the child entry
+	// (when not running as root); the reconciler must log and move on.
+	if err := os.Chmod(localPath, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(localPath, 0o700)
+		_ = os.RemoveAll(filepath.Join(sourceRepoBaseDir, ns))
+	})
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: ns, Name: name},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile must not fail when clone cleanup fails, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Scope

Zeroes out every open gosec code-scanning alert (82 in the operator module; the 2 stale chatcli G704 alerts are already fixed on main and close on the next main analysis).

## Fixes by class — root causes, no blanket suppressions

| Class | Count | Fix |
|---|---|---|
| G115/G109 integer overflow | 43 | New `safecast` helpers: `parseInt32` errors on out-of-range strings (a replicas param of `4294967297` previously wrapped to **1**); `clampInt32` saturates count conversions. Fully unit-tested. |
| G104 unhandled errors | 21 | Each site handles or explicitly documents its error. Unchecked `fmt.Sscanf` → `leadingInt` (preserves trailing-junk tolerance, zero-fallback explicit); audit `Close()` now propagates; blast-radius warns on unparseable params instead of predicting with target 0. |
| G204 subprocess | 6 | `validateGitInputs`: URL scheme allowlist + branch charset rejecting leading `-` — closes the `--upload-pack` **argument-injection vector** for tenant-authored SourceRepository CRs. Exec sites annotated post-validation. |
| G304/G703 path traversal | 6 | Stack-frame reads via **`os.Root`** scoped to the clone (traces on Issue objects are untrusted); config reads re-check confinement; env paths (audit log, gRPC CA) canonicalized + absolute-required. |
| G101 hardcoded credential | 1 | `X-API-Key` header **name** moved to a named constant (`authHeaderName`) — was pattern-matching as a credential. |
| G118 context misuse | 1 | Shutdown deadline via `context.WithoutCancel(ctx)` — keeps lifecycle values without inheriting the already-fired cancellation. |
| G706 log injection | 1 | Method/path `%q`-escaped in REST access logs; annotated (taint engine has no sanitizer model for fmt quoting). |

## Validation

- Local gosec: **0 issues** in both modules (was 82).
- `go build ./...` + full operator test suite green; new helpers (`parseInt32`, `clampInt32`, `leadingInt`, `validateGitInputs`) fully covered, including injection cases.
- Behavior preserved where intended (zero-fallback parsing) and corrected where the silence was a bug (overflow wrap, swallowed audit flush errors).