### PR TITLE
fix(context): re-chunk knowledge corpora on update and harden docs-flatten envelope

### DIFF
--- a/cli/ctxmgr/knowledge_test.go
+++ b/cli/ctxmgr/knowledge_test.go
@@ -258,6 +258,151 @@ func TestManager_CreateKnowledgeContextFromJSONL(t *testing.T) {
 	}
 }
 
+// TestManager_UpdateKnowledgeContextFromJSONL is the regression for the update
+// path swallowing a JSONL corpus as a single monolithic unit (units: 1) and
+// leaving kb.* provenance stale. Re-ingestion must re-chunk per line and refresh
+// commit/sources, exactly like CreateContext does.
+func TestManager_UpdateKnowledgeContextFromJSONL(t *testing.T) {
+	m := newTestManager(t)
+	orig := writeCorpus(t, []string{
+		`{"id":"a.md#0001","source":"a.md","content":"# Alpha\nold","repoUrl":"https://github.com/org/docs.git","commit":"oldcommit0000"}`,
+	})
+	fc, err := m.CreateContext(context.Background(), "kb-docs", "docs corpus", []string{orig}, ModeKnowledge, nil, false)
+	if err != nil {
+		t.Fatalf("CreateContext: %v", err)
+	}
+	if fc.FileCount != 1 || fc.Metadata[knowledgeMetaCommit] != "oldcommit0000" {
+		t.Fatalf("seed context = %d files, commit %q", fc.FileCount, fc.Metadata[knowledgeMetaCommit])
+	}
+
+	updated := writeCorpus(t, []string{
+		`{"id":"a.md#0001","source":"a.md","content":"# Alpha\nnew","repoUrl":"https://github.com/org/docs.git","commit":"newcommit1111"}`,
+		`{"id":"b.md#0001","source":"b.md","content":"# Beta\nnew section"}`,
+		`{"id":"c.md#0001","source":"c.md","content":"# Gamma\nthird doc"}`,
+	})
+	got, err := m.UpdateContext(context.Background(), "kb-docs", []string{updated}, "", nil, "")
+	if err != nil {
+		t.Fatalf("UpdateContext: %v", err)
+	}
+	// The whole point: 3 chunks, NOT 1 monolithic unit.
+	if got.FileCount != 3 {
+		t.Fatalf("FileCount = %d, want 3 (corpus re-chunked, not swallowed as one unit)", got.FileCount)
+	}
+	if got.Mode != ModeKnowledge {
+		t.Errorf("mode drifted to %s, want knowledge", got.Mode)
+	}
+	if got.Metadata[knowledgeMetaCommit] != "newcommit1111" {
+		t.Errorf("kb.commit = %q, want refreshed newcommit1111", got.Metadata[knowledgeMetaCommit])
+	}
+	if got.Metadata[knowledgeMetaSources] != "3" {
+		t.Errorf("kb.sources = %q, want 3", got.Metadata[knowledgeMetaSources])
+	}
+}
+
+// TestManager_UpdateClearsStaleChunkStateOnModeSwitch pins that switching a
+// context away from chunked mode during update drops the orphaned chunk index
+// (Chunks/IsChunked/ChunkStrategy) — a phantom IsChunked on a knowledge context
+// is a landmine for any path that branches on it.
+func TestManager_UpdateClearsStaleChunkStateOnModeSwitch(t *testing.T) {
+	m := newTestManager(t)
+	dir := t.TempDir()
+	src := filepath.Join(dir, "doc.md")
+	if err := os.WriteFile(src, []byte("# Title\n"+strings.Repeat("body line\n", 50)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fc, err := m.CreateContext(context.Background(), "kb-switch", "chunked seed", []string{src}, ModeChunked, nil, false)
+	if err != nil {
+		t.Fatalf("CreateContext: %v", err)
+	}
+	if !fc.IsChunked || len(fc.Chunks) == 0 {
+		t.Fatalf("seed must be chunked: IsChunked=%v chunks=%d", fc.IsChunked, len(fc.Chunks))
+	}
+
+	corpus := writeCorpus(t, []string{
+		`{"id":"a.md#0001","source":"a.md","content":"# Alpha\nknowledge now"}`,
+	})
+	got, err := m.UpdateContext(context.Background(), "kb-switch", []string{corpus}, ModeKnowledge, nil, "")
+	if err != nil {
+		t.Fatalf("UpdateContext: %v", err)
+	}
+	if got.Mode != ModeKnowledge {
+		t.Fatalf("mode = %s, want knowledge", got.Mode)
+	}
+	if got.IsChunked || got.Chunks != nil || got.ChunkStrategy != "" {
+		t.Errorf("stale chunk state survived mode switch: IsChunked=%v chunks=%d strategy=%q",
+			got.IsChunked, len(got.Chunks), got.ChunkStrategy)
+	}
+}
+
+// TestManager_UpdateChunkedRechunksOnNewFiles covers the chunked-mode update
+// path: re-supplying files must re-divide the corpus and keep the context
+// chunked, replacing the previous chunk set with the new content's.
+func TestManager_UpdateChunkedRechunksOnNewFiles(t *testing.T) {
+	m := newTestManager(t)
+	dir := t.TempDir()
+	f1 := filepath.Join(dir, "a.md")
+	if err := os.WriteFile(f1, []byte("# A\n"+strings.Repeat("alpha line\n", 60)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fc, err := m.CreateContext(context.Background(), "chk", "seed", []string{f1}, ModeChunked, nil, false)
+	if err != nil {
+		t.Fatalf("CreateContext: %v", err)
+	}
+	if !fc.IsChunked || len(fc.Chunks) == 0 {
+		t.Fatalf("seed must be chunked: IsChunked=%v chunks=%d", fc.IsChunked, len(fc.Chunks))
+	}
+
+	f2 := filepath.Join(dir, "b.md")
+	if err := os.WriteFile(f2, []byte("# B\n"+strings.Repeat("beta line\n", 120)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := m.UpdateContext(context.Background(), "chk", []string{f2}, "", nil, "")
+	if err != nil {
+		t.Fatalf("UpdateContext: %v", err)
+	}
+	if got.Mode != ModeChunked || !got.IsChunked || len(got.Chunks) == 0 {
+		t.Fatalf("update must keep it chunked and re-divide: mode=%s chunked=%v chunks=%d",
+			got.Mode, got.IsChunked, len(got.Chunks))
+	}
+	if got.FileCount != 1 {
+		t.Errorf("FileCount = %d, want 1 (rescanned to the new file)", got.FileCount)
+	}
+}
+
+// TestManager_UpdateNonKnowledgeRescansPaths covers the non-knowledge update
+// branch: paths go through the normal scanner and replace the file set, with no
+// phantom chunk state left behind.
+func TestManager_UpdateNonKnowledgeRescansPaths(t *testing.T) {
+	m := newTestManager(t)
+	dir := t.TempDir()
+	f1 := filepath.Join(dir, "a.md")
+	if err := os.WriteFile(f1, []byte("# A\nalpha"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fc, err := m.CreateContext(context.Background(), "full-ctx", "seed", []string{f1}, ModeFull, nil, false)
+	if err != nil {
+		t.Fatalf("CreateContext: %v", err)
+	}
+	if fc.Mode != ModeFull || fc.FileCount != 1 {
+		t.Fatalf("seed = mode %s, %d files", fc.Mode, fc.FileCount)
+	}
+
+	f2 := filepath.Join(dir, "b.md")
+	if err := os.WriteFile(f2, []byte("# B\nbeta beta"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := m.UpdateContext(context.Background(), "full-ctx", []string{f2}, "", nil, "")
+	if err != nil {
+		t.Fatalf("UpdateContext: %v", err)
+	}
+	if got.Mode != ModeFull || got.FileCount != 1 {
+		t.Fatalf("update = mode %s, %d files, want full/1", got.Mode, got.FileCount)
+	}
+	if got.IsChunked || got.Chunks != nil {
+		t.Errorf("non-chunked update must not carry chunk state: IsChunked=%v chunks=%d", got.IsChunked, len(got.Chunks))
+	}
+}
+
 // countingProvider records every Embed batch size, delegating to conceptProvider.
 type countingProvider struct {
 	conceptProvider

--- a/cli/ctxmgr/manager.go
+++ b/cli/ctxmgr/manager.go
@@ -515,10 +515,44 @@ func (m *Manager) UpdateContext(ctx context.Context, name string, newPaths []str
 			mode = existingCtx.Mode // Manter modo anterior se não especificado
 		}
 
-		var err error
-		files, scanOpts, err = m.processor.ProcessPaths(ctx, newPaths, mode)
-		if err != nil {
-			return nil, fmt.Errorf("erro ao processar arquivos: %w", err)
+		// Mesmo gate de knowledge mode do CreateContext: corpora .jsonl do
+		// docs-flatten entram pelo parser nativo (um FileInfo por chunk,
+		// preservando source/título/proveniência), enquanto os demais caminhos
+		// seguem pelo scanner normal. Sem isto, um .jsonl seria ingerido como um
+		// único arquivo monolítico (units: 1) e a proveniência kb.* ficaria stale.
+		knowledgeMeta := map[string]string{}
+		var scanPaths []string
+		if mode == ModeKnowledge {
+			for _, p := range newPaths {
+				if !isJSONLPath(p) {
+					scanPaths = append(scanPaths, p)
+					continue
+				}
+				expanded, expandErr := utils.ExpandPath(p)
+				if expandErr != nil {
+					expanded = p
+				}
+				kfiles, kmeta, ingestErr := ingestKnowledgeJSONL(expanded, m.logger)
+				if ingestErr != nil {
+					return nil, ingestErr
+				}
+				files = append(files, kfiles...)
+				for k, v := range kmeta {
+					knowledgeMeta[k] = v
+				}
+			}
+		} else {
+			scanPaths = newPaths
+		}
+
+		scanOpts = utils.DefaultDirectoryScanOptions(m.logger)
+		if len(scanPaths) > 0 {
+			scanned, opts, err := m.processor.ProcessPaths(ctx, scanPaths, mode)
+			if err != nil {
+				return nil, fmt.Errorf("erro ao processar arquivos: %w", err)
+			}
+			files = append(files, scanned...)
+			scanOpts = opts
 		}
 
 		for _, f := range files {
@@ -542,6 +576,18 @@ func (m *Manager) UpdateContext(ctx context.Context, name string, newPaths []str
 			ExcludePatterns:   scanOpts.ExcludePatterns,
 			IncludeHidden:     scanOpts.IncludeHidden,
 		}
+
+		// Refrescar a proveniência kb.* a partir do novo corpus — commit e
+		// contagem de sources mudam a cada re-ingestão. Merge (não overwrite)
+		// preserva quaisquer outras chaves de metadata já gravadas no contexto.
+		if len(knowledgeMeta) > 0 {
+			if existingCtx.Metadata == nil {
+				existingCtx.Metadata = map[string]string{}
+			}
+			for k, v := range knowledgeMeta {
+				existingCtx.Metadata[k] = v
+			}
+		}
 	}
 
 	// Atualizar descrição se fornecida
@@ -558,20 +604,32 @@ func (m *Manager) UpdateContext(ctx context.Context, name string, newPaths []str
 	existingCtx.UpdatedAt = time.Now()
 
 	// Re-dividir em chunks se necessário
-	if existingCtx.Mode == ModeChunked && len(files) > 0 {
-		m.logger.Info("Re-dividindo arquivos em chunks após atualização",
-			zap.String("context_name", name),
-			zap.Int("total_files", len(files)))
+	if existingCtx.Mode == ModeChunked {
+		// Só re-chunka quando há arquivos novos; um update apenas de descrição/
+		// tags preserva os chunks existentes (conteúdo inalterado).
+		if len(files) > 0 {
+			m.logger.Info("Re-dividindo arquivos em chunks após atualização",
+				zap.String("context_name", name),
+				zap.Int("total_files", len(files)))
 
-		chunker := NewChunker(m.logger)
-		chunks, err := chunker.DivideIntoChunks(files, ChunkSmart)
-		if err != nil {
-			return nil, fmt.Errorf("erro ao dividir em chunks: %w", err)
+			chunker := NewChunker(m.logger)
+			chunks, err := chunker.DivideIntoChunks(files, ChunkSmart)
+			if err != nil {
+				return nil, fmt.Errorf("erro ao dividir em chunks: %w", err)
+			}
+
+			existingCtx.Chunks = chunks
+			existingCtx.IsChunked = true
+			existingCtx.ChunkStrategy = string(ChunkSmart)
 		}
-
-		existingCtx.Chunks = chunks
-		existingCtx.IsChunked = true
-		existingCtx.ChunkStrategy = string(ChunkSmart)
+	} else if len(files) > 0 {
+		// O modo deixou de ser chunked nesta atualização (ex.: chunked→knowledge):
+		// descartar o estado de chunk órfão para que um contexto knowledge/full
+		// nunca carregue um índice de chunks fantasma (IsChunked stale é landmine
+		// para qualquer caminho que ramifique em fc.IsChunked).
+		existingCtx.Chunks = nil
+		existingCtx.IsChunked = false
+		existingCtx.ChunkStrategy = ""
 	}
 
 	// Salvar no disco

--- a/cli/plugins/builtin_docsflatten.go
+++ b/cli/plugins/builtin_docsflatten.go
@@ -241,10 +241,21 @@ func parseDocsFlattenArgs(args []string) (docsFlattenArgs, error) {
 		if err := json.Unmarshal([]byte(payload), &raw); err != nil {
 			return out, fmt.Errorf("malformed JSON args: %w", err)
 		}
+		// Accept the {"cmd","args"} envelope the model tends to emit (mirroring
+		// @context's shape) as well as flat JSON. Merge the nested args OVER any
+		// sibling top-level keys instead of replacing the map wholesale: a partial
+		// envelope like {"cmd":"flatten","repo":"…","args":{"format":"jsonl"}}
+		// must keep its source key rather than silently drop it (which surfaced as
+		// a misleading "source required"/"mutually exclusive" error and cost the
+		// agent a retry turn). The "cmd" verb is dropped — it is not a flatten flag.
 		if inner, ok := raw["args"]; ok {
 			var innerMap map[string]json.RawMessage
 			if err := json.Unmarshal(inner, &innerMap); err == nil {
-				raw = innerMap
+				delete(raw, "args")
+				delete(raw, "cmd")
+				for k, v := range innerMap {
+					raw[k] = v
+				}
 			}
 		}
 	default:

--- a/cli/plugins/builtin_docsflatten_test.go
+++ b/cli/plugins/builtin_docsflatten_test.go
@@ -216,6 +216,17 @@ func TestParseDocsFlattenArgs(t *testing.T) {
 			t.Errorf("unexpected cfg: %+v", cfg)
 		}
 	})
+	t.Run("partial envelope keeps sibling source key", func(t *testing.T) {
+		// {cmd, repo at top-level, args:{...}} — the nested args must merge over
+		// the siblings, not replace them, so the source key survives.
+		cfg, err := parseDocsFlattenArgs([]string{`{"cmd":"flatten","repo":"https://github.com/org/x","args":{"format":"jsonl","output":"/tmp/x.jsonl"}}`})
+		if err != nil {
+			t.Fatalf("partial envelope must not drop the top-level source: %v", err)
+		}
+		if cfg.Repo != "https://github.com/org/x" || cfg.Format != "jsonl" || cfg.Output != "/tmp/x.jsonl" {
+			t.Errorf("unexpected cfg: %+v", cfg)
+		}
+	})
 	t.Run("argv flags", func(t *testing.T) {
 		cfg, err := parseDocsFlattenArgs([]string{"--root", "./docs", "--format", "yaml", "--include", "a.md,b/**/*.md"})
 		if err != nil {


### PR DESCRIPTION
## Problema

Ao re-ingerir um corpus `@docs-flatten` num contexto `--mode knowledge` via `update`, o `UpdateContext` ingeria o `.jsonl` inteiro como **uma única unidade monolítica** (`units: 1`) em vez de re-chunkar por linha, e **não refrescava** a proveniência `kb.*` (`kb.commit`/`kb.sources` ficavam stale). A causa: o `UpdateContext` chamava `processor.ProcessPaths` direto, sem o gate de knowledge-mode que o `CreateContext` já aplica.

Em paralelo, o agente perdia um turno com o `@docs-flatten`: ao emitir um envelope parcial (chave de fonte no topo + `args` aninhado), o parser substituía o mapa inteiro pelos `args`, **descartando a chave de fonte** e falhando com um erro enganoso.

## Mudanças

- **`UpdateContext` aplica o mesmo gate de knowledge do `CreateContext`**: corpora `.jsonl` entram pelo parser nativo (um `FileInfo` por chunk, proveniência preservada); os demais caminhos seguem pelo scanner normal. A metadata `kb.*` é refrescada do novo corpus via merge.
- **Limpa estado de chunk órfão na troca de modo**: ao sair de `chunked` num update, `Chunks`/`IsChunked`/`ChunkStrategy` são zerados, evitando um `IsChunked` fantasma num contexto knowledge/full.
- **`@docs-flatten` faz merge do envelope** em vez de substituir: um envelope parcial mantém a chave de fonte do topo; a verb `cmd` é descartada.
- **Testes de regressão**: re-chunking no update, refresh da metadata `kb.*`, limpeza de chunk na troca de modo e o merge de envelope parcial.

## Validação

- `go build ./...` ✓
- `gofmt -l` vazio · `go vet` limpo ✓
- `go test ./cli/ctxmgr/ ./cli/plugins/` ✓

## Nota

Os dois bugs já existiam na `main`; este fix foi portado para as assinaturas da `main` (`ProcessPaths` sem `ctx`). A branch `feat/context-full-parity` carrega os mesmos bugs na forma com `ctx` e deve herdar a correção ao mergear a `main`.
