### PR TITLE
fix(engine): expand env vars and tilde in file tool paths

### DIFF
--- a/pkg/coder/engine/diff.go
+++ b/pkg/coder/engine/diff.go
@@ -163,7 +163,10 @@ func normalizeDiffPath(p string) string {
 	p = strings.TrimSpace(p)
 	p = strings.TrimPrefix(p, "a/")
 	p = strings.TrimPrefix(p, "b/")
-	return p
+	// Diff-header paths bypass the parseFlags path expansion, so resolve
+	// "~"/env references here too and keep them comparable to the (already
+	// expanded) --file argument when matching hunks to a target file.
+	return expandPath(p)
 }
 
 func (e *Engine) applyHunksToFile(path string, hunks []diffHunk) error {

--- a/pkg/coder/engine/helpers.go
+++ b/pkg/coder/engine/helpers.go
@@ -8,16 +8,24 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"unicode/utf8"
 )
 
-// pathFlagNames are the path-bearing string flags whose leading "~" must be
-// expanded to the user's home directory after parsing. Without this, a model
-// passing "~/proj/main.go" makes the engine create a literal "~" directory
-// under the cwd (filepath.Abs leaves "~" untouched). Expanding here is a single
-// chokepoint that covers every command (write/patch/read/tree/search/git/...).
+// pathFlagNames are the path-bearing string flags whose shell-style references
+// (a leading "~" and environment variables) must be expanded after parsing.
+// Without this, a model passing "~/proj/main.go" or "$CHATCLI_AGENT_TMPDIR/x"
+// makes the engine create a literal "~" / "$CHATCLI_AGENT_TMPDIR" directory
+// under the cwd (filepath.Abs leaves both untouched). Expanding here is a
+// single chokepoint that covers every command (write/patch/read/tree/search/
+// git/...).
 var pathFlagNames = []string{"file", "dir", "path"}
+
+// winEnvVarPattern matches Windows-style "%VAR%" environment references. Only
+// applied on Windows so a literal "%" on POSIX (valid filename char) is never
+// misread as a variable delimiter.
+var winEnvVarPattern = regexp.MustCompile(`%([A-Za-z_][A-Za-z0-9_]*)%`)
 
 // parseFlags parses flags with ContinueOnError and returns a descriptive error.
 func parseFlags(fs *flag.FlagSet, args []string) error {
@@ -35,11 +43,58 @@ func parseFlags(fs *flag.FlagSet, args []string) error {
 		if f == nil {
 			continue
 		}
-		if v := f.Value.String(); strings.HasPrefix(v, "~") {
-			_ = f.Value.Set(expandUserPath(v))
+		// Expand unconditionally: env-var references can sit anywhere in the
+		// value ("$DIR/file", "%TEMP%\\x"), not just at the front like "~".
+		if v := f.Value.String(); v != "" {
+			if exp := expandPath(v); exp != v {
+				_ = f.Value.Set(exp)
+			}
 		}
 	}
 	return nil
+}
+
+// expandPath normalizes a path-bearing value the way a shell would, so the
+// engine writes to the intended location instead of creating a literal
+// directory named after an unexpanded token. Environment variables are
+// resolved first (their values may themselves begin with "~"), then a leading
+// "~"/"~/". It is OS-aware (POSIX "$VAR"/"${VAR}" everywhere, Windows "%VAR%")
+// and idempotent on already-expanded or plain paths.
+func expandPath(path string) string {
+	if path == "" {
+		return path
+	}
+	return expandUserPath(expandEnv(path))
+}
+
+// expandEnv resolves environment-variable references in a path: "$VAR" and
+// "${VAR}" on every OS, plus "%VAR%" on Windows.
+//
+// Unset variables are deliberately preserved verbatim instead of collapsing to
+// the empty string. os.ExpandEnv would turn "$UNSET/file" into "/file" —
+// silently retargeting a write to the filesystem root — so we map through
+// os.Expand with a lookup that keeps the original reference when a variable is
+// missing. validatePath/Write then fails loudly on the literal token rather
+// than writing somewhere unexpected.
+func expandEnv(path string) string {
+	expanded := os.Expand(path, func(name string) string {
+		if name == "" {
+			return "$" // lone "$" with no following name: keep it literal
+		}
+		if v, ok := os.LookupEnv(name); ok {
+			return v
+		}
+		return "${" + name + "}"
+	})
+	if runtime.GOOS == "windows" {
+		expanded = winEnvVarPattern.ReplaceAllStringFunc(expanded, func(tok string) string {
+			if v, ok := os.LookupEnv(tok[1 : len(tok)-1]); ok {
+				return v
+			}
+			return tok // unset: leave "%VAR%" literal, never collapse
+		})
+	}
+	return expanded
 }
 
 // expandUserPath expands a leading "~" or "~/" to the user's home directory.

--- a/pkg/coder/engine/multipatch.go
+++ b/pkg/coder/engine/multipatch.go
@@ -127,7 +127,11 @@ func (e *Engine) handleMultipatch(args []string) error {
 			return fmt.Errorf("edit #%d: replace decode failed: %w", idx, err)
 		}
 
-		abs, err := filepath.Abs(ed.File)
+		// ed.File arrives inside the --edits JSON, so it bypasses the
+		// path-flag expansion in parseFlags; expand it here too or a
+		// "~/x" / "$CHATCLI_AGENT_TMPDIR/x" edit target would resolve
+		// to a literal directory under the cwd.
+		abs, err := filepath.Abs(expandPath(ed.File))
 		if err != nil {
 			return fmt.Errorf("edit #%d: resolve path: %w", idx, err)
 		}

--- a/pkg/coder/engine/tilde_expand_test.go
+++ b/pkg/coder/engine/tilde_expand_test.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -57,5 +58,80 @@ func TestParseFlagsLeavesNonTildeUntouched(t *testing.T) {
 	}
 	if *file != "./cli/main.go" {
 		t.Errorf("relative path should be untouched, got %q", *file)
+	}
+}
+
+// TestExpandEnvSetVar proves "$VAR"/"${VAR}" references mid-path are resolved,
+// matching what the agent is told to do (e.g. "$CHATCLI_AGENT_TMPDIR/patch.sh").
+func TestExpandEnvSetVar(t *testing.T) {
+	t.Setenv("CHATCLI_AGENT_TMPDIR", filepath.FromSlash("/tmp/chatcli-scratch"))
+	cases := map[string]string{
+		"$CHATCLI_AGENT_TMPDIR/patch.sh":   filepath.FromSlash("/tmp/chatcli-scratch") + "/patch.sh",
+		"${CHATCLI_AGENT_TMPDIR}/patch.sh": filepath.FromSlash("/tmp/chatcli-scratch") + "/patch.sh",
+		"./rel/$CHATCLI_AGENT_TMPDIR":      "./rel/" + filepath.FromSlash("/tmp/chatcli-scratch"),
+	}
+	for in, want := range cases {
+		if got := expandEnv(in); got != want {
+			t.Errorf("expandEnv(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestExpandEnvUnsetIsPreserved is the safety contract: an unset variable must
+// NOT collapse to "" (which would turn "$UNSET/x" into "/x" and retarget a
+// write to the filesystem root). The literal reference is kept so downstream
+// validation/IO fails loudly instead.
+func TestExpandEnvUnsetIsPreserved(t *testing.T) {
+	os.Unsetenv("CHATCLI_DEFINITELY_UNSET_VAR")
+	got := expandEnv("$CHATCLI_DEFINITELY_UNSET_VAR/x")
+	if got != "${CHATCLI_DEFINITELY_UNSET_VAR}/x" {
+		t.Errorf("unset var must be preserved, got %q", got)
+	}
+	if got == "/x" {
+		t.Fatal("unset var collapsed to root-relative path — silent retarget bug")
+	}
+}
+
+// TestExpandPathEnvThenTilde proves env vars are resolved before "~", so a
+// variable whose value itself begins with "~" still lands in the home dir.
+func TestExpandPathEnvThenTilde(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home dir")
+	}
+	t.Setenv("CHATCLI_TEST_HOMEISH", "~/sub")
+	if got, want := expandPath("$CHATCLI_TEST_HOMEISH/file"), filepath.Join(home, "sub", "file"); got != want {
+		t.Errorf("expandPath = %q, want %q", got, want)
+	}
+}
+
+// TestParseFlagsExpandsEnvVar is the end-to-end chokepoint proof for env vars:
+// a --file/--dir carrying "$VAR" is resolved before any command does I/O.
+func TestParseFlagsExpandsEnvVar(t *testing.T) {
+	scratch := filepath.FromSlash("/tmp/chatcli-scratch")
+	t.Setenv("CHATCLI_AGENT_TMPDIR", scratch)
+	fs := flag.NewFlagSet("write", flag.ContinueOnError)
+	file := fs.String("file", "", "")
+	if err := parseFlags(fs, []string{"--file", "$CHATCLI_AGENT_TMPDIR/out.txt"}); err != nil {
+		t.Fatal(err)
+	}
+	if want := scratch + "/out.txt"; *file != want {
+		t.Errorf("--file = %q, want expanded %q", *file, want)
+	}
+}
+
+// TestExpandEnvWindowsPercent covers the Windows-native "%VAR%" syntax. The
+// expansion is OS-gated, so on POSIX a literal "%" must survive untouched.
+func TestExpandEnvWindowsPercent(t *testing.T) {
+	t.Setenv("CHATCLI_AGENT_TMPDIR", `C:\scratch`)
+	got := expandEnv(`%CHATCLI_AGENT_TMPDIR%\out.txt`)
+	if runtime.GOOS == "windows" {
+		if want := `C:\scratch\out.txt`; got != want {
+			t.Errorf("expandEnv(%%VAR%%) = %q, want %q", got, want)
+		}
+	} else {
+		if got != `%CHATCLI_AGENT_TMPDIR%\out.txt` {
+			t.Errorf("%%VAR%% must be untouched on %s, got %q", runtime.GOOS, got)
+		}
 	}
 }


### PR DESCRIPTION
## Problema

As ferramentas de arquivo do engine (`write`/`read`/`patch`/`multipatch`/`tree`/`search`/`exec`/`git`) expandiam apenas o `~` no prefixo, **nunca** variáveis de ambiente. Como o próprio system prompt do agent instrui o modelo a escrever em `$CHATCLI_AGENT_TMPDIR/...`, o `os.MkdirAll(filepath.Dir(file), …)` em `commands.go` criava uma **pasta literal** chamada `$CHATCLI_AGENT_TMPDIR` (ou `~`) no diretório de execução do binário, em vez de escrever no scratch pretendido.

## Fix

- **Chokepoint único** `expandPath` em `parseFlags` (`helpers.go`), cobrindo todos os flags de path (`file`/`dir`/`path`) → atinge todos os comandos do engine de uma vez.
- **Dois call sites que fazem bypass do flag parsing** expandem explícito: alvos por-edit no `multipatch` e paths vindos dos headers de unified-diff (`normalizeDiffPath`).
- Expansão **OS-aware** e multi-SO: `$VAR`/`${VAR}` em todas as plataformas, `%VAR%` apenas no Windows (gated por `runtime.GOOS`, senão `%` literal — char válido no POSIX — seria mal interpretado). `~`/`~\` já tratado por `expandUserPath`.

## Segurança (preserve-unset)

Variável não-setada é mantida **literal** (`${NAME}`), nunca colapsada para `""`. `os.ExpandEnv` cru transformaria `$UNSET/x` → `/x`, **retargetando silenciosamente um write pra raiz do filesystem**. Agora a validação/IO falha de forma ruidosa no token literal. Env é resolvida **antes** do tilde (valor de uma var pode começar com `~`).

## Testes (red→green)

`tilde_expand_test.go` estendido: env var set/`${}`/mid-path, preserve-unset (assert anti-retarget pra raiz), env-antes-de-tilde, chokepoint end-to-end via `parseFlags`, e `%VAR%` Windows OS-gated.

`go build ./...`, `go vet ./pkg/coder/engine/` e `go test ./pkg/coder/engine/` todos verdes.