### PR TITLE
perf(context): bound knowledge retrieval cost by query, not corpus size

### DIFF
--- a/cli/ctxmgr/knowledge_query.go
+++ b/cli/ctxmgr/knowledge_query.go
@@ -33,6 +33,33 @@ type KnowledgeHit struct {
 	Seg         Segment
 }
 
+// knowledgeDigestEntry memoizes one rendered index card per context revision.
+type knowledgeDigestEntry struct {
+	fingerprint string
+	digest      string
+}
+
+// KnowledgeDigest returns fc's index card, memoized per context revision.
+// Prompt assembly calls this every turn; without the memo a 50k-passage
+// corpus would pay an O(corpus) walk and sort on each one.
+func (m *Manager) KnowledgeDigest(fc *FileContext) string {
+	if fc == nil {
+		return ""
+	}
+	fp := contextFingerprint(fc)
+	m.digestMu.Lock()
+	defer m.digestMu.Unlock()
+	if m.digestCache == nil {
+		m.digestCache = make(map[string]knowledgeDigestEntry)
+	}
+	if e, ok := m.digestCache[fc.ID]; ok && e.fingerprint == fp {
+		return e.digest
+	}
+	d := BuildKnowledgeDigest(fc, 0)
+	m.digestCache[fc.ID] = knowledgeDigestEntry{fingerprint: fp, digest: d}
+	return d
+}
+
 // AttachedKnowledge returns the knowledge-mode contexts attached to the
 // session, sorted by name for deterministic listings.
 func (m *Manager) AttachedKnowledge(sessionID string) []*FileContext {
@@ -182,21 +209,41 @@ func (m *Manager) KnowledgeTOC(sessionID, kb, prefix string) (string, error) {
 	return strings.TrimRight(b.String(), "\n"), nil
 }
 
+// searchSnippetChars bounds one passage inside a search result. Search is the
+// LOCATE step — it must stay skimmable in the action feed and cheap in the
+// conversation; the model reads full content through `get`. 8 hits land near
+// 3KB instead of 10KB+ of raw passages.
+const searchSnippetChars = 360
+
 // FormatKnowledgeHits renders search results for the tool transcript: each
-// passage cites its knowledge base, source path and position so the model can
-// follow up with `get` on the exact document.
+// passage cites its knowledge base, source path and position, with a bounded
+// snippet, so the model can follow up with `get` on the exact document.
 func FormatKnowledgeHits(query string, hits []KnowledgeHit) string {
 	if len(hits) == 0 {
 		return "No passages matched. Try different terms, or use toc to inspect what the knowledge base covers."
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "%d passage(s) for %q:\n\n", len(hits), query)
+	fmt.Fprintf(&b, "%d passage(s) for %q (snippets — read full documents with get):\n\n", len(hits), query)
 	for i, h := range hits {
 		fmt.Fprintf(&b, "[%d] %s :: %s (lines %d-%d)\n", i+1, h.ContextName, h.Seg.FilePath, h.Seg.StartLine, h.Seg.EndLine)
 		b.WriteString("```\n")
-		b.WriteString(h.Seg.Content)
+		b.WriteString(snippet(h.Seg.Content, searchSnippetChars))
 		b.WriteString("\n```\n\n")
 	}
 	b.WriteString("Use {\"cmd\":\"get\",\"args\":{\"source\":\"<path before the #>\"}} to read a full document.")
 	return b.String()
+}
+
+// snippet trims s to at most limit bytes, cutting at a word boundary and
+// flagging the elision so the model knows there is more behind `get`.
+func snippet(s string, limit int) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= limit {
+		return s
+	}
+	cut := s[:limit]
+	if i := strings.LastIndexAny(cut, " \n\t"); i > limit/2 {
+		cut = cut[:i]
+	}
+	return cut + " […]"
 }

--- a/cli/ctxmgr/knowledge_test.go
+++ b/cli/ctxmgr/knowledge_test.go
@@ -8,6 +8,7 @@ package ctxmgr
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -127,19 +128,18 @@ func TestRetrieveHybrid_BlendsVectorAndLexical(t *testing.T) {
 	}
 }
 
-func TestLexicalFor_CachesUntilContextChanges(t *testing.T) {
+func TestEntryFor_CachesUntilContextChanges(t *testing.T) {
 	e := NewRetrievalEngine(embedding.NewNull(), t.TempDir(), zap.NewNop())
 	fc := authDBCacheContext()
 
-	segs1, lex1 := e.lexicalFor(fc)
-	segs2, lex2 := e.lexicalFor(fc)
-	if &segs1[0] != &segs2[0] || lex1 != lex2 {
-		t.Error("unchanged context must reuse the cached lexical index")
+	e1 := e.entryFor(fc)
+	e2 := e.entryFor(fc)
+	if e1 != e2 {
+		t.Error("unchanged context must reuse the cached entry")
 	}
 	fc.TotalSize += 100 // fingerprint component changes
-	_, lex3 := e.lexicalFor(fc)
-	if lex3 == lex1 {
-		t.Error("changed context must rebuild the lexical index")
+	if e3 := e.entryFor(fc); e3 == e1 {
+		t.Error("changed context must rebuild the entry")
 	}
 }
 
@@ -255,5 +255,128 @@ func TestManager_CreateKnowledgeContextFromJSONL(t *testing.T) {
 	}
 	if fc.Metadata[knowledgeMetaSources] != "2" {
 		t.Errorf("sources metadata = %v", fc.Metadata)
+	}
+}
+
+// countingProvider records every Embed batch size, delegating to conceptProvider.
+type countingProvider struct {
+	conceptProvider
+	batches []int
+}
+
+func (c *countingProvider) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+	c.batches = append(c.batches, len(texts))
+	return c.conceptProvider.Embed(ctx, texts)
+}
+
+// bigAuthCorpus builds a corpus with far more passages than the rerank pool.
+func bigAuthCorpus(n int) *FileContext {
+	fc := &FileContext{ID: "big-kb", Name: "big-kb", Mode: ModeKnowledge}
+	for i := 0; i < n; i++ {
+		fc.Files = append(fc.Files, utils.FileInfo{
+			Path:    fmt.Sprintf("docs/page-%04d.md#0001", i),
+			Type:    "md",
+			Content: "oauth login bearer token authentication flows for page " + itoa(i),
+			Size:    60,
+		})
+	}
+	fc.FileCount = len(fc.Files)
+	fc.TotalSize = int64(60 * n)
+	return fc
+}
+
+// TestRetrieveHybrid_EmbedsOnlyTheCandidatePool pins the scalability contract:
+// per-query embedding cost is bounded by the pool, never the corpus size.
+func TestRetrieveHybrid_EmbedsOnlyTheCandidatePool(t *testing.T) {
+	prov := &countingProvider{}
+	e := NewRetrievalEngine(prov, t.TempDir(), zap.NewNop())
+	fc := bigAuthCorpus(500) // 500 passages >> pool
+
+	if _, err := e.RetrieveHybrid(context.Background(), fc, "oauth login authentication", 8); err != nil {
+		t.Fatal(err)
+	}
+	var passagesEmbedded int
+	for _, b := range prov.batches {
+		if b > hybridMaxPool {
+			t.Fatalf("one Embed batch carried %d texts — corpus leaked past the pool cap %d", b, hybridMaxPool)
+		}
+		if b > 1 {
+			passagesEmbedded += b
+		}
+	}
+	if passagesEmbedded == 0 || passagesEmbedded > hybridMaxPool {
+		t.Fatalf("passages embedded = %d, want 1..%d (pool-bounded)", passagesEmbedded, hybridMaxPool)
+	}
+
+	// Same query again: candidates already cached — only the query re-embeds.
+	prov.batches = nil
+	if _, err := e.RetrieveHybrid(context.Background(), fc, "oauth login authentication", 8); err != nil {
+		t.Fatal(err)
+	}
+	for _, b := range prov.batches {
+		if b != 1 {
+			t.Fatalf("repeat query must embed nothing but the query, got batch of %d", b)
+		}
+	}
+}
+
+// TestRetrieveHybrid_SemanticFallbackUsesCachedVectors covers queries with zero
+// lexical overlap: cosine over already-cached vectors, no new passage embeds.
+func TestRetrieveHybrid_SemanticFallbackUsesCachedVectors(t *testing.T) {
+	prov := &countingProvider{}
+	e := NewRetrievalEngine(prov, t.TempDir(), zap.NewNop())
+	fc := authDBCacheContext()
+
+	// Prime the vector cache through a lexical query.
+	if _, err := e.RetrieveHybrid(context.Background(), fc, "oauth login token", 2); err != nil {
+		t.Fatal(err)
+	}
+	prov.batches = nil
+
+	// No corpus term matches; concept-space still maps to auth.
+	segs, err := e.RetrieveHybrid(context.Background(), fc, "signin credential verification password", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(segs) == 0 || segs[0].FilePath != "auth.go" {
+		t.Fatalf("semantic fallback top hit = %v, want auth.go", segs)
+	}
+	for _, b := range prov.batches {
+		if b != 1 {
+			t.Fatalf("semantic fallback must only embed the query, got batch of %d", b)
+		}
+	}
+}
+
+// TestKnowledgeDigest_MemoizedPerRevision pins the per-turn digest cost.
+func TestKnowledgeDigest_MemoizedPerRevision(t *testing.T) {
+	m := newTestManager(t)
+	fc := knowledgeTestContext()
+	m.contexts[fc.ID] = fc
+
+	first := m.KnowledgeDigest(fc)
+	fc.Files = fc.Files[:1] // mutate WITHOUT touching the fingerprint
+	if got := m.KnowledgeDigest(fc); got != first {
+		t.Fatal("same revision must serve the memoized digest")
+	}
+	fc.TotalSize += 1 // revision changes → rebuild
+	if got := m.KnowledgeDigest(fc); got == first {
+		t.Fatal("new revision must rebuild the digest")
+	}
+}
+
+// TestFormatKnowledgeHits_Snippets pins the compact search output: bounded
+// passages with an elision marker, never the raw segment dump.
+func TestFormatKnowledgeHits_Snippets(t *testing.T) {
+	long := strings.Repeat("word ", 200) // ~1000 chars
+	out := FormatKnowledgeHits("q", []KnowledgeHit{{
+		ContextName: "docs",
+		Seg:         Segment{FilePath: "a.md#0001", StartLine: 1, EndLine: 30, Content: long},
+	}})
+	if !strings.Contains(out, "[…]") || !strings.Contains(out, "snippets") {
+		t.Errorf("long passages must be elided with a marker:\n%s", out)
+	}
+	if len(out) > 1200 {
+		t.Errorf("single-hit result = %d bytes, want snippet-bounded", len(out))
 	}
 }

--- a/cli/ctxmgr/manager.go
+++ b/cli/ctxmgr/manager.go
@@ -35,6 +35,12 @@ type Manager struct {
 	// via AttachEmbeddingProvider. nil/disabled → --rag attachments degrade to the
 	// legacy whole-content path, so retrieval is purely additive.
 	retrieval *RetrievalEngine
+
+	// digestMu/digestCache memoize the knowledge index card per context
+	// revision: prompt assembly runs every turn and the digest walk is
+	// O(corpus), so recomputing it per turn scales with the corpus for free.
+	digestMu    sync.Mutex
+	digestCache map[string]knowledgeDigestEntry
 }
 
 // AttachEmbeddingProvider wires (or rewires) the embedding provider that powers
@@ -291,8 +297,13 @@ func (m *Manager) DeleteContext(contextID string) error {
 		return fmt.Errorf("erro ao deletar contexto do disco: %w", err)
 	}
 
-	// Deletar da memória
+	// Deletar da memória + caches derivados (lexical/vetorial em RAM, vetores
+	// persistidos em disco e o digest memoizado) — nada órfão sobrevive.
 	delete(m.contexts, contextID)
+	m.retrieval.DropCache(contextID)
+	m.digestMu.Lock()
+	delete(m.digestCache, contextID)
+	m.digestMu.Unlock()
 
 	m.logger.Info("Contexto deletado",
 		zap.String("id", contextID),
@@ -610,7 +621,7 @@ func (m *Manager) BuildPromptMessages(sessionID string, opts FormatOptions) ([]m
 		if ctx.Mode == ModeKnowledge {
 			messages = append(messages, models.Message{
 				Role:    promptRole(opts.Role),
-				Content: BuildKnowledgeDigest(ctx, 0),
+				Content: m.KnowledgeDigest(ctx),
 			})
 			continue
 		}

--- a/cli/ctxmgr/retrieval.go
+++ b/cli/ctxmgr/retrieval.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/diillson/chatcli/llm/embedding"
 	"github.com/diillson/chatcli/llm/embedding/vindex"
@@ -45,6 +46,12 @@ const (
 const (
 	hybridVecWeight = 0.55
 	hybridLexWeight = 0.45
+
+	// hybridMaxPool caps the BM25 candidate pool, which is also the per-call
+	// embedding budget of the rerank stage: the engine NEVER embeds more than
+	// this many passages for one query — corpus size does not enter the cost.
+	// Comfortably under every provider's batch limit (Voyage caps at 128).
+	hybridMaxPool = 96
 )
 
 // RetrievalEngine builds and queries per-context passage vectors.
@@ -67,11 +74,15 @@ type lexCacheStore struct {
 	entries map[string]*lexCacheEntry
 }
 
-// lexCacheEntry memoizes the expensive per-context derivations.
+// lexCacheEntry memoizes the expensive per-context derivations: segments,
+// BM25 index and the vector-index handle. Holding the vindex here is what
+// keeps the per-call cost flat — constructing it per query re-parses the
+// whole persisted JSON, which grows with everything ever embedded.
 type lexCacheEntry struct {
 	fingerprint string
 	segs        []Segment
 	lex         *lexicalIndex
+	vec         *vindex.Index
 }
 
 // NewRetrievalEngine wires an engine over an embedding provider. baseDir is the
@@ -157,6 +168,12 @@ func (e *RetrievalEngine) Retrieve(ctx context.Context, fc *FileContext, query s
 // configured. This is the knowledge-mode path: unlike Retrieve it never
 // requires an API key — without a provider it degrades to lexical-only, and a
 // failing embedding call degrades the same way instead of breaking the turn.
+//
+// Scalability contract: BM25 does RECALL over the whole corpus (in-memory,
+// fingerprint-cached); embeddings only RERANK the candidate pool. Per-query
+// embedding cost is bounded by hybridMaxPool regardless of corpus size — a
+// 60MB corpus is never embedded wholesale, and the vector cache only ever
+// holds passages that some query actually surfaced.
 func (e *RetrievalEngine) RetrieveHybrid(ctx context.Context, fc *FileContext, query string, k int) ([]Segment, error) {
 	if e == nil || fc == nil || strings.TrimSpace(query) == "" {
 		return nil, nil
@@ -164,18 +181,29 @@ func (e *RetrievalEngine) RetrieveHybrid(ctx context.Context, fc *FileContext, q
 	if k <= 0 {
 		k = DefaultRetrievalTopK
 	}
-	segs, lex := e.lexicalFor(fc)
-	if len(segs) == 0 {
+	entry := e.entryFor(fc)
+	if len(entry.segs) == 0 {
 		return nil, nil
 	}
-	// Over-fetch each signal so fusion has real candidates to rerank.
-	pool := k * 3
-	if pool < 24 {
-		pool = 24
+	// Over-fetch so the rerank has real candidates; the pool is also the
+	// per-query embedding budget.
+	pool := k * 6
+	if pool < 48 {
+		pool = 48
+	}
+	if pool > hybridMaxPool {
+		pool = hybridMaxPool
 	}
 
-	lexScores := normalizeHits(lex.search(query, pool))
-	vecScores := e.vectorScores(ctx, fc, segs, query, pool)
+	lexHits := entry.lex.search(query, pool)
+	if len(lexHits) == 0 {
+		// No lexical signal at all (query terms absent from the corpus): fall
+		// back to cosine over the vectors already cached by past queries.
+		// Cheap — one query embedding, zero new passage embeddings.
+		return e.semanticOnly(ctx, entry, query, k), nil
+	}
+	lexScores := normalizeHits(lexHits)
+	vecScores := e.rerankCandidates(ctx, entry, lexHits, query)
 
 	fused := make(map[int]float64, len(lexScores)+len(vecScores))
 	if len(vecScores) == 0 {
@@ -204,43 +232,42 @@ func (e *RetrievalEngine) RetrieveHybrid(ctx context.Context, fc *FileContext, q
 	}
 	out := make([]Segment, 0, len(order))
 	for _, i := range order {
-		out = append(out, segs[i])
+		out = append(out, entry.segs[i])
 	}
 	return out, nil
 }
 
-// vectorScores returns min-max-normalized cosine scores by segment index, or
-// nil when embeddings are unavailable or fail (the hybrid then runs lexical-only).
-func (e *RetrievalEngine) vectorScores(ctx context.Context, fc *FileContext, segs []Segment, query string, pool int) map[int]float64 {
-	if !e.Enabled() {
+// rerankCandidates embeds ONLY the BM25 candidates still missing from the
+// vector cache (≤ pool per query, one small provider batch), then returns
+// min-max-normalized cosine scores by segment index. Nil when embeddings are
+// unavailable or fail — the hybrid then runs lexical-only.
+func (e *RetrievalEngine) rerankCandidates(ctx context.Context, entry *lexCacheEntry, candidates []lexHit, query string) map[int]float64 {
+	if !e.Enabled() || entry.vec == nil {
 		return nil
 	}
-	idxByID := make(map[string]int, len(segs))
-	keep := make(map[string]struct{}, len(segs))
-	allIDs := make([]string, 0, len(segs))
-	for i, s := range segs {
-		idxByID[s.ID] = i
-		keep[s.ID] = struct{}{}
-		allIDs = append(allIDs, s.ID)
+	idxByID := make(map[string]int, len(candidates))
+	ids := make([]string, 0, len(candidates))
+	for _, h := range candidates {
+		s := entry.segs[h.idx]
+		idxByID[s.ID] = h.idx
+		ids = append(ids, s.ID)
 	}
-	idx := vindex.New(e.vectorPath(fc.ID), e.provider, vindex.WithLogger(e.logger))
-	idx.Prune(keep)
-	if missing := idx.MissingFor(allIDs); len(missing) > 0 {
+	if missing := entry.vec.MissingFor(ids); len(missing) > 0 {
 		sub := make(map[string]string, len(missing))
 		for _, id := range missing {
-			sub[id] = segs[idxByID[id]].Content
+			sub[id] = entry.segs[idxByID[id]].Content
 		}
-		if err := idx.Upsert(ctx, sub); err != nil {
+		if err := entry.vec.Upsert(ctx, sub); err != nil {
 			e.logger.Warn("knowledge: embedding unavailable; falling back to lexical retrieval", zap.Error(err))
 			return nil
 		}
 	}
-	qv, err := idx.EmbedQuery(ctx, query)
+	qv, err := entry.vec.EmbedQuery(ctx, query)
 	if err != nil {
 		e.logger.Warn("knowledge: query embedding failed; falling back to lexical retrieval", zap.Error(err))
 		return nil
 	}
-	hits := idx.Search(qv, pool, segmentScoreFloor)
+	hits := entry.vec.ScoreAgainst(qv, ids, segmentScoreFloor)
 	if len(hits) == 0 {
 		return nil
 	}
@@ -260,24 +287,76 @@ func (e *RetrievalEngine) vectorScores(ctx context.Context, fc *FileContext, seg
 	return out
 }
 
-// lexicalFor returns the cached segment list and BM25 index for fc, rebuilding
-// both when the context changed since the last call.
-func (e *RetrievalEngine) lexicalFor(fc *FileContext) ([]Segment, *lexicalIndex) {
+// semanticOnly answers queries with zero lexical overlap using the vectors
+// already accumulated by previous queries. It never embeds new passages.
+func (e *RetrievalEngine) semanticOnly(ctx context.Context, entry *lexCacheEntry, query string, k int) []Segment {
+	if !e.Enabled() || entry.vec == nil || entry.vec.Count() == 0 {
+		return nil
+	}
+	qv, err := entry.vec.EmbedQuery(ctx, query)
+	if err != nil {
+		e.logger.Warn("knowledge: query embedding failed; no results for non-lexical query", zap.Error(err))
+		return nil
+	}
+	byID := make(map[string]Segment, len(entry.segs))
+	for _, s := range entry.segs {
+		byID[s.ID] = s
+	}
+	hits := entry.vec.Search(qv, k, segmentScoreFloor)
+	out := make([]Segment, 0, len(hits))
+	for _, h := range hits {
+		if s, ok := byID[h.ID]; ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// entryFor returns the cached derivations for fc — segments, BM25 index and
+// the vector-index handle — rebuilding them when the context changed. The
+// vindex file is loaded ONCE per rebuild (not per query) and pruned of
+// segments that no longer exist at the same moment.
+func (e *RetrievalEngine) entryFor(fc *FileContext) *lexCacheEntry {
+	fp := contextFingerprint(fc)
 	if e.lex == nil {
 		// Engine built without the constructor (zero value): compute uncached.
-		segs := SegmentFiles(fc.Files, e.segOpts)
-		return segs, newLexicalIndex(segs)
+		return e.buildEntry(fc, fp)
 	}
-	fp := fmt.Sprintf("%s|%d|%d", fc.UpdatedAt.UTC().Format("20060102T150405.000"), fc.FileCount, fc.TotalSize)
 	e.lex.mu.Lock()
 	defer e.lex.mu.Unlock()
 	if entry, ok := e.lex.entries[fc.ID]; ok && entry.fingerprint == fp {
-		return entry.segs, entry.lex
+		return entry
 	}
+	entry := e.buildEntry(fc, fp)
+	e.lex.entries[fc.ID] = entry
+	return entry
+}
+
+// buildEntry performs the one-time-per-corpus derivations and logs their cost
+// so a multi-second first call on a large corpus is explainable, not mysterious.
+func (e *RetrievalEngine) buildEntry(fc *FileContext, fp string) *lexCacheEntry {
+	start := time.Now()
 	segs := SegmentFiles(fc.Files, e.segOpts)
 	entry := &lexCacheEntry{fingerprint: fp, segs: segs, lex: newLexicalIndex(segs)}
-	e.lex.entries[fc.ID] = entry
-	return entry.segs, entry.lex
+	if e.Enabled() {
+		entry.vec = vindex.New(e.vectorPath(fc.ID), e.provider, vindex.WithLogger(e.logger))
+		keep := make(map[string]struct{}, len(segs))
+		for _, s := range segs {
+			keep[s.ID] = struct{}{}
+		}
+		entry.vec.Prune(keep)
+	}
+	e.logger.Info("knowledge: corpus indexed",
+		zap.String("context", fc.Name),
+		zap.Int("passages", len(segs)),
+		zap.Duration("took", time.Since(start)))
+	return entry
+}
+
+// contextFingerprint identifies one revision of a context's content; caches
+// keyed by it invalidate exactly when the context is updated.
+func contextFingerprint(fc *FileContext) string {
+	return fmt.Sprintf("%s|%d|%d", fc.UpdatedAt.UTC().Format("20060102T150405.000"), fc.FileCount, fc.TotalSize)
 }
 
 // normalizeHits min-max-normalizes BM25 scores to [0,1] by segment index.

--- a/cli/knowledge_adapter.go
+++ b/cli/knowledge_adapter.go
@@ -129,13 +129,14 @@ func (cli *ChatCLI) knowledgeAgentBlock() string {
 	if sessionID == "" {
 		sessionID = "default"
 	}
-	kbs := cli.contextHandler.GetManager().AttachedKnowledge(sessionID)
+	mgr := cli.contextHandler.GetManager()
+	kbs := mgr.AttachedKnowledge(sessionID)
 	if len(kbs) == 0 {
 		return ""
 	}
 	var b strings.Builder
 	for _, fc := range kbs {
-		b.WriteString(ctxmgr.BuildKnowledgeDigest(fc, 0))
+		b.WriteString(mgr.KnowledgeDigest(fc))
 		b.WriteString("\n")
 	}
 	b.WriteString("Use the @knowledge tool to work with these bases: search passages, read full documents with get (paged), inspect coverage with toc. Ground answers in retrieved content and cite source paths.")

--- a/llm/embedding/vindex/vindex.go
+++ b/llm/embedding/vindex/vindex.go
@@ -203,6 +203,38 @@ func (x *Index) Search(query []float32, k int, minScore float64) []Hit {
 	return sel.sortedDesc()
 }
 
+// ScoreAgainst scores ONLY the given ids against query, returning hits that
+// clear minScore, strongest first (ties by ascending id). This is the rerank
+// primitive: callers that pre-filter candidates (e.g. BM25 recall) pay cosine
+// cost proportional to the candidate pool, never the index size. Ids without
+// a stored vector are skipped silently.
+func (x *Index) ScoreAgainst(query []float32, ids []string, minScore float64) []Hit {
+	if !x.Enabled() || len(query) == 0 || len(ids) == 0 {
+		return nil
+	}
+	x.mu.RLock()
+	defer x.mu.RUnlock()
+	out := make([]Hit, 0, len(ids))
+	for _, id := range ids {
+		vec, ok := x.entries[id]
+		if !ok || len(vec) != len(query) {
+			continue
+		}
+		score := float64(embedding.CosineSimilarity(query, vec))
+		if score < minScore {
+			continue
+		}
+		out = append(out, Hit{ID: id, Score: score})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Score != out[j].Score {
+			return out[i].Score > out[j].Score
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out
+}
+
 // Forget removes the given ids and persists.
 func (x *Index) Forget(ids ...string) {
 	if !x.Enabled() || len(ids) == 0 {
@@ -310,7 +342,10 @@ func (x *Index) persist() error {
 	if err := os.MkdirAll(filepath.Dir(x.path), 0o750); err != nil {
 		return err
 	}
-	data, err := json.MarshalIndent(f, "", "  ")
+	// Compact encoding on purpose: a corpus-scale index serializes to tens of
+	// MB, and indented JSON made every persist (and the file itself) several
+	// times heavier for zero benefit — nobody reads vectors by eye.
+	data, err := json.Marshal(f)
 	if err != nil {
 		return err
 	}

--- a/llm/embedding/vindex/vindex_test.go
+++ b/llm/embedding/vindex/vindex_test.go
@@ -158,3 +158,48 @@ func TestIndex_ForgetRemoves(t *testing.T) {
 		t.Fatalf("Forget should drop a, count=%d", x.Count())
 	}
 }
+
+func TestIndex_ScoreAgainst(t *testing.T) {
+	x := New(filepath.Join(t.TempDir(), "v.json"), newProvider())
+	if err := x.Upsert(context.Background(), map[string]string{
+		"alpha": "alpha text",
+		"beta":  "beta text",
+		"gamma": "gamma text",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	qv, err := x.EmbedQuery(context.Background(), "alpha question")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Scores ONLY the requested ids; unknown ids are skipped silently.
+	hits := x.ScoreAgainst(qv, []string{"alpha", "beta", "nope"}, 0)
+	if len(hits) != 2 || hits[0].ID != "alpha" {
+		t.Fatalf("hits = %+v, want alpha first and nope skipped", hits)
+	}
+	if hits[0].Score <= hits[1].Score {
+		t.Fatalf("alpha must outscore beta: %+v", hits)
+	}
+
+	// gamma is in the index but not in the candidate set — never scored.
+	for _, h := range hits {
+		if h.ID == "gamma" {
+			t.Fatal("non-candidate id leaked into the rerank")
+		}
+	}
+
+	// The relevance floor applies per call.
+	if got := x.ScoreAgainst(qv, []string{"beta"}, 0.99); len(got) != 0 {
+		t.Fatalf("floor must filter weak candidates, got %+v", got)
+	}
+
+	// Disabled/empty inputs are nil-safe.
+	if x.ScoreAgainst(nil, []string{"alpha"}, 0) != nil || x.ScoreAgainst(qv, nil, 0) != nil {
+		t.Fatal("empty inputs must return nil")
+	}
+	off := New(filepath.Join(t.TempDir(), "v2.json"), embedding.NewNull())
+	if off.ScoreAgainst(qv, []string{"alpha"}, 0) != nil {
+		t.Fatal("disabled index must return nil")
+	}
+}


### PR DESCRIPTION
## Problema (reportado em uso real)

`@knowledge search` em docs grandes: **demora enorme** e **flood de output no terminal** durante o spinner.

## Causa raiz (3 problemas estruturais)

1. **Embedding do corpus inteiro na primeira busca** — `vectorScores` fazia `Upsert` de TODOS os segmentos faltantes num único batch pro provider (um corpus de 6MB ≈ 5k trechos; o limite do Voyage é 128 inputs por chamada).
2. **Índice vetorial reconstruído POR QUERY** — `vindex.New` a cada busca re-parseava o `.vec.json` inteiro (dezenas de MB depois do corpus embedado), e o persist usava `MarshalIndent` (arquivo ~2x maior, serialização mais cara). `Prune` por chamada repersistia tudo.
3. **Resultado do search com passagens completas** — cards enormes e repetidos no feed de ações.

## Arquitetura nova: recall → rerank

```
BM25 (corpus inteiro, em memória, cacheado por revisão)  →  recall
embeddings (SÓ os ≤96 candidatos do pool)                →  rerank
```

- **Custo de embedding por query limitado a 96 trechos**, independente do corpus ter 6MB ou 60MB; o cache vetorial só guarda trechos que alguma query realmente trouxe.
- Query **sem overlap lexical** cai em cosine sobre os vetores já cacheados (1 embedding de query, zero de trechos).
- **Handle do vindex no cache por contexto**: arquivo carregado e podado **uma vez por revisão do corpus**, não por query; persist em JSON compacto.
- `vindex.ScoreAgainst` novo: scoring restrito ao conjunto de candidatos (aditivo, coberto por teste).
- **Snippets no resultado do search** (limite de 360 chars por trecho, corte em fronteira de palavra, marcador de elisão) — o locate fica skimmável; leitura completa continua no `get`.
- **Digest memoizado por revisão** (montagem de prompt roda a cada turno; antes era walk O(corpus) por turno), com eviction no delete do contexto.
- Indexação única do corpus loga custo/duração (`knowledge: corpus indexed`).

## Testes que pinam o contrato

- `EmbedsOnlyTheCandidatePool`: corpus de 500 trechos → nenhum batch acima de 96; repetir a query embeda só a query.
- `SemanticFallbackUsesCachedVectors`: query sem termos do corpus resolve via vetores cacheados, sem novos embeds.
- `KnowledgeDigest_MemoizedPerRevision`, `FormatKnowledgeHits_Snippets`, `ScoreAgainst` (floor, candidatos-só, nil-safety), cache de entry por fingerprint.

Gates locais: API breaking ✅ (aditivo), AI smells ✅, patch coverage **92.4%** ✅.