### PR TITLE
fix(scheduler): synchronize JobStatus reads against concurrent transitions

### DIFF
--- a/cli/scheduler/dispatcher.go
+++ b/cli/scheduler/dispatcher.go
@@ -55,8 +55,9 @@ func (s *Scheduler) handleJob(ctx context.Context, id JobID, workerID int) {
 		return
 	}
 
-	// Cheap check without taking the job lock; handleJob takes it below.
-	if j.Status.IsTerminal() || j.Status == StatusPaused {
+	// Cheap pre-check before the per-cycle work. Read the status under the job
+	// lock — JobStatus is a string and a concurrent Cancel/transition writes it.
+	if st := j.statusSnapshot(); st.IsTerminal() || st == StatusPaused {
 		return
 	}
 
@@ -526,7 +527,7 @@ func (s *Scheduler) unblockDependents(finished JobID) {
 	s.mu.RLock()
 	candidates := make([]*Job, 0)
 	for _, j := range s.jobs {
-		if j.Status != StatusBlocked {
+		if j.statusSnapshot() != StatusBlocked {
 			continue
 		}
 		for _, dep := range j.DependsOn {

--- a/cli/scheduler/job.go
+++ b/cli/scheduler/job.go
@@ -210,6 +210,19 @@ func (j *Job) Validate() error {
 func (j *Job) lock()   { j.mu.Lock() }
 func (j *Job) unlock() { j.mu.Unlock() }
 
+// statusSnapshot returns the job's status under its lock. JobStatus is a
+// string, and transitions write j.Status under j.lock(), so any read of the
+// field from another goroutine must hold the lock too — an unsynchronized read
+// can tear against a concurrent write. Read-only callers that only need a
+// point-in-time status (fire pre-checks, registry scans) go through here
+// instead of touching the field directly. Mirrors the inline snapshot already
+// used in resolveDependency.
+func (j *Job) statusSnapshot() JobStatus {
+	j.lock()
+	defer j.unlock()
+	return j.Status
+}
+
 // JobSummary is the compact view returned by List and the status line.
 // Stripping history and transitions keeps the JSON small for IPC.
 type JobSummary struct {

--- a/cli/scheduler/scheduler.go
+++ b/cli/scheduler/scheduler.go
@@ -422,7 +422,7 @@ func (s *Scheduler) Enqueue(ctx context.Context, job *Job) (*Job, error) {
 			cur := s.jobs[existing]
 			return cur.Clone(), nil
 		}
-		if cur, ok := s.jobs[existing]; ok && !cur.Status.IsTerminal() {
+		if cur, ok := s.jobs[existing]; ok && !cur.statusSnapshot().IsTerminal() {
 			s.mu.Unlock()
 			s.metrics.EnqueueErrors.WithLabelValues("duplicate_name").Inc()
 			return nil, fmt.Errorf("%w: %q is live as %s", ErrDuplicateName, job.Name, existing)
@@ -454,7 +454,7 @@ func (s *Scheduler) Enqueue(ctx context.Context, job *Job) (*Job, error) {
 	if len(job.DependsOn) > 0 && job.Status == StatusPending {
 		// Are any deps still non-terminal?
 		for _, depID := range job.DependsOn {
-			if d, ok := s.jobs[depID]; ok && !d.Status.IsTerminal() {
+			if d, ok := s.jobs[depID]; ok && !d.statusSnapshot().IsTerminal() {
 				job.Status = StatusBlocked
 				break
 			}
@@ -808,7 +808,7 @@ func (s *Scheduler) activeCount() int {
 	defer s.mu.RUnlock()
 	n := 0
 	for _, j := range s.jobs {
-		if !j.Status.IsTerminal() {
+		if !j.statusSnapshot().IsTerminal() {
 			n++
 		}
 	}

--- a/cli/scheduler/scheduler_test.go
+++ b/cli/scheduler/scheduler_test.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -310,6 +311,60 @@ func TestScheduler_RecurringInterval_RearmsInPlace(t *testing.T) {
 	if len(allJobs) != 1 {
 		t.Errorf("recurring should reuse one Job; got %d total entries", len(allJobs))
 	}
+}
+
+// TestScheduler_StatusReadsAreRaceFree drives the registry-scan status read
+// (activeCount — the same unsynchronized-read class as handleJob's fire
+// pre-check) concurrently with status writes under the job lock. JobStatus is a
+// string, so before these reads were routed through statusSnapshot they tore
+// against concurrent transitions. Under -race this fails on the old code and
+// passes on the fixed code; it is what TestScheduler_RecurringInterval_
+// CancelStopsRearm only hit intermittently.
+func TestScheduler_StatusReadsAreRaceFree(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.DataDir = t.TempDir()
+	cfg.AuditEnabled = false
+	cfg.SnapshotInterval = 0
+	cfg.WALGCInterval = 0
+	cfg.DaemonAutoConnect = false
+	s, err := New(cfg, NewNoopBridge(), SchedulerDeps{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Register the job directly — no Start, no dispatcher — so the only
+	// concurrent accessors are the two goroutines below.
+	j := NewJob("racer",
+		Owner{Kind: OwnerUser, ID: "u"},
+		Schedule{Kind: ScheduleInterval, Interval: time.Hour},
+		Action{Type: ActionType("fake_act")})
+	s.mu.Lock()
+	s.jobs[j.ID] = j
+	s.mu.Unlock()
+
+	const iters = 5000
+	var wg sync.WaitGroup
+	wg.Add(2)
+	// Writer: flip the status under the job lock, exactly as transition does.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			j.lock()
+			if j.Status == StatusRunning {
+				j.Status = StatusPending
+			} else {
+				j.Status = StatusRunning
+			}
+			j.unlock()
+		}
+	}()
+	// Reader: the registry scan that previously read j.Status without the lock.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			_ = s.activeCount()
+		}
+	}()
+	wg.Wait()
 }
 
 // TestScheduler_RecurringInterval_CancelStopsRearm ensures cancelling


### PR DESCRIPTION
## The race

`JobStatus` is a `string` written under the per-job lock (`j.lock()`) by every `transition`. Several read sites touched `j.Status` **without** that lock:

- `dispatcher.go` — `handleJob`'s fire pre-check (the one that flagged in CI)
- `scheduler.go` — `activeCount` and the duplicate-name / dependency checks in `Enqueue`
- `dispatcher.go` — `unblockDependents`'s registry scan

An unsynchronized read of a string can tear against a concurrent write. This is the data race behind the intermittent failure of `TestScheduler_RecurringInterval_CancelStopsRearm` under `-race`: a `Cancel` (which writes status under the lock) landing while a recurring cycle fires (`handleJob` reading status without it).

## The fix

Route every read-only status read through a new `statusSnapshot()` accessor that takes the job lock — mirroring the inline snapshot `resolveDependency` already did by hand (`"Snapshot the dependency's status safely"`).

**Lock ordering is preserved and safe:** the established order is scheduler lock → job lock. The reads in `activeCount`/`unblockDependents`/`Enqueue` already hold `s.mu` and now take `j.mu` second (same order). No path holds `j.mu` while reaching for `s.mu` — `emit`, `queue`, and `wal` use their own locks — so no inversion is introduced.

## Proof (red → green)

A new deterministic regression test, `TestScheduler_StatusReadsAreRaceFree`, drives the registry-scan read against status writes under the job lock:

- **Old code** (read reverted to `j.Status`): `-race` reports `WARNING: DATA RACE` at `scheduler.go:811` → test FAILS.
- **Fixed code**: passes clean (verified ×5, and the full package ×10 under `-race`).

Unlike the original timing-based test, this one triggers the race on the first concurrent access, so it is a reliable guard rather than a flaky one.

## Gates (validated locally)

- `go test -race -count=10 ./cli/scheduler/`: green
- go vet / golangci-lint (`--new-from-rev=origin/main`): clean
- Floor 3 patch coverage: 90.0%