### PR TITLE
fix(bedrock): route Fable 5 via Mantle and canonicalize profile IDs on the Messages wire

### DIFF
--- a/llm/bedrock/converse_family.go
+++ b/llm/bedrock/converse_family.go
@@ -266,6 +266,17 @@ func wrapBedrockInferenceProfileError(model string, err error) error {
 		msg = apiErr.ErrorMessage()
 	}
 	low := strings.ToLower(msg)
+	if strings.Contains(low, "data retention mode") {
+		// Fable-5-class models are served under the Claude-in-Amazon-Bedrock
+		// agreement (30-day retention) and reject the legacy InvokeModel
+		// surface, which runs under the account's default retention mode.
+		return fmt.Errorf(
+			"bedrock: model %q is served by the Claude in Amazon Bedrock Messages endpoint and rejects legacy InvokeModel "+
+				"(its data-retention terms are not available there). ChatCLI routes this model through bedrock-mantle "+
+				"automatically — if you pinned BEDROCK_ANTHROPIC_ENDPOINT=invoke, unset it or set BEDROCK_ANTHROPIC_ENDPOINT=mantle. "+
+				"Also confirm the model is enabled with a data retention mode under \"Model access\" in the AWS Bedrock console. Original: %w",
+			model, err)
+	}
 	if !strings.Contains(low, "inference profile") &&
 		!strings.Contains(low, "on-demand throughput isn't supported") &&
 		!strings.Contains(low, "on-demand throughput is not supported") {

--- a/llm/bedrock/family_test.go
+++ b/llm/bedrock/family_test.go
@@ -1,6 +1,7 @@
 package bedrock
 
 import (
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -90,6 +91,41 @@ func TestSupportsOnDemand(t *testing.T) {
 				t.Errorf("supportsOnDemand(%v) = %v, want %v", tc.in, got, tc.want)
 			}
 		})
+	}
+}
+
+// AWS answers the legacy InvokeModel surface with a 400
+// ValidationException when a model is only served under the
+// Claude-in-Amazon-Bedrock data-retention agreement (Fable 5 requires
+// 30-day retention; the default retention mode is rejected). The raw
+// message doesn't say what to do about it — the wrapper must point at the
+// Mantle endpoint and the console opt-in.
+func TestWrapBedrockDataRetentionError(t *testing.T) {
+	base := errors.New("operation error Bedrock Runtime: InvokeModel, " +
+		"https response error StatusCode: 400, ValidationException: " +
+		"Data retention mode 'default' is not available for this model.")
+	err := wrapBedrockInferenceProfileError("us.anthropic.claude-fable-5", base)
+	if err == nil {
+		t.Fatal("expected a wrapped error, got nil")
+	}
+	for _, want := range []string{
+		"Claude in Amazon Bedrock",
+		"BEDROCK_ANTHROPIC_ENDPOINT",
+		"us.anthropic.claude-fable-5",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("wrapped error %q missing %q", err.Error(), want)
+		}
+	}
+	if !errors.Is(err, base) {
+		t.Error("wrapped error must preserve the original via %w")
+	}
+
+	// Unrelated errors pass through untouched (same value, no wrapping).
+	other := errors.New("ThrottlingException: too many requests")
+	got := wrapBedrockInferenceProfileError("anthropic.claude-fable-5", other)
+	if !errors.Is(got, other) || got.Error() != other.Error() {
+		t.Errorf("unrelated error must pass through untouched, got %v", got)
 	}
 }
 

--- a/llm/bedrock/mantle.go
+++ b/llm/bedrock/mantle.go
@@ -52,11 +52,18 @@ func mantleMessagesURL(region string) string {
 // usesMantleEndpoint decides whether an Anthropic-family request must go
 // through the Mantle Messages endpoint instead of legacy InvokeModel.
 //
-// Default: catalog-driven — models flagged bedrock_mantle_only (Sonnet 5
-// has no InvokeModel surface at all) route to Mantle; everything else
-// stays on the proven InvokeModel path. BEDROCK_ANTHROPIC_ENDPOINT
-// overrides for operators: "mantle" forces every Anthropic request onto
-// the Messages endpoint, "invoke"/"legacy" pins them all to InvokeModel.
+// Default: catalog-driven — models flagged bedrock_mantle_only route to
+// Mantle; everything else stays on the proven InvokeModel path. Sonnet 5
+// has no InvokeModel surface at all, and Fable 5 rejects InvokeModel with
+// 400 "data retention mode 'default' is not available for this model"
+// (it requires 30-day retention, provided only under the
+// Claude-in-Amazon-Bedrock agreement the Mantle endpoint serves).
+// Catalog resolution matches inference-profile spellings too
+// (us./eu./apac./global. + the embedded claude segment), so a profile id
+// picked from ListInferenceProfiles routes the same as the canonical id.
+// BEDROCK_ANTHROPIC_ENDPOINT overrides for operators: "mantle" forces
+// every Anthropic request onto the Messages endpoint, "invoke"/"legacy"
+// pins them all to InvokeModel.
 func usesMantleEndpoint(model string) bool {
 	switch strings.ToLower(strings.TrimSpace(os.Getenv("BEDROCK_ANTHROPIC_ENDPOINT"))) {
 	case "mantle":
@@ -65,6 +72,37 @@ func usesMantleEndpoint(model string) bool {
 		return false
 	}
 	return catalog.HasCapability(catalog.ProviderBedrock, model, "bedrock_mantle_only")
+}
+
+// mantleProfilePrefixes are the cross-region inference-profile prefixes
+// AWS prepends to Bedrock model IDs (ListInferenceProfiles spelling).
+// The Mantle Messages endpoint does not know these — it serves the
+// canonical "anthropic."-prefixed dateless IDs only.
+var mantleProfilePrefixes = []string{"us.", "eu.", "apac.", "jp.", "au.", "global."}
+
+// mantleModelID canonicalizes whatever Bedrock-side spelling the user
+// selected — an inference-profile ID discovered via ListInferenceProfiles
+// ("us.anthropic.claude-sonnet-5", "global.anthropic.claude-sonnet-5-v1:0"),
+// a bare first-party id or a catalog alias — into the id the Mantle
+// Messages endpoint actually serves. Sending a profile id verbatim
+// returns 404 not_found_error ("model does not exist").
+//
+// Resolution order: the Bedrock catalog first (it owns the invokable
+// Mantle id, and Resolve matches the embedded claude segment inside
+// profile-prefixed IDs); a mechanical profile-prefix strip as fallback
+// for real-but-uncataloged Claude IDs; non-Claude ids pass through.
+func mantleModelID(model string) string {
+	if meta, ok := catalog.Resolve(catalog.ProviderBedrock, model); ok &&
+		strings.HasPrefix(strings.ToLower(meta.ID), "anthropic.") {
+		return meta.ID
+	}
+	m := strings.ToLower(strings.TrimSpace(model))
+	for _, p := range mantleProfilePrefixes {
+		if strings.HasPrefix(m, p) && strings.HasPrefix(m[len(p):], "anthropic.") {
+			return strings.TrimSpace(model)[len(p):]
+		}
+	}
+	return model
 }
 
 // sendPromptAnthropicMantle sends a Messages API request to the
@@ -81,8 +119,14 @@ func (c *BedrockClient) sendPromptAnthropicMantle(ctx context.Context, prompt st
 
 	messages, systemObj := c.buildMessagesAndSystem(prompt, history)
 
+	wireModel := mantleModelID(c.model)
+	if wireModel != c.model {
+		c.logger.Info("bedrock-mantle: canonicalized inference-profile id for the Messages wire",
+			zap.String("from", c.model), zap.String("to", wireModel))
+	}
+
 	reqBody := map[string]interface{}{
-		"model":      c.model,
+		"model":      wireModel,
 		"max_tokens": effectiveMaxTokens,
 		"messages":   messages,
 	}

--- a/llm/bedrock/mantle_test.go
+++ b/llm/bedrock/mantle_test.go
@@ -54,24 +54,96 @@ func TestMantleMessagesURL(t *testing.T) {
 }
 
 // Sonnet 5 exists ONLY on the bedrock-mantle Messages endpoint (no
-// InvokeModel surface), so it must route to Mantle by default. Fable 5 /
-// Opus 4.8 stay on InvokeModel unless the operator forces the endpoint.
+// InvokeModel surface) and Fable 5 rejects legacy InvokeModel outright
+// (400 "data retention mode 'default' is not available for this model" —
+// it requires 30-day retention, which only the Claude-in-Amazon-Bedrock
+// agreement provides), so both must route to Mantle by default — whatever
+// spelling the user selected, including inference-profile IDs discovered
+// via ListInferenceProfiles. Opus 4.8 stays on InvokeModel unless the
+// operator forces the endpoint.
 func TestUsesMantleEndpoint(t *testing.T) {
 	setEnvForTest(t, "BEDROCK_ANTHROPIC_ENDPOINT", "")
 
 	assert.True(t, usesMantleEndpoint("anthropic.claude-sonnet-5"))
 	assert.True(t, usesMantleEndpoint("claude-sonnet-5"))
-	assert.False(t, usesMantleEndpoint("anthropic.claude-fable-5"))
+	assert.True(t, usesMantleEndpoint("us.anthropic.claude-sonnet-5"))
+	assert.True(t, usesMantleEndpoint("global.anthropic.claude-sonnet-5"))
+	assert.True(t, usesMantleEndpoint("anthropic.claude-fable-5"))
+	assert.True(t, usesMantleEndpoint("us.anthropic.claude-fable-5"))
+	assert.True(t, usesMantleEndpoint("global.anthropic.claude-fable-5"))
 	assert.False(t, usesMantleEndpoint("anthropic.claude-opus-4-8"))
 	assert.False(t, usesMantleEndpoint("global.anthropic.claude-opus-4-6-v1"))
 
 	// Operator override: force every Anthropic request through Mantle…
 	setEnvForTest(t, "BEDROCK_ANTHROPIC_ENDPOINT", "mantle")
-	assert.True(t, usesMantleEndpoint("anthropic.claude-fable-5"))
+	assert.True(t, usesMantleEndpoint("anthropic.claude-opus-4-8"))
 
 	// …or pin everything to the legacy InvokeModel path.
 	setEnvForTest(t, "BEDROCK_ANTHROPIC_ENDPOINT", "invoke")
 	assert.False(t, usesMantleEndpoint("anthropic.claude-sonnet-5"))
+	assert.False(t, usesMantleEndpoint("anthropic.claude-fable-5"))
+}
+
+// The Mantle Messages endpoint serves the canonical "anthropic."-prefixed
+// dateless IDs only. Regional/global inference-profile IDs — exactly what
+// ListInferenceProfiles hands the user in /switch — return 404
+// not_found_error if sent verbatim, so the wire model must be
+// canonicalized before the request is built.
+func TestMantleModelID(t *testing.T) {
+	cases := map[string]string{
+		// Already canonical: untouched.
+		"anthropic.claude-sonnet-5": "anthropic.claude-sonnet-5",
+		"anthropic.claude-fable-5":  "anthropic.claude-fable-5",
+		// Inference-profile spellings resolve through the catalog to the
+		// invokable Mantle id.
+		"us.anthropic.claude-sonnet-5":      "anthropic.claude-sonnet-5",
+		"global.anthropic.claude-sonnet-5":  "anthropic.claude-sonnet-5",
+		"us.anthropic.claude-sonnet-5-v1:0": "anthropic.claude-sonnet-5",
+		"us.anthropic.claude-fable-5":       "anthropic.claude-fable-5",
+		"global.anthropic.claude-fable-5":   "anthropic.claude-fable-5",
+		// Bare first-party id (users type it out of habit).
+		"claude-sonnet-5": "anthropic.claude-sonnet-5",
+		// Unknown-but-real Claude profile id the catalog can't resolve:
+		// the mechanical prefix strip is the fallback.
+		"us.anthropic.claude-zeta-9-v1:0": "anthropic.claude-zeta-9-v1:0",
+		// Non-Claude ids pass through untouched.
+		"meta.llama3-70b-instruct-v1:0": "meta.llama3-70b-instruct-v1:0",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, mantleModelID(in), "mantleModelID(%q)", in)
+	}
+}
+
+// A client bound to a discovered inference-profile ID must put the
+// canonical Mantle id on the wire — this is the exact scenario behind the
+// production 404: /switch lists "us.anthropic.claude-sonnet-5", the user
+// selects it, and the Messages endpoint doesn't know that id.
+func TestSendPromptAnthropicMantleNormalizesProfileID(t *testing.T) {
+	var gotBody map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(raw, &gotBody))
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"pong"}]}`))
+	}))
+	defer srv.Close()
+
+	setEnvForTest(t, "BEDROCK_MANTLE_BASE_URL", srv.URL)
+	setEnvForTest(t, "AWS_BEARER_TOKEN_BEDROCK", "test-bearer-token")
+
+	c := &BedrockClient{
+		model:       "us.anthropic.claude-sonnet-5",
+		region:      "us-east-1",
+		logger:      zap.NewNop(),
+		maxAttempts: 1,
+	}
+
+	out, err := c.sendPromptAnthropicMantle(t.Context(), "ping", nil, 512)
+	require.NoError(t, err)
+	assert.Equal(t, "pong", out)
+	assert.Equal(t, "anthropic.claude-sonnet-5", gotBody["model"],
+		"inference-profile id must be canonicalized for the Mantle wire")
 }
 
 // End-to-end request assembly against a fake Mantle endpoint: the body is

--- a/llm/catalog/catalog.go
+++ b/llm/catalog/catalog.go
@@ -1177,9 +1177,14 @@ var registry = []ModelMeta{
 
 	// Fable 5 (Jun 9 2026). Dateless ID per Anthropic's Bedrock docs —
 	// Fable 5, Opus 4.8 and Opus 4.7 have NO ARN-versioned model IDs on
-	// Bedrock and are reachable through InvokeModel with the plain
-	// "anthropic."-prefixed id (served by the Claude-in-Amazon-Bedrock
-	// Messages infrastructure).
+	// Bedrock. Fable 5 is served EXCLUSIVELY by the Claude-in-Amazon-
+	// Bedrock Messages endpoint: it requires 30-day data retention, which
+	// only that agreement provides — legacy InvokeModel runs under the
+	// account's default retention mode and answers 400 ValidationException
+	// "data retention mode 'default' is not available for this model",
+	// whatever profile prefix (us./global.) the caller uses. The
+	// bedrock_mantle_only capability routes it through the Mantle path,
+	// same as Sonnet 5.
 	{
 		ID:              "anthropic.claude-fable-5",
 		Aliases:         []string{"bedrock-fable-5", "global.anthropic.claude-fable-5", "claude-fable-5", "fable-5"},
@@ -1188,7 +1193,7 @@ var registry = []ModelMeta{
 		ContextWindow:   1000000,
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking"},
+		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking", "bedrock_mantle_only"},
 	},
 	// Sonnet 5 (Jun 2026). Served EXCLUSIVELY by the Claude-in-Amazon-
 	// Bedrock Messages endpoint (bedrock-mantle.{region}.api.aws) — it has


### PR DESCRIPTION
## Summary

Follow-up to #1111. Two production failures remained on the new-generation Claude models on Bedrock:

### Fable 5 → Mantle (400 data retention)
Fable 5 requires **30-day data retention**, provided only under the *Claude in Amazon Bedrock* agreement — legacy InvokeModel runs under the account's default retention mode and answers `400 ValidationException: data retention mode 'default' is not available for this model`, regardless of `us.`/`global.` profile prefix. The catalog entry now carries `bedrock_mantle_only` and routes through the Messages endpoint, same as Sonnet 5.

### Profile-ID canonicalization (404 on the Mantle wire)
The Mantle Messages endpoint only serves the dateless `anthropic.*` IDs. Selecting a discovered inference-profile ID (`us.anthropic.claude-sonnet-5` — exactly what `ListInferenceProfiles`/`/switch` lists) sent it verbatim in the request body → `404 not_found_error` ("model does not exist"). New `mantleModelID()` canonicalizes any spelling — regional/global profile, bare first-party id, catalog alias — through the catalog before building the request, with a mechanical prefix-strip fallback for real-but-uncataloged Claude IDs.

### Actionable retention error
`wrapBedrockInferenceProfileError` now annotates the retention 400 with a hint pointing at `BEDROCK_ANTHROPIC_ENDPOINT` and the Bedrock console Model access opt-in, for operators who pinned the legacy wire.

## Tests
- `TestMantleModelID` + `TestSendPromptAnthropicMantleNormalizesProfileID` reproduce the production 404 scenario against a fake Mantle endpoint and pin the canonical wire model.
- `TestUsesMantleEndpoint` extended: Fable 5 and every profile spelling route to Mantle; Opus 4.8/4.7 stay on InvokeModel; operator overrides pinned.
- `TestWrapBedrockDataRetentionError` uses the exact AWS error string and pins pass-through of unrelated errors.

Docs (pt+en) updated in chatcli.ai.