### PR TITLE
chore(lint): eliminate misspell false-positives in the bilingual codebase

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -94,9 +94,43 @@ linters-settings:
 
   misspell:
     locale: US
-    # Some pt-BR/portuguese strings in i18n bodies might trip
-    # misspell — keep US dictionary and rely on golangci to skip
-    # JSON-encoded blobs.
+    # ChatCLI is a bilingual (pt-BR/en) codebase: comments, log messages and
+    # i18n bodies are routinely Portuguese. The US dictionary reads many
+    # legitimate Portuguese words as English typos ("comando" -> "commando",
+    # "contextos" -> "contexts", ...). ignore-words whitelists those so the
+    # linter only flags genuine English mistakes — without it, every future
+    # edit to a Portuguese line gets a false positive.
+    #
+    # A few entries are deliberate ENGLISH vocabulary, not Portuguese:
+    #   - cancelled / cancelling: the scheduler's serialized job state
+    #     (StatusCancelled, the "job.cancelled" event) — renaming would break
+    #     persisted state and the event contract.
+    #   - instal: a fragment of the Portuguese regex alternative `instal[ae]r?`
+    #     in cli/agent_routing.go; "fixing" it would corrupt the pattern.
+    ignore-words:
+      - alternar
+      - argumentos
+      - autor
+      - calcular
+      - cancelled
+      - cancelling
+      - clientes
+      - comando
+      - comandos
+      - contextos
+      - duplicatas
+      - eles
+      - exclusivos
+      - exponencial
+      - instal
+      - operacional
+      - presentes
+      - problemas
+      - profissional
+      - progresso
+      - sucess
+      - tradicional
+      - variantes
 
 issues:
   # Don't enforce on generated files.

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -128,7 +128,7 @@ type AgentMode struct {
 //
 // Both '\n' and '\r' end a line. Cooked TTYs deliver '\n' (ICRNL converts
 // the user's CR), but a raw-mode TTY — or one left in a transient state
-// after a TIOCSTI inject for park auto-resume — delivers '\r'. Recognising
+// after a TIOCSTI inject for park auto-resume — delivers '\r'. Recognizing
 // both keeps the security prompt responsive in either mode. CRLF pairs are
 // collapsed into a single line (the trailing '\n' is consumed).
 func splitStdinChunk(chunk []byte, lineBuf *strings.Builder) []string {

--- a/cli/agent_routing.go
+++ b/cli/agent_routing.go
@@ -29,7 +29,7 @@ type trivialQueryClassification struct {
 	trivial bool
 	// reason is a short tag (for logs / telemetry) describing why the
 	// classifier reached its verdict. Useful when deciding whether the
-	// downgrade behaviour is working as intended.
+	// downgrade behavior is working as intended.
 	reason string
 }
 

--- a/cli/mcp/mcp_test.go
+++ b/cli/mcp/mcp_test.go
@@ -101,10 +101,10 @@ func TestJSONRPCRequestMarshalWithParams(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !strings.Contains(string(data), `"my_tool"`) {
-		t.Error("expected tool name in marshalled JSON")
+		t.Error("expected tool name in marshaled JSON")
 	}
 	if !strings.Contains(string(data), `"key"`) {
-		t.Error("expected arguments key in marshalled JSON")
+		t.Error("expected arguments key in marshaled JSON")
 	}
 }
 

--- a/cli/plugins/builtin_webfetch.go
+++ b/cli/plugins/builtin_webfetch.go
@@ -25,7 +25,7 @@ import (
 // 20_000 chars ≈ 5k tokens with standard BPE — roughly the point where
 // one fetch alone starts dwarfing the system prompt. The knob is
 // overridable via CHATCLI_WEBFETCH_AUTOSAVE_BYTES in case a user wants
-// looser or tighter behaviour.
+// looser or tighter behavior.
 const (
 	defaultWebFetchMaxLength    = 20_000
 	defaultWebFetchAutoSaveSize = 10_000

--- a/cli/scheduler/action/webhook.go
+++ b/cli/scheduler/action/webhook.go
@@ -5,7 +5,7 @@
  *   url              string — required
  *   method           string — optional (default POST)
  *   body             string — optional raw body
- *   json             any    — optional; when set, marshalled to JSON
+ *   json             any    — optional; when set, marshaled to JSON
  *                             and overrides body
  *   headers          map    — optional request headers
  *   expected_status  int    — optional (default any 2xx)

--- a/cli/workspace/memory/hyde_test.go
+++ b/cli/workspace/memory/hyde_test.go
@@ -79,7 +79,7 @@ func TestHyDEAugmenter_RespectsNumKeywordsCap(t *testing.T) {
 	got := aug.Augment(context.Background(), "q", []string{"orig"})
 	// 1 original + at most 2 hypothesis keywords
 	if len(got) > 3 {
-		t.Errorf("NumKeywords cap not honoured; got %v", got)
+		t.Errorf("NumKeywords cap not honored; got %v", got)
 	}
 }
 


### PR DESCRIPTION
## Problem

The `misspell` linter runs a US-English dictionary over a bilingual (pt-BR/en) codebase. ~200 legitimate Portuguese words in comments, logs and i18n bodies are reported as English typos (`comando`→`commando`, `contextos`→`contexts`, `argumentos`→`arguments`, …). Because lint is diff-only, every future edit to one of those lines drew a false positive, and the noise masked the genuine English mistakes.

## Fix

**Root cause (config):** whitelist the recurring Portuguese terms via `misspell.ignore-words` in `.golangci.yml`. Two entries are deliberate *English* vocabulary that must not be rewritten:
- `cancelled` / `cancelling` — the scheduler's serialized job state (`StatusCancelled`, the `job.cancelled` event). Renaming would break the event contract and persisted state.
- `instal` — a fragment of the Portuguese verb regex `instal[ae]r?` in `cli/agent_routing.go`; "fixing" it would corrupt the pattern.

**Genuine mistakes (code):** with the false positives gone, fix the real ones the noise was hiding — British→American spelling in prose comments and test strings:
- `behaviour`→`behavior` (agent_routing.go, builtin_webfetch.go)
- `marshalled`→`marshaled` (mcp_test.go, scheduler/action/webhook.go)
- `honoured`→`honored` (workspace/memory/hyde_test.go)
- `Recognising`→`Recognizing` (agent_mode.go)

## Result

`misspell` is now **clean across the whole module** (`golangci-lint run --disable-all --enable misspell ./...` → 0). Future edits to Portuguese lines no longer trip false positives, and the linter again flags only genuine English mistakes.

`go build ./...` and the touched packages' tests pass.