### PR TITLE
refactor(hyde): extract hydeAugmenterFor seam, drop dead wrapper

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -1013,11 +1013,7 @@ func (a *AgentMode) buildWorkspaceBlocks(ctx context.Context, query string) (str
 	// "full" (push) injects the whole hint-driven retrieval. Agent/coder
 	// can pull, so they honor the configured mode directly.
 	mode := loadMemoryMode()
-	var aug *memory.HyDEAugmenter
-	if a.qualityConfig.HyDE.Enabled && a.qualityConfig.Enabled {
-		a.cli.ensureHyDEVectors(a.qualityConfig)
-		aug = a.cli.hydeAugmenter(a.qualityConfig)
-	}
+	aug := a.cli.hydeAugmenterFor(a.qualityConfig)
 	recallHint := ""
 	if mode == memModeIndex {
 		recallHint = memoryRecallHint

--- a/cli/chat_pipeline.go
+++ b/cli/chat_pipeline.go
@@ -207,11 +207,7 @@ func (cli *ChatCLI) retrieveWorkspaceContext(ctx context.Context, userInput stri
 	if mode == memModeIndex {
 		mode = memModeFull // chat cannot recall; fall back to the push model
 	}
-	var aug *memory.HyDEAugmenter
-	if qcfg := quality.LoadFromEnv(); qcfg.HyDE.Enabled && qcfg.Enabled {
-		cli.ensureHyDEVectors(qcfg)
-		aug = cli.hydeAugmenter(qcfg)
-	}
+	aug := cli.hydeAugmenterFor(quality.LoadFromEnv())
 	return cli.contextBuilder.BuildWorkspaceContextMode(ctx, userInput, hints, aug, mode, "")
 }
 

--- a/cli/hyde_setup.go
+++ b/cli/hyde_setup.go
@@ -154,14 +154,20 @@ func (cli *ChatCLI) ensureHyDEVectors(qcfg quality.Config) {
 		zap.Int("loaded", idx.Count()))
 }
 
-// hydeRetrieveContext is the entry point used by chat (cli_llm.go) and
-// agent (agent_mode.go) to assemble the workspace context with HyDE
-// applied. Falls back to the non-HyDE path when augmenter is nil.
-func (cli *ChatCLI) hydeRetrieveContext(ctx context.Context, query string, hints []string, qcfg quality.Config) string {
-	if cli.contextBuilder == nil {
-		return ""
+// hydeAugmenterFor resolves the per-call HyDE augmenter: it lazily attaches the
+// vector index when needed and returns the augmenter, or nil when HyDE is
+// disabled (or no LLM client is wired). This is the single setup seam every
+// retrieval path shares — chat, agent/coder, and the @memory recall tool.
+//
+// Only this preparation step is centralized; what each caller does with the
+// augmenter (mode-aware workspace context, direct memory recall, ...)
+// legitimately differs and stays at the call site. Downstream builders already
+// treat a nil augmenter as the non-HyDE path, so callers can pass the result
+// straight through.
+func (cli *ChatCLI) hydeAugmenterFor(qcfg quality.Config) *memory.HyDEAugmenter {
+	if !qcfg.Enabled || !qcfg.HyDE.Enabled {
+		return nil
 	}
 	cli.ensureHyDEVectors(qcfg)
-	aug := cli.hydeAugmenter(qcfg)
-	return cli.contextBuilder.BuildSystemPromptPrefixWithHyDE(ctx, query, hints, aug)
+	return cli.hydeAugmenter(qcfg)
 }

--- a/cli/hyde_setup_test.go
+++ b/cli/hyde_setup_test.go
@@ -1,9 +1,13 @@
 package cli
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/diillson/chatcli/cli/agent/quality"
 	"github.com/diillson/chatcli/cli/workspace"
 	"github.com/diillson/chatcli/cli/workspace/memory"
 	"github.com/diillson/chatcli/llm/embedding"
@@ -123,6 +127,51 @@ func TestRefreshEmbeddingProvider_RewiresContextRetrieval(t *testing.T) {
 	cli.refreshEmbeddingProvider()
 	if ch.GetManager().RetrievalEnabled() {
 		t.Fatal("expected /context retrieval disabled after provider removal")
+	}
+}
+
+func TestHydeAugmenterFor(t *testing.T) {
+	resetHydeProvider(t)
+	cli := &ChatCLI{logger: zap.NewNop()}
+
+	// Master switch off — augmenter is nil regardless of the HyDE block.
+	if aug := cli.hydeAugmenterFor(quality.Config{Enabled: false, HyDE: quality.HyDEConfig{Enabled: true}}); aug != nil {
+		t.Fatal("disabled quality pipeline must yield a nil augmenter")
+	}
+
+	// Master on but HyDE off — still nil.
+	if aug := cli.hydeAugmenterFor(quality.Config{Enabled: true, HyDE: quality.HyDEConfig{Enabled: false}}); aug != nil {
+		t.Fatal("HyDE disabled must yield a nil augmenter")
+	}
+
+	// HyDE enabled but no LLM client wired — the augmenter cannot be built, so
+	// the seam degrades to nil (callers then take their non-HyDE path). This
+	// also exercises the ensureHyDEVectors/hydeAugmenter body; UseVectors stays
+	// false so no embedding provider or memory store is required.
+	enabled := quality.Config{Enabled: true, HyDE: quality.HyDEConfig{Enabled: true, UseVectors: false}}
+	if aug := cli.hydeAugmenterFor(enabled); aug != nil {
+		t.Fatal("with no LLM client wired the augmenter must be nil")
+	}
+}
+
+// TestRetrieveWorkspaceContext_NoHyDE exercises the refactored chat retrieval
+// call site: with HyDE off, hydeAugmenterFor returns nil and the workspace
+// context is still assembled normally through BuildWorkspaceContextMode.
+func TestRetrieveWorkspaceContext_NoHyDE(t *testing.T) {
+	resetHydeProvider(t)
+	t.Setenv("CHATCLI_EMBED_PROVIDER", "") // no augmenter even if HyDE is on
+
+	wsDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(wsDir, "SOUL.md"), []byte("You are a helpful assistant"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	bl := workspace.NewBootstrapLoader(wsDir, t.TempDir(), zap.NewNop())
+	ms := workspace.NewMemoryStore(t.TempDir(), zap.NewNop())
+	cli := &ChatCLI{logger: zap.NewNop(), contextBuilder: workspace.NewContextBuilder(bl, ms, t.TempDir())}
+
+	out := cli.retrieveWorkspaceContext(context.Background(), "hello", nil)
+	if !strings.Contains(out, "You are a helpful assistant") {
+		t.Fatalf("expected workspace context to include bootstrap content, got %q", out)
 	}
 }
 

--- a/cli/memory_adapter.go
+++ b/cli/memory_adapter.go
@@ -106,8 +106,7 @@ func (a *memoryPluginAdapter) Recall(query string) (string, error) {
 			hints = strings.Fields(q)
 		}
 		if qcfg := quality.LoadFromEnv(); qcfg.Enabled && qcfg.HyDE.Enabled {
-			a.cli.ensureHyDEVectors(qcfg)
-			out = a.cli.memoryStore.GetRelevantContextWithHyDE(ctx, q, hints, a.cli.hydeAugmenter(qcfg))
+			out = a.cli.memoryStore.GetRelevantContextWithHyDE(ctx, q, hints, a.cli.hydeAugmenterFor(qcfg))
 		} else {
 			out = a.cli.memoryStore.GetRelevantContext(hints)
 		}


### PR DESCRIPTION
## Why

Three retrieval paths use HyDE — chat (`retrieveWorkspaceContext`), agent/coder (`buildWorkspaceContext`), and the `@memory` recall tool (`memory_adapter.go`). Each repeated the same two-line setup (ensure the vector index is attached, then build the per-call augmenter) and then diverged in what they did with the augmenter.

There was also a dead `hydeRetrieveContext` wrapper whose doc comment falsely claimed to be "the entry point used by chat and agent" — nothing called it, and it hard-coded `BuildSystemPromptPrefixWithHyDE`, a downstream none of the live paths use. golangci-lint (full-repo) flagged it as `unused`; the CI's diff-only lint hid it because the file was untouched.

## What

- Extract the shared setup into a single seam, `hydeAugmenterFor(qcfg)`, which returns the augmenter or `nil` when HyDE is disabled / no client is wired. Downstream builders already treat a nil augmenter as the non-HyDE path.
- Each call site keeps its own downstream (mode-aware workspace context with `recallHint`, or direct memory recall) — only the setup is centralized. **Mechanism is DRY'd; policy stays distributed.**
- Delete the dead `hydeRetrieveContext` wrapper.

This is the deliberate middle between "force everything through one wrapper" (which would need a flag-zoo to carry the divergence) and "leave three inline copies". HyDE stays **wired in the retriever, not the quality pipeline**, so the seven-pattern harness is untouched.

## Behavior preservation

The guard `!qcfg.Enabled || !qcfg.HyDE.Enabled` is the exact negation of the old build condition `qcfg.Enabled && qcfg.HyDE.Enabled`, and the call order (`ensureHyDEVectors` then `hydeAugmenter`) is preserved. All three sites are provably equivalent. The `@memory` site keeps its outer branch and only swaps the two inline lines for the seam.

## Tests / gates (validated locally)

- New `TestHydeAugmenterFor` (disabled + no-client paths) and `TestRetrieveWorkspaceContext_NoHyDE` (chat call site assembles context with HyDE off).
- `go test -race ./cli/...` across the full seven-pattern harness (`cli`, `cli/agent/quality` + convergence + lessonq, workspace): green.
- gofmt / go vet / golangci-lint (`--new-from-rev=origin/main`): clean — the `unused` finding is resolved at the root.
- Floor 3 patch coverage: 71.4%.

Net: production code shrinks; a regression test is added.