### PR TITLE
fix(coder): recover stdin after Ctrl+C at a security confirmation

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -95,6 +95,21 @@ type AgentMode struct {
 	stdinWg      sync.WaitGroup
 	multilineBuf MultilineBuffer // ``` delimited multiline input
 
+	// cancelSignal is the Done() channel of the in-flight Run/ReAct loop's
+	// context. Blocking stdin reads (security confirmations, batch prompts)
+	// select on it so a Ctrl+C aborts them the instant the operation is
+	// cancelled — instead of hanging on the channel receive until the user
+	// presses Enter. That hang previously left the terminal in cooked mode
+	// and the centralized reader half-torn-down, which corrupted the next
+	// REPL prompt (the "/coder enters but nothing fires" bug). We store only
+	// the cancellation channel, not the context.Context: the reader needs the
+	// signal, nothing else, and a nil channel selects as "never" — exactly the
+	// "no operation in flight, nothing to cancel" semantics, with no fallback
+	// needed. Guarded by cancelSignalMu because the scheduler bridge inspects
+	// this instance from another goroutine while Run swaps the signal.
+	cancelSignal   <-chan struct{}
+	cancelSignalMu sync.RWMutex
+
 	// Skill hints captured at the start of Run() from auto-activated or
 	// manually invoked skills. Applied to each LLM turn via ctx for the
 	// duration of the agent loop. Cleared when the loop exits.
@@ -146,6 +161,38 @@ func splitStdinChunk(chunk []byte, lineBuf *strings.Builder) []string {
 		}
 	}
 	return lines
+}
+
+// drainStdin discards bytes left unread in the terminal input buffer. After an
+// interrupted agent/coder turn — especially one cancelled at a cooked-mode
+// security prompt — the TTY may hold orphan bytes: the stray newline that the
+// user pressed while Ctrl+C was racing the read, or type-ahead queued for the
+// now-dead turn. Left in place, those bytes get consumed by the next go-prompt
+// REPL line, so the following /coder or /agent command "doesn't fire".
+//
+// Must only be called when no stdin reader goroutine and no go-prompt own the
+// TTY (i.e. between an agent op returning and the next prompt) — otherwise it
+// races them for input. The poll(0) gate is non-blocking and the iteration cap
+// bounds it to 32 KiB; the whole drain runs under a short deadline so a Windows
+// WaitForSingleObject false positive (which can leave Read blocking) can never
+// hang the REPL.
+func drainStdin() {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf := make([]byte, 512)
+		for i := 0; i < 64 && stdinPollReady(0); i++ {
+			if _, err := os.Stdin.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		// Stuck on a blocking Read (Windows false positive). Don't wait —
+		// the orphan read is discarded when the goroutine eventually wakes.
+	}
 }
 
 // startStdinReader starts a goroutine that reads lines from stdin and sends
@@ -304,15 +351,56 @@ func (a *AgentMode) handleAgentAsk(ctx context.Context, argsJSON string) (string
 // human or stdin. It also starts with "s", satisfying the lighter [s/y] prompts.
 const unattendedConfirmAnswer = "sim, quero executar conscientemente"
 
-// readLine reads a single line from the centralized stdin reader.
-// Falls back to direct stdin read if the reader is not active. In unattended
-// mode there is no human/stdin, so every confirmation auto-approves.
+// setCancelSignal publishes the active loop's cancellation channel so blocking
+// stdin reads abort when the operation is interrupted. Pass nil to detach it
+// when the loop exits; a nil channel selects as "never", so reads simply block
+// on input again — the correct "nothing in flight to cancel" behavior.
+func (a *AgentMode) setCancelSignal(done <-chan struct{}) {
+	a.cancelSignalMu.Lock()
+	a.cancelSignal = done
+	a.cancelSignalMu.Unlock()
+}
+
+// currentCancelSignal returns the active loop's cancellation channel, or nil
+// when no Run is executing (e.g. unit tests that call readLine directly).
+func (a *AgentMode) currentCancelSignal() <-chan struct{} {
+	a.cancelSignalMu.RLock()
+	defer a.cancelSignalMu.RUnlock()
+	return a.cancelSignal
+}
+
+// readLine reads a single line from the centralized stdin reader, aborting on
+// cancellation of the active operation (Ctrl+C). See readLineSignal.
 func (a *AgentMode) readLine() string {
+	return a.readLineSignal(a.currentCancelSignal())
+}
+
+// readLineSignal reads a single line from the centralized stdin reader and
+// returns it, or returns "" the moment the cancel channel fires. Returning ""
+// on cancellation is the safe default for every interactive prompt that funnels
+// through here: an empty answer never matches an affirmative confirmation
+// phrase, so a Ctrl+C at a dangerous-command guard declines the action instead
+// of hanging on the channel receive until the user presses Enter — the hang
+// that left the terminal and reader in a broken state for the next REPL turn.
+//
+// A nil cancel channel never fires (select treats it as "never"), so callers
+// with no operation in flight simply block on input as before.
+//
+// In unattended mode there is no human/stdin, so every confirmation
+// auto-approves. When the centralized reader is inactive (tests, non-TTY) it
+// falls back to a direct blocking read; that path has no concurrent operation
+// to cancel, so it is intentionally not cancellation-aware.
+func (a *AgentMode) readLineSignal(cancel <-chan struct{}) string {
 	if a.cli != nil && a.cli.unattended {
 		return unattendedConfirmAnswer
 	}
 	if a.stdinLines != nil {
-		return <-a.stdinLines
+		select {
+		case line := <-a.stdinLines:
+			return line
+		case <-cancel:
+			return ""
+		}
 	}
 	// Fallback: direct stdin read
 	reader := bufio.NewReader(os.Stdin)
@@ -1280,6 +1368,15 @@ func (a *AgentMode) getToolContextString() string {
 //
 //nolint:gocyclo // legacy main loop; split tracked separately.
 func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) error {
+	// Publish the loop's cancel channel so blocking confirmation reads abort on
+	// Ctrl+C instead of hanging until Enter. Save/restore (not clear-to-nil)
+	// because this loop is re-entrant — handleCommandBlocks menu actions and
+	// park resume call back into it — so an inner turn must hand the outer
+	// turn's signal back when it returns, never leave a later read unguarded.
+	prevCancel := a.currentCancelSignal()
+	a.setCancelSignal(ctx.Done())
+	defer a.setCancelSignal(prevCancel)
+
 	// Start centralized stdin reader for type-ahead queue support
 	a.startStdinReader()
 	defer a.stopStdinReader()

--- a/cli/agent_mode_cancelread_test.go
+++ b/cli/agent_mode_cancelread_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 // TestReadLineSignal_ReturnsLineWhenAvailable pins the happy path: a line
@@ -166,5 +167,58 @@ func TestDrainStdin_DoesNotHang(t *testing.T) {
 	case <-done:
 	case <-time.After(1 * time.Second):
 		t.Fatal("drainStdin exceeded its safety deadline and blocked the REPL")
+	}
+}
+
+// TestRunWithCancellation_CancelledPathNormalizes drives the wrapper with an
+// already-cancelled parent context: the wrapped function returns cleanly, but
+// because the operation context is cancelled the wrapper must run the terminal
+// recovery path before returning to the REPL. Asserts the call completes within
+// a deadline (the recovery never hangs) and that the wrapped fn observed a
+// cancelled context.
+func TestRunWithCancellation_CancelledPathNormalizes(t *testing.T) {
+	cli := &ChatCLI{logger: zap.NewNop()}
+
+	parent, cancel := context.WithCancel(context.Background())
+	cancel() // operation is interrupted before the work even starts
+
+	var sawCancelled bool
+	done := make(chan struct{})
+	go func() {
+		cli.runWithCancellation(parent, "test", func(ctx context.Context) error {
+			sawCancelled = ctx.Err() != nil
+			return nil
+		})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("runWithCancellation hung on the cancelled recovery path")
+	}
+
+	assert.True(t, sawCancelled, "wrapped fn should see the cancelled operation context")
+	assert.False(t, cli.isExecuting.Load(), "isExecuting must be reset on return")
+}
+
+// TestNormalizeTerminalForREPL_Completes exercises the post-cancel terminal
+// recovery: it must run the line-discipline reset and stdin drain and return
+// without panicking or hanging, even when stdin is not a TTY (CI), where the
+// stty reset errors and is logged rather than fatal. Guarded by a deadline so a
+// regression that blocks the REPL fails loudly instead of stalling the suite.
+func TestNormalizeTerminalForREPL_Completes(t *testing.T) {
+	cli := &ChatCLI{logger: zap.NewNop()}
+
+	done := make(chan struct{})
+	go func() {
+		cli.normalizeTerminalForREPL()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("normalizeTerminalForREPL blocked — terminal recovery must never stall the REPL")
 	}
 }

--- a/cli/agent_mode_cancelread_test.go
+++ b/cli/agent_mode_cancelread_test.go
@@ -1,0 +1,170 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReadLineSignal_ReturnsLineWhenAvailable pins the happy path: a line
+// already queued on the centralized reader is returned verbatim, regardless of
+// the cancel channel.
+func TestReadLineSignal_ReturnsLineWhenAvailable(t *testing.T) {
+	a := &AgentMode{cli: &ChatCLI{}}
+	a.stdinLines = make(chan string, 1)
+	a.stdinLines <- "sim, quero executar conscientemente"
+
+	got := a.readLineSignal(nil)
+
+	assert.Equal(t, "sim, quero executar conscientemente", got)
+}
+
+// TestReadLineSignal_AbortsOnCancel is the regression test for the core bug: a
+// Ctrl+C cancels the operation, and a confirmation read blocked on the stdin
+// channel must unblock immediately with "" instead of hanging until the user
+// presses Enter. The cancel races an empty channel, so the only way out is the
+// cancel arm.
+func TestReadLineSignal_AbortsOnCancel(t *testing.T) {
+	a := &AgentMode{cli: &ChatCLI{}}
+	a.stdinLines = make(chan string) // unbuffered + never written: would hang without the fix
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan string, 1)
+	go func() { done <- a.readLineSignal(ctx.Done()) }()
+
+	// Give the goroutine a beat to block on the receive, then interrupt.
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case got := <-done:
+		assert.Equal(t, "", got, "cancelled confirmation must decline (empty) not hang")
+	case <-time.After(2 * time.Second):
+		t.Fatal("readLineSignal hung after cancellation — the Ctrl+C abort regressed")
+	}
+}
+
+// TestReadLineSignal_AlreadyCancelled covers the edge where the signal is
+// already fired before the read starts (e.g. a second confirmation after the
+// first interrupt): it must still return "" without blocking.
+func TestReadLineSignal_AlreadyCancelled(t *testing.T) {
+	a := &AgentMode{cli: &ChatCLI{}}
+	a.stdinLines = make(chan string)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan string, 1)
+	go func() { done <- a.readLineSignal(ctx.Done()) }()
+
+	select {
+	case got := <-done:
+		assert.Equal(t, "", got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("readLineSignal hung on an already-cancelled signal")
+	}
+}
+
+// TestReadLineSignal_NilChannelBlocksForInput verifies that with no operation in
+// flight (nil cancel channel) the read waits for input rather than treating the
+// nil channel as fired — a nil channel must select as "never".
+func TestReadLineSignal_NilChannelBlocksForInput(t *testing.T) {
+	a := &AgentMode{cli: &ChatCLI{}}
+	a.stdinLines = make(chan string, 1)
+
+	done := make(chan string, 1)
+	go func() { done <- a.readLineSignal(nil) }()
+
+	// Nothing queued yet: the read must still be blocking (not returned "").
+	select {
+	case got := <-done:
+		t.Fatalf("nil cancel channel must not fire; read returned early with %q", got)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Once a line arrives, it is delivered normally.
+	a.stdinLines <- "ok"
+	select {
+	case got := <-done:
+		assert.Equal(t, "ok", got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("read did not deliver the line after it was queued")
+	}
+}
+
+// TestReadLineSignal_UnattendedAutoApproves keeps the daemon contract:
+// unattended runs have no human/stdin, so confirmations auto-approve regardless
+// of the cancel channel.
+func TestReadLineSignal_UnattendedAutoApproves(t *testing.T) {
+	a := &AgentMode{cli: &ChatCLI{unattended: true}}
+
+	got := a.readLineSignal(nil)
+
+	assert.Equal(t, unattendedConfirmAnswer, got)
+}
+
+// TestReadLine_UsesActiveCancelSignal verifies the wiring: readLine() (the
+// signature every confirmation site calls) resolves the active loop's cancel
+// channel published by setCancelSignal, so cancelling that operation aborts the
+// read.
+func TestReadLine_UsesActiveCancelSignal(t *testing.T) {
+	a := &AgentMode{cli: &ChatCLI{}}
+	a.stdinLines = make(chan string)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	a.setCancelSignal(ctx.Done())
+
+	done := make(chan string, 1)
+	go func() { done <- a.readLine() }()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case got := <-done:
+		assert.Equal(t, "", got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("readLine did not honor the active cancel signal")
+	}
+}
+
+// TestCancelSignal_SaveRestore guarantees the re-entrant save/restore contract:
+// the getter reflects whatever was last set, including detaching with nil.
+func TestCancelSignal_SaveRestore(t *testing.T) {
+	a := &AgentMode{cli: &ChatCLI{}}
+
+	require.Nil(t, a.currentCancelSignal(), "no run set => nil signal")
+
+	outer := make(chan struct{})
+	a.setCancelSignal(outer)
+	assert.Equal(t, (<-chan struct{})(outer), a.currentCancelSignal())
+
+	a.setCancelSignal(nil)
+	require.Nil(t, a.currentCancelSignal(), "detaching must restore the nil signal")
+}
+
+// TestDrainStdin_DoesNotHang is a smoke test for the post-cancel cleanup: with
+// no data pending, drainStdin must return promptly via the poll(0) gate, and it
+// must always honor its internal safety deadline rather than blocking the REPL.
+func TestDrainStdin_DoesNotHang(t *testing.T) {
+	done := make(chan struct{})
+	go func() {
+		drainStdin()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("drainStdin exceeded its safety deadline and blocked the REPL")
+	}
+}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1197,6 +1197,26 @@ func (cli *ChatCLI) restoreTerminal() {
 	fmt.Print("\033[2J\033[H")
 }
 
+// normalizeTerminalForREPL restores a sane terminal line discipline and drains
+// orphan stdin bytes after an interrupted agent/coder turn, WITHOUT clearing the
+// screen (unlike restoreTerminal, which is for full mode switches and wipes the
+// scrollback). A Ctrl+C can land mid-read at a cooked-mode security prompt,
+// leaving the TTY's line discipline inconsistent and stray type-ahead in its
+// buffer; both corrupt the next go-prompt REPL line — the "/coder enters but
+// nothing fires" failure. Safe only between an agent op returning and the next
+// prompt, where the centralized stdin reader is already stopped and go-prompt is
+// not yet running, so nothing else owns the TTY.
+func (cli *ChatCLI) normalizeTerminalForREPL() {
+	if runtime.GOOS != "windows" {
+		cmd := exec.Command(sttyPath, "sane")
+		cmd.Stdin = os.Stdin
+		if err := cmd.Run(); err != nil {
+			cli.logger.Warn("falha ao normalizar o terminal com 'stty sane'", zap.Error(err))
+		}
+	}
+	drainStdin()
+}
+
 // Helper para executar lógica do agente com cancelamento via Ctrl+C
 func (cli *ChatCLI) runWithCancellation(parent context.Context, taskName string, fn func(context.Context) error) {
 	// Cria contexto cancelável derivado do contexto pai
@@ -1234,6 +1254,17 @@ func (cli *ChatCLI) runWithCancellation(parent context.Context, taskName string,
 
 	// Executa a função do agente
 	err := fn(ctx)
+
+	// When the operation was cancelled (Ctrl+C), the interrupt may have landed
+	// mid-read at a cooked-mode security prompt — leaving the TTY's line
+	// discipline inconsistent and stray type-ahead in its buffer. By now the
+	// centralized stdin reader is stopped (the ReAct loop's deferred
+	// stopStdinReader ran as fn returned) and go-prompt is not yet running, so
+	// nothing owns the TTY: normalize it and discard the orphan bytes before
+	// control returns to the REPL, so the next /coder or /agent command fires.
+	if ctx.Err() != nil {
+		cli.normalizeTerminalForREPL()
+	}
 
 	// Tratamento de erro específico para cancelamento
 	if err != nil {


### PR DESCRIPTION
## Problema

Ao iniciar uma iteração no `/coder` (ou `/agent`) que chega numa confirmação de segurança (comando perigoso) e apertar **CTRL+C**, a iteração era cancelada e o modo encerrado — mas o REPL ficava quebrado: o próximo `/coder`/`/agent` aparentava entrar no modo, porém **não disparava**.

## Causa raiz (3 fatores)

1. **Durante a confirmação o go-prompt já retornou** (panic-unwind `errCoderModeRequest`), então o keybind `handleCtrlC` está inativo; quem captura o sinal é o watcher de SIGINT em `runWithCancellation`, que apenas chama `cancel()`.
2. **A leitura da confirmação não era cancelável** — `readLine()` ficava preso em `<-a.stdinLines`. O `cancel()` virava o contexto, mas a leitura só retornava quando o usuário apertava Enter (terminal em modo cooked por causa do `stty sane` em `getCriticalInput`).
3. **Volta ao REPL com o terminal em cooked + bytes órfãos** no buffer do TTY, que eram consumidos pela próxima linha do go-prompt — daí o comando "não disparar".

## Correções

- **Leitura cancelável:** o loop ReAct publica seu canal de cancelamento (`ctx.Done()`) e a leitura faz `select` entre a linha e o cancelamento, declinando a ação com resposta vazia no instante do CTRL+C. Guardamos o canal `Done()`, não o `context.Context`, porque o reader só precisa do sinal e um canal nil seleciona como "never" (sem fallback). Wiring com save/restore porque o loop é reentrante.
- **Normalização do terminal:** novo `normalizeTerminalForREPL` restaura a disciplina de linha (`stty sane`) **sem** limpar a tela, executado só no caminho cancelado, quando nada mais é dono do TTY.
- **Drain de bytes órfãos:** descarte não-bloqueante e limitado (poll(0), cap de 32 KiB, deadline de 200ms como blindagem para falso-positivo do `WaitForSingleObject` no Windows) antes de devolver o controle ao prompt.

## Testes

Novo `cli/agent_mode_cancelread_test.go` cobre: regressão do hang (abort no cancelamento), sinal já-cancelado, canal nil bloqueia por input, unattended auto-aprova, wiring via sinal ativo, save/restore reentrante e drain-não-trava.

- `go build ./...` ✅
- `go test ./cli/ -race` ✅ (suíte completa)
- `gofmt` limpo ✅
- `golangci-lint --new-from-rev=origin/main` → zero findings novos ✅