### PR TITLE
feat(tls): global corporate TLS trust overrides for all outbound clients

### DIFF
--- a/cli/config_env_defaults.go
+++ b/cli/config_env_defaults.go
@@ -137,6 +137,10 @@ var envDefaults = map[string]envDefault{
 	"CHATCLI_TOOL_RESULT_BUDGET_CHARS":     {Value: "200000", Source: "agent.DefaultTurnBudgetChars"},
 	"CHATCLI_TOOL_RESULT_MAX_CHARS":        {Value: "20000", Source: "agent.DefaultPerResultMaxChars"},
 
+	// ─── Resilience: global TLS trust ────────────────────────────
+	"CHATCLI_CA_BUNDLE":                {Value: "(system trust store)", Source: "utils.ApplyGlobalTLSTrust"},
+	"CHATCLI_TLS_INSECURE_SKIP_VERIFY": {Value: "false", IsBool: true, Source: "utils.ApplyGlobalTLSTrust"},
+
 	// ─── Resilience: bedrock proxy ───────────────────────────────
 	"CHATCLI_BEDROCK_INSECURE_SKIP_VERIFY": {Value: "false", IsBool: true, Source: "bedrock client"},
 	"CHATCLI_BEDROCK_ENABLE_IMDS":          {Value: "false", IsBool: true, Source: "bedrock client"},

--- a/cli/config_sections.go
+++ b/cli/config_sections.go
@@ -725,6 +725,11 @@ func (cli *ChatCLI) showConfigResilience() {
 	kv(p, "CHATCLI_TOOL_RESULT_MAX_CHARS", envOr("CHATCLI_TOOL_RESULT_MAX_CHARS"))
 
 	fmt.Println(p)
+	subheader(p, "cfg.sub.resil.tls_trust")
+	kv(p, "CHATCLI_CA_BUNDLE", envOr("CHATCLI_CA_BUNDLE"))
+	kv(p, "CHATCLI_TLS_INSECURE_SKIP_VERIFY", envBool("CHATCLI_TLS_INSECURE_SKIP_VERIFY"))
+
+	fmt.Println(p)
 	subheader(p, "cfg.sub.resil.bedrock_proxy")
 	kv(p, "CHATCLI_BEDROCK_CA_BUNDLE", envOr("CHATCLI_BEDROCK_CA_BUNDLE"))
 	kv(p, "CHATCLI_BEDROCK_INSECURE_SKIP_VERIFY", envBool("CHATCLI_BEDROCK_INSECURE_SKIP_VERIFY"))

--- a/cli/plugins/builtin_web_httpclient.go
+++ b/cli/plugins/builtin_web_httpclient.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/diillson/chatcli/utils"
 	"golang.org/x/net/http/httpproxy"
 )
 
@@ -149,6 +150,10 @@ func newWebTransport() *http.Transport {
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
+		// Corporate TLS trust overrides (CHATCLI_CA_BUNDLE /
+		// CHATCLI_TLS_INSECURE_SKIP_VERIFY) — web tools cross the same
+		// TLS-intercepting proxy as the LLM providers.
+		TLSClientConfig: utils.GlobalTLSConfig().Clone(),
 	}
 }
 

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -1844,6 +1844,7 @@
   "cfg.sub.resil.payload": "── Payload & recovery",
   "cfg.sub.resil.streaming": "── Streaming",
   "cfg.sub.resil.compaction": "── Compaction",
+  "cfg.sub.resil.tls_trust": "── Global TLS trust (corporate proxy CA)",
   "cfg.sub.resil.bedrock_proxy": "── Bedrock corporate proxy",
   "cfg.sub.resil.web_proxy": "── Web tools corporate proxy (webfetch/websearch/osv)",
   "cfg.sub.resil.session_state": "── Session state",

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -1997,7 +1997,7 @@
   "complete.config.general": "dotenv, locale, logging, version check",
   "complete.config.providers": "Env vars for all providers (OpenAI, Claude, Bedrock, etc)",
   "complete.config.agent": "Agent runtime — workers, subagents, coder UI",
-  "complete.config.resilience": "Payload caps, recovery, stream timeout, Bedrock proxy",
+  "complete.config.resilience": "Payload caps, recovery, stream timeout, global TLS trust, Bedrock proxy",
   "complete.config.session": "Session, cost, budget, contexts, memory",
   "complete.config.integrations": "MCP, hooks, plugins, websearch, skills, worktrees, watcher, remote",
   "complete.config.auth": "OAuth status per provider + keychain",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1844,6 +1844,7 @@
   "cfg.sub.resil.payload": "── Payload & recovery",
   "cfg.sub.resil.streaming": "── Streaming",
   "cfg.sub.resil.compaction": "── Compaction",
+  "cfg.sub.resil.tls_trust": "── Global TLS trust (corporate proxy CA)",
   "cfg.sub.resil.bedrock_proxy": "── Bedrock corporate proxy",
   "cfg.sub.resil.web_proxy": "── Web tools corporate proxy (webfetch/websearch/osv)",
   "cfg.sub.resil.session_state": "── Session state",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1997,7 +1997,7 @@
   "complete.config.general": "dotenv, locale, logging, version check",
   "complete.config.providers": "Env vars for all providers (OpenAI, Claude, Bedrock, etc)",
   "complete.config.agent": "Agent runtime — workers, subagents, coder UI",
-  "complete.config.resilience": "Payload caps, recovery, stream timeout, Bedrock proxy",
+  "complete.config.resilience": "Payload caps, recovery, stream timeout, global TLS trust, Bedrock proxy",
   "complete.config.session": "Session, cost, budget, contexts, memory",
   "complete.config.integrations": "MCP, hooks, plugins, websearch, skills, worktrees, watcher, remote",
   "complete.config.auth": "OAuth status per provider + keychain",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -1997,7 +1997,7 @@
   "complete.config.general": "dotenv, locale, logging, version check",
   "complete.config.providers": "Env vars de todos os providers (OpenAI, Claude, Bedrock, etc)",
   "complete.config.agent": "Runtime do modo agente — workers, subagents, coder UI",
-  "complete.config.resilience": "Caps de payload, recovery, timeout de stream, proxy Bedrock",
+  "complete.config.resilience": "Caps de payload, recovery, timeout de stream, confiança TLS global, proxy Bedrock",
   "complete.config.session": "Sessão, custo, budget, contextos, memory",
   "complete.config.integrations": "MCP, hooks, plugins, websearch, skills, worktrees, watcher, remote",
   "complete.config.auth": "Status OAuth por provider + keychain",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -1844,6 +1844,7 @@
   "cfg.sub.resil.payload": "── Payload & recovery",
   "cfg.sub.resil.streaming": "── Streaming",
   "cfg.sub.resil.compaction": "── Compactação",
+  "cfg.sub.resil.tls_trust": "── Confiança TLS global (CA de proxy corporativo)",
   "cfg.sub.resil.bedrock_proxy": "── Proxy corporativo do Bedrock",
   "cfg.sub.resil.web_proxy": "── Proxy corporativo das ferramentas web (webfetch/websearch/osv)",
   "cfg.sub.resil.session_state": "── Estado da sessão",

--- a/llm/bedrock/bedrock_client.go
+++ b/llm/bedrock/bedrock_client.go
@@ -432,6 +432,17 @@ func buildCorporateHTTPClient(logger *zap.Logger) (aws.HTTPClient, string) {
 	insecure := strings.EqualFold(strings.TrimSpace(os.Getenv("CHATCLI_BEDROCK_INSECURE_SKIP_VERIFY")), "true")
 	bundlePath := strings.TrimSpace(os.Getenv("CHATCLI_BEDROCK_CA_BUNDLE"))
 
+	// Bedrock goes through the AWS SDK's own HTTP client, so the global
+	// corporate-trust overrides applied by utils.ApplyGlobalTLSTrust don't
+	// reach it. Fall back to them per variable; the Bedrock-specific ones
+	// keep precedence.
+	if !insecure {
+		insecure = strings.EqualFold(strings.TrimSpace(os.Getenv("CHATCLI_TLS_INSECURE_SKIP_VERIFY")), "true")
+	}
+	if bundlePath == "" {
+		bundlePath = strings.TrimSpace(os.Getenv("CHATCLI_CA_BUNDLE"))
+	}
+
 	if !insecure && bundlePath == "" {
 		return nil, ""
 	}
@@ -441,7 +452,7 @@ func buildCorporateHTTPClient(logger *zap.Logger) (aws.HTTPClient, string) {
 
 	if insecure {
 		tlsCfg.InsecureSkipVerify = true
-		note = "Bedrock: CHATCLI_BEDROCK_INSECURE_SKIP_VERIFY=true — TLS verification is DISABLED. Do NOT use in production; configure CHATCLI_BEDROCK_CA_BUNDLE with your corporate CA instead."
+		note = "Bedrock: TLS verification is DISABLED (CHATCLI_BEDROCK_INSECURE_SKIP_VERIFY or CHATCLI_TLS_INSECURE_SKIP_VERIFY). Do NOT use in production; configure CHATCLI_BEDROCK_CA_BUNDLE or CHATCLI_CA_BUNDLE with your corporate CA instead."
 	} else {
 		pool, err := x509.SystemCertPool()
 		if err != nil || pool == nil {

--- a/llm/bedrock/corporate_http_test.go
+++ b/llm/bedrock/corporate_http_test.go
@@ -1,0 +1,51 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package bedrock
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestBuildCorporateHTTPClientUnset(t *testing.T) {
+	t.Setenv("CHATCLI_BEDROCK_INSECURE_SKIP_VERIFY", "")
+	t.Setenv("CHATCLI_BEDROCK_CA_BUNDLE", "")
+	t.Setenv("CHATCLI_TLS_INSECURE_SKIP_VERIFY", "")
+	t.Setenv("CHATCLI_CA_BUNDLE", "")
+	client, note := buildCorporateHTTPClient(zap.NewNop())
+	if client != nil || note != "" {
+		t.Fatalf("expected SDK default client when no override is set, got %v / %q", client, note)
+	}
+}
+
+func TestBuildCorporateHTTPClientGlobalInsecureFallback(t *testing.T) {
+	t.Setenv("CHATCLI_BEDROCK_INSECURE_SKIP_VERIFY", "")
+	t.Setenv("CHATCLI_BEDROCK_CA_BUNDLE", "")
+	t.Setenv("CHATCLI_TLS_INSECURE_SKIP_VERIFY", "true")
+	t.Setenv("CHATCLI_CA_BUNDLE", "")
+	client, note := buildCorporateHTTPClient(zap.NewNop())
+	if client == nil {
+		t.Fatal("expected a custom client when the global insecure override is set")
+	}
+	if note == "" {
+		t.Fatal("expected the insecure warning note")
+	}
+}
+
+func TestBuildCorporateHTTPClientBedrockBundleKeepsPrecedence(t *testing.T) {
+	// A Bedrock-specific bundle pointing to a missing file must fail open
+	// (nil client), even when the global bundle var also points somewhere —
+	// proving the Bedrock-specific var is the one being read.
+	t.Setenv("CHATCLI_BEDROCK_INSECURE_SKIP_VERIFY", "")
+	t.Setenv("CHATCLI_TLS_INSECURE_SKIP_VERIFY", "")
+	t.Setenv("CHATCLI_BEDROCK_CA_BUNDLE", t.TempDir()+"/missing-bedrock.pem")
+	t.Setenv("CHATCLI_CA_BUNDLE", t.TempDir()+"/missing-global.pem")
+	client, _ := buildCorporateHTTPClient(zap.NewNop())
+	if client != nil {
+		t.Fatal("unreadable bundle must fall back to the SDK default client")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -96,6 +96,7 @@ func main() {
 
 	config.InitGlobal(logger)
 	config.Global.Load()
+	utils.ApplyGlobalTLSTrust(logger)
 	utils.LogStartupInfo(logger)
 
 	defer func() {
@@ -223,6 +224,7 @@ func runSubcommand(subcmd string, args []string) {
 
 	config.InitGlobal(logger)
 	config.Global.Load()
+	utils.ApplyGlobalTLSTrust(logger)
 
 	defer func() {
 		if err := logger.Sync(); err != nil {
@@ -308,6 +310,7 @@ func runDaemonSubcommand(args []string) {
 
 	config.InitGlobal(logger)
 	config.Global.Load()
+	utils.ApplyGlobalTLSTrust(logger)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/utils/http_client.go
+++ b/utils/http_client.go
@@ -33,6 +33,12 @@ func NewHTTPClient(logger *zap.Logger, timeout time.Duration) *http.Client {
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 	}
+	// Corporate TLS trust overrides (CHATCLI_CA_BUNDLE /
+	// CHATCLI_TLS_INSECURE_SKIP_VERIFY). Cloned so each provider keeps its
+	// dedicated TLS session cache.
+	if tlsCfg := GlobalTLSConfig(); tlsCfg != nil {
+		transport.TLSClientConfig = tlsCfg.Clone()
+	}
 	return NewHTTPClientWithTransport(logger, timeout, transport)
 }
 

--- a/utils/tls_config.go
+++ b/utils/tls_config.go
@@ -1,0 +1,118 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package utils
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net/http"
+	"os"
+	"strings"
+	"sync/atomic"
+
+	"go.uber.org/zap"
+)
+
+// Global TLS trust overrides for corporate proxies that perform TLS
+// interception with a private CA. They apply to every outbound HTTPS
+// client in the process (LLM providers, TTS/STT, embeddings, web tools,
+// gateway channels, MCP transports, registries), mirroring how
+// NODE_EXTRA_CA_CERTS / NODE_TLS_REJECT_UNAUTHORIZED behave process-wide
+// in Node.js tools such as Claude Code:
+//
+//   - CHATCLI_CA_BUNDLE=/path/to/pem
+//     Merges the PEM into the system cert pool and uses it as RootCAs.
+//     Go already trusts the OS cert store by default, so this is only
+//     needed when the corporate CA cannot be installed system-wide.
+//
+//   - CHATCLI_TLS_INSECURE_SKIP_VERIFY=true
+//     Disables TLS verification entirely. INSECURE — use only to confirm
+//     a corporate-proxy issue, then switch to CHATCLI_CA_BUNDLE.
+//
+// Provider-specific overrides (CHATCLI_BEDROCK_CA_BUNDLE,
+// CHATCLI_BEDROCK_INSECURE_SKIP_VERIFY) take precedence over these.
+const (
+	envCABundle           = "CHATCLI_CA_BUNDLE"
+	envInsecureSkipVerify = "CHATCLI_TLS_INSECURE_SKIP_VERIFY"
+)
+
+// globalTLSConfig holds the trust overrides resolved by ApplyGlobalTLSTrust.
+// nil means "no override": Go's defaults (system cert store) stay in effect.
+var globalTLSConfig atomic.Pointer[tls.Config]
+
+// GlobalTLSConfig returns the process-wide TLS overrides resolved by
+// ApplyGlobalTLSTrust, or nil when none are configured. Callers that build
+// their own transports should Clone() the result before mutating it.
+func GlobalTLSConfig() *tls.Config {
+	return globalTLSConfig.Load()
+}
+
+// ApplyGlobalTLSTrust resolves the CHATCLI_CA_BUNDLE /
+// CHATCLI_TLS_INSECURE_SKIP_VERIFY overrides and wires them into both the
+// transports built by NewHTTPClient and http.DefaultTransport — so bare
+// &http.Client{} instances (gateway channels, MCP transports, registries,
+// version check) inherit the corporate trust as well.
+//
+// Must run after the dotenv load so overrides set only in the .env file are
+// seen. Idempotent; calling it with no overrides set is a no-op that leaves
+// http.DefaultTransport untouched.
+func ApplyGlobalTLSTrust(logger *zap.Logger) {
+	cfg := newTLSConfigFromEnv(logger)
+	globalTLSConfig.Store(cfg)
+	if cfg == nil {
+		return
+	}
+	if t, ok := http.DefaultTransport.(*http.Transport); ok {
+		t.TLSClientConfig = cfg.Clone()
+	}
+}
+
+// newTLSConfigFromEnv builds the override config from the environment.
+// Returns nil when neither variable is set or the CA bundle is unusable
+// (unreadable file, no valid certificates) — failing open to Go's default
+// verification rather than silently weakening it.
+func newTLSConfigFromEnv(logger *zap.Logger) *tls.Config {
+	insecure := strings.EqualFold(strings.TrimSpace(os.Getenv(envInsecureSkipVerify)), "true")
+	bundlePath := strings.TrimSpace(os.Getenv(envCABundle))
+
+	if !insecure && bundlePath == "" {
+		return nil
+	}
+
+	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
+
+	if insecure {
+		// Explicit operator opt-in, mirroring NODE_TLS_REJECT_UNAUTHORIZED=0.
+		// #nosec G402 -- documented escape hatch for corporate-proxy debugging
+		cfg.InsecureSkipVerify = true
+		logger.Warn(envInsecureSkipVerify + "=true — TLS verification is DISABLED for ALL outbound connections. " +
+			"Do NOT use in production; configure " + envCABundle + " with your corporate CA instead.")
+		return cfg
+	}
+
+	pool, err := x509.SystemCertPool()
+	if err != nil || pool == nil {
+		pool = x509.NewCertPool()
+	}
+	// The CA bundle path is intentionally operator-supplied via env var —
+	// this is the documented way to trust a corporate proxy's CA.
+	// #nosec G304 G703 -- user-controlled path by design (CHATCLI_CA_BUNDLE)
+	pem, err := os.ReadFile(bundlePath)
+	if err != nil {
+		logger.Warn("failed to read "+envCABundle+"; keeping default TLS trust",
+			zap.String("path", bundlePath), zap.Error(err))
+		return nil
+	}
+	if !pool.AppendCertsFromPEM(pem) {
+		logger.Warn("no valid certificates found in "+envCABundle+"; keeping default TLS trust",
+			zap.String("path", bundlePath))
+		return nil
+	}
+	cfg.RootCAs = pool
+	logger.Info("using "+envCABundle+" for TLS trust on all outbound connections",
+		zap.String("path", bundlePath))
+	return cfg
+}

--- a/utils/tls_config_test.go
+++ b/utils/tls_config_test.go
@@ -1,0 +1,174 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package utils
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// writeTestCABundle generates a self-signed CA and writes it as PEM,
+// returning the file path.
+func writeTestCABundle(t *testing.T) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "chatcli-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "ca.pem")
+	out := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	if err := os.WriteFile(path, out, 0o600); err != nil {
+		t.Fatalf("write bundle: %v", err)
+	}
+	return path
+}
+
+func TestNewTLSConfigFromEnvUnset(t *testing.T) {
+	t.Setenv(envCABundle, "")
+	t.Setenv(envInsecureSkipVerify, "")
+	if cfg := newTLSConfigFromEnv(zap.NewNop()); cfg != nil {
+		t.Fatalf("expected nil config when no override is set, got %+v", cfg)
+	}
+}
+
+func TestNewTLSConfigFromEnvInsecure(t *testing.T) {
+	t.Setenv(envCABundle, "")
+	t.Setenv(envInsecureSkipVerify, "TRUE") // case-insensitive, like the Bedrock knob
+	cfg := newTLSConfigFromEnv(zap.NewNop())
+	if cfg == nil || !cfg.InsecureSkipVerify {
+		t.Fatalf("expected InsecureSkipVerify=true, got %+v", cfg)
+	}
+	if cfg.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("expected MinVersion TLS1.2, got %d", cfg.MinVersion)
+	}
+}
+
+func TestNewTLSConfigFromEnvCABundle(t *testing.T) {
+	t.Setenv(envCABundle, writeTestCABundle(t))
+	t.Setenv(envInsecureSkipVerify, "")
+	cfg := newTLSConfigFromEnv(zap.NewNop())
+	if cfg == nil || cfg.RootCAs == nil {
+		t.Fatalf("expected RootCAs from bundle, got %+v", cfg)
+	}
+	if cfg.InsecureSkipVerify {
+		t.Fatal("CA bundle must not disable verification")
+	}
+}
+
+func TestNewTLSConfigFromEnvInsecureWinsOverBundle(t *testing.T) {
+	t.Setenv(envCABundle, writeTestCABundle(t))
+	t.Setenv(envInsecureSkipVerify, "true")
+	cfg := newTLSConfigFromEnv(zap.NewNop())
+	if cfg == nil || !cfg.InsecureSkipVerify {
+		t.Fatalf("insecure must take precedence over the bundle, got %+v", cfg)
+	}
+}
+
+func TestNewTLSConfigFromEnvBadBundleFailsOpen(t *testing.T) {
+	t.Setenv(envInsecureSkipVerify, "")
+
+	t.Setenv(envCABundle, filepath.Join(t.TempDir(), "missing.pem"))
+	if cfg := newTLSConfigFromEnv(zap.NewNop()); cfg != nil {
+		t.Fatalf("unreadable bundle must keep default trust, got %+v", cfg)
+	}
+
+	garbage := filepath.Join(t.TempDir(), "garbage.pem")
+	if err := os.WriteFile(garbage, []byte("not a pem"), 0o600); err != nil {
+		t.Fatalf("write garbage: %v", err)
+	}
+	t.Setenv(envCABundle, garbage)
+	if cfg := newTLSConfigFromEnv(zap.NewNop()); cfg != nil {
+		t.Fatalf("garbage bundle must keep default trust, got %+v", cfg)
+	}
+}
+
+func TestApplyGlobalTLSTrustWiresClientsAndDefaultTransport(t *testing.T) {
+	dt, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		t.Skip("http.DefaultTransport is not *http.Transport")
+	}
+	prevDefault := dt.TLSClientConfig
+	prevGlobal := globalTLSConfig.Load()
+	t.Cleanup(func() {
+		dt.TLSClientConfig = prevDefault
+		globalTLSConfig.Store(prevGlobal)
+	})
+
+	t.Setenv(envCABundle, writeTestCABundle(t))
+	t.Setenv(envInsecureSkipVerify, "")
+	ApplyGlobalTLSTrust(zap.NewNop())
+
+	got := GlobalTLSConfig()
+	if got == nil || got.RootCAs == nil {
+		t.Fatalf("GlobalTLSConfig not populated: %+v", got)
+	}
+	if dt.TLSClientConfig == nil || dt.TLSClientConfig.RootCAs == nil {
+		t.Fatal("http.DefaultTransport did not inherit the trust override")
+	}
+
+	client := NewHTTPClient(zap.NewNop(), time.Second)
+	lt, ok := client.Transport.(*LoggingTransport)
+	if !ok {
+		t.Fatalf("unexpected outer transport %T", client.Transport)
+	}
+	inner, ok := lt.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("unexpected inner transport %T", lt.Transport)
+	}
+	if inner.TLSClientConfig == nil || inner.TLSClientConfig.RootCAs == nil {
+		t.Fatal("NewHTTPClient did not inherit the trust override")
+	}
+}
+
+func TestApplyGlobalTLSTrustNoOverridesIsNoOp(t *testing.T) {
+	dt, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		t.Skip("http.DefaultTransport is not *http.Transport")
+	}
+	prevDefault := dt.TLSClientConfig
+	prevGlobal := globalTLSConfig.Load()
+	t.Cleanup(func() {
+		dt.TLSClientConfig = prevDefault
+		globalTLSConfig.Store(prevGlobal)
+	})
+
+	t.Setenv(envCABundle, "")
+	t.Setenv(envInsecureSkipVerify, "")
+	ApplyGlobalTLSTrust(zap.NewNop())
+
+	if GlobalTLSConfig() != nil {
+		t.Fatal("expected nil global config with no overrides")
+	}
+	if dt.TLSClientConfig != prevDefault {
+		t.Fatal("DefaultTransport must not be touched when no override is set")
+	}
+}

--- a/utils/utls_transport.go
+++ b/utils/utls_transport.go
@@ -56,10 +56,17 @@ func (*chromeTLSTransport) dialUTLS(ctx context.Context, addr string) (*utls.UCo
 		return nil, fmt.Errorf("dial %s: %w", addr, err)
 	}
 
-	uConn := utls.UClient(rawConn, &utls.Config{
+	uCfg := &utls.Config{
 		ServerName: host,
 		MinVersion: tls.VersionTLS12,
-	}, utls.HelloChrome_Auto)
+	}
+	// Propagate the corporate TLS trust overrides — uTLS has its own
+	// handshake and does not see http.Transport's TLSClientConfig.
+	if g := GlobalTLSConfig(); g != nil {
+		uCfg.RootCAs = g.RootCAs
+		uCfg.InsecureSkipVerify = g.InsecureSkipVerify // #nosec G402 -- mirrors the documented global opt-in
+	}
+	uConn := utls.UClient(rawConn, uCfg, utls.HelloChrome_Auto)
 
 	if err := uConn.HandshakeContext(ctx); err != nil {
 		_ = rawConn.Close()


### PR DESCRIPTION
## Problema

Atrás de proxy corporativo com inspeção TLS (CA privado), o chatcli só tinha resposta no Bedrock (`CHATCLI_BEDROCK_CA_BUNDLE` / `CHATCLI_BEDROCK_INSECURE_SKIP_VERIFY`). Todos os outros providers e ferramentas falhavam sem saída além de instalar o CA no sistema — e quando nem isso resolve (cert re-assinado quebrado), não havia escape hatch.
## Mudanças

Duas envs novas, processo-global, espelhando essa experiência:

- **`CHATCLI_CA_BUNDLE=/path/ca.pem`** — merge do PEM no system cert pool, usado como RootCAs. O Go já confia no trust store do OS por default; isso cobre o caso em que o CA corporativo não pode ser instalado system-wide.
- **`CHATCLI_TLS_INSECURE_SKIP_VERIFY=true`** — desliga a verificação TLS inteira. Escape hatch explícito com warning alto no log, só pra confirmar diagnóstico de proxy.

Wiring único no startup (pós-dotenv) nos 3 entrypoints (CLI interativa, subcommands, daemon), alcançando todos os caminhos HTTPS de saída:

- `utils.NewHTTPClient` — todos os clients LLM/TTS/STT/embeddings/transcription (config clonado por provider, preservando session cache TLS dedicado)
- Client proxy-aware dos web tools (@webfetch/@websearch/@osv)
- Transport uTLS (fingerprint Chrome), que tem handshake próprio e não herda do http.Transport
- `http.DefaultTransport` — gateway channels, MCP transports, registries, version check herdam sem mudança de código

Bedrock mantém as vars específicas com precedência e ganha fallback pras globais (o AWS SDK monta o próprio HTTP client). Bundle inválido/ilegível **falha aberto** pra verificação default — nunca enfraquece trust silenciosamente.

Exposto em `/config resilience`, nova subseção “Global TLS trust” (i18n pt-BR/en/en-US) + registry de defaults.

## Testes

- `utils`: unset → nil; insecure case-insensitive; bundle válido (CA self-signed gerado no teste) → RootCAs sem skip-verify; precedência insecure > bundle; arquivo ausente/PEM lixo → fail-open; wiring completo de `ApplyGlobalTLSTrust` (DefaultTransport + NewHTTPClient) com no-op garantido quando nada setado
- `bedrock`: fallback global, precedência das vars específicas, unset → client default do SDK
- `go build ./...`, `go test ./...` e `golangci-lint --new-from-rev=main` limpos