### PR TITLE
feat(models): Claude Sonnet 5 + GLM-5.2 + Bedrock Fable 5/Sonnet 5 support

### DIFF
--- a/cli/config_sections.go
+++ b/cli/config_sections.go
@@ -534,6 +534,9 @@ func (cli *ChatCLI) showConfigProviders() {
 	kv(p, "BEDROCK_MAX_TOKENS", envOr("BEDROCK_MAX_TOKENS"))
 	kv(p, "BEDROCK_TEMPERATURE", envOr("BEDROCK_TEMPERATURE"))
 	kv(p, "BEDROCK_TOP_P", envOr("BEDROCK_TOP_P"))
+	kv(p, "BEDROCK_ANTHROPIC_ENDPOINT", envOr("BEDROCK_ANTHROPIC_ENDPOINT"))
+	kv(p, "BEDROCK_MANTLE_BASE_URL", envOr("BEDROCK_MANTLE_BASE_URL"))
+	kv(p, "AWS_BEARER_TOKEN_BEDROCK", presence(os.Getenv("AWS_BEARER_TOKEN_BEDROCK")))
 
 	fmt.Println(p)
 	subheader(p, "cfg.sub.prov.copilot")

--- a/cli/cost_tracker.go
+++ b/cli/cost_tracker.go
@@ -445,6 +445,7 @@ func getModelPricing(provider, model string) (inputCost, outputCost float64) {
 		googlePricing,
 		grokPricing,
 		deepseekPricing,
+		zaiPricing,
 	} {
 		if in, out, ok := fn(model); ok {
 			return in, out
@@ -532,6 +533,21 @@ func grokPricing(model string) (float64, float64, bool) {
 		return 2.0, 10.0, true
 	case strings.Contains(model, "grok"):
 		return 5.0, 15.0, true
+	}
+	return 0, 0, false
+}
+
+// zaiPricing covers Z.AI's GLM-5 family. Public list prices (docs.z.ai,
+// Jun 2026): GLM-5.2 $1.40/$4.40, GLM-5 $1.00/$3.20 per MTok. Ordering
+// matters: the specific "glm-5.2" tag must win before the bare "glm-5"
+// prefix. GLM-4.x and other Z.AI ids fall through to the conservative
+// flat rate in providerFallbackPricing.
+func zaiPricing(model string) (float64, float64, bool) {
+	switch {
+	case strings.Contains(model, "glm-5.2"), strings.Contains(model, "glm-5-2"):
+		return 1.40, 4.40, true
+	case strings.Contains(model, "glm-5"):
+		return 1.00, 3.20, true
 	}
 	return 0, 0, false
 }

--- a/cli/cost_tracker_pricing_test.go
+++ b/cli/cost_tracker_pricing_test.go
@@ -59,8 +59,15 @@ func TestGetModelPricing(t *testing.T) {
 		// Provider-keyed fallbacks
 		{"minimax via model", "OTHER", "minimax-m2.7", 0.20, 1.10},
 		{"minimax via provider", "MINIMAX", "anything", 0.20, 1.10},
+		// Z.AI GLM-5 family — public list prices (docs.z.ai, Jun 2026):
+		// GLM-5.2 $1.40/$4.40, GLM-5 $1.00/$3.20 per MTok. The specific
+		// "glm-5.2" tag must win before the bare "glm-5" prefix; unknown
+		// GLM/ZAI ids keep the conservative flat fallback.
+		{"glm-5.2", "ZAI", "glm-5.2", 1.40, 4.40},
+		{"glm-5.2 via model on other provider", "OTHER", "glm-5.2", 1.40, 4.40},
+		{"glm-5 via glm model", "OTHER", "glm-5", 1.00, 3.20},
 		{"zai via provider", "ZAI", "anything", 0.50, 0.50},
-		{"zai via glm model", "OTHER", "glm-5", 0.50, 0.50},
+		{"zai legacy glm model", "OTHER", "glm-4.5", 0.50, 0.50},
 
 		// Moonshot (Kimi) — K2.6 list price, conservative single tier.
 		{"moonshot via provider", "MOONSHOT", "kimi-k2.6", 0.95, 4.00},

--- a/llm/bedrock/bedrock_client.go
+++ b/llm/bedrock/bedrock_client.go
@@ -152,10 +152,13 @@ type BedrockClient struct {
 	backoff     time.Duration
 	runtime     *bedrockruntime.Client
 	control     *bedrocksvc.Client
-	// awsCfg carries the resolved credential chain for endpoints outside
-	// the AWS SDK service clients — the bedrock-mantle Messages endpoint
-	// signs raw HTTP requests with SigV4 using these credentials.
-	awsCfg aws.Config
+	// credentials carries the resolved credential chain for endpoints
+	// outside the AWS SDK service clients — the bedrock-mantle Messages
+	// endpoint signs raw HTTP requests with SigV4 using it. Kept as the
+	// provider interface (not aws.Config) so BedrockClient stays a
+	// comparable type: aws.Config embeds slices and would break any
+	// downstream == comparison of client values.
+	credentials aws.CredentialsProvider
 }
 
 // NewBedrockClient creates a client bound to a model id and region.
@@ -239,7 +242,7 @@ func (c *BedrockClient) ensureRuntime(ctx context.Context) error {
 	c.region = resolvedRegion
 	c.runtime = runtime
 	c.control = bedrocksvc.NewFromConfig(cfg)
-	c.awsCfg = cfg
+	c.credentials = cfg.Credentials
 	c.logger.Info(i18n.T("llm.info.configuring_provider", "Bedrock"),
 		zap.String("region", c.region),
 		zap.String("endpoint", RuntimeEndpointURL(c.region)),

--- a/llm/bedrock/bedrock_client.go
+++ b/llm/bedrock/bedrock_client.go
@@ -52,8 +52,12 @@ const (
 // resolveFamily picks the dispatch path. Precedence:
 //  1. BEDROCK_PROVIDER env var ("anthropic"/"claude", "openai"/"gpt",
 //     "converse"/"auto").
-//  2. Model ID prefix: "openai.*" → OpenAI; any "anthropic" segment
-//     (bare or behind a global./us./eu./apac. profile prefix) → Anthropic.
+//  2. Model ID content: "openai.*" → OpenAI; any Claude marker (an
+//     "anthropic" segment — bare or behind a global./us./eu./apac.
+//     profile prefix — or a bare "claude"/"fable" first-party id) →
+//     Anthropic. Claude models always speak the Anthropic Messages
+//     schema; routing them through Converse would silently drop
+//     cache_control markers and extended-thinking knobs.
 //  3. Default: Converse — covers Llama, Nova, Mistral, Cohere, AI21,
 //     DeepSeek, Stability and any unknown provider through the unified
 //     Bedrock Converse API.
@@ -70,10 +74,60 @@ func resolveFamily(model string) modelFamily {
 	if strings.HasPrefix(m, "openai.") || strings.Contains(m, ".openai.") {
 		return familyOpenAI
 	}
-	if strings.HasPrefix(m, "anthropic.") || strings.Contains(m, ".anthropic.") {
+	if isClaudeModelID(m) {
 		return familyAnthropic
 	}
 	return familyConverse
+}
+
+// isClaudeModelID reports whether a Bedrock model id refers to an Anthropic
+// Claude model, whatever the surface spelling: "anthropic."-prefixed base
+// IDs, inference-profile IDs (global./us./eu./apac. + ".anthropic."), or a
+// bare first-party id ("claude-fable-5", "fable-5", "claude-sonnet-5") the
+// user picked out of habit.
+func isClaudeModelID(model string) bool {
+	m := strings.ToLower(model)
+	return strings.HasPrefix(m, "anthropic.") ||
+		strings.Contains(m, ".anthropic.") ||
+		strings.Contains(m, "claude") ||
+		strings.Contains(m, "fable")
+}
+
+// normalizeBedrockModelID upgrades a bare first-party Claude id to the
+// invokable Bedrock id from the catalog (e.g. "claude-fable-5" →
+// "anthropic.claude-fable-5"). IDs that already carry an "anthropic."
+// segment — including account-specific inference profiles — and non-Claude
+// IDs pass through untouched.
+func normalizeBedrockModelID(model string) string {
+	m := strings.ToLower(strings.TrimSpace(model))
+	if m == "" || strings.Contains(m, "anthropic.") || !isClaudeModelID(m) {
+		return model
+	}
+	if meta, ok := catalog.Resolve(catalog.ProviderBedrock, model); ok &&
+		strings.Contains(strings.ToLower(meta.ID), "anthropic.") {
+		return meta.ID
+	}
+	return model
+}
+
+// filterBedrockCapabilities strips capability flags that exist on the
+// first-party Claude API but are not served by Bedrock, per Anthropic's
+// platform-availability matrix: fast_mode (research preview, first-party
+// only) and mid_conversation_system (unsupported on Bedrock). Advertising
+// either on a Bedrock entry would make the request builders emit
+// parameters AWS rejects.
+func filterBedrockCapabilities(caps []string) []string {
+	if caps == nil {
+		return nil
+	}
+	out := make([]string, 0, len(caps))
+	for _, c := range caps {
+		if c == "fast_mode" || c == "mid_conversation_system" {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out
 }
 
 // BedrockClient invokes foundation models hosted on AWS Bedrock.
@@ -104,6 +158,11 @@ type BedrockClient struct {
 // The AWS SDK is initialized lazily on the first call so that a missing
 // credentials chain does not break provider discovery.
 func NewBedrockClient(model, region, profile string, logger *zap.Logger, maxAttempts int, backoff time.Duration) *BedrockClient {
+	if normalized := normalizeBedrockModelID(model); normalized != model {
+		logger.Info("bedrock: normalized bare Claude model id to invokable Bedrock id",
+			zap.String("from", model), zap.String("to", normalized))
+		model = normalized
+	}
 	return &BedrockClient{
 		model:       model,
 		region:      region,
@@ -621,13 +680,26 @@ func registerBedrockModel(id, displayName string) {
 	if _, ok := catalog.Resolve(catalog.ProviderBedrock, id); ok {
 		return
 	}
-	catalog.Register(catalog.ModelMeta{
+	meta := catalog.ModelMeta{
 		ID:           id,
 		Aliases:      []string{id},
 		DisplayName:  displayName,
 		Provider:     catalog.ProviderBedrock,
 		PreferredAPI: preferredAPIFor(id),
-	})
+	}
+	// Discovered Claude IDs inherit context window, output ceiling and
+	// capabilities from the first-party catalog entry (Resolve matches the
+	// embedded "claude-…" segment inside profile-prefixed IDs). Without
+	// this, an unknown-but-real Claude id would fall back to the generic
+	// 50K context default and trip auto-compaction on almost every turn.
+	if isClaudeModelID(id) {
+		if fp, ok := catalog.Resolve(catalog.ProviderClaudeAI, id); ok {
+			meta.ContextWindow = fp.ContextWindow
+			meta.MaxOutputTokens = fp.MaxOutputTokens
+			meta.Capabilities = filterBedrockCapabilities(fp.Capabilities)
+		}
+	}
+	catalog.Register(meta)
 }
 
 // preferredAPIFor matches the dispatch family to a catalog PreferredAPI so

--- a/llm/bedrock/bedrock_client.go
+++ b/llm/bedrock/bedrock_client.go
@@ -152,6 +152,10 @@ type BedrockClient struct {
 	backoff     time.Duration
 	runtime     *bedrockruntime.Client
 	control     *bedrocksvc.Client
+	// awsCfg carries the resolved credential chain for endpoints outside
+	// the AWS SDK service clients — the bedrock-mantle Messages endpoint
+	// signs raw HTTP requests with SigV4 using these credentials.
+	awsCfg aws.Config
 }
 
 // NewBedrockClient creates a client bound to a model id and region.
@@ -235,6 +239,7 @@ func (c *BedrockClient) ensureRuntime(ctx context.Context) error {
 	c.region = resolvedRegion
 	c.runtime = runtime
 	c.control = bedrocksvc.NewFromConfig(cfg)
+	c.awsCfg = cfg
 	c.logger.Info(i18n.T("llm.info.configuring_provider", "Bedrock"),
 		zap.String("region", c.region),
 		zap.String("endpoint", RuntimeEndpointURL(c.region)),
@@ -276,6 +281,9 @@ func (c *BedrockClient) SendPrompt(ctx context.Context, prompt string, history [
 	case familyConverse:
 		return c.sendPromptConverse(ctx, prompt, history, maxTokens)
 	default:
+		if usesMantleEndpoint(c.model) {
+			return c.sendPromptAnthropicMantle(ctx, prompt, history, maxTokens)
+		}
 		return c.sendPromptAnthropic(ctx, prompt, history, maxTokens)
 	}
 }

--- a/llm/bedrock/mantle.go
+++ b/llm/bedrock/mantle.go
@@ -1,0 +1,198 @@
+/*
+ * ChatCLI - Claude in Amazon Bedrock (bedrock-mantle Messages endpoint)
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package bedrock
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	"go.uber.org/zap"
+
+	"github.com/diillson/chatcli/i18n"
+	"github.com/diillson/chatcli/llm/catalog"
+	"github.com/diillson/chatcli/llm/client"
+	"github.com/diillson/chatcli/models"
+	"github.com/diillson/chatcli/utils"
+)
+
+// mantleSigningService is the SigV4 service name for the Claude-in-Amazon-
+// Bedrock Messages endpoint (distinct from "bedrock" / "bedrock-runtime").
+const mantleSigningService = "bedrock-mantle"
+
+// mantleAnthropicVersion travels in the anthropic-version HTTP header —
+// the Mantle endpoint speaks the first-party Messages wire shape, so the
+// body carries NO anthropic_version field (that one is InvokeModel-only).
+const mantleAnthropicVersion = "2023-06-01"
+
+// mantleMessagesURL resolves the Messages endpoint for a region.
+// BEDROCK_MANTLE_BASE_URL overrides scheme+host for VPC endpoints,
+// corporate proxies and tests.
+func mantleMessagesURL(region string) string {
+	base := strings.TrimSpace(os.Getenv("BEDROCK_MANTLE_BASE_URL"))
+	if base == "" {
+		base = "https://bedrock-mantle." + region + ".api.aws"
+	}
+	return strings.TrimSuffix(base, "/") + "/anthropic/v1/messages"
+}
+
+// usesMantleEndpoint decides whether an Anthropic-family request must go
+// through the Mantle Messages endpoint instead of legacy InvokeModel.
+//
+// Default: catalog-driven — models flagged bedrock_mantle_only (Sonnet 5
+// has no InvokeModel surface at all) route to Mantle; everything else
+// stays on the proven InvokeModel path. BEDROCK_ANTHROPIC_ENDPOINT
+// overrides for operators: "mantle" forces every Anthropic request onto
+// the Messages endpoint, "invoke"/"legacy" pins them all to InvokeModel.
+func usesMantleEndpoint(model string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("BEDROCK_ANTHROPIC_ENDPOINT"))) {
+	case "mantle":
+		return true
+	case "invoke", "invokemodel", "legacy":
+		return false
+	}
+	return catalog.HasCapability(catalog.ProviderBedrock, model, "bedrock_mantle_only")
+}
+
+// sendPromptAnthropicMantle sends a Messages API request to the
+// Claude-in-Amazon-Bedrock endpoint. The body builder, thinking dispatch
+// and cache_control budget are shared with the InvokeModel path — the
+// only wire differences are the endpoint, the auth (SigV4 with the
+// bedrock-mantle service, or AWS_BEARER_TOKEN_BEDROCK via x-api-key) and
+// the anthropic-version header replacing the anthropic_version body field.
+func (c *BedrockClient) sendPromptAnthropicMantle(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {
+	effectiveMaxTokens := maxTokens
+	if effectiveMaxTokens <= 0 {
+		effectiveMaxTokens = c.getMaxTokens()
+	}
+
+	messages, systemObj := c.buildMessagesAndSystem(prompt, history)
+
+	reqBody := map[string]interface{}{
+		"model":      c.model,
+		"max_tokens": effectiveMaxTokens,
+		"messages":   messages,
+	}
+	if systemObj != nil {
+		reqBody["system"] = systemObj
+	}
+
+	applyAnthropicThinkingForEffort(reqBody, c.model, ctx)
+	enforceCacheControlBudget(reqBody, anthropicMaxCacheBreakpoints)
+
+	payload, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", i18n.T("llm.error.prepare_request"), err)
+	}
+
+	endpoint := mantleMessagesURL(c.region)
+	start := time.Now()
+	client.LogRequestStart(c.logger, "BEDROCK", c.model,
+		zap.String("family", "anthropic-mantle"),
+		zap.String("region", c.region),
+		zap.String("endpoint", endpoint),
+		zap.Int("payload_bytes", len(payload)),
+		zap.Int("history_len", len(history)),
+		zap.Int("max_tokens", effectiveMaxTokens),
+		zap.Int("cache_markers", client.CountAnthropicCacheMarkers(reqBody)),
+	)
+
+	responseText, err := utils.Retry(ctx, c.logger, c.maxAttempts, c.backoff, func(ctx context.Context) (string, error) {
+		return c.doMantleRequest(ctx, endpoint, payload)
+	})
+
+	if err != nil {
+		client.LogRequestFinish(c.logger, "BEDROCK", c.model, "error", time.Since(start),
+			zap.String("family", "anthropic-mantle"),
+		)
+		c.logger.Error(i18n.T("llm.error.get_response_after_retries", "Bedrock"), zap.Error(err))
+		return "", err
+	}
+	client.LogRequestFinish(c.logger, "BEDROCK", c.model, "success", time.Since(start),
+		zap.String("family", "anthropic-mantle"),
+		zap.Int("response_chars", len(responseText)),
+	)
+	return responseText, nil
+}
+
+// doMantleRequest performs one signed HTTP round-trip against the Mantle
+// Messages endpoint and parses the standard Anthropic response envelope.
+func (c *BedrockClient) doMantleRequest(ctx context.Context, endpoint string, payload []byte) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return "", fmt.Errorf("bedrock-mantle: build request: %w", err)
+	}
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("anthropic-version", mantleAnthropicVersion)
+
+	if bearer := strings.TrimSpace(os.Getenv("AWS_BEARER_TOKEN_BEDROCK")); bearer != "" {
+		// Short-term bearer tokens (aws-bedrock-token-generator) travel in
+		// x-api-key — no SigV4 signature on this path.
+		req.Header.Set("x-api-key", bearer)
+	} else {
+		creds, err := c.awsCfg.Credentials.Retrieve(ctx)
+		if err != nil {
+			return "", fmt.Errorf("bedrock-mantle: resolve AWS credentials (or set AWS_BEARER_TOKEN_BEDROCK): %w", err)
+		}
+		sum := sha256.Sum256(payload)
+		if err := v4.NewSigner().SignHTTP(ctx, creds, req, hex.EncodeToString(sum[:]),
+			mantleSigningService, c.region, time.Now()); err != nil {
+			return "", fmt.Errorf("bedrock-mantle: sign request: %w", err)
+		}
+	}
+
+	resp, err := c.mantleHTTPClient().Do(req)
+	if resp != nil {
+		// Close unconditionally — a redirect error can hand back a non-nil
+		// response alongside a non-nil error.
+		defer func() { _ = resp.Body.Close() }()
+	}
+	if err != nil {
+		return "", fmt.Errorf("bedrock-mantle: %w", err)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64<<20))
+	if err != nil {
+		return "", fmt.Errorf("bedrock-mantle: read response: %w", err)
+	}
+
+	if resp.StatusCode >= 300 {
+		// The endpoint answers with the standard Anthropic error envelope;
+		// parseAnthropicBody surfaces type+message when present.
+		if _, perr := parseAnthropicBody(body); perr != nil {
+			return "", fmt.Errorf("bedrock-mantle: HTTP %d: %w", resp.StatusCode, perr)
+		}
+		return "", fmt.Errorf("bedrock-mantle: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return parseAnthropicBody(body)
+}
+
+// mantleHTTPClient reuses the corporate-TLS-aware transport when the
+// operator configured one; otherwise the default transport applies, which
+// already honors the process-global trust overrides from
+// utils.ApplyGlobalTLSTrust. Returns a concrete *http.Client so response
+// bodies stay statically trackable by callers.
+func (c *BedrockClient) mantleHTTPClient() *http.Client {
+	if httpClient, note := buildCorporateHTTPClient(c.logger); httpClient != nil {
+		if note != "" {
+			c.logger.Warn(note)
+		}
+		if bc, ok := httpClient.(*awshttp.BuildableClient); ok {
+			return &http.Client{Transport: bc.GetTransport(), Timeout: bc.GetTimeout()}
+		}
+	}
+	return &http.Client{Timeout: 10 * time.Minute}
+}

--- a/llm/bedrock/mantle.go
+++ b/llm/bedrock/mantle.go
@@ -143,7 +143,10 @@ func (c *BedrockClient) doMantleRequest(ctx context.Context, endpoint string, pa
 		// x-api-key — no SigV4 signature on this path.
 		req.Header.Set("x-api-key", bearer)
 	} else {
-		creds, err := c.awsCfg.Credentials.Retrieve(ctx)
+		if c.credentials == nil {
+			return "", fmt.Errorf("bedrock-mantle: AWS credential chain not initialized (or set AWS_BEARER_TOKEN_BEDROCK)")
+		}
+		creds, err := c.credentials.Retrieve(ctx)
 		if err != nil {
 			return "", fmt.Errorf("bedrock-mantle: resolve AWS credentials (or set AWS_BEARER_TOKEN_BEDROCK): %w", err)
 		}

--- a/llm/bedrock/mantle_test.go
+++ b/llm/bedrock/mantle_test.go
@@ -6,6 +6,7 @@
 package bedrock
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -139,6 +141,134 @@ func TestSendPromptAnthropicMantleRoundTrip(t *testing.T) {
 		}
 	}
 	assert.Equal(t, 1, markers, "cache_control marker must reach the Mantle wire")
+}
+
+// Without AWS_BEARER_TOKEN_BEDROCK the request is SigV4-signed with the
+// bedrock-mantle service using the resolved credential chain.
+func TestSendPromptAnthropicMantleSigV4(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"signed"}]}`))
+	}))
+	defer srv.Close()
+
+	setEnvForTest(t, "BEDROCK_MANTLE_BASE_URL", srv.URL)
+	setEnvForTest(t, "AWS_BEARER_TOKEN_BEDROCK", "")
+
+	c := &BedrockClient{
+		model:       "anthropic.claude-sonnet-5",
+		region:      "us-east-1",
+		logger:      zap.NewNop(),
+		maxAttempts: 1,
+		credentials: aws.CredentialsProviderFunc(func(context.Context) (aws.Credentials, error) {
+			return aws.Credentials{AccessKeyID: "AKIDTEST", SecretAccessKey: "secret"}, nil
+		}),
+	}
+	out, err := c.sendPromptAnthropicMantle(t.Context(), "ping", nil, 0)
+	require.NoError(t, err)
+	assert.Equal(t, "signed", out)
+	assert.Contains(t, gotAuth, "AWS4-HMAC-SHA256")
+	assert.Contains(t, gotAuth, "/bedrock-mantle/aws4_request",
+		"signature must use the bedrock-mantle service name")
+}
+
+// No bearer token and no initialized credential chain must produce an
+// actionable error, not a nil-pointer panic.
+func TestSendPromptAnthropicMantleNoCredentials(t *testing.T) {
+	setEnvForTest(t, "BEDROCK_MANTLE_BASE_URL", "http://127.0.0.1:1")
+	setEnvForTest(t, "AWS_BEARER_TOKEN_BEDROCK", "")
+
+	c := &BedrockClient{
+		model:       "anthropic.claude-sonnet-5",
+		region:      "us-east-1",
+		logger:      zap.NewNop(),
+		maxAttempts: 1,
+	}
+	_, err := c.sendPromptAnthropicMantle(t.Context(), "ping", nil, 128)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "AWS_BEARER_TOKEN_BEDROCK")
+}
+
+// A transport-level failure (connection refused) must surface through the
+// retry wrapper as a bedrock-mantle error.
+func TestSendPromptAnthropicMantleTransportError(t *testing.T) {
+	setEnvForTest(t, "BEDROCK_MANTLE_BASE_URL", "http://127.0.0.1:1")
+	setEnvForTest(t, "AWS_BEARER_TOKEN_BEDROCK", "test-bearer-token")
+
+	c := &BedrockClient{
+		model:       "anthropic.claude-sonnet-5",
+		region:      "us-east-1",
+		logger:      zap.NewNop(),
+		maxAttempts: 1,
+	}
+	_, err := c.sendPromptAnthropicMantle(t.Context(), "ping", nil, 128)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bedrock-mantle")
+}
+
+// Non-JSON error bodies (load balancers, proxies) fall back to the raw
+// status + body instead of getting swallowed.
+func TestSendPromptAnthropicMantleHTTPErrorNonJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("upstream exploded"))
+	}))
+	defer srv.Close()
+
+	setEnvForTest(t, "BEDROCK_MANTLE_BASE_URL", srv.URL)
+	setEnvForTest(t, "AWS_BEARER_TOKEN_BEDROCK", "test-bearer-token")
+
+	c := &BedrockClient{
+		model:       "anthropic.claude-sonnet-5",
+		region:      "us-east-1",
+		logger:      zap.NewNop(),
+		maxAttempts: 1,
+	}
+	_, err := c.sendPromptAnthropicMantle(t.Context(), "ping", nil, 128)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP 502")
+}
+
+// The corporate-TLS override must reach the Mantle transport the same way
+// it reaches the AWS SDK clients.
+func TestMantleHTTPClientCorporateTLS(t *testing.T) {
+	setEnvForTest(t, "CHATCLI_BEDROCK_INSECURE_SKIP_VERIFY", "true")
+	setEnvForTest(t, "CHATCLI_BEDROCK_CA_BUNDLE", "")
+
+	c := &BedrockClient{logger: zap.NewNop()}
+	hc := c.mantleHTTPClient()
+	require.NotNil(t, hc)
+	assert.NotNil(t, hc.Transport, "corporate override must install a custom transport")
+
+	// Without overrides, the default client (process-global trust) is used.
+	setEnvForTest(t, "CHATCLI_BEDROCK_INSECURE_SKIP_VERIFY", "")
+	setEnvForTest(t, "CHATCLI_TLS_INSECURE_SKIP_VERIFY", "")
+	hc = c.mantleHTTPClient()
+	require.NotNil(t, hc)
+	assert.Nil(t, hc.Transport)
+}
+
+// SendPrompt must dispatch mantle-only models through the Messages
+// endpoint end to end (ensureRuntime included).
+func TestSendPromptDispatchesSonnet5ToMantle(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"via-mantle"}]}`))
+	}))
+	defer srv.Close()
+
+	setEnvForTest(t, "BEDROCK_MANTLE_BASE_URL", srv.URL)
+	setEnvForTest(t, "AWS_BEARER_TOKEN_BEDROCK", "test-bearer-token")
+	setEnvForTest(t, "AWS_REGION", "us-east-1")
+	setEnvForTest(t, "BEDROCK_PROVIDER", "")
+	setEnvForTest(t, "BEDROCK_ANTHROPIC_ENDPOINT", "")
+
+	c := NewBedrockClient("anthropic.claude-sonnet-5", "us-east-1", "", zap.NewNop(), 1, 0)
+	out, err := c.SendPrompt(t.Context(), "ping", nil, 128)
+	require.NoError(t, err)
+	assert.Equal(t, "via-mantle", out)
 }
 
 // Mantle errors come back in the standard Anthropic error envelope; the

--- a/llm/bedrock/mantle_test.go
+++ b/llm/bedrock/mantle_test.go
@@ -1,0 +1,167 @@
+/*
+ * ChatCLI - Tests for the Claude-in-Amazon-Bedrock (bedrock-mantle) path
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package bedrock
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/diillson/chatcli/models"
+)
+
+func setEnvForTest(t *testing.T, key, value string) {
+	t.Helper()
+	prev, had := os.LookupEnv(key)
+	t.Cleanup(func() {
+		if had {
+			os.Setenv(key, prev)
+		} else {
+			os.Unsetenv(key)
+		}
+	})
+	if value == "" {
+		os.Unsetenv(key)
+	} else {
+		os.Setenv(key, value)
+	}
+}
+
+func TestMantleMessagesURL(t *testing.T) {
+	setEnvForTest(t, "BEDROCK_MANTLE_BASE_URL", "")
+	assert.Equal(t,
+		"https://bedrock-mantle.us-east-1.api.aws/anthropic/v1/messages",
+		mantleMessagesURL("us-east-1"))
+
+	// Operator override (VPC endpoints, proxies, tests). Trailing slash
+	// must not produce a double slash.
+	setEnvForTest(t, "BEDROCK_MANTLE_BASE_URL", "https://proxy.corp.example/")
+	assert.Equal(t,
+		"https://proxy.corp.example/anthropic/v1/messages",
+		mantleMessagesURL("us-east-1"))
+}
+
+// Sonnet 5 exists ONLY on the bedrock-mantle Messages endpoint (no
+// InvokeModel surface), so it must route to Mantle by default. Fable 5 /
+// Opus 4.8 stay on InvokeModel unless the operator forces the endpoint.
+func TestUsesMantleEndpoint(t *testing.T) {
+	setEnvForTest(t, "BEDROCK_ANTHROPIC_ENDPOINT", "")
+
+	assert.True(t, usesMantleEndpoint("anthropic.claude-sonnet-5"))
+	assert.True(t, usesMantleEndpoint("claude-sonnet-5"))
+	assert.False(t, usesMantleEndpoint("anthropic.claude-fable-5"))
+	assert.False(t, usesMantleEndpoint("anthropic.claude-opus-4-8"))
+	assert.False(t, usesMantleEndpoint("global.anthropic.claude-opus-4-6-v1"))
+
+	// Operator override: force every Anthropic request through Mantle…
+	setEnvForTest(t, "BEDROCK_ANTHROPIC_ENDPOINT", "mantle")
+	assert.True(t, usesMantleEndpoint("anthropic.claude-fable-5"))
+
+	// …or pin everything to the legacy InvokeModel path.
+	setEnvForTest(t, "BEDROCK_ANTHROPIC_ENDPOINT", "invoke")
+	assert.False(t, usesMantleEndpoint("anthropic.claude-sonnet-5"))
+}
+
+// End-to-end request assembly against a fake Mantle endpoint: the body is
+// the first-party Messages shape (NO anthropic_version body field — the
+// version travels in the anthropic-version header), cache_control markers
+// survive, and bearer-token auth lands in x-api-key.
+func TestSendPromptAnthropicMantleRoundTrip(t *testing.T) {
+	var (
+		gotPath    string
+		gotHeaders http.Header
+		gotBody    map[string]interface{}
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotHeaders = r.Header.Clone()
+		raw, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(raw, &gotBody))
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"pong"}]}`))
+	}))
+	defer srv.Close()
+
+	setEnvForTest(t, "BEDROCK_MANTLE_BASE_URL", srv.URL)
+	setEnvForTest(t, "AWS_BEARER_TOKEN_BEDROCK", "test-bearer-token")
+
+	c := &BedrockClient{
+		model:       "anthropic.claude-sonnet-5",
+		region:      "us-east-1",
+		logger:      zap.NewNop(),
+		maxAttempts: 1,
+	}
+
+	history := []models.Message{
+		{
+			Role: "system",
+			SystemParts: []models.ContentBlock{
+				{Type: "text", Text: "stable system prompt"},
+				{Type: "text", Text: "attached context", CacheControl: &models.CacheControl{Type: "ephemeral"}},
+			},
+		},
+		{Role: "user", Content: "ping"},
+	}
+
+	out, err := c.sendPromptAnthropicMantle(t.Context(), "ping", history, 2048)
+	require.NoError(t, err)
+	assert.Equal(t, "pong", out)
+
+	assert.Equal(t, "/anthropic/v1/messages", gotPath)
+	assert.Equal(t, "test-bearer-token", gotHeaders.Get("x-api-key"))
+	assert.Equal(t, "2023-06-01", gotHeaders.Get("anthropic-version"))
+	assert.Empty(t, gotHeaders.Get("Authorization"), "bearer path must not SigV4-sign")
+
+	assert.Equal(t, "anthropic.claude-sonnet-5", gotBody["model"])
+	assert.NotContains(t, gotBody, "anthropic_version",
+		"Mantle speaks the first-party Messages shape; anthropic_version is InvokeModel-only")
+	assert.EqualValues(t, 2048, gotBody["max_tokens"])
+
+	system, ok := gotBody["system"].([]interface{})
+	require.True(t, ok, "system must be a structured block list")
+	markers := 0
+	for _, b := range system {
+		if blk, ok := b.(map[string]interface{}); ok {
+			if _, has := blk["cache_control"]; has {
+				markers++
+			}
+		}
+	}
+	assert.Equal(t, 1, markers, "cache_control marker must reach the Mantle wire")
+}
+
+// Mantle errors come back in the standard Anthropic error envelope; the
+// client must surface type+message instead of a raw HTTP status.
+func TestSendPromptAnthropicMantleAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"invalid_request_error","message":"boom"}}`))
+	}))
+	defer srv.Close()
+
+	setEnvForTest(t, "BEDROCK_MANTLE_BASE_URL", srv.URL)
+	setEnvForTest(t, "AWS_BEARER_TOKEN_BEDROCK", "test-bearer-token")
+
+	c := &BedrockClient{
+		model:       "anthropic.claude-sonnet-5",
+		region:      "us-east-1",
+		logger:      zap.NewNop(),
+		maxAttempts: 1,
+	}
+	_, err := c.sendPromptAnthropicMantle(t.Context(), "ping", nil, 128)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid_request_error")
+	assert.Contains(t, err.Error(), "boom")
+}

--- a/llm/bedrock/newmodels_test.go
+++ b/llm/bedrock/newmodels_test.go
@@ -1,0 +1,135 @@
+/*
+ * ChatCLI - Tests for Claude Fable 5 / new-generation model support on Bedrock
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package bedrock
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/diillson/chatcli/models"
+)
+
+// Claude models on Bedrock always speak the Anthropic Messages schema —
+// routing a bare "claude-*" ID (no "anthropic." segment) through Converse
+// silently drops cache_control markers and extended-thinking knobs. These
+// cases pin the content-based fallback in resolveFamily.
+func TestResolveFamilyBareClaudeIDs(t *testing.T) {
+	prev, had := os.LookupEnv("BEDROCK_PROVIDER")
+	t.Cleanup(func() {
+		if had {
+			os.Setenv("BEDROCK_PROVIDER", prev)
+		} else {
+			os.Unsetenv("BEDROCK_PROVIDER")
+		}
+	})
+	os.Unsetenv("BEDROCK_PROVIDER")
+
+	cases := []struct {
+		model string
+		want  modelFamily
+	}{
+		// Dateless new-generation IDs (Fable 5 / Opus 4.8 / 4.7 have no
+		// ARN-versioned variants on Bedrock).
+		{"anthropic.claude-fable-5", familyAnthropic},
+		{"global.anthropic.claude-fable-5", familyAnthropic},
+		{"anthropic.claude-opus-4-8", familyAnthropic},
+		// Bare first-party IDs a user may pick out of habit: still Claude,
+		// still Anthropic schema. Converse would drop the cache markers.
+		{"claude-fable-5", familyAnthropic},
+		{"claude-sonnet-5", familyAnthropic},
+		{"claude-opus-4-8", familyAnthropic},
+		// Non-Claude models keep the Converse default.
+		{"meta.llama3-70b-instruct-v1:0", familyConverse},
+		{"amazon.nova-pro-v1:0", familyConverse},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, resolveFamily(tc.model), "resolveFamily(%q)", tc.model)
+	}
+}
+
+// normalizeBedrockModelID upgrades bare first-party Claude IDs to the
+// invokable Bedrock ID from the catalog so a `/switch --model claude-fable-5`
+// doesn't die with an AWS ValidationException for a model ID that only
+// exists on the first-party API.
+func TestNormalizeBedrockModelID(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"claude-fable-5", "anthropic.claude-fable-5"},
+		{"fable-5", "anthropic.claude-fable-5"},
+		// Already-invokable IDs must pass through untouched — the user may
+		// have picked an account-specific inference profile.
+		{"anthropic.claude-fable-5", "anthropic.claude-fable-5"},
+		{"global.anthropic.claude-opus-4-6-v1", "global.anthropic.claude-opus-4-6-v1"},
+		{"us.anthropic.claude-sonnet-4-5-20250929-v1:0", "us.anthropic.claude-sonnet-4-5-20250929-v1:0"},
+		// Non-Claude IDs are never rewritten.
+		{"meta.llama3-70b-instruct-v1:0", "meta.llama3-70b-instruct-v1:0"},
+		// Unknown Claude IDs without a catalog match stay as typed.
+		{"claude-nonexistent-99", "claude-nonexistent-99"},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, normalizeBedrockModelID(tc.in), "normalizeBedrockModelID(%q)", tc.in)
+	}
+}
+
+// filterBedrockCapabilities strips first-party-only capability flags when a
+// Claude model is mirrored onto Bedrock: fast_mode (research preview,
+// first-party API only) and mid_conversation_system (not served by Bedrock
+// per Anthropic's platform-availability matrix).
+func TestFilterBedrockCapabilities(t *testing.T) {
+	in := []string{
+		"vision", "json_mode", "tools",
+		"adaptive_thinking", "fast_mode",
+		"mid_conversation_system", "low_cache_minimum",
+	}
+	got := filterBedrockCapabilities(in)
+	assert.ElementsMatch(t,
+		[]string{"vision", "json_mode", "tools", "adaptive_thinking", "low_cache_minimum"},
+		got)
+	assert.Nil(t, filterBedrockCapabilities(nil))
+}
+
+// The whole point of routing Fable 5 through the Anthropic InvokeModel path:
+// structured system parts keep their cache_control markers on the wire.
+// Bedrock supports per-block prompt caching for Claude; only the top-level
+// automatic cache parameter is a first-party-only feature (never emitted
+// by this client).
+func TestFable5CacheMarkersSurviveRequestAssembly(t *testing.T) {
+	c := &BedrockClient{model: "anthropic.claude-fable-5"}
+
+	history := []models.Message{
+		{
+			Role: "system",
+			SystemParts: []models.ContentBlock{
+				{Type: "text", Text: "stable system prompt"},
+				{Type: "text", Text: "attached context", CacheControl: &models.CacheControl{Type: "ephemeral"}},
+			},
+		},
+		{Role: "user", Content: "hello"},
+	}
+
+	messages, systemObj := c.buildMessagesAndSystem("hello", history)
+	reqBody := map[string]interface{}{
+		"anthropic_version": anthropicBedrockVersion,
+		"max_tokens":        4096,
+		"messages":          messages,
+		"system":            systemObj,
+	}
+	enforceCacheControlBudget(reqBody, anthropicMaxCacheBreakpoints)
+
+	blocks, ok := reqBody["system"].([]map[string]interface{})
+	assert.True(t, ok, "system must stay a structured block list")
+	markers := 0
+	for _, b := range blocks {
+		if _, has := b["cache_control"]; has {
+			markers++
+		}
+	}
+	assert.Equal(t, 1, markers, "cache_control marker must survive request assembly")
+}

--- a/llm/bedrock/newmodels_test.go
+++ b/llm/bedrock/newmodels_test.go
@@ -10,7 +10,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
+	"github.com/diillson/chatcli/llm/catalog"
 	"github.com/diillson/chatcli/models"
 )
 
@@ -100,6 +103,62 @@ func TestFilterBedrockCapabilities(t *testing.T) {
 		[]string{"vision", "json_mode", "tools", "adaptive_thinking", "low_cache_minimum"},
 		got)
 	assert.Nil(t, filterBedrockCapabilities(nil))
+}
+
+// The constructor applies the normalization so every downstream consumer
+// (dispatch, catalog lookups, ListModels registration) sees the invokable
+// id from the very first call.
+func TestNewBedrockClientNormalizesBareClaudeID(t *testing.T) {
+	c := NewBedrockClient("claude-fable-5", "us-east-1", "", zap.NewNop(), 1, 0)
+	assert.Equal(t, "anthropic.claude-fable-5", c.model)
+
+	// Profile ids the user picked from ListModels pass through untouched.
+	c = NewBedrockClient("us.anthropic.claude-sonnet-4-5-20250929-v1:0", "us-east-1", "", zap.NewNop(), 1, 0)
+	assert.Equal(t, "us.anthropic.claude-sonnet-4-5-20250929-v1:0", c.model)
+}
+
+// Dynamically discovered Claude ids must inherit specs from the
+// first-party catalog so an unknown-but-real Claude model doesn't fall
+// back to the generic 50K context default (auto-compaction on every
+// turn). Non-Claude ids register without enrichment; already-known ids
+// are left alone.
+func TestRegisterBedrockModelEnrichment(t *testing.T) {
+	// Synthetic first-party model that has no Bedrock mirror — the only
+	// deterministic way to exercise the inheritance branch, since every
+	// real first-party Claude id already has a Bedrock catalog entry.
+	catalog.Register(catalog.ModelMeta{
+		ID:              "claude-zeta-9-test",
+		Aliases:         []string{"claude-zeta-9-test"},
+		DisplayName:     "Claude Zeta 9 (test fixture)",
+		Provider:        catalog.ProviderClaudeAI,
+		ContextWindow:   777000,
+		MaxOutputTokens: 77000,
+		PreferredAPI:    catalog.APIAnthropicMessages,
+		Capabilities:    []string{"tools", "adaptive_thinking", "fast_mode", "mid_conversation_system"},
+	})
+
+	registerBedrockModel("global.anthropic.claude-zeta-9-test", "Claude Zeta 9 (Bedrock)")
+	meta, ok := catalog.Resolve(catalog.ProviderBedrock, "global.anthropic.claude-zeta-9-test")
+	require.True(t, ok)
+	assert.Equal(t, 777000, meta.ContextWindow, "discovered Claude id must inherit the first-party context window")
+	assert.Equal(t, 77000, meta.MaxOutputTokens)
+	assert.Contains(t, meta.Capabilities, "adaptive_thinking")
+	assert.NotContains(t, meta.Capabilities, "fast_mode", "first-party-only capability must be filtered")
+	assert.NotContains(t, meta.Capabilities, "mid_conversation_system")
+
+	// Known ids short-circuit: re-registering must not clobber the static
+	// entry's specs.
+	registerBedrockModel("anthropic.claude-fable-5", "should be ignored")
+	fable, ok := catalog.Resolve(catalog.ProviderBedrock, "anthropic.claude-fable-5")
+	require.True(t, ok)
+	assert.Equal(t, "Claude Fable 5 (Bedrock, 1M ctx)", fable.DisplayName)
+
+	// Non-Claude ids register without first-party inheritance.
+	registerBedrockModel("meta.llama-test-x9", "Meta Llama Test (Bedrock)")
+	llama, ok := catalog.Resolve(catalog.ProviderBedrock, "meta.llama-test-x9")
+	require.True(t, ok)
+	assert.Zero(t, llama.ContextWindow)
+	assert.Equal(t, catalog.APIChatCompletions, llama.PreferredAPI)
 }
 
 // The whole point of routing Fable 5 through the Anthropic InvokeModel path:

--- a/llm/bedrock/newmodels_test.go
+++ b/llm/bedrock/newmodels_test.go
@@ -14,6 +14,13 @@ import (
 	"github.com/diillson/chatcli/models"
 )
 
+// Compile-time guard: BedrockClient must stay a comparable type. Floor 13
+// (apidiff) treats losing comparability as a breaking API change — adding
+// a field with a non-comparable type (slice, map, aws.Config, …) breaks
+// any downstream == comparison of client values. Using the type as a map
+// key only compiles while it remains comparable.
+var _ = map[BedrockClient]struct{}(nil)
+
 // Claude models on Bedrock always speak the Anthropic Messages schema —
 // routing a bare "claude-*" ID (no "anthropic." segment) through Converse
 // silently drops cache_control markers and extended-thinking knobs. These

--- a/llm/catalog/catalog.go
+++ b/llm/catalog/catalog.go
@@ -1179,11 +1179,7 @@ var registry = []ModelMeta{
 	// Fable 5, Opus 4.8 and Opus 4.7 have NO ARN-versioned model IDs on
 	// Bedrock and are reachable through InvokeModel with the plain
 	// "anthropic."-prefixed id (served by the Claude-in-Amazon-Bedrock
-	// Messages infrastructure). Claude Sonnet 5 is NOT available on the
-	// InvokeModel surface (anthropic.claude-sonnet-5 exists only on the
-	// bedrock-mantle Messages endpoint), so it deliberately has no static
-	// entry here — it will appear via dynamic discovery once this client
-	// speaks the Mantle endpoint.
+	// Messages infrastructure).
 	{
 		ID:              "anthropic.claude-fable-5",
 		Aliases:         []string{"bedrock-fable-5", "global.anthropic.claude-fable-5", "claude-fable-5", "fable-5"},
@@ -1193,6 +1189,21 @@ var registry = []ModelMeta{
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
 		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking"},
+	},
+	// Sonnet 5 (Jun 2026). Served EXCLUSIVELY by the Claude-in-Amazon-
+	// Bedrock Messages endpoint (bedrock-mantle.{region}.api.aws) — it has
+	// no InvokeModel surface. The bedrock_mantle_only capability tells the
+	// Bedrock client to route the request through the Mantle path; sending
+	// this id to InvokeModel would return a ValidationException.
+	{
+		ID:              "anthropic.claude-sonnet-5",
+		Aliases:         []string{"bedrock-sonnet-5", "global.anthropic.claude-sonnet-5", "claude-sonnet-5", "sonnet-5"},
+		DisplayName:     "Claude Sonnet 5 (Bedrock, 1M ctx)",
+		Provider:        ProviderBedrock,
+		ContextWindow:   1000000,
+		MaxOutputTokens: 128000,
+		PreferredAPI:    APIAnthropicMessages,
+		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking", "bedrock_mantle_only"},
 	},
 	// Claude 4.8 (May 28 2026). Opus 4.8 = 1M / 128K per Anthropic.
 	// The previously-shipped dated profile IDs (…-20260528-v1:0) never

--- a/llm/catalog/catalog.go
+++ b/llm/catalog/catalog.go
@@ -328,6 +328,25 @@ var registry = []ModelMeta{
 		},
 	},
 	{
+		// Sonnet 5 (claude-sonnet-5, Jun 2026): the Sonnet-tier successor —
+		// Anthropic skipped a "Sonnet 4.7"/"4.8" and jumped straight to 5.
+		// 1M context, 128K max output, adaptive thinking (effort defaults to
+		// "high" server-side on the Claude API). $3/$15 per MTok (intro
+		// $2/$10 through Aug 31 2026 — cost_tracker uses the standard rate).
+		// No fast_mode (Opus-tier research preview only) and no
+		// mid_conversation_system (documented for Opus 4.8 only). Dateless
+		// pinned-snapshot ID per the Jun 2026 models overview.
+		ID:              "claude-sonnet-5",
+		Aliases:         []string{"claude-sonnet-5", "sonnet-5", "claude-5-sonnet"},
+		DisplayName:     "Claude Sonnet 5 (1M context)",
+		Provider:        ProviderClaudeAI,
+		ContextWindow:   1000000,
+		MaxOutputTokens: 128000,
+		PreferredAPI:    APIAnthropicMessages,
+		APIVersion:      config.ClaudeAIAPIVersionDefault,
+		Capabilities:    []string{"vision", "json_mode", "tools", "adaptive_thinking"},
+	},
+	{
 		// Opus 4.8 (claude-opus-4-8, May 28 2026): 1M context by default on
 		// the Claude API, 128K max output. Same API constraints as 4.7
 		// (no temperature/top_p/top_k; adaptive thinking only — extended
@@ -782,6 +801,20 @@ var registry = []ModelMeta{
 	// so generic alias prefixes ("glm-5") don't shadow the more specific
 	// "glm-5.1" / "glm-5-turbo" tags.
 	{
+		// GLM-5.2 (Jun 13 2026): 1M-token context, 128K max output
+		// (docs.z.ai/guides/llm/glm-5.2). Open-weight MoE, MIT license,
+		// tuned for coding/agentic workloads with thinking mode, function
+		// calling and structured output.
+		ID:              "glm-5.2",
+		Aliases:         []string{"glm-5.2", "glm-5-2"},
+		DisplayName:     "GLM-5.2 (1M context)",
+		Provider:        ProviderZAI,
+		ContextWindow:   1000000,
+		MaxOutputTokens: 128000,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"tools", "json_mode"},
+	},
+	{
 		// GLM-5.1: 200K / 128K (docs.z.ai/guides/llm/glm-5.1).
 		ID:              "glm-5.1",
 		Aliases:         []string{"glm-5.1", "glm-5-1"},
@@ -1134,49 +1167,56 @@ var registry = []ModelMeta{
 	// A listagem dinâmica via `bedrock:ListInferenceProfiles` complementa
 	// este catálogo com o que a conta AWS realmente tem acesso.
 
-	// Claude 4.6 (abr 2026 — mais recentes). Bedrock specs follow the
-	// Anthropic models page: Sonnet 4.6 = 1M / 64K, Opus 4.6 = 1M / 128K.
+	// NOTE (capabilities on Bedrock mirrors): fast_mode is a first-party
+	// research preview and mid_conversation_system is not served by Bedrock
+	// (Anthropic platform-availability matrix) — neither flag may appear on
+	// ProviderBedrock entries or the client would emit parameters AWS
+	// rejects. Per-block prompt caching (cache_control) IS supported for
+	// Claude on Bedrock; only the top-level automatic cache parameter is
+	// first-party-only, and this client never emits it.
+
+	// Fable 5 (Jun 9 2026). Dateless ID per Anthropic's Bedrock docs —
+	// Fable 5, Opus 4.8 and Opus 4.7 have NO ARN-versioned model IDs on
+	// Bedrock and are reachable through InvokeModel with the plain
+	// "anthropic."-prefixed id (served by the Claude-in-Amazon-Bedrock
+	// Messages infrastructure). Claude Sonnet 5 is NOT available on the
+	// InvokeModel surface (anthropic.claude-sonnet-5 exists only on the
+	// bedrock-mantle Messages endpoint), so it deliberately has no static
+	// entry here — it will appear via dynamic discovery once this client
+	// speaks the Mantle endpoint.
 	{
-		ID:              "global.anthropic.claude-sonnet-4-6-20260115-v1:0",
-		Aliases:         []string{"bedrock-sonnet-4-6", "anthropic.claude-sonnet-4-6-20260115-v1:0", "claude-sonnet-4-6"},
-		DisplayName:     "Claude Sonnet 4.6 (Bedrock, global, 1M ctx)",
-		Provider:        ProviderBedrock,
-		ContextWindow:   1000000,
-		MaxOutputTokens: 64000,
-		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode"},
-	},
-	{
-		ID:              "global.anthropic.claude-opus-4-6-20260115-v1:0",
-		Aliases:         []string{"bedrock-opus-4-6", "anthropic.claude-opus-4-6-20260115-v1:0", "claude-opus-4-6"},
-		DisplayName:     "Claude Opus 4.6 (Bedrock, global, 1M ctx)",
+		ID:              "anthropic.claude-fable-5",
+		Aliases:         []string{"bedrock-fable-5", "global.anthropic.claude-fable-5", "claude-fable-5", "fable-5"},
+		DisplayName:     "Claude Fable 5 (Bedrock, 1M ctx)",
 		Provider:        ProviderBedrock,
 		ContextWindow:   1000000,
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode"},
+		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking"},
 	},
-	// Claude 4.8 (May 28 2026 — newest). Opus 4.8 = 1M / 128K per Anthropic.
-	// Same on-demand restrictions as 4.7: needs an inference profile prefix
-	// (global./us./eu./apac.) — the bare id is kept as an alias for
-	// resolution by callers that pin the foundation-model name.
+	// Claude 4.8 (May 28 2026). Opus 4.8 = 1M / 128K per Anthropic.
+	// The previously-shipped dated profile IDs (…-20260528-v1:0) never
+	// existed on AWS; they stay as aliases so pinned configs keep resolving.
 	{
-		ID:              "global.anthropic.claude-opus-4-8-20260528-v1:0",
-		Aliases:         []string{"bedrock-opus-4-8", "anthropic.claude-opus-4-8-20260528-v1:0", "claude-opus-4-8"},
-		DisplayName:     "Claude Opus 4.8 (Bedrock, global, 1M ctx)",
+		ID: "anthropic.claude-opus-4-8",
+		Aliases: []string{
+			"bedrock-opus-4-8", "global.anthropic.claude-opus-4-8",
+			"global.anthropic.claude-opus-4-8-20260528-v1:0",
+			"anthropic.claude-opus-4-8-20260528-v1:0", "claude-opus-4-8",
+		},
+		DisplayName:     "Claude Opus 4.8 (Bedrock, 1M ctx)",
 		Provider:        ProviderBedrock,
 		ContextWindow:   1000000,
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
 		Capabilities: []string{
 			"tools", "vision", "json_mode",
-			"adaptive_thinking", "fast_mode",
-			"mid_conversation_system", "low_cache_minimum",
+			"adaptive_thinking", "low_cache_minimum",
 		},
 	},
 
 	// Claude 4.7. Sonnet 4.7 mirrors 4.6's profile (forward-projected),
-	// Opus 4.7 = 1M / 128K per Anthropic.
+	// Opus 4.7 = 1M / 128K per Anthropic (dateless id, same rule as 4.8).
 	{
 		ID:              "global.anthropic.claude-sonnet-4-7-20260401-v1:0",
 		Aliases:         []string{"bedrock-sonnet-4-7", "anthropic.claude-sonnet-4-7-20260401-v1:0", "claude-sonnet-4-7"},
@@ -1188,14 +1228,53 @@ var registry = []ModelMeta{
 		Capabilities:    []string{"tools", "vision", "json_mode"},
 	},
 	{
-		ID:              "global.anthropic.claude-opus-4-7-20260401-v1:0",
-		Aliases:         []string{"bedrock-opus-4-7", "anthropic.claude-opus-4-7-20260401-v1:0", "claude-opus-4-7"},
-		DisplayName:     "Claude Opus 4.7 (Bedrock, global, 1M ctx)",
+		ID: "anthropic.claude-opus-4-7",
+		Aliases: []string{
+			"bedrock-opus-4-7", "global.anthropic.claude-opus-4-7",
+			"global.anthropic.claude-opus-4-7-20260401-v1:0",
+			"anthropic.claude-opus-4-7-20260401-v1:0", "claude-opus-4-7",
+		},
+		DisplayName:     "Claude Opus 4.7 (Bedrock, 1M ctx)",
 		Provider:        ProviderBedrock,
 		ContextWindow:   1000000,
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
 		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking"},
+	},
+
+	// Claude 4.6 (abr 2026). Bedrock specs follow the Anthropic models
+	// page: Sonnet 4.6 = 1M / 64K, Opus 4.6 = 1M / 128K. Real Bedrock IDs
+	// per the docs: anthropic.claude-sonnet-4-6 and
+	// anthropic.claude-opus-4-6-v1 behind a global. inference profile.
+	// The previously-shipped dated IDs (…-20260115-v1:0) never existed on
+	// AWS; kept as aliases for pinned configs.
+	{
+		ID: "global.anthropic.claude-sonnet-4-6",
+		Aliases: []string{
+			"bedrock-sonnet-4-6", "anthropic.claude-sonnet-4-6",
+			"global.anthropic.claude-sonnet-4-6-20260115-v1:0",
+			"anthropic.claude-sonnet-4-6-20260115-v1:0", "claude-sonnet-4-6",
+		},
+		DisplayName:     "Claude Sonnet 4.6 (Bedrock, global, 1M ctx)",
+		Provider:        ProviderBedrock,
+		ContextWindow:   1000000,
+		MaxOutputTokens: 64000,
+		PreferredAPI:    APIAnthropicMessages,
+		Capabilities:    []string{"tools", "vision", "json_mode"},
+	},
+	{
+		ID: "global.anthropic.claude-opus-4-6-v1",
+		Aliases: []string{
+			"bedrock-opus-4-6", "anthropic.claude-opus-4-6-v1",
+			"global.anthropic.claude-opus-4-6-20260115-v1:0",
+			"anthropic.claude-opus-4-6-20260115-v1:0", "claude-opus-4-6",
+		},
+		DisplayName:     "Claude Opus 4.6 (Bedrock, global, 1M ctx)",
+		Provider:        ProviderBedrock,
+		ContextWindow:   1000000,
+		MaxOutputTokens: 128000,
+		PreferredAPI:    APIAnthropicMessages,
+		Capabilities:    []string{"tools", "vision", "json_mode"},
 	},
 	{
 		ID:              "global.anthropic.claude-haiku-4-5-20251001-v1:0",

--- a/llm/catalog/catalog_test.go
+++ b/llm/catalog/catalog_test.go
@@ -218,15 +218,104 @@ func TestClaudeOpus48Specs(t *testing.T) {
 			"claude-opus-4-8 should advertise %q capability", capability)
 	}
 
-	// Bedrock mirror — inference-profile-prefixed id.
+	// Bedrock mirror — dateless id per Anthropic's Bedrock docs (Opus 4.8
+	// has no ARN-versioned model ID on Bedrock).
 	bedMeta, ok := Resolve(ProviderBedrock, "claude-opus-4-8")
 	assert.True(t, ok, "claude-opus-4-8 must resolve via Bedrock alias")
-	assert.Equal(t, "global.anthropic.claude-opus-4-8-20260528-v1:0", bedMeta.ID)
+	assert.Equal(t, "anthropic.claude-opus-4-8", bedMeta.ID)
 	assert.Equal(t, 1000000, bedMeta.ContextWindow)
 	assert.Equal(t, 128000, bedMeta.MaxOutputTokens)
 	assert.True(t,
 		HasCapability(ProviderBedrock, "claude-opus-4-8", "adaptive_thinking"),
 		"Bedrock Opus 4.8 mirror should advertise adaptive_thinking")
+	// The previously-shipped (fabricated) dated profile ID must keep
+	// resolving for anyone who pinned it in scripts or env.
+	legacy, ok := Resolve(ProviderBedrock, "global.anthropic.claude-opus-4-8-20260528-v1:0")
+	assert.True(t, ok, "legacy dated Bedrock id must still resolve as alias")
+	assert.Equal(t, "anthropic.claude-opus-4-8", legacy.ID)
+	// fast_mode is a first-party research preview and
+	// mid_conversation_system is not served by Bedrock — neither may be
+	// advertised on the Bedrock mirror or the client would emit
+	// parameters AWS rejects.
+	assert.False(t, HasCapability(ProviderBedrock, "claude-opus-4-8", "fast_mode"))
+	assert.False(t, HasCapability(ProviderBedrock, "claude-opus-4-8", "mid_conversation_system"))
+}
+
+// TestClaudeSonnet5Specs pins the published Sonnet 5 specs (models
+// overview, Jun 2026): 1M context, 128K max output, adaptive thinking,
+// $3/$15 tier. "sonnet-5" shorthand must resolve to it and must NOT be
+// swallowed by any sonnet-4.x alias.
+func TestClaudeSonnet5Specs(t *testing.T) {
+	for _, id := range []string{"claude-sonnet-5", "sonnet-5"} {
+		meta, ok := Resolve(ProviderClaudeAI, id)
+		assert.True(t, ok, "expected %s to resolve on ProviderClaudeAI", id)
+		assert.Equal(t, "claude-sonnet-5", meta.ID, "alias %s must resolve to claude-sonnet-5", id)
+		assert.Equal(t, 1000000, meta.ContextWindow, "Sonnet 5 context window is 1M tokens")
+		assert.Equal(t, 128000, meta.MaxOutputTokens, "Sonnet 5 max output is 128K")
+		assert.Equal(t, APIAnthropicMessages, meta.PreferredAPI)
+	}
+	for _, capability := range []string{"tools", "json_mode", "vision", "adaptive_thinking"} {
+		assert.True(t,
+			HasCapability(ProviderClaudeAI, "claude-sonnet-5", capability),
+			"claude-sonnet-5 should advertise %q capability", capability)
+	}
+	assert.False(t,
+		HasCapability(ProviderClaudeAI, "claude-sonnet-5", "fast_mode"),
+		"claude-sonnet-5 must not advertise fast_mode (Opus-tier research preview only)")
+	// Regression guard: sonnet-4-x lookups must keep resolving to their own
+	// entries after the sonnet-5 entry lands.
+	m46, ok := Resolve(ProviderClaudeAI, "claude-sonnet-4-6")
+	assert.True(t, ok)
+	assert.Equal(t, "claude-sonnet-4-6", m46.ID)
+}
+
+// TestBedrockFable5Entry pins Fable 5 on Bedrock: dateless
+// anthropic.claude-fable-5 id (reachable through InvokeModel per the
+// Bedrock docs), 1M context so auto-compaction doesn't fire on the
+// 50K unknown-model default, and adaptive_thinking so effort routing
+// emits `thinking:{type:"adaptive"}` instead of a budgeted block.
+func TestBedrockFable5Entry(t *testing.T) {
+	for _, id := range []string{
+		"anthropic.claude-fable-5",
+		"global.anthropic.claude-fable-5",
+		"claude-fable-5",
+		"bedrock-fable-5",
+	} {
+		meta, ok := Resolve(ProviderBedrock, id)
+		assert.True(t, ok, "expected %s to resolve on ProviderBedrock", id)
+		assert.Equal(t, "anthropic.claude-fable-5", meta.ID, "alias %s must resolve to the Bedrock Fable 5 entry", id)
+		assert.Equal(t, 1000000, meta.ContextWindow)
+		assert.Equal(t, 128000, meta.MaxOutputTokens)
+		assert.Equal(t, APIAnthropicMessages, meta.PreferredAPI)
+	}
+	assert.Equal(t, 1000000, GetContextWindow(ProviderBedrock, "anthropic.claude-fable-5"))
+	assert.True(t,
+		HasCapability(ProviderBedrock, "anthropic.claude-fable-5", "adaptive_thinking"),
+		"Bedrock Fable 5 must advertise adaptive_thinking")
+	assert.False(t,
+		HasCapability(ProviderBedrock, "anthropic.claude-fable-5", "fast_mode"))
+	assert.False(t,
+		HasCapability(ProviderBedrock, "anthropic.claude-fable-5", "mid_conversation_system"))
+}
+
+// TestGLM52Entry pins GLM-5.2 (Z.AI, Jun 13 2026): 1M-token context and
+// 128K max output per docs.z.ai/guides/llm/glm-5.2. The entry must sit
+// ahead of the glm-5 / glm-5.1 entries so the more specific id is never
+// shadowed by their alias prefixes.
+func TestGLM52Entry(t *testing.T) {
+	for _, id := range []string{"glm-5.2", "glm-5-2"} {
+		meta, ok := Resolve(ProviderZAI, id)
+		assert.True(t, ok, "expected %s to resolve on ProviderZAI", id)
+		assert.Equal(t, "glm-5.2", meta.ID, "alias %s must resolve to glm-5.2", id)
+		assert.Equal(t, 1000000, meta.ContextWindow, "GLM-5.2 context window is 1M tokens")
+		assert.Equal(t, 128000, meta.MaxOutputTokens, "GLM-5.2 max output is 128K")
+		assert.Equal(t, APIChatCompletions, meta.PreferredAPI)
+	}
+	assert.Equal(t, 1000000, GetContextWindow(ProviderZAI, "glm-5.2"))
+	// glm-5 must keep resolving to its own entry (no shadowing either way).
+	m5, ok := Resolve(ProviderZAI, "glm-5")
+	assert.True(t, ok)
+	assert.Equal(t, "glm-5", m5.ID)
 }
 
 // TestGPT55LimitsAndCapabilities pins the published Apr 23 2026 specs:

--- a/llm/catalog/catalog_test.go
+++ b/llm/catalog/catalog_test.go
@@ -298,6 +298,40 @@ func TestBedrockFable5Entry(t *testing.T) {
 		HasCapability(ProviderBedrock, "anthropic.claude-fable-5", "mid_conversation_system"))
 }
 
+// TestBedrockSonnet5Entry pins Sonnet 5 on Bedrock. The model is served
+// exclusively by the bedrock-mantle Messages endpoint (no InvokeModel
+// surface), which the entry advertises through the bedrock_mantle_only
+// capability — the client uses it to route the request to the right wire.
+func TestBedrockSonnet5Entry(t *testing.T) {
+	for _, id := range []string{
+		"anthropic.claude-sonnet-5",
+		"global.anthropic.claude-sonnet-5",
+		"claude-sonnet-5",
+		"bedrock-sonnet-5",
+	} {
+		meta, ok := Resolve(ProviderBedrock, id)
+		assert.True(t, ok, "expected %s to resolve on ProviderBedrock", id)
+		assert.Equal(t, "anthropic.claude-sonnet-5", meta.ID, "alias %s must resolve to the Bedrock Sonnet 5 entry", id)
+		assert.Equal(t, 1000000, meta.ContextWindow)
+		assert.Equal(t, 128000, meta.MaxOutputTokens)
+		assert.Equal(t, APIAnthropicMessages, meta.PreferredAPI)
+	}
+	assert.True(t,
+		HasCapability(ProviderBedrock, "anthropic.claude-sonnet-5", "adaptive_thinking"))
+	assert.True(t,
+		HasCapability(ProviderBedrock, "anthropic.claude-sonnet-5", "bedrock_mantle_only"),
+		"Sonnet 5 must be flagged mantle-only so the client picks the Messages endpoint")
+	assert.False(t,
+		HasCapability(ProviderBedrock, "anthropic.claude-sonnet-5", "fast_mode"))
+	assert.False(t,
+		HasCapability(ProviderBedrock, "anthropic.claude-sonnet-5", "mid_conversation_system"))
+	// Regression guard: the 4.x Bedrock sonnets keep resolving to their
+	// own entries.
+	m46, ok := Resolve(ProviderBedrock, "claude-sonnet-4-6")
+	assert.True(t, ok)
+	assert.Equal(t, "global.anthropic.claude-sonnet-4-6", m46.ID)
+}
+
 // TestGLM52Entry pins GLM-5.2 (Z.AI, Jun 13 2026): 1M-token context and
 // 128K max output per docs.z.ai/guides/llm/glm-5.2. The entry must sit
 // ahead of the glm-5 / glm-5.1 entries so the more specific id is never


### PR DESCRIPTION
## Summary

Three model-support updates verified against the live Anthropic and Z.AI docs (Jul 2026):

### Claude Sonnet 5 (first-party)
- New `claude-sonnet-5` catalog entry: 1M context, 128K max output, adaptive thinking, `APIAnthropicMessages`. Aliases `sonnet-5` / `claude-5-sonnet`.
- Sonnet-tier pricing already covered by the cost tracker (3/15 USD per MTok; intro pricing 2/10 through Aug 31 2026 is noted in the entry comment — tracker stays on the standard rate, conservative).
- Completer and palette inherit automatically via `catalog.ListByProvider`.

### Bedrock: Fable 5 works, prompt caching root cause fixed
- **Root cause of "caching doesn't work on Bedrock"**: `resolveFamily` only recognized `anthropic.`-prefixed IDs, so bare Claude ids (e.g. `claude-fable-5`) fell through to the **Converse** path, which intentionally drops `cache_control` markers. Claude ids now always route through the Anthropic Messages path, where per-block prompt caching is supported by AWS and markers reach the wire (pinned by test).
- New `anthropic.claude-fable-5` Bedrock entry (1M/128K, adaptive thinking) — previously the model fell back to the 50K unknown-model default and tripped auto-compaction on nearly every turn.
- Bare first-party ids are normalized to the invokable Bedrock id at client construction (`claude-fable-5` → `anthropic.claude-fable-5`).
- Fixed fabricated dated Bedrock ids for Opus 4.8/4.7 and the 4.6 pair — Anthropic documents dateless ids for the new generation (no ARN-versioned variants exist). Old dated ids remain as aliases so pinned configs keep resolving.
- Bedrock mirrors no longer advertise `fast_mode` / `mid_conversation_system` (first-party-only per the platform-availability matrix); dynamically discovered Claude models inherit context window, output ceiling and filtered capabilities from the first-party catalog.

### Bedrock: Claude Sonnet 5 served via the bedrock-mantle Messages endpoint
Sonnet 5 has **no InvokeModel surface** on AWS — it is served only by the Claude-in-Amazon-Bedrock Messages endpoint. New dedicated path in `llm/bedrock/mantle.go`:
- `POST bedrock-mantle.{region}.api.aws/anthropic/v1/messages` with the first-party Messages body shape (version travels in the `anthropic-version` header; the InvokeModel-only `anthropic_version` body field is never sent).
- Auth: SigV4 with the `bedrock-mantle` service name over the resolved AWS credential chain, or `AWS_BEARER_TOKEN_BEDROCK` via `x-api-key`.
- Catalog-driven routing through the `bedrock_mantle_only` capability; operator overrides `BEDROCK_ANTHROPIC_ENDPOINT=mantle|invoke` and `BEDROCK_MANTLE_BASE_URL` (VPC endpoints/proxies), both exposed in `/config` alongside `AWS_BEARER_TOKEN_BEDROCK` presence.
- Shares the message builder, adaptive-thinking dispatch and cache_control budget with the InvokeModel path — cache markers verified on the wire by an httptest round-trip.
- Corporate TLS overrides honored by reusing the existing corporate transport.

### GLM-5.2 (Z.AI)
- New `glm-5.2` catalog entry: 1M context, 128K max output (docs.z.ai, Jun 13 2026), ordered ahead of `glm-5`/`glm-5.1` to avoid alias shadowing.
- Dedicated GLM-5 family pricing: 1.40/4.40 USD per MTok for GLM-5.2 and 1.00/3.20 for GLM-5, replacing the flat ZAI fallback for these models. ZAI default model stays `glm-5` (product decision left untouched).

## Testing
- Red→green: new tests reproduced the Converse cache-drop routing, the missing catalog entries and the missing Mantle path before the fixes.
- Full `go test ./...` green; `golangci-lint` clean on touched packages; `gofmt` clean.
- Coverage: family routing (bare ids, profiles, env overrides), model-id normalization, capability filtering, cache markers surviving request assembly on both Bedrock wires, Mantle httptest round-trip (headers, body shape, error envelope), catalog spec pins for Sonnet 5 / Fable 5 Bedrock / Sonnet 5 Bedrock / GLM-5.2, and pricing pins for the GLM-5 family.