### PR TITLE
fix(imagegen): refresh model catalog and pin image HTTP calls to HTTP/1.1

### DIFF
--- a/cli/config_image_mutate_test.go
+++ b/cli/config_image_mutate_test.go
@@ -53,7 +53,7 @@ func TestImageModelsCatalog_Content(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "") // skip live GET
 	cli := &ChatCLI{logger: zap.NewNop()}
 	out := cli.imageModelsCatalog(context.Background())
-	for _, want := range []string{"gpt-image-1", "gpt-5.5", "grok-2-image", "nova-canvas"} {
+	for _, want := range []string{"gpt-image-1", "gpt-5.5", "grok-imagine-image", "nova-canvas"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("catalog missing %q", want)
 		}

--- a/llm/imagegen/automatic1111.go
+++ b/llm/imagegen/automatic1111.go
@@ -50,7 +50,7 @@ func NewAutomatic1111(baseURL string, steps int, logger *zap.Logger) (*Automatic
 	if logger == nil {
 		logger = zap.NewNop()
 	}
-	return &Automatic1111{baseURL: baseURL, steps: steps, client: utils.NewHTTPClient(logger, imageGenTimeout)}, nil
+	return &Automatic1111{baseURL: baseURL, steps: steps, client: utils.NewHTTPClientH1(logger, imageGenTimeout)}, nil
 }
 
 // Name returns "sdwebui".

--- a/llm/imagegen/catalog.go
+++ b/llm/imagegen/catalog.go
@@ -45,15 +45,22 @@ func KnownModels() []ModelInfo {
 		// OpenAI Responses API (a chat model generates via the image_generation tool).
 		{Name: "gpt-5.5", Provider: "openai", API: "responses", Note: "Chat model w/ image_generation tool (Responses API)."},
 		{Name: "gpt-5", Provider: "openai", API: "responses", Note: "gpt-5 and newer support the image_generation tool."},
-		// Google.
-		{Name: "imagen-3.0-generate-002", Provider: "google", API: "native", Note: "Google Imagen (predict)."},
-		// xAI.
-		{Name: "grok-2-image", Provider: "xai", API: "native", Note: "xAI image (OpenAI-shaped /images/generations, no size)."},
-		{Name: "grok-imagine-image-quality", Provider: "xai", API: "imagine", Note: "xAI Imagine quality model (Imagine API)."},
+		// Google Imagen (:predict, generation-only). Imagen 3 was retired from the
+		// Gemini API (only 404s now) — Imagen 4 is the current family.
+		{Name: "imagen-4.0-generate-001", Provider: "google", API: "native", Note: "Google Imagen 4 (predict; default)."},
+		{Name: "imagen-4.0-ultra-generate-001", Provider: "google", API: "native", Note: "Google Imagen 4 Ultra (predict; highest quality)."},
+		{Name: "imagen-4.0-fast-generate-001", Provider: "google", API: "native", Note: "Google Imagen 4 Fast (predict; cheapest/fast)."},
+		// Google Gemini image models (:generateContent — text-to-image AND editing).
+		{Name: "gemini-2.5-flash-image", Provider: "google", API: "gemini", Note: "Gemini 2.5 Flash Image (gen + edit; default editor)."},
+		{Name: "gemini-3-pro-image", Provider: "google", API: "gemini", Note: "Gemini 3 Pro Image (gen + edit; highest quality)."},
+		{Name: "gemini-3.1-flash-image", Provider: "google", API: "gemini", Note: "Gemini 3.1 Flash Image (gen + edit; fast)."},
+		// xAI. grok-2-image was retired and grok-imagine-image-quality is async
+		// (it resets the connection on /images/generations → EOF) — removed.
+		{Name: "grok-imagine-image", Provider: "xai", API: "native", Note: "xAI Grok Imagine (OpenAI-shaped /images/generations, no size; URL response)."},
 		// Z.AI (Zhipu) — OpenAI-shaped /images/generations, returns image URLs.
+		// cogview-3-flash is China-only (open.bigmodel.cn) and not on api.z.ai — omitted.
 		{Name: "glm-image", Provider: "zai", API: "images", Note: "Z.AI GLM-Image (newest; bilingual text-in-image; default)."},
 		{Name: "cogview-4-250304", Provider: "zai", API: "images", Note: "Z.AI CogView-4 flagship (bilingual)."},
-		{Name: "cogview-3-flash", Provider: "zai", API: "images", Note: "Z.AI CogView-3 Flash (free tier)."},
 		// MiniMax (Hailuo) — custom /v1/image_generation endpoint, base64 response.
 		{Name: "image-01", Provider: "minimax", API: "native", Note: "MiniMax Image-01 (text-to-image, up to 9 images)."},
 		// AWS Bedrock (InvokeModel). Current Stability models use the text-to-image
@@ -63,7 +70,7 @@ func KnownModels() []ModelInfo {
 		{Name: "stability.stable-image-ultra-v1:1", Provider: "bedrock", API: "stability", Note: "Bedrock Stability Stable Image Ultra (current; highest quality)."},
 		{Name: "stability.sd3-5-large-v1:0", Provider: "bedrock", API: "stability", Note: "Bedrock Stability SD3.5 Large (current; flagship)."},
 		{Name: "amazon.nova-canvas-v1:0", Provider: "bedrock", API: "native", Note: "Bedrock Nova Canvas (TEXT_IMAGE; LEGACY, EOL 2026-09-30)."},
-		{Name: "amazon.titan-image-generator-v2:0", Provider: "bedrock", API: "native", Note: "Bedrock Titan Image v2 (TEXT_IMAGE; legacy)."},
+		{Name: "amazon.titan-image-generator-v2:0", Provider: "bedrock", API: "native", Note: "Bedrock Titan Image v2 (TEXT_IMAGE; LEGACY, EOL 2026-06-30)."},
 	}
 }
 
@@ -85,7 +92,7 @@ func FetchOpenAIModels(ctx context.Context, baseURL, apiKey string, logger *zap.
 		return nil, err
 	}
 	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(apiKey))
-	resp, err := utils.NewHTTPClient(logger, imageGenTimeout).Do(req)
+	resp, err := utils.NewHTTPClientH1(logger, imageGenTimeout).Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/llm/imagegen/factory.go
+++ b/llm/imagegen/factory.go
@@ -38,9 +38,12 @@ import (
 )
 
 const (
-	openAIBaseURL   = "https://api.openai.com/v1"
-	xaiBaseURL      = "https://api.x.ai/v1"
-	defaultXAIModel = "grok-2-image"
+	openAIBaseURL = "https://api.openai.com/v1"
+	xaiBaseURL    = "https://api.x.ai/v1"
+	// defaultXAIModel is xAI's current image model. grok-2-image was retired
+	// (404s now); grok-imagine-image is the current Grok Imagine generator
+	// (OpenAI-shaped /images/generations, returns an image URL).
+	defaultXAIModel = "grok-imagine-image"
 
 	// Z.AI (Zhipu) CogView / GLM-Image: OpenAI-shaped /images/generations, but
 	// the response carries image URLs and the "n" field is rejected.
@@ -406,7 +409,7 @@ func providerFromModel(model string) string {
 		return "minimax"
 	case strings.HasPrefix(model, "grok"):
 		return "xai"
-	case strings.HasPrefix(model, "imagen"):
+	case strings.HasPrefix(model, "imagen"), strings.HasPrefix(model, "gemini"):
 		return "google"
 	case strings.HasPrefix(model, "gpt-image"), strings.HasPrefix(model, "dall-e"):
 		return "openai"

--- a/llm/imagegen/google.go
+++ b/llm/imagegen/google.go
@@ -27,8 +27,11 @@ import (
 )
 
 const (
-	googleImageBase    = "https://generativelanguage.googleapis.com"
-	defaultImagenModel = "imagen-3.0-generate-002"
+	googleImageBase = "https://generativelanguage.googleapis.com"
+	// defaultImagenModel is the current Imagen generation model. Imagen 3
+	// (imagen-3.0-generate-002) was retired from the Gemini API and only 404s
+	// now; Imagen 4 is the current family.
+	defaultImagenModel = "imagen-4.0-generate-001"
 	// defaultGeminiImageModel is a Gemini image model ("Nano Banana") that
 	// edits via :generateContent with an inline input image. Imagen's :predict
 	// endpoint is generation-only, so editing routes through this model.
@@ -54,16 +57,27 @@ func NewGoogle(apiKey, model string, logger *zap.Logger) (*Google, error) {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
-	return &Google{baseURL: googleImageBase, apiKey: strings.TrimSpace(apiKey), model: model, client: utils.NewHTTPClient(logger, imageGenTimeout)}, nil
+	return &Google{baseURL: googleImageBase, apiKey: strings.TrimSpace(apiKey), model: model, client: utils.NewHTTPClientH1(logger, imageGenTimeout)}, nil
 }
 
 // Name returns "google".
 func (*Google) Name() string { return "google" }
 
-// Generate posts the prompt and decodes the returned base64 images.
+// isGeminiModel reports whether the configured model is a Gemini image model
+// (gen + edit via :generateContent) rather than an Imagen model (:predict).
+func isGeminiModel(model string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(model)), "gemini")
+}
+
+// Generate produces images from a text prompt. Imagen models use the :predict
+// endpoint; Gemini image models (gemini-*-image) generate via :generateContent
+// with an IMAGE response modality, so they route through the shared helper.
 func (g *Google) Generate(ctx context.Context, prompt string, opts Options) ([]Image, error) {
 	if strings.TrimSpace(prompt) == "" {
 		return nil, fmt.Errorf("imagegen: empty prompt")
+	}
+	if isGeminiModel(g.model) {
+		return g.generateContentImages(ctx, g.model, []map[string]interface{}{{"text": prompt}})
 	}
 	n := opts.N
 	if n <= 0 {
@@ -155,6 +169,14 @@ func (g *Google) Edit(ctx context.Context, prompt string, inputs []Image, opts E
 		})
 	}
 
+	return g.generateContentImages(ctx, model, parts)
+}
+
+// generateContentImages posts a :generateContent request (IMAGE modality) with
+// the given parts and decodes the returned inline images. It serves both
+// text-to-image generation (parts = just the prompt) and editing (parts =
+// prompt + inline input images) for Gemini image models.
+func (g *Google) generateContentImages(ctx context.Context, model string, parts []map[string]interface{}) ([]Image, error) {
 	body, _ := json.Marshal(map[string]interface{}{
 		"contents": []map[string]interface{}{{"role": "user", "parts": parts}},
 		"generationConfig": map[string]interface{}{
@@ -174,7 +196,7 @@ func (g *Google) Edit(ctx context.Context, prompt string, inputs []Image, opts E
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrBody))
-		return nil, fmt.Errorf("imagegen: google edit returned %d: %s", resp.StatusCode, strings.TrimSpace(string(snippet)))
+		return nil, fmt.Errorf("imagegen: google returned %d: %s", resp.StatusCode, strings.TrimSpace(string(snippet)))
 	}
 
 	var out struct {
@@ -214,7 +236,7 @@ func (g *Google) Edit(ctx context.Context, prompt string, inputs []Image, opts E
 		}
 	}
 	if len(images) == 0 {
-		return nil, fmt.Errorf("imagegen: google edit returned no image (model %q may not support image output)", model)
+		return nil, fmt.Errorf("imagegen: google returned no image (model %q may not support image output)", model)
 	}
 	return images, nil
 }

--- a/llm/imagegen/google_edit_test.go
+++ b/llm/imagegen/google_edit_test.go
@@ -75,11 +75,61 @@ func TestGoogleEdit_RoutesImagenToGemini(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	g := &Google{baseURL: srv.URL, apiKey: "k", model: "imagen-3.0-generate-002", client: srv.Client()}
+	g := &Google{baseURL: srv.URL, apiKey: "k", model: "imagen-4.0-generate-001", client: srv.Client()}
 	if _, err := g.Edit(context.Background(), "x", []Image{{Data: []byte("i"), Mime: "image/png"}}, EditOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(path, defaultGeminiImageModel) {
 		t.Errorf("Imagen edit should route to %q, path was %q", defaultGeminiImageModel, path)
+	}
+}
+
+// A Gemini image model generates from text via :generateContent (not Imagen's
+// :predict). Proves Generate routes gemini-* to the generateContent endpoint.
+func TestGoogleGenerate_GeminiUsesGenerateContent(t *testing.T) {
+	var path string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.Path
+		resp := map[string]interface{}{
+			"candidates": []map[string]interface{}{{
+				"content": map[string]interface{}{
+					"parts": []map[string]interface{}{{
+						"inlineData": map[string]interface{}{"data": base64.StdEncoding.EncodeToString([]byte("Y"))},
+					}},
+				},
+			}},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	g := &Google{baseURL: srv.URL, apiKey: "k", model: "gemini-2.5-flash-image", client: srv.Client()}
+	imgs, err := g.Generate(context.Background(), "a fox", Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(path, ":generateContent") {
+		t.Errorf("gemini Generate should hit :generateContent, path was %q", path)
+	}
+	if len(imgs) != 1 || string(imgs[0].Data) != "Y" {
+		t.Errorf("unexpected images %+v", imgs)
+	}
+}
+
+// An Imagen model must keep using the :predict endpoint for generation.
+func TestGoogleGenerate_ImagenUsesPredict(t *testing.T) {
+	var path string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.Path
+		_, _ = w.Write([]byte(`{"predictions":[{"bytesBase64Encoded":"` + base64.StdEncoding.EncodeToString([]byte("Z")) + `","mimeType":"image/png"}]}`))
+	}))
+	defer srv.Close()
+
+	g := &Google{baseURL: srv.URL, apiKey: "k", model: "imagen-4.0-generate-001", client: srv.Client()}
+	if _, err := g.Generate(context.Background(), "a fox", Options{}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(path, ":predict") {
+		t.Errorf("imagen Generate should hit :predict, path was %q", path)
 	}
 }

--- a/llm/imagegen/imagegen_more_test.go
+++ b/llm/imagegen/imagegen_more_test.go
@@ -161,7 +161,7 @@ func TestAspectRatio(t *testing.T) {
 }
 
 func TestKnownModels_NewIDs(t *testing.T) {
-	want := map[string]bool{"gpt-image-2": false, "gpt-image-1-mini": false, "grok-imagine-image-quality": false, "amazon.nova-canvas-v1:0": false, "stability.sd3-5-large-v1:0": false}
+	want := map[string]bool{"gpt-image-2": false, "gpt-image-1-mini": false, "grok-imagine-image": false, "imagen-4.0-generate-001": false, "gemini-2.5-flash-image": false, "amazon.nova-canvas-v1:0": false, "stability.sd3-5-large-v1:0": false}
 	for _, m := range KnownModels() {
 		if _, ok := want[m.Name]; ok {
 			want[m.Name] = true

--- a/llm/imagegen/imagegen_test.go
+++ b/llm/imagegen/imagegen_test.go
@@ -120,7 +120,7 @@ func TestGoogle_Generate(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	g, err := NewGoogle("gkey", "imagen-3.0-generate-002", zap.NewNop())
+	g, err := NewGoogle("gkey", "imagen-4.0-generate-001", zap.NewNop())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,7 +154,7 @@ func TestXAI_OmitsSize(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p, err := NewOpenAICompatible(srv.URL, "xkey", "grok-2-image", "xai", zap.NewNop())
+	p, err := NewOpenAICompatible(srv.URL, "xkey", "grok-imagine-image", "xai", zap.NewNop())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/llm/imagegen/minimax.go
+++ b/llm/imagegen/minimax.go
@@ -58,7 +58,7 @@ func NewMiniMax(baseURL, apiKey, model string, logger *zap.Logger) (*MiniMax, er
 		baseURL: baseURL,
 		apiKey:  strings.TrimSpace(apiKey),
 		model:   model,
-		client:  utils.NewHTTPClient(logger, imageGenTimeout),
+		client:  utils.NewHTTPClientH1(logger, imageGenTimeout),
 	}, nil
 }
 

--- a/llm/imagegen/minimax_zai_test.go
+++ b/llm/imagegen/minimax_zai_test.go
@@ -188,8 +188,9 @@ func TestProviderFromModel(t *testing.T) {
 		"image-01":                         "minimax",
 		"gpt-image-1":                      "openai",
 		"gpt-5.5":                          "openai-responses",
-		"grok-2-image":                     "xai",
-		"imagen-3.0-generate-002":          "google",
+		"grok-imagine-image":               "xai",
+		"imagen-4.0-generate-001":          "google",
+		"gemini-2.5-flash-image":           "google",
 		"stability.stable-image-core-v1:1": "bedrock",
 		"amazon.nova-canvas-v1:0":          "bedrock",
 		"":                                 "",
@@ -243,8 +244,8 @@ func TestFactoryAutoRoutesEachProvider(t *testing.T) {
 	}{
 		{"gpt-image-1", "OPENAI_API_KEY", "ok", "openai"},
 		{"gpt-5.5", "OPENAI_API_KEY", "ok", ""}, // responses backend; just must not be Null
-		{"imagen-3.0-generate-002", "GOOGLEAI_API_KEY", "gk", "google"},
-		{"grok-2-image", "XAI_API_KEY", "xk", "xai"},
+		{"imagen-4.0-generate-001", "GOOGLEAI_API_KEY", "gk", "google"},
+		{"grok-imagine-image", "XAI_API_KEY", "xk", "xai"},
 	}
 	for _, c := range cases {
 		clear()

--- a/llm/imagegen/openai_compatible.go
+++ b/llm/imagegen/openai_compatible.go
@@ -78,7 +78,7 @@ func NewOpenAICompatible(baseURL, apiKey, model, label string, logger *zap.Logge
 		apiKey:  strings.TrimSpace(apiKey),
 		model:   model,
 		label:   label,
-		client:  utils.NewHTTPClient(logger, imageGenTimeout),
+		client:  utils.NewHTTPClientH1(logger, imageGenTimeout),
 	}, nil
 }
 

--- a/llm/imagegen/openai_responses.go
+++ b/llm/imagegen/openai_responses.go
@@ -64,7 +64,7 @@ func NewOpenAIResponses(baseURL, apiKey, model string, logger *zap.Logger) (*Ope
 		baseURL: baseURL,
 		apiKey:  strings.TrimSpace(apiKey),
 		model:   model,
-		client:  utils.NewHTTPClient(logger, imageGenTimeout),
+		client:  utils.NewHTTPClientH1(logger, imageGenTimeout),
 	}, nil
 }
 

--- a/utils/http_client.go
+++ b/utils/http_client.go
@@ -6,6 +6,7 @@
 package utils
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
@@ -38,6 +39,41 @@ func NewHTTPClient(logger *zap.Logger, timeout time.Duration) *http.Client {
 	// dedicated TLS session cache.
 	if tlsCfg := GlobalTLSConfig(); tlsCfg != nil {
 		transport.TLSClientConfig = tlsCfg.Clone()
+	}
+	return NewHTTPClientWithTransport(logger, timeout, transport)
+}
+
+// NewHTTPClientH1 is like NewHTTPClient but pins the connection to HTTP/1.1.
+//
+// Go's bundled HTTP/2 client intermittently fails a POST-with-body with
+// "unexpected EOF" against some Cloudflare-fronted hosts (observed on
+// api.openai.com and api.x.ai image endpoints): the edge closes an idle h2
+// connection and the next request races the GOAWAY, and net/http does NOT
+// retry requests that carry a body. HTTP/1.1 sidesteps the whole race and is
+// rock-solid for request/response calls. Use it for non-streaming endpoints
+// that send/receive large payloads (image generation), where h2 multiplexing
+// buys nothing. Corporate TLS trust (CHATCLI_CA_BUNDLE /
+// CHATCLI_TLS_INSECURE_SKIP_VERIFY) is preserved; only ALPN is constrained.
+func NewHTTPClientH1(logger *zap.Logger, timeout time.Duration) *http.Client {
+	tlsCfg := &tls.Config{NextProtos: []string{"http/1.1"}, MinVersion: tls.VersionTLS12}
+	if g := GlobalTLSConfig(); g != nil {
+		tlsCfg = g.Clone()
+		tlsCfg.NextProtos = []string{"http/1.1"}
+	}
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     false,
+		TLSClientConfig:       tlsCfg,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		// Non-nil empty map is the canonical way to disable HTTP/2 upgrade.
+		TLSNextProto: map[string]func(string, *tls.Conn) http.RoundTripper{},
 	}
 	return NewHTTPClientWithTransport(logger, timeout, transport)
 }

--- a/utils/http_client_test.go
+++ b/utils/http_client_test.go
@@ -1,0 +1,43 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package utils
+
+import (
+	"crypto/tls"
+	"net/http"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// NewHTTPClientH1 must pin HTTP/1.1: ForceAttemptHTTP2 off, ALPN restricted to
+// http/1.1, and TLSNextProto a non-nil empty map (the canonical h2-disable).
+// This is the fix for the intermittent "unexpected EOF" Go's h2 client returns
+// on POST-with-body to some Cloudflare-fronted hosts (api.openai.com, api.x.ai).
+func TestNewHTTPClientH1_DisablesHTTP2(t *testing.T) {
+	c := NewHTTPClientH1(zap.NewNop(), 5*time.Second)
+	lt, ok := c.Transport.(*LoggingTransport)
+	if !ok {
+		t.Fatalf("expected *LoggingTransport, got %T", c.Transport)
+	}
+	tr, ok := lt.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport inner, got %T", lt.Transport)
+	}
+	if tr.ForceAttemptHTTP2 {
+		t.Error("ForceAttemptHTTP2 must be false")
+	}
+	if tr.TLSNextProto == nil || len(tr.TLSNextProto) != 0 {
+		t.Errorf("TLSNextProto must be a non-nil empty map, got %v", tr.TLSNextProto)
+	}
+	if tr.TLSClientConfig == nil || len(tr.TLSClientConfig.NextProtos) != 1 || tr.TLSClientConfig.NextProtos[0] != "http/1.1" {
+		t.Errorf("TLSClientConfig.NextProtos must be [http/1.1], got %v", tr.TLSClientConfig)
+	}
+	if tr.TLSClientConfig.MinVersion < tls.VersionTLS12 {
+		t.Errorf("MinVersion must be >= TLS 1.2, got %x", tr.TLSClientConfig.MinVersion)
+	}
+}


### PR DESCRIPTION
## Problema

Geração de imagem estava quebrada com vários sintomas convergindo: OpenAI "não gerava", Google retornava 404 de modelo, e tentativas em vários providers terminavam em `unexpected EOF`. São **três bugs distintos**.

### 1. Modelos defasados no catálogo
- Google: default `imagen-3.0-generate-002` foi **descontinuado** → 404.
- xAI: default `grok-2-image` **não existe mais** → 404; e `grok-imagine-image-quality` reseta a conexão (contribuía para o "EOF").
- Validado ao vivo: a única opção válida no Google é a família `imagen-4.0-*`; no xAI é `grok-imagine-image`.

### 2. Geração via Gemini
Modelos Gemini de imagem geram por `:generateContent`, não pelo `:predict` do Imagen. O `Generate` agora roteia ids `gemini-*` para o helper de `generateContent`.

### 3. `unexpected EOF` (causa-raiz real)
O cliente HTTP/2 do Go retorna `unexpected EOF` de forma **intermitente** em POST-com-corpo para hosts atrás de Cloudflare (`api.openai.com`, `api.x.ai`); o edge fecha a conexão ociosa e o `net/http` **não** faz retry de request com body. HTTP/1.1 é 100% estável nesses endpoints.

## Mudanças
- Novo `utils.NewHTTPClientH1` que fixa HTTP/1.1 (ALPN `http/1.1`, `TLSNextProto` vazio, `MinVersion` TLS 1.2). Todos os backends de imagem passam a usá-lo.
- Catálogo atualizado: família Imagen 4 + modelos Gemini de imagem + `grok-imagine-image`; removidos ids mortos e o `cogview-3-flash` (China-only); nota de EOL do Titan v2.
- Defaults: xAI `grok-imagine-image`, Google `imagen-4.0-generate-001`.
- `providerFromModel` mapeia prefixo `gemini` → google.
- Testes novos: client HTTP/1.1 desliga h2; roteamento Gemini→generateContent e Imagen→predict.

## Validação
- `go build ./...`, `go vet`, `gofmt`, e suítes `utils` / `llm/imagegen` / `cli` passam.
- Validação end-to-end contra as APIs reais (OpenAI `gpt-image-1`, Google `imagen-4.0-generate-001`, Google `gemini-2.5-flash-image`, xAI `grok-imagine-image`) — todas retornam imagem.

## Providers sem key local
Z.AI, MiniMax e Bedrock foram validados via docs oficiais (MiniMax `image-01` e os 5 ids do Bedrock seguem válidos; `cogview-3-flash` removido por ser China-only). Não houve teste ao vivo nesses três.
