### PR TITLE
fix(signals): SIGINT during an operation must not cancel the session

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -163,38 +163,6 @@ func splitStdinChunk(chunk []byte, lineBuf *strings.Builder) []string {
 	return lines
 }
 
-// drainStdin discards bytes left unread in the terminal input buffer. After an
-// interrupted agent/coder turn — especially one cancelled at a cooked-mode
-// security prompt — the TTY may hold orphan bytes: the stray newline that the
-// user pressed while Ctrl+C was racing the read, or type-ahead queued for the
-// now-dead turn. Left in place, those bytes get consumed by the next go-prompt
-// REPL line, so the following /coder or /agent command "doesn't fire".
-//
-// Must only be called when no stdin reader goroutine and no go-prompt own the
-// TTY (i.e. between an agent op returning and the next prompt) — otherwise it
-// races them for input. The poll(0) gate is non-blocking and the iteration cap
-// bounds it to 32 KiB; the whole drain runs under a short deadline so a Windows
-// WaitForSingleObject false positive (which can leave Read blocking) can never
-// hang the REPL.
-func drainStdin() {
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		buf := make([]byte, 512)
-		for i := 0; i < 64 && stdinPollReady(0); i++ {
-			if _, err := os.Stdin.Read(buf); err != nil {
-				return
-			}
-		}
-	}()
-	select {
-	case <-done:
-	case <-time.After(200 * time.Millisecond):
-		// Stuck on a blocking Read (Windows false positive). Don't wait —
-		// the orphan read is discarded when the goroutine eventually wakes.
-	}
-}
-
 // startStdinReader starts a goroutine that reads lines from stdin and sends
 // them to the stdinLines channel. This centralizes all stdin reads in agent
 // mode, enabling type-ahead queue support.

--- a/cli/agent_mode_cancelread_test.go
+++ b/cli/agent_mode_cancelread_test.go
@@ -153,30 +153,11 @@ func TestCancelSignal_SaveRestore(t *testing.T) {
 	require.Nil(t, a.currentCancelSignal(), "detaching must restore the nil signal")
 }
 
-// TestDrainStdin_DoesNotHang is a smoke test for the post-cancel cleanup: with
-// no data pending, drainStdin must return promptly via the poll(0) gate, and it
-// must always honor its internal safety deadline rather than blocking the REPL.
-func TestDrainStdin_DoesNotHang(t *testing.T) {
-	done := make(chan struct{})
-	go func() {
-		drainStdin()
-		close(done)
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(1 * time.Second):
-		t.Fatal("drainStdin exceeded its safety deadline and blocked the REPL")
-	}
-}
-
-// TestRunWithCancellation_CancelledPathNormalizes drives the wrapper with an
-// already-cancelled parent context: the wrapped function returns cleanly, but
-// because the operation context is cancelled the wrapper must run the terminal
-// recovery path before returning to the REPL. Asserts the call completes within
-// a deadline (the recovery never hangs) and that the wrapped fn observed a
-// cancelled context.
-func TestRunWithCancellation_CancelledPathNormalizes(t *testing.T) {
+// TestRunWithCancellation_CancelledParentReturnsClean drives the wrapper with an
+// already-cancelled parent context: the wrapped function must observe the
+// cancelled operation context, the call must return within a deadline (never
+// hang), and isExecuting must be reset so the REPL is usable again.
+func TestRunWithCancellation_CancelledParentReturnsClean(t *testing.T) {
 	cli := &ChatCLI{logger: zap.NewNop()}
 
 	parent, cancel := context.WithCancel(context.Background())
@@ -195,30 +176,9 @@ func TestRunWithCancellation_CancelledPathNormalizes(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(3 * time.Second):
-		t.Fatal("runWithCancellation hung on the cancelled recovery path")
+		t.Fatal("runWithCancellation hung on the cancelled path")
 	}
 
 	assert.True(t, sawCancelled, "wrapped fn should see the cancelled operation context")
 	assert.False(t, cli.isExecuting.Load(), "isExecuting must be reset on return")
-}
-
-// TestNormalizeTerminalForREPL_Completes exercises the post-cancel terminal
-// recovery: it must run the line-discipline reset and stdin drain and return
-// without panicking or hanging, even when stdin is not a TTY (CI), where the
-// stty reset errors and is logged rather than fatal. Guarded by a deadline so a
-// regression that blocks the REPL fails loudly instead of stalling the suite.
-func TestNormalizeTerminalForREPL_Completes(t *testing.T) {
-	cli := &ChatCLI{logger: zap.NewNop()}
-
-	done := make(chan struct{})
-	go func() {
-		cli.normalizeTerminalForREPL()
-		close(done)
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("normalizeTerminalForREPL blocked — terminal recovery must never stall the REPL")
-	}
 }

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1197,26 +1197,6 @@ func (cli *ChatCLI) restoreTerminal() {
 	fmt.Print("\033[2J\033[H")
 }
 
-// normalizeTerminalForREPL restores a sane terminal line discipline and drains
-// orphan stdin bytes after an interrupted agent/coder turn, WITHOUT clearing the
-// screen (unlike restoreTerminal, which is for full mode switches and wipes the
-// scrollback). A Ctrl+C can land mid-read at a cooked-mode security prompt,
-// leaving the TTY's line discipline inconsistent and stray type-ahead in its
-// buffer; both corrupt the next go-prompt REPL line — the "/coder enters but
-// nothing fires" failure. Safe only between an agent op returning and the next
-// prompt, where the centralized stdin reader is already stopped and go-prompt is
-// not yet running, so nothing else owns the TTY.
-func (cli *ChatCLI) normalizeTerminalForREPL() {
-	if runtime.GOOS != "windows" {
-		cmd := exec.Command(sttyPath, "sane")
-		cmd.Stdin = os.Stdin
-		if err := cmd.Run(); err != nil {
-			cli.logger.Warn("falha ao normalizar o terminal com 'stty sane'", zap.Error(err))
-		}
-	}
-	drainStdin()
-}
-
 // Helper para executar lógica do agente com cancelamento via Ctrl+C
 func (cli *ChatCLI) runWithCancellation(parent context.Context, taskName string, fn func(context.Context) error) {
 	// Cria contexto cancelável derivado do contexto pai
@@ -1254,17 +1234,6 @@ func (cli *ChatCLI) runWithCancellation(parent context.Context, taskName string,
 
 	// Executa a função do agente
 	err := fn(ctx)
-
-	// When the operation was cancelled (Ctrl+C), the interrupt may have landed
-	// mid-read at a cooked-mode security prompt — leaving the TTY's line
-	// discipline inconsistent and stray type-ahead in its buffer. By now the
-	// centralized stdin reader is stopped (the ReAct loop's deferred
-	// stopStdinReader ran as fn returned) and go-prompt is not yet running, so
-	// nothing owns the TTY: normalize it and discard the orphan bytes before
-	// control returns to the REPL, so the next /coder or /agent command fires.
-	if ctx.Err() != nil {
-		cli.normalizeTerminalForREPL()
-	}
 
 	// Tratamento de erro específico para cancelamento
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -72,26 +72,42 @@ func applyStackSpotFlags(llmManager manager.LLMManager, targetProvider string, o
 	}
 }
 
-// installInterruptHandler wires SIGINT so an in-flight operation is canceled
-// first, and otherwise the root context is canceled for a clean shutdown.
-func installInterruptHandler(chatCLI *cli.ChatCLI, cancel context.CancelFunc, logger *zap.Logger) {
+// installSignalHandlers wires process signals to the correct cancellation
+// scope. It is the SINGLE handler for SIGINT and SIGTERM — having two
+// independent handlers is exactly what caused the coder/agent re-entry bug
+// (see below).
+//
+//   - SIGTERM is always a shutdown request → cancel the root context.
+//   - SIGINT (Ctrl+C) cancels the in-flight operation when one is running
+//     (the interactive "interrupt this, keep the session" semantics), and only
+//     shuts the session down when idle at the prompt.
+//
+// CRITICAL: a SIGINT delivered WHILE a coder/agent operation runs must NOT
+// cancel the root context. During a security confirmation the TTY is in cooked
+// mode, so Ctrl+C arrives as a real signal (not a go-prompt key). If that
+// cancels the root context, every later coder/agent run — which derives its
+// context from root — is born already-cancelled and "doesn't fire", while chat
+// keeps working on a fresh background context. The only recovery was restarting
+// the process. Cancelling just the operation is the correct response; the root
+// context stays alive for the rest of the session.
+//
+// On a clean shutdown the root cancel lets chatCLI.Start() return so the
+// deferred cli.cleanup() runs (stopping MCP child processes, draining the
+// scheduler, flushing history) — os.Exit() would skip every defer and orphan
+// the npx-spawned MCP servers.
+func installSignalHandlers(isExecuting func() bool, cancelOperation, cancelRoot func(), logger *zap.Logger) {
 	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 
 	go func() {
-		for range sigChan {
-			if chatCLI.IsExecuting() {
-				logger.Info("Cancelando operação em andamento")
-				chatCLI.CancelOperation()
-			} else {
-				// Cancel the root context so chatCLI.Start() returns
-				// and the deferred cli.cleanup() runs — that's what
-				// stops MCP child processes, drains the scheduler and
-				// flushes history. os.Exit() would skip every defer
-				// and orphan the npx-spawned MCP servers.
-				logger.Info("Encerrando aplicação")
-				cancel()
+		for sig := range sigChan {
+			if sig == syscall.SIGINT && isExecuting() {
+				logger.Info("Cancelando operação em andamento (SIGINT)")
+				cancelOperation()
+				continue
 			}
+			logger.Info("Encerrando aplicação", zap.String("signal", sig.String()))
+			cancelRoot()
 		}
 	}()
 }
@@ -205,25 +221,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	installInterruptHandler(chatCLI, cancel, logger)
+	installSignalHandlers(chatCLI.IsExecuting, chatCLI.CancelOperation, cancel, logger)
 
 	if chatCLI.HandleOneShotOrFatal(ctx, opts) {
 		return
 	}
 
-	handleGracefulShutdown(cancel, logger)
-
 	chatCLI.Start(ctx)
-}
-
-func handleGracefulShutdown(cancelFunc context.CancelFunc, logger *zap.Logger) {
-	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
-	go func() {
-		sig := <-signals
-		logger.Info("Recebido sinal para finalizar a aplicação", zap.String("sinal", sig.String()))
-		cancelFunc()
-	}()
 }
 
 // runSubcommand handles the 'server' and 'connect' subcommands.

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,111 @@
+//go:build !windows
+
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package main
+
+import (
+	"os"
+	"os/signal"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// raiseSignal delivers sig to the current process. signal.Notify (installed by
+// installSignalHandlers) captures it before the default disposition fires.
+func raiseSignal(t *testing.T, sig syscall.Signal) {
+	t.Helper()
+	if err := syscall.Kill(os.Getpid(), sig); err != nil {
+		t.Fatalf("kill(self, %v): %v", sig, err)
+	}
+}
+
+// TestInstallSignalHandlers_SIGINTWhileExecuting is the regression test for the
+// coder/agent re-entry bug: a Ctrl+C that arrives as a REAL SIGINT while an
+// operation is in flight — e.g. at a cooked-mode security confirmation — must
+// cancel ONLY the in-flight operation, never the root/session context. A root
+// cancel there permanently poisoned every later coder/agent run (born from a
+// cancelled context) while chat kept working on a fresh background context, and
+// the only recovery was restarting the process.
+func TestInstallSignalHandlers_SIGINTWhileExecuting(t *testing.T) {
+	signal.Reset(syscall.SIGINT, syscall.SIGTERM)
+
+	var rootCanceled atomic.Bool
+	opCanceled := make(chan struct{}, 1)
+
+	installSignalHandlers(
+		func() bool { return true }, // operation in flight
+		func() { opCanceled <- struct{}{} },
+		func() { rootCanceled.Store(true) },
+		zap.NewNop(),
+	)
+
+	raiseSignal(t, syscall.SIGINT)
+
+	select {
+	case <-opCanceled:
+	case <-time.After(3 * time.Second):
+		t.Fatal("SIGINT while executing did not cancel the operation")
+	}
+
+	// Give a wrong root-cancel a chance to fire before asserting it did not.
+	time.Sleep(150 * time.Millisecond)
+	if rootCanceled.Load() {
+		t.Fatal("SIGINT while executing cancelled the ROOT context — this is the coder/agent re-entry bug")
+	}
+}
+
+// TestInstallSignalHandlers_SIGINTWhileIdle confirms the other half: when no
+// operation is running, Ctrl+C at the prompt is a shutdown request and cancels
+// the root context so Start() returns and cleanup runs.
+func TestInstallSignalHandlers_SIGINTWhileIdle(t *testing.T) {
+	signal.Reset(syscall.SIGINT, syscall.SIGTERM)
+
+	rootDone := make(chan struct{}, 1)
+
+	installSignalHandlers(
+		func() bool { return false }, // idle at the prompt
+		func() { t.Error("operation cancel must not run when idle") },
+		func() { rootDone <- struct{}{} },
+		zap.NewNop(),
+	)
+
+	raiseSignal(t, syscall.SIGINT)
+
+	select {
+	case <-rootDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("idle SIGINT did not cancel the root context (shutdown regressed)")
+	}
+}
+
+// TestInstallSignalHandlers_SIGTERMAlwaysShutsDown verifies SIGTERM cancels the
+// root context even mid-operation — a kill is always a shutdown, never an
+// operation interrupt.
+func TestInstallSignalHandlers_SIGTERMAlwaysShutsDown(t *testing.T) {
+	signal.Reset(syscall.SIGINT, syscall.SIGTERM)
+
+	rootDone := make(chan struct{}, 1)
+
+	installSignalHandlers(
+		func() bool { return true }, // even while executing
+		func() { t.Error("SIGTERM must not be treated as an operation cancel") },
+		func() { rootDone <- struct{}{} },
+		zap.NewNop(),
+	)
+
+	raiseSignal(t, syscall.SIGTERM)
+
+	select {
+	case <-rootDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("SIGTERM did not cancel the root context")
+	}
+}


### PR DESCRIPTION
## A causa REAL (a anterior, #1077, não resolveu)

Sintoma: depois de cancelar uma **confirmação de segurança no /coder com CTRL+C**, `/coder` e `/agent` param de disparar — só o chat funciona — até reabrir o chatcli.

Havia **dois handlers de SIGINT** independentes no `main.go`:
- `installInterruptHandler` — op-aware: se executando cancela só a operação, senão cancela o root. **Correto.**
- `handleGracefulShutdown` — `signal.Notify(..., os.Interrupt, ...)` → cancela o root **incondicionalmente**. **O bug.**

Durante a confirmação de segurança o TTY está em **cooked mode** (a confirmação roda `stty sane`), então o CTRL+C chega como **SIGINT real**. O handler incondicional cancela o **root context pra sempre**. Coder/agent derivam o contexto do root → nascem já cancelados → retornam na hora ("não dispara"). O chat usa `context.Background()` → imune. Só restart reconstrói o root.

Por isso só acontece via a confirmação: no prompt normal o CTRL+C é tecla do go-prompt (raw mode, byte 0x03, sem SIGINT).

## O fix

Consolida os dois num **único** handler:
- **SIGTERM** → sempre shutdown (cancela root).
- **SIGINT** → cancela só a operação em andamento quando há uma; só faz shutdown quando ocioso no prompt.

O root context agora sobrevive a uma interrupção interativa.

## Verificação (red→green comprovado)

`main_test.go` entrega um **SIGINT real** e afirma que a operação é cancelada enquanto o root **permanece vivo**; mais os casos de SIGINT ocioso e SIGTERM (shutdown). Confirmei que o teste do caso "executando" **FALHA no comportamento antigo** (reintroduzido temporariamente) e passa no fix — é uma reprodução genuína, não só um teste que acompanha o código.

Verde: `go build ./...`, `go vet ./...`, gofmt, `golangci-lint --new-from-rev=origin/main` (zero), suítes root + cli.