### PR TITLE
fix(completer): offer the knowledge mode after /context --mode

### DIFF
--- a/cli/cli_completer.go
+++ b/cli/cli_completer.go
@@ -694,6 +694,7 @@ func contextModeValueSuggestions() []prompt.Suggest {
 		{Text: "summary", Description: i18n.T("complete.context.mode_summary")},
 		{Text: "chunked", Description: i18n.T("complete.context.mode_chunked")},
 		{Text: "smart", Description: i18n.T("complete.context.mode_smart")},
+		{Text: "knowledge", Description: i18n.T("complete.context.mode_knowledge")},
 	}
 }
 

--- a/cli/cli_completer_context_test.go
+++ b/cli/cli_completer_context_test.go
@@ -105,6 +105,29 @@ func TestContextCreateOrUpdateSuggestions_FlagPrefixOffersFlagList(t *testing.T)
 	}
 }
 
+// TestContextModeValueSuggestions_ListsEveryProcessingMode drives the
+// create-path completer to the position right after `--mode` and asserts
+// every mode the handler's validator accepts is offered — including
+// `knowledge`, which was missing from the value list (the flag's own
+// description already advertised it). The palette overlay reuses this same
+// completer output, so the gate here covers both surfaces.
+func TestContextModeValueSuggestions_ListsEveryProcessingMode(t *testing.T) {
+	cli := newCompleterTestCLI(t)
+	line := "/context create myctx ./src --mode "
+	d := docWithCursor(line, len(line))
+	out := cli.contextCreateOrUpdateSuggestions("create",
+		[]string{"/context", "create", "myctx", "./src", "--mode"}, line, d)
+	seen := map[string]bool{}
+	for _, s := range out {
+		seen[s.Text] = true
+	}
+	for _, want := range []string{"full", "summary", "chunked", "smart", "knowledge"} {
+		if !seen[want] {
+			t.Errorf("expected mode %q after --mode; got %+v", want, out)
+		}
+	}
+}
+
 func TestContextExportSuggestions_AfterNameSuggestsPath(t *testing.T) {
 	cli := newCompleterTestCLI(t)
 	line := "/context export myctx "

--- a/cli/cli_completer_static_test.go
+++ b/cli/cli_completer_static_test.go
@@ -135,6 +135,7 @@ func TestContextModeValueSuggestions_KnownValuesOnly(t *testing.T) {
 	got := contextModeValueSuggestions()
 	wantValues := map[string]bool{
 		"full": true, "summary": true, "chunked": true, "smart": true,
+		"knowledge": true,
 	}
 	if len(got) != len(wantValues) {
 		t.Errorf("len = %d, want %d", len(got), len(wantValues))

--- a/cli/palette_bridge_test.go
+++ b/cli/palette_bridge_test.go
@@ -54,3 +54,26 @@ func TestPaletteTriggerGating(t *testing.T) {
 		t.Error("suppressPaletteOnce was not cleared after use")
 	}
 }
+
+// TestPaletteSuggest_ContextModeValuesIncludeKnowledge pins the palette
+// surface for `/context … --mode`: the overlay renders whatever the live
+// completer returns, so every processing mode — knowledge included — must
+// come back through paletteSuggest with a human description attached.
+func TestPaletteSuggest_ContextModeValuesIncludeKnowledge(t *testing.T) {
+	c := newCompleterTestCLI(t)
+	out := c.paletteSuggest("/context create myctx ./src --mode ")
+	seen := map[string]string{}
+	for _, s := range out {
+		seen[s.Text] = s.Desc
+	}
+	for _, want := range []string{"full", "summary", "chunked", "smart", "knowledge"} {
+		desc, ok := seen[want]
+		if !ok {
+			t.Errorf("palette is missing mode %q after --mode; got %+v", want, out)
+			continue
+		}
+		if desc == "" {
+			t.Errorf("palette mode %q has an empty description", want)
+		}
+	}
+}

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -2355,6 +2355,7 @@
   "complete.context.mode_summary": "Only directory structure and metadata",
   "complete.context.mode_chunked": "Split into manageable chunks",
   "complete.context.mode_smart": "AI selects files relevant to the prompt",
+  "complete.context.mode_knowledge": "Knowledge base: injects an index card + per-turn retrieval (BM25 + vectors)",
   "complete.context.prompt_name": "Type the context name (e.g. my-project)",
   "complete.context.prompt_merge_name": "Type the name of the new merged context",
   "complete.context.not_chunked_warning": "⚠️  This context is not split into chunks",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -2355,6 +2355,7 @@
   "complete.context.mode_summary": "Only directory structure and metadata",
   "complete.context.mode_chunked": "Split into manageable chunks",
   "complete.context.mode_smart": "AI selects files relevant to the prompt",
+  "complete.context.mode_knowledge": "Knowledge base: injects an index card + per-turn retrieval (BM25 + vectors)",
   "complete.context.prompt_name": "Type the context name (e.g. my-project)",
   "complete.context.prompt_merge_name": "Type the name of the new merged context",
   "complete.context.not_chunked_warning": "⚠️  This context is not split into chunks",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -2355,6 +2355,7 @@
   "complete.context.mode_summary": "Apenas estrutura de diretórios e metadados",
   "complete.context.mode_chunked": "Divide em chunks gerenciáveis",
   "complete.context.mode_smart": "IA seleciona arquivos relevantes ao prompt",
+  "complete.context.mode_knowledge": "Base de conhecimento: injeta index card + retrieval por turno (BM25 + vetores)",
   "complete.context.prompt_name": "Digite o nome do contexto (ex: meu-projeto)",
   "complete.context.prompt_merge_name": "Digite o nome do novo contexto mesclado",
   "complete.context.not_chunked_warning": "⚠️  Este contexto não está dividido em chunks",


### PR DESCRIPTION
## Problema

O completer de valores do `--mode` no `/context create`/`update` parou em `full/summary/chunked/smart` — o modo `knowledge` (shipped nos PRs #1037/#1039/#1040) nunca era sugerido. Como o command palette renderiza exatamente a saída do completer (`paletteSuggest` → `cli.completer`), o gap aparecia nas duas superfícies: inline e overlay.

Curiosamente só a lista de valores ficou pra trás — a descrição da flag (`complete.context.flag_mode`), os help texts e o validator do handler já conheciam `knowledge`.

## Mudanças

- `knowledge` adicionado a `contextModeValueSuggestions()` com a key i18n `complete.context.mode_knowledge` nos três locales (pt-BR, en, en-US)
- Testes em três camadas pra evitar drift futuro:
  - lista estática (`TestContextModeValueSuggestions_KnownValuesOnly` atualizado pra 5 modos)
  - dispatcher do create na posição pós `--mode` (`TestContextModeValueSuggestions_ListsEveryProcessingMode`)
  - superfície do palette via `paletteSuggest` (`TestPaletteSuggest_ContextModeValuesIncludeKnowledge`), confirmando que o overlay completa e exibe o modo com descrição

## Verificação

- Auditei o restante dos completers do `/context` contra os parsers reais: create/update (`--mode/--description/--tags/--force`), attach (`--priority/--chunk/--chunks/--rag`), inspect (`--chunk`) — todos já cobertos; o `@knowledge` tool já entra dinamicamente via registry de plugins
- `go test ./cli/ ./i18n/...` verde; gates de i18n parity e patch coverage rodados localmente (100%)
