### PR TITLE
fix(memory): eliminate silent memory-loss vectors and harden retrieval

### DIFF
--- a/cli/workspace/memory.go
+++ b/cli/workspace/memory.go
@@ -63,7 +63,8 @@ func (ms *MemoryStore) ReadLongTerm() string {
 	return ms.manager.ReadLongTerm()
 }
 
-// WriteLongTerm replaces all long-term memory.
+// WriteLongTerm parses content into facts and merges them into long-term
+// memory (existing facts are kept; duplicates reinforce).
 func (ms *MemoryStore) WriteLongTerm(content string) error {
 	return ms.manager.WriteLongTerm(content)
 }

--- a/cli/workspace/memory/backfill_singleflight_test.go
+++ b/cli/workspace/memory/backfill_singleflight_test.go
@@ -1,0 +1,78 @@
+package memory
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// blockingProvider counts backfill Embed BATCHES (len > 1) and holds them
+// until release is closed, so a test can observe how many concurrent
+// backfills were launched. Single-text embeds — the synchronous EmbedQuery on
+// the retrieval path — pass through immediately, otherwise the retrieval
+// itself would deadlock the test.
+type blockingProvider struct {
+	dim     int
+	calls   atomic.Int32
+	release chan struct{}
+}
+
+func (p *blockingProvider) Name() string   { return "blocking-fake" }
+func (p *blockingProvider) Dimension() int { return p.dim }
+func (p *blockingProvider) Embed(_ context.Context, texts []string) ([][]float32, error) {
+	if len(texts) > 1 { // a backfill batch, not a query embed
+		p.calls.Add(1)
+		<-p.release
+	}
+	out := make([][]float32, len(texts))
+	for i := range texts {
+		v := make([]float32, p.dim)
+		v[0] = 1
+		out[i] = v
+	}
+	return out, nil
+}
+
+// TestVectorBackfillIsSingleFlight pins the cost guard: every HyDE retrieval
+// fires a detached backfill goroutine for facts lacking vectors. Concurrent
+// retrievals (MoA participants, gateway turns) used to launch overlapping
+// backfills embedding the SAME facts — double the embedding bill for zero
+// benefit. Only one backfill may be in flight at a time.
+func TestVectorBackfillIsSingleFlight(t *testing.T) {
+	dir := t.TempDir()
+	m := NewManager(dir, DefaultConfig(), zap.NewNop())
+	p := &blockingProvider{dim: 64, release: make(chan struct{})}
+	v := NewVectorIndex(dir, p, nil)
+	m.AttachVectorIndex(v)
+
+	m.RememberFact("service alpha listens on port 3001 behind nginx", "general")
+	m.RememberFact("service beta stores queue state in redis db 2", "general")
+
+	ctx := context.Background()
+	// Two retrievals back-to-back: the first launches the backfill (blocked in
+	// Embed); the second must observe it in flight and not launch another.
+	m.GetRelevantContextWithHyDE(ctx, "which port does alpha use", []string{"alpha", "port"}, nil)
+	m.GetRelevantContextWithHyDE(ctx, "where does beta store state", []string{"beta", "redis"}, nil)
+
+	// Give any (incorrectly) spawned second goroutine time to reach Embed.
+	time.Sleep(150 * time.Millisecond)
+	got := p.calls.Load()
+	close(p.release)
+
+	// Wait for the detached backfill to finish persisting before the test's
+	// TempDir cleanup runs (the goroutine outlives the retrieval on purpose).
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) && v.Count() < 2 {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if got != 1 {
+		t.Fatalf("%d concurrent backfill batches launched, want 1 (single-flight)", got)
+	}
+	if v.Count() != 2 {
+		t.Fatalf("backfill did not complete: %d vectors stored, want 2", v.Count())
+	}
+}

--- a/cli/workspace/memory/compactor.go
+++ b/cli/workspace/memory/compactor.go
@@ -2,13 +2,28 @@ package memory
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"go.uber.org/zap"
 )
+
+// compactionMinKeepRatio is the shrink guard on LLM-assisted consolidation: a
+// result keeping fewer than this fraction of the original facts is treated as
+// truncated/defective model output and rejected (score-based curation runs
+// instead). Models cut long lists routinely; before this guard a truncated
+// answer was applied wholesale, permanently deleting every fact the model
+// failed to echo.
+const compactionMinKeepRatio = 0.5
+
+// compactorStateFile persists the last-compaction timestamp so a process
+// restart does not re-trigger the (LLM-billed, destructive-adjacent)
+// consolidation pass that just ran.
+const compactorStateFile = "compactor_state.json"
 
 // Compactor handles LLM-based memory consolidation and cleanup.
 type Compactor struct {
@@ -21,14 +36,48 @@ type Compactor struct {
 	lastCompaction time.Time
 }
 
-// NewCompactor creates a new memory compactor.
+// compactorState is the on-disk shape of the compactor's durable state.
+type compactorState struct {
+	LastCompaction time.Time `json:"last_compaction"`
+}
+
+// NewCompactor creates a new memory compactor, restoring the last-compaction
+// timestamp from the previous process when present.
 func NewCompactor(facts *FactIndex, daily *DailyNoteStore, config Config, memDir string, logger *zap.Logger) *Compactor {
-	return &Compactor{
+	c := &Compactor{
 		facts:  facts,
 		daily:  daily,
 		config: config,
 		logger: logger,
 		memDir: memDir,
+	}
+	c.loadState()
+	return c
+}
+
+// loadState restores lastCompaction from disk. Any read/parse failure just
+// leaves the zero value — the worst case is one extra compaction check.
+func (c *Compactor) loadState() {
+	data, err := os.ReadFile(filepath.Join(c.memDir, compactorStateFile))
+	if err != nil {
+		return
+	}
+	var s compactorState
+	if err := json.Unmarshal(data, &s); err != nil {
+		return
+	}
+	c.lastCompaction = s.LastCompaction
+}
+
+// markCompacted records a completed compaction in memory and on disk.
+func (c *Compactor) markCompacted() {
+	c.lastCompaction = time.Now()
+	data, err := json.Marshal(compactorState{LastCompaction: c.lastCompaction})
+	if err != nil {
+		return
+	}
+	if err := atomicWriteFile(filepath.Join(c.memDir, compactorStateFile), data, 0o600); err != nil {
+		c.logger.Warn("failed to persist compactor state", zap.Error(err))
 	}
 }
 
@@ -58,7 +107,7 @@ func (c *Compactor) RunWithLLM(ctx context.Context, sendPrompt func(ctx context.
 	facts := c.facts.GetAll()
 	if len(facts) < 10 {
 		c.logger.Debug("Too few facts for compaction", zap.Int("count", len(facts)))
-		c.lastCompaction = time.Now()
+		c.markCompacted()
 		return nil
 	}
 
@@ -83,16 +132,50 @@ func (c *Compactor) RunWithLLM(ctx context.Context, sendPrompt func(ctx context.
 	consolidated := c.parseCompactionResponse(response, facts)
 	if len(consolidated) == 0 {
 		c.logger.Warn("LLM returned empty compaction, keeping original facts")
-		c.lastCompaction = time.Now()
+		c.markCompacted()
 		return nil
+	}
+
+	// Shrink guard: consolidation legitimately merges near-duplicates, but a
+	// result that keeps under half the facts is far more likely a truncated
+	// model answer than a real cleanup. Refuse it — memory loss is the one
+	// failure this subsystem must never have — and curate conservatively.
+	if float64(len(consolidated)) < float64(len(facts))*compactionMinKeepRatio {
+		c.logger.Warn("LLM compaction kept too few facts — rejecting as truncated output",
+			zap.Int("before", len(facts)),
+			zap.Int("after", len(consolidated)))
+		return c.RunScoreBased()
+	}
+
+	// Archive whatever the consolidation dropped BEFORE replacing, so every
+	// removed fact stays individually recoverable from memory_archive.json.
+	kept := make(map[string]struct{}, len(consolidated))
+	for _, f := range consolidated {
+		kept[f.ID] = struct{}{}
+	}
+	var dropped []*Fact
+	for _, f := range facts {
+		if _, ok := kept[f.ID]; !ok {
+			dropped = append(dropped, f)
+		}
+	}
+	if len(dropped) > 0 {
+		archivePath := filepath.Join(c.memDir, "memory_archive.json")
+		if err := appendFactsToArchive(dropped, archivePath); err != nil {
+			c.logger.Warn("failed to archive facts dropped by compaction — keeping original facts",
+				zap.Error(err))
+			c.markCompacted()
+			return nil
+		}
 	}
 
 	c.logger.Info("Memory compaction complete",
 		zap.Int("before", len(facts)),
-		zap.Int("after", len(consolidated)))
+		zap.Int("after", len(consolidated)),
+		zap.Int("archived", len(dropped)))
 
 	c.facts.ReplaceFacts(consolidated)
-	c.lastCompaction = time.Now()
+	c.markCompacted()
 
 	// Regenerate MEMORY.md
 	c.writeMemoryMD()
@@ -109,7 +192,7 @@ func (c *Compactor) RunScoreBased() error {
 	candidates := c.facts.GetArchiveCandidates(threshold)
 
 	if len(candidates) > 0 {
-		archivePath := c.memDir + "/memory_archive.json"
+		archivePath := filepath.Join(c.memDir, "memory_archive.json")
 		if err := c.facts.ArchiveFacts(candidates, archivePath); err != nil {
 			c.logger.Warn("Failed to archive facts", zap.Error(err))
 		} else {
@@ -118,7 +201,7 @@ func (c *Compactor) RunScoreBased() error {
 		}
 	}
 
-	c.lastCompaction = time.Now()
+	c.markCompacted()
 	c.writeMemoryMD()
 
 	return nil
@@ -133,7 +216,7 @@ func (c *Compactor) CleanupDailyNotes() (int, error) {
 func (c *Compactor) writeMemoryMD() {
 	content := c.facts.GenerateMarkdown(c.config.MaxMemoryMDSize)
 	path := c.memDir + "/MEMORY.md"
-	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+	if err := atomicWriteFile(path, []byte(content), 0o600); err != nil {
 		c.logger.Warn("Failed to regenerate MEMORY.md", zap.Error(err))
 	}
 }
@@ -201,6 +284,12 @@ func (c *Compactor) parseCompactionResponse(response string, originalFacts []*Fa
 			fact.CreatedAt = matchedFact.CreatedAt
 			fact.AccessCount = matchedFact.AccessCount
 			fact.Tags = matchedFact.Tags
+			// Trust metadata must survive consolidation: without this, every
+			// compaction silently downgraded user-stated facts (0.9/1.0) to
+			// the extraction default and erased where they were learned.
+			fact.Confidence = matchedFact.Confidence
+			fact.Provenance = matchedFact.Provenance
+			fact.SourceProject = matchedFact.SourceProject
 		}
 
 		// Generate ID from content

--- a/cli/workspace/memory/compactor_safety_test.go
+++ b/cli/workspace/memory/compactor_safety_test.go
@@ -1,0 +1,173 @@
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// seedFactContent yields the i-th distinct fact body. Each opens on a unique
+// subject token so the add-time reconciliation (near-duplicate reinforce /
+// same-subject supersede) never merges two seeds.
+func seedFactContent(i int) string {
+	return fmt.Sprintf("service%d listens on port %d and writes logs under /var/log/service%d", i, 3000+i, i)
+}
+
+// seedFacts adds n distinct facts and returns the index.
+func seedFacts(t *testing.T, dir string, n int) *FactIndex {
+	t.Helper()
+	fi := NewFactIndex(dir, DefaultConfig(), zap.NewNop())
+	for i := 0; i < n; i++ {
+		if !fi.AddFact(seedFactContent(i), "general", nil) {
+			t.Fatalf("seed fact %d not added", i)
+		}
+	}
+	if fi.Count() != n {
+		t.Fatalf("seed collapsed: %d facts stored, want %d", fi.Count(), n)
+	}
+	return fi
+}
+
+// TestCompactionRejectsTruncatedLLMOutput pins the shrink guard: models
+// truncate long lists routinely, and a truncated consolidation used to be
+// applied wholesale — permanently deleting every fact the model didn't echo.
+// A result that keeps less than half the facts must be rejected (falling back
+// to conservative score-based curation), never applied.
+func TestCompactionRejectsTruncatedLLMOutput(t *testing.T) {
+	dir := t.TempDir()
+	fi := seedFacts(t, dir, 40)
+	c := NewCompactor(fi, NewDailyNoteStore(dir, zap.NewNop()), DefaultConfig(), dir, zap.NewNop())
+
+	truncated := func(ctx context.Context, prompt string) (string, error) {
+		// The model "answers" with only 5 of the 40 facts.
+		var b strings.Builder
+		for i := 0; i < 5; i++ {
+			fmt.Fprintf(&b, "- [general] %s\n", seedFactContent(i))
+		}
+		return b.String(), nil
+	}
+
+	if err := c.RunWithLLM(context.Background(), truncated); err != nil {
+		t.Fatalf("RunWithLLM: %v", err)
+	}
+	if got := fi.Count(); got != 40 {
+		t.Fatalf("truncated LLM output was applied: %d facts remain, want all 40 preserved", got)
+	}
+}
+
+// TestCompactionArchivesRemovedFacts pins recoverability: facts a legitimate
+// consolidation drops must land in memory_archive.json, not vanish.
+func TestCompactionArchivesRemovedFacts(t *testing.T) {
+	dir := t.TempDir()
+	fi := seedFacts(t, dir, 20)
+	c := NewCompactor(fi, NewDailyNoteStore(dir, zap.NewNop()), DefaultConfig(), dir, zap.NewNop())
+
+	keep15 := func(ctx context.Context, prompt string) (string, error) {
+		var b strings.Builder
+		for i := 0; i < 15; i++ {
+			fmt.Fprintf(&b, "- [general] %s\n", seedFactContent(i))
+		}
+		return b.String(), nil
+	}
+
+	if err := c.RunWithLLM(context.Background(), keep15); err != nil {
+		t.Fatalf("RunWithLLM: %v", err)
+	}
+	if got := fi.Count(); got != 15 {
+		t.Fatalf("Count = %d after consolidation, want 15", got)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "memory_archive.json"))
+	if err != nil {
+		t.Fatalf("dropped facts were not archived: %v", err)
+	}
+	var archived []*Fact
+	if err := json.Unmarshal(data, &archived); err != nil {
+		t.Fatalf("archive unparseable: %v", err)
+	}
+	if len(archived) != 5 {
+		t.Fatalf("archive holds %d facts, want the 5 dropped ones", len(archived))
+	}
+}
+
+// TestCompactionPreservesFactMetadata pins trust metadata across compaction:
+// a user-stated fact (confidence 0.9, provenance "user", source project) must
+// not be silently downgraded to an extraction-grade guess when the model
+// echoes it back.
+func TestCompactionPreservesFactMetadata(t *testing.T) {
+	dir := t.TempDir()
+	fi := NewFactIndex(dir, DefaultConfig(), zap.NewNop())
+	for i := 0; i < 10; i++ {
+		fi.AddFact(seedFactContent(i), "general", nil)
+	}
+	if fi.Count() != 10 {
+		t.Fatalf("filler seed collapsed: %d", fi.Count())
+	}
+	content := "commits are always GPG-signed on project gamma"
+	if !fi.AddFactWithMeta(content, "preference", []string{"git"}, "/ws/gamma", ConfidenceUser, ProvenanceUser) {
+		t.Fatal("meta fact not added")
+	}
+	c := NewCompactor(fi, NewDailyNoteStore(dir, zap.NewNop()), DefaultConfig(), dir, zap.NewNop())
+
+	echoAll := func(ctx context.Context, prompt string) (string, error) {
+		var b strings.Builder
+		for i := 0; i < 10; i++ {
+			fmt.Fprintf(&b, "- [general] %s\n", seedFactContent(i))
+		}
+		b.WriteString("- [preference] " + content + "\n")
+		return b.String(), nil
+	}
+
+	if err := c.RunWithLLM(context.Background(), echoAll); err != nil {
+		t.Fatalf("RunWithLLM: %v", err)
+	}
+
+	id := fi.hashContent(content)
+	f, ok := fi.GetByID(id)
+	if !ok {
+		t.Fatal("meta fact lost in compaction")
+	}
+	if f.Confidence != ConfidenceUser {
+		t.Fatalf("Confidence downgraded by compaction: %v, want %v", f.Confidence, ConfidenceUser)
+	}
+	if f.Provenance != ProvenanceUser {
+		t.Fatalf("Provenance lost in compaction: %q", f.Provenance)
+	}
+	if f.SourceProject != "/ws/gamma" {
+		t.Fatalf("SourceProject lost in compaction: %q", f.SourceProject)
+	}
+}
+
+// TestCompactionIntervalSurvivesRestart pins the trigger: lastCompaction used
+// to live only in memory, so every process start with a well-filled index
+// re-triggered the (destructive-adjacent, LLM-billed) compaction pass.
+func TestCompactionIntervalSurvivesRestart(t *testing.T) {
+	dir := t.TempDir()
+	cfg := DefaultConfig()
+	cfg.MaxFactsCount = 10 // 9 facts ≈ 90% of cap → the count trigger is armed
+	fi := NewFactIndex(dir, cfg, zap.NewNop())
+	for i := 0; i < 9; i++ {
+		fi.AddFact(seedFactContent(i), "general", nil)
+	}
+
+	c1 := NewCompactor(fi, NewDailyNoteStore(dir, zap.NewNop()), cfg, dir, zap.NewNop())
+	if err := c1.RunScoreBased(); err != nil { // completes a compaction "now"
+		t.Fatal(err)
+	}
+	if c1.NeedsCompaction() {
+		t.Fatal("compaction wanted immediately after completing one")
+	}
+
+	// "Restart": a fresh compactor over the same directory must remember that
+	// a compaction just ran, not fire another one on startup.
+	c2 := NewCompactor(fi, NewDailyNoteStore(dir, zap.NewNop()), cfg, dir, zap.NewNop())
+	if c2.NeedsCompaction() {
+		t.Fatal("restart forgot lastCompaction — compaction storms on every process start")
+	}
+}

--- a/cli/workspace/memory/facts.go
+++ b/cli/workspace/memory/facts.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"go.uber.org/zap"
 	"golang.org/x/text/cases"
@@ -17,21 +19,62 @@ import (
 )
 
 // FactIndex manages scored long-term memory facts with JSON persistence.
+//
+// Multiple ChatCLI processes (REPL and gateway daemon) share the same memory
+// directory, so persistence is reconciling, not last-writer-wins: every
+// persist first merges the on-disk state (facts learned by the other process)
+// and applies tombstones (facts explicitly forgotten by either process)
+// before rewriting the file. See mergeFromDiskLocked.
 type FactIndex struct {
 	facts  map[string]*Fact // keyed by ID
 	mu     sync.RWMutex
 	path   string // path to memory_index.json
 	logger *zap.Logger
 	config Config
+
+	// tombstones records explicit deletions (id → when) so reconciliation
+	// never resurrects a forgotten fact from the shared file — and so the
+	// deletion propagates to the other process's next persist. A tombstone
+	// kills any copy whose CreatedAt predates it: passive access does not
+	// undo a forget, only a deliberate re-add (fresh CreatedAt) does.
+	tombstones    map[string]time.Time
+	tombstonePath string
+
+	// MarkAccessed debounce: access bumps happen on every retrieval, and a
+	// full-file rewrite per retrieval is wasted IO that also widens the
+	// multi-process race window. Bumps are folded into the next real persist,
+	// or flushed when the interval elapses.
+	accessFlushInterval time.Duration
+	lastAccessFlush     time.Time
+	accessDirty         bool
+
+	// onRemoved, when set, is invoked for every explicit fact removal
+	// (forget, archive, replace/compaction, supersede, cap prune) so derived
+	// per-fact state — today the vector index — is dropped in lockstep and
+	// never orphans. Invoked synchronously with fi.mu held; the callback must
+	// not call back into the FactIndex.
+	onRemoved func(ids []string)
 }
+
+// factAccessFlushInterval bounds how often bare access-metadata bumps rewrite
+// the index file. Real mutations always persist immediately.
+const factAccessFlushInterval = 30 * time.Second
+
+// tombstoneRetention is how long a deletion marker is kept. Long enough for
+// every co-running process to observe it; bounded so the sidecar never grows
+// without limit.
+const tombstoneRetention = 30 * 24 * time.Hour
 
 // NewFactIndex creates a new fact index.
 func NewFactIndex(memoryDir string, config Config, logger *zap.Logger) *FactIndex {
 	fi := &FactIndex{
-		facts:  make(map[string]*Fact),
-		path:   fmt.Sprintf("%s/memory_index.json", memoryDir),
-		logger: logger,
-		config: config,
+		facts:               make(map[string]*Fact),
+		path:                fmt.Sprintf("%s/memory_index.json", memoryDir),
+		logger:              logger,
+		config:              config,
+		tombstones:          make(map[string]time.Time),
+		tombstonePath:       fmt.Sprintf("%s/memory_tombstones.json", memoryDir),
+		accessFlushInterval: factAccessFlushInterval,
 	}
 	fi.load()
 	return fi
@@ -116,6 +159,9 @@ func (fi *FactIndex) AddFactWithMeta(content, category string, tags []string, so
 			zap.String("new", content),
 		)
 		delete(fi.facts, target.ID)
+		// Tombstone the superseded fact or the shared-file merge re-adopts it
+		// from disk and the update never sticks.
+		fi.recordTombstonesLocked(target.ID)
 		if provenance == "" {
 			provenance = ProvenanceExtraction
 		}
@@ -213,6 +259,7 @@ func (fi *FactIndex) RemoveFact(id string) bool {
 		return false
 	}
 	delete(fi.facts, id)
+	fi.recordTombstonesLocked(id)
 	fi.persistLocked()
 	return true
 }
@@ -232,13 +279,16 @@ func (fi *FactIndex) ForgetMatching(substr string) []*Fact {
 	defer fi.mu.Unlock()
 
 	var removed []*Fact
+	var removedIDs []string
 	for id, f := range fi.facts {
 		if strings.Contains(strings.ToLower(f.Content), substr) {
 			removed = append(removed, f)
+			removedIDs = append(removedIDs, id)
 			delete(fi.facts, id)
 		}
 	}
 	if len(removed) > 0 {
+		fi.recordTombstonesLocked(removedIDs...)
 		fi.persistLocked()
 	}
 	return removed
@@ -249,25 +299,33 @@ func (fi *FactIndex) GetAll() []*Fact {
 	fi.mu.RLock()
 	defer fi.mu.RUnlock()
 
-	fi.recalcScoresLocked()
 	return fi.sortedByScoreLocked()
 }
 
 // sortedByScoreLocked returns every fact ordered by temporal score descending,
 // with a deterministic id tie-break so output never depends on Go's randomized
-// map iteration order. The caller must hold at least a read lock and is
-// responsible for calling recalcScoresLocked first if fresh scores are needed.
+// map iteration order. Scores are computed purely (scoreOf) — never written
+// back — so the caller may hold just a read lock.
 func (fi *FactIndex) sortedByScoreLocked() []*Fact {
-	facts := make([]*Fact, 0, len(fi.facts))
-	for _, f := range fi.facts {
-		facts = append(facts, f)
+	now := time.Now()
+	type scored struct {
+		f *Fact
+		s float64
 	}
-	sort.Slice(facts, func(i, j int) bool {
-		if facts[i].Score != facts[j].Score {
-			return facts[i].Score > facts[j].Score
+	list := make([]scored, 0, len(fi.facts))
+	for _, f := range fi.facts {
+		list = append(list, scored{f: f, s: fi.scoreOf(f, now)})
+	}
+	sort.Slice(list, func(i, j int) bool {
+		if list[i].s != list[j].s {
+			return list[i].s > list[j].s
 		}
-		return facts[i].ID < facts[j].ID
+		return list[i].f.ID < list[j].f.ID
 	})
+	facts := make([]*Fact, len(list))
+	for i, it := range list {
+		facts[i] = it.f
+	}
 	return facts
 }
 
@@ -287,7 +345,7 @@ func (fi *FactIndex) GetByCategory(category string) []*Fact {
 	fi.mu.RLock()
 	defer fi.mu.RUnlock()
 
-	fi.recalcScoresLocked()
+	now := time.Now()
 	var results []*Fact
 	for _, f := range fi.facts {
 		if f.Category == category {
@@ -295,7 +353,7 @@ func (fi *FactIndex) GetByCategory(category string) []*Fact {
 		}
 	}
 	sort.Slice(results, func(i, j int) bool {
-		return results[i].Score > results[j].Score
+		return fi.scoreOf(results[i], now) > fi.scoreOf(results[j], now)
 	})
 	return results
 }
@@ -310,26 +368,25 @@ func (fi *FactIndex) Search(keywords []string) []*Fact {
 	fi.mu.RLock()
 	defer fi.mu.RUnlock()
 
-	fi.recalcScoresLocked()
+	now := time.Now()
 
 	type scoredFact struct {
-		fact      *Fact
-		relevance float64
+		fact     *Fact
+		combined float64
 	}
 
 	var results []scoredFact
 	for _, f := range fi.facts {
 		rel := fi.computeRelevance(f, keywords)
 		if rel > 0 {
-			results = append(results, scoredFact{fact: f, relevance: rel})
+			// Combined score: temporal score × relevance, both computed
+			// purely so concurrent readers never write shared state.
+			results = append(results, scoredFact{fact: f, combined: fi.scoreOf(f, now) * rel})
 		}
 	}
 
 	sort.Slice(results, func(i, j int) bool {
-		// Combined score: temporal score * relevance
-		si := results[i].fact.Score * results[i].relevance
-		sj := results[j].fact.Score * results[j].relevance
-		return si > sj
+		return results[i].combined > results[j].combined
 	})
 
 	facts := make([]*Fact, len(results))
@@ -358,7 +415,7 @@ func (fi *FactIndex) SearchBlended(keywords []string, semantic map[string]float6
 	fi.mu.RLock()
 	defer fi.mu.RUnlock()
 
-	fi.recalcScoresLocked()
+	now := time.Now()
 	w = w.normalized()
 
 	cands := make(map[string]*candidate, len(semantic)+8)
@@ -366,7 +423,7 @@ func (fi *FactIndex) SearchBlended(keywords []string, semantic map[string]float6
 	if len(keywords) > 0 {
 		for _, f := range fi.facts {
 			if rel := fi.computeRelevance(f, keywords); rel > 0 {
-				cands[f.ID] = &candidate{fact: f, lexical: rel, temporal: f.Score}
+				cands[f.ID] = &candidate{fact: f, lexical: rel, temporal: fi.scoreOf(f, now)}
 			}
 		}
 	}
@@ -380,7 +437,7 @@ func (fi *FactIndex) SearchBlended(keywords []string, semantic map[string]float6
 			c.semantic = sem
 			continue
 		}
-		cands[id] = &candidate{fact: f, semantic: sem, temporal: f.Score}
+		cands[id] = &candidate{fact: f, semantic: sem, temporal: fi.scoreOf(f, now)}
 	}
 
 	if len(cands) == 0 {
@@ -410,7 +467,10 @@ func (fi *FactIndex) SearchBlended(keywords []string, semantic map[string]float6
 	return out
 }
 
-// MarkAccessed updates access metadata for retrieved facts.
+// MarkAccessed updates access metadata for retrieved facts. Bumps are
+// debounced: they fold into the next real persist, or flush when the
+// interval elapses — a bare access is not worth a full-file rewrite per
+// retrieval (see accessFlushInterval).
 func (fi *FactIndex) MarkAccessed(ids []string) {
 	fi.mu.Lock()
 	defer fi.mu.Unlock()
@@ -423,9 +483,14 @@ func (fi *FactIndex) MarkAccessed(ids []string) {
 			changed = true
 		}
 	}
-	if changed {
-		fi.persistLocked()
+	if !changed {
+		return
 	}
+	if time.Since(fi.lastAccessFlush) >= fi.accessFlushInterval {
+		fi.persistLocked()
+		return
+	}
+	fi.accessDirty = true
 }
 
 // Count returns the number of stored facts.
@@ -435,15 +500,25 @@ func (fi *FactIndex) Count() int {
 	return len(fi.facts)
 }
 
-// ReplaceFacts replaces the entire fact set (used by compaction).
+// ReplaceFacts replaces the entire fact set (used by compaction). Facts
+// dropped by the replacement are tombstoned so the shared-file merge (and the
+// other process) honors the consolidation instead of resurrecting them.
 func (fi *FactIndex) ReplaceFacts(facts []*Fact) {
 	fi.mu.Lock()
 	defer fi.mu.Unlock()
 
-	fi.facts = make(map[string]*Fact, len(facts))
+	next := make(map[string]*Fact, len(facts))
 	for _, f := range facts {
-		fi.facts[f.ID] = f
+		next[f.ID] = f
 	}
+	var droppedIDs []string
+	for id := range fi.facts {
+		if _, kept := next[id]; !kept {
+			droppedIDs = append(droppedIDs, id)
+		}
+	}
+	fi.facts = next
+	fi.recordTombstonesLocked(droppedIDs...)
 	fi.persistLocked()
 }
 
@@ -452,23 +527,23 @@ func (fi *FactIndex) GetArchiveCandidates(threshold float64) []*Fact {
 	fi.mu.RLock()
 	defer fi.mu.RUnlock()
 
-	fi.recalcScoresLocked()
+	now := time.Now()
 	var candidates []*Fact
 	for _, f := range fi.facts {
-		if f.Score < threshold {
+		if fi.scoreOf(f, now) < threshold {
 			candidates = append(candidates, f)
 		}
 	}
 	return candidates
 }
 
-// ArchiveFacts moves low-scoring facts to an archive file and removes them from the index.
-func (fi *FactIndex) ArchiveFacts(facts []*Fact, archivePath string) error {
+// appendFactsToArchive appends facts to the JSON archive at archivePath,
+// creating it when absent. It never removes anything — pure append, so a
+// fact archived twice is duplicated rather than risk being lost.
+func appendFactsToArchive(facts []*Fact, archivePath string) error {
 	if len(facts) == 0 {
 		return nil
 	}
-
-	// Read existing archive
 	var archive []*Fact
 	if data, err := os.ReadFile(archivePath); err == nil { //#nosec G304 -- path supplied by user/agent through validated tool surface (boundary check upstream)
 		_ = json.Unmarshal(data, &archive)
@@ -479,16 +554,27 @@ func (fi *FactIndex) ArchiveFacts(facts []*Fact, archivePath string) error {
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(archivePath, data, 0o600); err != nil {
+	return atomicWriteFile(archivePath, data, 0o600)
+}
+
+// ArchiveFacts moves low-scoring facts to an archive file and removes them from the index.
+func (fi *FactIndex) ArchiveFacts(facts []*Fact, archivePath string) error {
+	if len(facts) == 0 {
+		return nil
+	}
+	if err := appendFactsToArchive(facts, archivePath); err != nil {
 		return err
 	}
 
 	// Remove from index
 	fi.mu.Lock()
 	defer fi.mu.Unlock()
+	ids := make([]string, 0, len(facts))
 	for _, f := range facts {
 		delete(fi.facts, f.ID)
+		ids = append(ids, f.ID)
 	}
+	fi.recordTombstonesLocked(ids...)
 	fi.persistLocked()
 	return nil
 }
@@ -554,14 +640,17 @@ var reconcileStopwords = map[string]bool{
 }
 
 // sigTokens returns the lowercased significant tokens of content in order:
-// alphanumeric runs of length ≥ 3 that are not stopwords.
+// letter/digit runs of at least 3 runes that are not stopwords. Tokenization
+// is Unicode-aware — an ASCII-only splitter shreds accented Portuguese words
+// ("configuração" → "configura" + debris), silently degrading the Jaccard
+// dedupe/supersede similarity for exactly the language most facts arrive in.
 func sigTokens(content string) []string {
 	fields := strings.FieldsFunc(strings.ToLower(content), func(r rune) bool {
-		return !(r >= 'a' && r <= 'z' || r >= '0' && r <= '9')
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
 	})
 	out := make([]string, 0, len(fields))
 	for _, t := range fields {
-		if len(t) < 3 || reconcileStopwords[t] {
+		if utf8.RuneCountInString(t) < 3 || reconcileStopwords[t] {
 			continue
 		}
 		out = append(out, t)
@@ -619,17 +708,27 @@ func sharesSubject(a, b string) bool {
 	return true
 }
 
+// minRunesForPrefixMatch is the shortest keyword allowed to match as a token
+// PREFIX ("compress" → "compression"). Shorter keywords match tokens exactly
+// only — raw substring matching let 2-3 letter keywords fire inside unrelated
+// words ("go" inside "django"), polluting retrieval with noise facts that the
+// access boost then entrenched.
+const minRunesForPrefixMatch = 4
+
 func (fi *FactIndex) computeRelevance(f *Fact, keywords []string) float64 {
-	contentLower := strings.ToLower(f.Content)
-	tagsJoined := strings.ToLower(strings.Join(f.Tags, " "))
+	contentToks := allTokens(f.Content)
+	tagToks := allTokens(strings.Join(f.Tags, " "))
 
 	var score float64
 	for _, kw := range keywords {
-		kwLower := strings.ToLower(kw)
-		if strings.Contains(contentLower, kwLower) {
+		kwLower := strings.ToLower(strings.TrimSpace(kw))
+		if kwLower == "" {
+			continue
+		}
+		if anyTokenMatches(contentToks, kwLower) {
 			score += 1.0
 		}
-		if strings.Contains(tagsJoined, kwLower) {
+		if anyTokenMatches(tagToks, kwLower) {
 			score += 0.5
 		}
 	}
@@ -637,32 +736,66 @@ func (fi *FactIndex) computeRelevance(f *Fact, keywords []string) float64 {
 	return score / float64(len(keywords))
 }
 
-// recalcScoresLocked recalculates temporal scores for all facts.
-// Must be called with at least a read lock held.
-func (fi *FactIndex) recalcScoresLocked() {
+// allTokens returns every lowercased letter/digit run of content — unfiltered
+// (no stopword/length cut), because filtering belongs to keyword EXTRACTION;
+// the matching side must be able to satisfy whatever keyword arrives.
+func allTokens(content string) []string {
+	return strings.FieldsFunc(strings.ToLower(content), func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	})
+}
+
+// anyTokenMatches reports whether kw matches any token: exactly, or as a
+// prefix when the keyword is long enough to be discriminating.
+func anyTokenMatches(tokens []string, kw string) bool {
+	prefixOK := utf8.RuneCountInString(kw) >= minRunesForPrefixMatch
+	for _, t := range tokens {
+		if t == kw {
+			return true
+		}
+		if prefixOK && strings.HasPrefix(t, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// scoreOf computes a fact's temporal score PURELY — no shared state is
+// written, so any number of readers may call it concurrently under the read
+// lock. The stored Fact.Score field is refreshed only at persist time (write
+// lock held) as a human-readable annotation in the JSON; ranking never reads
+// the stored field.
+func (fi *FactIndex) scoreOf(f *Fact, now time.Time) float64 {
 	halfLife := fi.config.DecayHalfLifeDays
 	if halfLife <= 0 {
 		halfLife = 30.0
 	}
-	now := time.Now()
+	daysSinceAccess := now.Sub(f.LastAccessed).Hours() / 24.0
+	if daysSinceAccess < 0 {
+		daysSinceAccess = 0
+	}
+	accessBoost := 1.0 + math.Log1p(float64(f.AccessCount))
+	decay := math.Exp(-daysSinceAccess * math.Ln2 / halfLife)
+	// Confidence ∈ (0,1] scales the score into (0.5, 1.5]×, so a trusted
+	// fact outranks a low-confidence guess of equal recency and survives
+	// decay and pruning longer.
+	return accessBoost * decay * (0.5 + f.confidence())
+}
 
+// recalcScoresLocked refreshes every fact's stored Score annotation. It
+// MUTATES shared state, so the caller must hold the WRITE lock — it is called
+// only from persistLocked, purely so the persisted JSON carries current
+// scores for human inspection.
+func (fi *FactIndex) recalcScoresLocked() {
+	now := time.Now()
 	for _, f := range fi.facts {
-		daysSinceAccess := now.Sub(f.LastAccessed).Hours() / 24.0
-		if daysSinceAccess < 0 {
-			daysSinceAccess = 0
-		}
-		accessBoost := 1.0 + math.Log1p(float64(f.AccessCount))
-		decay := math.Exp(-daysSinceAccess * math.Ln2 / halfLife)
-		// Confidence ∈ (0,1] scales the score into (0.5, 1.5]×, so a trusted
-		// fact outranks a low-confidence guess of equal recency and survives
-		// decay and pruning longer.
-		f.Score = accessBoost * decay * (0.5 + f.confidence())
+		f.Score = fi.scoreOf(f, now)
 	}
 }
 
 // pruneLowestLocked removes the N lowest-scoring facts. Must hold write lock.
 func (fi *FactIndex) pruneLowestLocked(n int) {
-	fi.recalcScoresLocked()
+	now := time.Now()
 
 	type idScore struct {
 		id    string
@@ -670,18 +803,23 @@ func (fi *FactIndex) pruneLowestLocked(n int) {
 	}
 	all := make([]idScore, 0, len(fi.facts))
 	for id, f := range fi.facts {
-		all = append(all, idScore{id: id, score: f.Score})
+		all = append(all, idScore{id: id, score: fi.scoreOf(f, now)})
 	}
 	sort.Slice(all, func(i, j int) bool {
 		return all[i].score < all[j].score
 	})
 
+	pruned := make([]string, 0, n)
 	for i := 0; i < n && i < len(all); i++ {
 		fi.logger.Debug("pruning low-score fact",
 			zap.String("id", all[i].id),
 			zap.Float64("score", all[i].score))
 		delete(fi.facts, all[i].id)
+		pruned = append(pruned, all[i].id)
 	}
+	// Tombstone so the shared-file merge doesn't re-adopt what the cap just
+	// evicted (and the other process converges on the same eviction).
+	fi.recordTombstonesLocked(pruned...)
 }
 
 func (fi *FactIndex) load() {
@@ -695,7 +833,16 @@ func (fi *FactIndex) load() {
 
 	var facts []*Fact
 	if err := json.Unmarshal(data, &facts); err != nil {
-		fi.logger.Warn("failed to parse fact index", zap.Error(err))
+		// Quarantine, never leave in place: an unparseable index left under
+		// the live name gets overwritten by the next persist, silently erasing
+		// every accumulated fact. Moving it aside keeps the bytes recoverable.
+		if qpath, qerr := quarantineCorrupt(fi.path); qerr == nil {
+			fi.logger.Warn("fact index corrupt; quarantined for recovery",
+				zap.String("quarantine", qpath), zap.Error(err))
+		} else {
+			fi.logger.Warn("fact index corrupt and quarantine failed; refusing to start empty over it",
+				zap.Error(qerr))
+		}
 		return
 	}
 
@@ -749,6 +896,13 @@ func legacyConfidence(accessCount int) float64 {
 }
 
 func (fi *FactIndex) persistLocked() {
+	// Reconcile with the shared file first: adopt facts the other process
+	// persisted and honor tombstones from either side, so a rewrite never
+	// erases the other process's learning.
+	fi.mergeFromDiskLocked()
+	// Refresh the persisted Score annotations (write lock is held here).
+	fi.recalcScoresLocked()
+
 	facts := make([]*Fact, 0, len(fi.facts))
 	for _, f := range fi.facts {
 		facts = append(facts, f)
@@ -765,7 +919,129 @@ func (fi *FactIndex) persistLocked() {
 		return
 	}
 
-	if err := os.WriteFile(fi.path, data, 0o600); err != nil {
+	if err := atomicWriteFile(fi.path, data, 0o600); err != nil {
 		fi.logger.Warn("failed to write fact index", zap.Error(err))
+	}
+	fi.lastAccessFlush = time.Now()
+	fi.accessDirty = false
+}
+
+// mergeFromDiskLocked reconciles the in-memory map with the shared on-disk
+// state before a rewrite:
+//
+//  1. Tombstones are unioned from the sidecar (deletions made by the other
+//     process) and applied — any copy whose CreatedAt predates its tombstone
+//     is dropped, here and from the write that follows.
+//  2. Facts present on disk but not in memory (learned by the other process)
+//     are adopted; facts known to both keep the freshest access metadata and
+//     the highest confidence.
+//
+// Read failures leave the current view untouched — worst case is the old
+// last-writer-wins behavior for one cycle. Caller must hold the write lock.
+func (fi *FactIndex) mergeFromDiskLocked() {
+	fi.loadTombstonesLocked()
+	for id, ts := range fi.tombstones {
+		if f, ok := fi.facts[id]; ok && ts.After(f.CreatedAt) {
+			delete(fi.facts, id)
+		}
+	}
+
+	data, err := os.ReadFile(fi.path)
+	if err != nil {
+		return
+	}
+	var onDisk []*Fact
+	if err := json.Unmarshal(data, &onDisk); err != nil {
+		return
+	}
+	for _, df := range onDisk {
+		if df == nil || df.ID == "" {
+			continue
+		}
+		if ts, dead := fi.tombstones[df.ID]; dead && ts.After(df.CreatedAt) {
+			continue
+		}
+		cur, ok := fi.facts[df.ID]
+		if !ok {
+			fi.facts[df.ID] = df
+			continue
+		}
+		if df.LastAccessed.After(cur.LastAccessed) {
+			cur.LastAccessed = df.LastAccessed
+		}
+		if df.AccessCount > cur.AccessCount {
+			cur.AccessCount = df.AccessCount
+		}
+		if df.Confidence > cur.Confidence {
+			cur.Confidence = df.Confidence
+		}
+	}
+	if excess := len(fi.facts) - fi.config.MaxFactsCount; excess > 0 {
+		fi.pruneLowestLocked(excess)
+	}
+}
+
+// SetOnRemoved registers the removal hook (see the field doc). Pass nil to
+// detach. Not safe to call concurrently with index operations — wire it at
+// construction/attach time.
+func (fi *FactIndex) SetOnRemoved(fn func(ids []string)) {
+	fi.mu.Lock()
+	fi.onRemoved = fn
+	fi.mu.Unlock()
+}
+
+// recordTombstonesLocked marks ids as explicitly deleted, persists the
+// sidecar so the deletion propagates to the other process, and notifies the
+// removal hook so derived state (vectors) is dropped in lockstep. This is the
+// single chokepoint every deletion path goes through. Caller must hold the
+// write lock.
+func (fi *FactIndex) recordTombstonesLocked(ids ...string) {
+	if len(ids) == 0 {
+		return
+	}
+	if fi.onRemoved != nil {
+		fi.onRemoved(ids)
+	}
+	now := time.Now()
+	for _, id := range ids {
+		fi.tombstones[id] = now
+	}
+	fi.pruneTombstonesLocked(now)
+	data, err := json.MarshalIndent(fi.tombstones, "", "  ")
+	if err != nil {
+		return
+	}
+	if err := atomicWriteFile(fi.tombstonePath, data, 0o600); err != nil {
+		fi.logger.Warn("failed to persist fact tombstones", zap.Error(err))
+	}
+}
+
+// loadTombstonesLocked unions the sidecar's tombstones into memory (the other
+// process may have recorded deletions since our last read).
+func (fi *FactIndex) loadTombstonesLocked() {
+	data, err := os.ReadFile(fi.tombstonePath)
+	if err != nil {
+		return
+	}
+	var onDisk map[string]time.Time
+	if err := json.Unmarshal(data, &onDisk); err != nil {
+		return
+	}
+	for id, ts := range onDisk {
+		if cur, ok := fi.tombstones[id]; !ok || ts.After(cur) {
+			fi.tombstones[id] = ts
+		}
+	}
+	fi.pruneTombstonesLocked(time.Now())
+}
+
+// pruneTombstonesLocked drops deletion markers past retention so the sidecar
+// stays bounded. Caller must hold the write lock.
+func (fi *FactIndex) pruneTombstonesLocked(now time.Time) {
+	cutoff := now.Add(-tombstoneRetention)
+	for id, ts := range fi.tombstones {
+		if ts.Before(cutoff) {
+			delete(fi.tombstones, id)
+		}
 	}
 }

--- a/cli/workspace/memory/facts_multiprocess_test.go
+++ b/cli/workspace/memory/facts_multiprocess_test.go
@@ -1,0 +1,131 @@
+package memory
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// The REPL and the gateway daemon are separate processes sharing the same
+// memory directory. Each FactIndex persists by rewriting the whole file from
+// its in-memory map, so without reconciliation the slower writer erases every
+// fact the other process learned — silent cross-process memory loss.
+
+// TestFactIndexPersistMergesOtherProcessFacts: A and B open the same store;
+// each learns a different fact; whoever persists last must not clobber the
+// other's fact.
+func TestFactIndexPersistMergesOtherProcessFacts(t *testing.T) {
+	dir := t.TempDir()
+	nop := zap.NewNop()
+
+	a := NewFactIndex(dir, DefaultConfig(), nop)
+	b := NewFactIndex(dir, DefaultConfig(), nop)
+
+	if !a.AddFact("service alpha listens on port 3001 behind nginx", "general", nil) {
+		t.Fatal("A's fact not added")
+	}
+	if !b.AddFact("service beta stores queue state in redis db 2", "general", nil) {
+		t.Fatal("B's fact not added")
+	}
+
+	// A fresh reader sees the union, not just the last writer's view.
+	c := NewFactIndex(dir, DefaultConfig(), nop)
+	if got := c.Count(); got != 2 {
+		t.Fatalf("cross-process clobber: fresh index has %d facts, want 2", got)
+	}
+}
+
+// TestFactIndexForgetIsNotResurrectedByMerge: reconciliation must respect
+// deletions. A forgets a fact; A's next persist (which merges with the file)
+// must not adopt the forgotten fact back from disk.
+func TestFactIndexForgetIsNotResurrectedByMerge(t *testing.T) {
+	dir := t.TempDir()
+	nop := zap.NewNop()
+
+	a := NewFactIndex(dir, DefaultConfig(), nop)
+	a.AddFact("service alpha listens on port 3001 behind nginx", "general", nil)
+	a.AddFact("service beta stores queue state in redis db 2", "general", nil)
+
+	if removed := a.ForgetMatching("redis db 2"); len(removed) != 1 {
+		t.Fatalf("ForgetMatching removed %d, want 1", len(removed))
+	}
+	// Trigger another persist cycle (any mutation persists).
+	a.AddFact("service gamma emits metrics to statsd on 8125", "general", nil)
+
+	c := NewFactIndex(dir, DefaultConfig(), nop)
+	if got := c.Count(); got != 2 {
+		t.Fatalf("forgotten fact resurrected by merge: %d facts, want 2", got)
+	}
+	for _, f := range c.GetAll() {
+		if f.Content == "service beta stores queue state in redis db 2" {
+			t.Fatal("forgotten fact came back from disk")
+		}
+	}
+}
+
+// TestFactIndexCrossProcessForgetPropagates: A forgets a fact both processes
+// know; when B persists afterwards, B must not write the fact back (the
+// tombstone on disk outranks B's stale in-memory copy).
+func TestFactIndexCrossProcessForgetPropagates(t *testing.T) {
+	dir := t.TempDir()
+	nop := zap.NewNop()
+
+	a := NewFactIndex(dir, DefaultConfig(), nop)
+	a.AddFact("service alpha listens on port 3001 behind nginx", "general", nil)
+
+	b := NewFactIndex(dir, DefaultConfig(), nop) // B loads the fact too
+	if b.Count() != 1 {
+		t.Fatal("B did not load the shared fact")
+	}
+
+	if removed := a.ForgetMatching("port 3001"); len(removed) != 1 {
+		t.Fatal("A's forget failed")
+	}
+
+	// B persists something new — its stale copy of the forgotten fact must
+	// not survive the reconciliation.
+	b.AddFact("service beta stores queue state in redis db 2", "general", nil)
+
+	c := NewFactIndex(dir, DefaultConfig(), nop)
+	for _, f := range c.GetAll() {
+		if f.Content == "service alpha listens on port 3001 behind nginx" {
+			t.Fatal("cross-process forget did not propagate: B resurrected the fact")
+		}
+	}
+}
+
+// TestMarkAccessedIsDebounced: access-metadata bumps happen on every
+// retrieval; rewriting the whole index each time is wasted IO and widens the
+// multi-process clobber window. Within the flush interval, MarkAccessed must
+// not persist.
+func TestMarkAccessedIsDebounced(t *testing.T) {
+	dir := t.TempDir()
+	nop := zap.NewNop()
+
+	fi := NewFactIndex(dir, DefaultConfig(), nop)
+	fi.AddFact("service alpha listens on port 3001 behind nginx", "general", nil)
+	id := fi.hashContent("service alpha listens on port 3001 behind nginx")
+
+	// First access flushes (interval elapsed since zero time).
+	fi.MarkAccessed([]string{id})
+
+	// Remove the file out from under the index: a debounced second access
+	// must NOT rewrite it.
+	path := filepath.Join(dir, "memory_index.json")
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	fi.MarkAccessed([]string{id})
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatal("MarkAccessed persisted within the flush interval — full-file rewrite per retrieval")
+	}
+
+	// A real mutation still persists immediately (and carries the pending
+	// access metadata with it).
+	fi.AddFact("service beta stores queue state in redis db 2", "general", nil)
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("mutation did not persist: %v", err)
+	}
+}

--- a/cli/workspace/memory/facts_race_test.go
+++ b/cli/workspace/memory/facts_race_test.go
@@ -1,0 +1,44 @@
+package memory
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// TestFactIndexConcurrentReadsAreRaceFree pins read-path thread safety under
+// the race detector. Concurrent retrieval is reachable in production: MoA runs
+// participants in parallel with @memory recall granted, while the background
+// extraction worker searches the same index. The old recalcScoresLocked wrote
+// f.Score while holding only the READ lock, so two concurrent readers raced
+// on every fact's Score field.
+func TestFactIndexConcurrentReadsAreRaceFree(t *testing.T) {
+	dir := t.TempDir()
+	fi := NewFactIndex(dir, DefaultConfig(), zap.NewNop())
+	for i := 0; i < 50; i++ {
+		fi.AddFact(fmt.Sprintf("service%d listens on port %d and logs to /var/log/s%d", i, 4000+i, i), "general", nil)
+	}
+
+	var wg sync.WaitGroup
+	for w := 0; w < 8; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for j := 0; j < 30; j++ {
+				switch (w + j) % 4 {
+				case 0:
+					fi.Search([]string{"service", "port"})
+				case 1:
+					fi.GetAll()
+				case 2:
+					fi.SearchBlended([]string{"logs"}, nil, DefaultRankWeights())
+				case 3:
+					fi.GetByCategory("general")
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+}

--- a/cli/workspace/memory/patterns.go
+++ b/cli/workspace/memory/patterns.go
@@ -288,7 +288,14 @@ func (pd *PatternDetector) load() {
 	}
 	var s UsageStats
 	if err := json.Unmarshal(data, &s); err != nil {
-		pd.logger.Warn("failed to parse usage stats", zap.Error(err))
+		// Quarantine for recovery instead of leaving the corrupt file in place
+		// for the next persist to overwrite (see persist.go).
+		if qpath, qerr := quarantineCorrupt(pd.path); qerr == nil {
+			pd.logger.Warn("usage stats corrupt; quarantined for recovery",
+				zap.String("quarantine", qpath), zap.Error(err))
+		} else {
+			pd.logger.Warn("usage stats corrupt and quarantine failed", zap.Error(qerr))
+		}
 		return
 	}
 	if s.CommandFrequency == nil {
@@ -305,5 +312,7 @@ func (pd *PatternDetector) persist() {
 	if err != nil {
 		return
 	}
-	_ = os.WriteFile(pd.path, data, 0o600)
+	if err := atomicWriteFile(pd.path, data, 0o600); err != nil {
+		pd.logger.Warn("failed to write usage stats", zap.Error(err))
+	}
 }

--- a/cli/workspace/memory/persist.go
+++ b/cli/workspace/memory/persist.go
@@ -65,9 +65,13 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 // original bytes remain recoverable.
 func quarantineCorrupt(path string) (string, error) {
 	dst := path + ".corrupt"
+	// #nosec G703 -- path is a fixed store filename under the operator-configured
+	// memory directory (~/.chatcli/memory), never user/model input; same
+	// precedent as the CCR store paths in cli/compress/ccr.go.
 	if _, err := os.Stat(dst); err == nil {
 		dst = fmt.Sprintf("%s.corrupt-%d", path, time.Now().Unix())
 	}
+	// #nosec G703 -- see above: operator-configured store path, not tainted input.
 	if err := os.Rename(path, dst); err != nil {
 		return "", err
 	}

--- a/cli/workspace/memory/persist.go
+++ b/cli/workspace/memory/persist.go
@@ -1,0 +1,75 @@
+/*
+ * ChatCLI - Long-term memory: durable persistence primitives.
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Every memory substore (facts, profile, topics, projects, patterns) persists
+ * as a small JSON file. Two disciplines keep those files from ever costing the
+ * user their accumulated memory:
+ *
+ *   1. Writes are atomic (temp file + rename in the same directory), so a
+ *      crash mid-write can never leave a half-written file under the store's
+ *      real name.
+ *   2. A file that fails to parse at load is QUARANTINED (renamed aside with a
+ *      ".corrupt" suffix), never left in place. Leaving it in place is how
+ *      memory used to vanish: the store started empty, the next persist
+ *      overwrote the only copy of the data, and no error was ever surfaced.
+ */
+package memory
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// atomicWriteFile writes data to path via a same-directory temp file and an
+// atomic rename, so readers (and crashes) only ever observe the old or the new
+// content — never a torn write.
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpName) }
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return err
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		cleanup()
+		return err
+	}
+	return nil
+}
+
+// quarantineCorrupt moves an unparseable store file aside as
+// "<path>.corrupt" (or a timestamped variant when a previous quarantine
+// already exists, so an older recovery copy is never clobbered). It returns
+// the quarantine path for logging. The caller decides how to proceed —
+// typically by starting the store empty, which is now safe because the
+// original bytes remain recoverable.
+func quarantineCorrupt(path string) (string, error) {
+	dst := path + ".corrupt"
+	if _, err := os.Stat(dst); err == nil {
+		dst = fmt.Sprintf("%s.corrupt-%d", path, time.Now().Unix())
+	}
+	if err := os.Rename(path, dst); err != nil {
+		return "", err
+	}
+	return dst, nil
+}

--- a/cli/workspace/memory/persist_test.go
+++ b/cli/workspace/memory/persist_test.go
@@ -1,0 +1,131 @@
+package memory
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// TestFactIndexCorruptFileIsQuarantinedNotClobbered pins the recovery contract
+// for the worst failure mode a memory system can have: silent, permanent loss.
+// A corrupted memory_index.json (crash mid-write, disk hiccup) must be moved
+// aside for recovery — NOT left in place for the next persist to overwrite
+// with the empty post-corruption state, which is how months of accumulated
+// memory used to vanish without a single visible error.
+func TestFactIndexCorruptFileIsQuarantinedNotClobbered(t *testing.T) {
+	dir := t.TempDir()
+	logger := zap.NewNop()
+
+	fi := NewFactIndex(dir, DefaultConfig(), logger)
+	if !fi.AddFact("user prefers tabs over spaces", "preference", nil) {
+		t.Fatal("seed fact not added")
+	}
+	path := filepath.Join(dir, "memory_index.json")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("index file missing after persist: %v", err)
+	}
+
+	// Corrupt the file — the shape a crash mid-write leaves behind.
+	corrupt := []byte(`[{"id":"abc","content":"user prefers tabs ov`)
+	if err := os.WriteFile(path, corrupt, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Restart: the new index cannot parse the file (starting empty is
+	// acceptable) but the corrupt bytes MUST survive somewhere recoverable.
+	fi2 := NewFactIndex(dir, DefaultConfig(), logger)
+	if fi2.Count() != 0 {
+		t.Fatalf("expected empty index after corruption, got %d facts", fi2.Count())
+	}
+	fi2.AddFact("a brand new fact after the incident", "general", nil) // triggers persist
+
+	// The live file now holds the new state...
+	live, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(live), "tabs ov") {
+		t.Fatal("live index still contains the corrupt payload")
+	}
+
+	// ...and the corrupt original must exist as a quarantine file so the user
+	// (or a recovery tool) can still extract the pre-crash facts.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, e := range entries {
+		if strings.Contains(e.Name(), "memory_index.json.corrupt") {
+			data, rerr := os.ReadFile(filepath.Join(dir, e.Name()))
+			if rerr != nil {
+				t.Fatal(rerr)
+			}
+			if string(data) == string(corrupt) {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatal("corrupt index was overwritten with no quarantine copy — accumulated memory unrecoverable")
+	}
+}
+
+// TestAtomicWriteFileMechanics pins the write helper: content lands intact,
+// no temp litter remains, and an existing file is replaced atomically.
+func TestAtomicWriteFileMechanics(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "store.json")
+
+	if err := atomicWriteFile(path, []byte(`{"v":1}`), 0o600); err != nil {
+		t.Fatalf("atomicWriteFile: %v", err)
+	}
+	if err := atomicWriteFile(path, []byte(`{"v":2}`), 0o600); err != nil {
+		t.Fatalf("atomicWriteFile overwrite: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != `{"v":2}` {
+		t.Fatalf("content = %s", data)
+	}
+
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp") {
+			t.Fatalf("temp file litter left behind: %s", e.Name())
+		}
+	}
+}
+
+// TestProfileCorruptFileIsQuarantined extends the quarantine contract to the
+// profile store — every memory substore shares the same failure mode.
+func TestProfileCorruptFileIsQuarantined(t *testing.T) {
+	dir := t.TempDir()
+	logger := zap.NewNop()
+
+	ps := NewUserProfileStore(dir, logger)
+	ps.Update(map[string]string{"name": "Edilson"})
+	path := filepath.Join(dir, "user_profile.json")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("profile file missing: %v", err)
+	}
+
+	if err := os.WriteFile(path, []byte(`{"name":"Edi`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_ = NewUserProfileStore(dir, logger)
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.Contains(e.Name(), "user_profile.json.corrupt") {
+			return // quarantined — contract honored
+		}
+	}
+	t.Fatal("corrupt user_profile.json not quarantined")
+}

--- a/cli/workspace/memory/profile.go
+++ b/cli/workspace/memory/profile.go
@@ -244,7 +244,14 @@ func (ps *UserProfileStore) load() {
 	}
 	var p UserProfile
 	if err := json.Unmarshal(data, &p); err != nil {
-		ps.logger.Warn("failed to parse user profile", zap.Error(err))
+		// Quarantine for recovery instead of leaving the corrupt file in place
+		// for the next persist to overwrite (see persist.go).
+		if qpath, qerr := quarantineCorrupt(ps.path); qerr == nil {
+			ps.logger.Warn("user profile corrupt; quarantined for recovery",
+				zap.String("quarantine", qpath), zap.Error(err))
+		} else {
+			ps.logger.Warn("user profile corrupt and quarantine failed", zap.Error(qerr))
+		}
 		return
 	}
 	if p.TopCommands == nil {
@@ -262,7 +269,7 @@ func (ps *UserProfileStore) persist() {
 		ps.logger.Warn("failed to marshal user profile", zap.Error(err))
 		return
 	}
-	if err := os.WriteFile(ps.path, data, 0o600); err != nil {
+	if err := atomicWriteFile(ps.path, data, 0o600); err != nil {
 		ps.logger.Warn("failed to write user profile", zap.Error(err))
 	}
 }

--- a/cli/workspace/memory/projects.go
+++ b/cli/workspace/memory/projects.go
@@ -215,7 +215,14 @@ func (pt *ProjectTracker) load() {
 	}
 	var projects []Project
 	if err := json.Unmarshal(data, &projects); err != nil {
-		pt.logger.Warn("failed to parse projects", zap.Error(err))
+		// Quarantine for recovery instead of leaving the corrupt file in place
+		// for the next persist to overwrite (see persist.go).
+		if qpath, qerr := quarantineCorrupt(pt.path); qerr == nil {
+			pt.logger.Warn("projects store corrupt; quarantined for recovery",
+				zap.String("quarantine", qpath), zap.Error(err))
+		} else {
+			pt.logger.Warn("projects store corrupt and quarantine failed", zap.Error(qerr))
+		}
 		return
 	}
 	for i := range projects {
@@ -236,5 +243,7 @@ func (pt *ProjectTracker) persist() {
 	if err != nil {
 		return
 	}
-	_ = os.WriteFile(pt.path, data, 0o600)
+	if err := atomicWriteFile(pt.path, data, 0o600); err != nil {
+		pt.logger.Warn("failed to write projects store", zap.Error(err))
+	}
 }

--- a/cli/workspace/memory/relevance_test.go
+++ b/cli/workspace/memory/relevance_test.go
@@ -1,0 +1,44 @@
+package memory
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// TestSearchDoesNotMatchInsideWords pins lexical precision: raw substring
+// matching made short keywords fire inside unrelated words ("go" inside
+// "django", "art" inside "artefact"), polluting retrieval with noise facts
+// that then get access-boosted and entrench themselves.
+func TestSearchDoesNotMatchInsideWords(t *testing.T) {
+	fi := NewFactIndex(t.TempDir(), DefaultConfig(), zap.NewNop())
+	fi.AddFact("the api service is built on the django framework", "architecture", nil)
+
+	if got := fi.Search([]string{"go"}); len(got) != 0 {
+		t.Fatalf("keyword \"go\" matched inside \"django\": %d facts returned", len(got))
+	}
+}
+
+// TestSearchPrefixMatchKeepsMorphology pins the counterweight: longer
+// keywords still match their morphological extensions ("compress" →
+// "compression"), so word-boundary precision does not cost recall on
+// inflected terms.
+func TestSearchPrefixMatchKeepsMorphology(t *testing.T) {
+	fi := NewFactIndex(t.TempDir(), DefaultConfig(), zap.NewNop())
+	fi.AddFact("compression uses reversible ccr markers for tool output", "architecture", nil)
+
+	if got := fi.Search([]string{"compress"}); len(got) != 1 {
+		t.Fatalf("keyword \"compress\" no longer matches \"compression\": %d facts", len(got))
+	}
+}
+
+// TestSearchMatchesAccentedTokens: the tokenizer behind relevance must be the
+// same Unicode-aware one used everywhere else.
+func TestSearchMatchesAccentedTokens(t *testing.T) {
+	fi := NewFactIndex(t.TempDir(), DefaultConfig(), zap.NewNop())
+	fi.AddFact("a configuração de produção fica no vault", "project", nil)
+
+	if got := fi.Search([]string{"configuração"}); len(got) != 1 {
+		t.Fatalf("accented keyword did not match accented token: %d facts", len(got))
+	}
+}

--- a/cli/workspace/memory/relevance_test.go
+++ b/cli/workspace/memory/relevance_test.go
@@ -8,7 +8,7 @@ import (
 
 // TestSearchDoesNotMatchInsideWords pins lexical precision: raw substring
 // matching made short keywords fire inside unrelated words ("go" inside
-// "django", "art" inside "artefact"), polluting retrieval with noise facts
+// "django", "art" inside "artifact"), polluting retrieval with noise facts
 // that then get access-boosted and entrench themselves.
 func TestSearchDoesNotMatchInsideWords(t *testing.T) {
 	fi := NewFactIndex(t.TempDir(), DefaultConfig(), zap.NewNop())

--- a/cli/workspace/memory/retriever.go
+++ b/cli/workspace/memory/retriever.go
@@ -3,7 +3,9 @@ package memory
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
+	"unicode/utf8"
 )
 
 // RelevanceRetriever selects the most relevant memories for the current conversation.
@@ -271,7 +273,8 @@ func ExtractKeywords(messages []string) []string {
 		for _, w := range words {
 			// Clean punctuation
 			w = strings.Trim(w, ".,;:!?\"'`()[]{}#*-_/\\<>")
-			if len(w) < 3 || stopWords[w] {
+			// Rune count, not byte length: accented pt-BR words are multi-byte.
+			if utf8.RuneCountInString(w) < 3 || stopWords[w] {
 				continue
 			}
 			wordFreq[w]++
@@ -291,14 +294,14 @@ func ExtractKeywords(messages []string) []string {
 		return nil
 	}
 
-	// Sort by frequency descending
-	for i := 0; i < len(sorted); i++ {
-		for j := i + 1; j < len(sorted); j++ {
-			if sorted[j].freq > sorted[i].freq {
-				sorted[i], sorted[j] = sorted[j], sorted[i]
-			}
+	// Sort by frequency descending, word ascending on ties so the hint set is
+	// deterministic across runs (map iteration order is randomized).
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].freq != sorted[j].freq {
+			return sorted[i].freq > sorted[j].freq
 		}
-	}
+		return sorted[i].word < sorted[j].word
+	})
 
 	// Return top 20 keywords
 	limit := 20

--- a/cli/workspace/memory/store.go
+++ b/cli/workspace/memory/store.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync/atomic"
 
 	"go.uber.org/zap"
 )
@@ -35,6 +36,12 @@ type Manager struct {
 	// llm/embedding directly. nil → keyword-only retrieval (no
 	// regression).
 	vectors *VectorIndex
+
+	// backfillInFlight single-flights the detached embedding backfill:
+	// concurrent retrievals (MoA participants, gateway turns) would otherwise
+	// launch overlapping backfills embedding the same facts — double the
+	// embedding bill for zero benefit.
+	backfillInFlight atomic.Bool
 }
 
 // NewManager creates a new memory manager. The memoryDir should be the
@@ -247,7 +254,11 @@ func (m *Manager) GetRelevantContextWithHyDE(ctx context.Context, query string, 
 			ids = append(ids, f.ID)
 		}
 		missing := m.vectors.MissingFor(ids)
-		if len(missing) > 0 {
+		// Single-flight: the CAS happens synchronously on the caller's
+		// goroutine, so a concurrent retrieval deterministically observes the
+		// in-flight backfill and skips — the missing set it would embed is
+		// the same one already being filled.
+		if len(missing) > 0 && m.backfillInFlight.CompareAndSwap(false, true) {
 			items := make(map[string]string, len(missing))
 			for _, id := range missing {
 				if f, ok := m.Facts.GetByID(id); ok {
@@ -263,6 +274,7 @@ func (m *Manager) GetRelevantContextWithHyDE(ctx context.Context, query string, 
 			// cancellation as required (see comment above).
 			bgCtx := context.WithoutCancel(ctx)
 			go func(items map[string]string) { //#nosec G118 -- detached on purpose; see comment above
+				defer m.backfillInFlight.Store(false)
 				if err := m.vectors.BackfillFacts(bgCtx, items); err != nil {
 					m.logger.Warn("vector backfill failed", zap.Error(err))
 				}
@@ -276,8 +288,18 @@ func (m *Manager) GetRelevantContextWithHyDE(ctx context.Context, query string, 
 // AttachVectorIndex wires a VectorIndex into the manager. Pass nil to
 // detach (returns retrieval to keyword-only mode). Safe to call
 // multiple times — only the most recent index is used.
+//
+// Attaching also registers the fact-removal hook so every deletion path
+// (forget, archive, compaction replace, supersede, cap prune) drops the
+// matching vector — orphan vectors would otherwise accumulate forever and
+// keep growing vector_index.json.
 func (m *Manager) AttachVectorIndex(v *VectorIndex) {
 	m.vectors = v
+	if v == nil {
+		m.Facts.SetOnRemoved(nil)
+		return
+	}
+	m.Facts.SetOnRemoved(func(ids []string) { v.Forget(ids...) })
 }
 
 // VectorIndex returns the attached vector index (may be nil).
@@ -290,8 +312,10 @@ func (m *Manager) ReadLongTerm() string {
 	return m.Facts.GenerateMarkdown(m.config.MaxMemoryMDSize)
 }
 
-// WriteLongTerm replaces all long-term memory with new content.
-// This parses the content into facts.
+// WriteLongTerm parses content (markdown headings + bullet lines) into facts
+// and MERGES them into long-term memory — existing facts are kept, with
+// duplicates deduplicated/reinforced by the add-time reconciliation. It does
+// not clear anything; use ForgetFacts for removals.
 func (m *Manager) WriteLongTerm(content string) error {
 	// Parse content into facts
 	lines := strings.Split(content, "\n")
@@ -554,20 +578,15 @@ func parseEnhancedResponse(response string) (daily, longTerm string, profile map
 		{"PROJECTS", findSection(upper, "PROJECTS")},
 	}
 
-	// Filter found sections and sort by position
+	// Filter found sections and sort by position (stable: PROFILE_UPDATE and
+	// PROFILE can match at the same index; declaration order must win).
 	var found []section
 	for _, s := range sections {
 		if s.idx >= 0 {
 			found = append(found, s)
 		}
 	}
-	for i := 0; i < len(found); i++ {
-		for j := i + 1; j < len(found); j++ {
-			if found[j].idx < found[i].idx {
-				found[i], found[j] = found[j], found[i]
-			}
-		}
-	}
+	sort.SliceStable(found, func(i, j int) bool { return found[i].idx < found[j].idx })
 
 	// Extract content between sections
 	extractContent := func(startIdx int, nextIdx int) string {

--- a/cli/workspace/memory/tokens_unicode_test.go
+++ b/cli/workspace/memory/tokens_unicode_test.go
@@ -1,0 +1,49 @@
+package memory
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// ChatCLI's primary audience writes memory in Portuguese. Tokenization that
+// only accepts ASCII a-z0-9 shreds accented words ("configuração" →
+// "configura" + debris), which silently degrades the Jaccard similarity that
+// drives dedupe/supersede and the subject gate — precisely for pt-BR facts.
+
+func TestSigTokensPreservesAccentedWords(t *testing.T) {
+	toks := sigTokens("Configuração do serviço de importação usa criptografia homomórfica")
+	want := map[string]bool{
+		"configuração": false, "serviço": false, "importação": false,
+		"criptografia": false, "homomórfica": false,
+	}
+	for _, tok := range toks {
+		if _, ok := want[tok]; ok {
+			want[tok] = true
+		}
+	}
+	for w, seen := range want {
+		if !seen {
+			t.Errorf("sigTokens mangled accented word %q (got %v)", w, toks)
+		}
+	}
+}
+
+// TestReconcileReinforcesAccentedRephrasing pins the behavioral consequence:
+// an exact-meaning pt-BR rephrasing (same significant tokens, one word
+// reordered) must REINFORCE the stored fact, not pile up a duplicate.
+func TestReconcileReinforcesAccentedRephrasing(t *testing.T) {
+	fi := NewFactIndex(t.TempDir(), DefaultConfig(), zap.NewNop())
+
+	if !fi.AddFact("configuração da importação usa criptografia homomórfica no serviço", "pattern", nil) {
+		t.Fatal("first fact not added")
+	}
+	// Rephrasing with identical significant-token set.
+	added := fi.AddFact("no serviço, a configuração da importação usa criptografia homomórfica", "pattern", nil)
+	if added {
+		t.Fatalf("accented rephrasing stored as a duplicate: %d facts", fi.Count())
+	}
+	if fi.Count() != 1 {
+		t.Fatalf("Count = %d, want 1 (reinforced)", fi.Count())
+	}
+}

--- a/cli/workspace/memory/topics.go
+++ b/cli/workspace/memory/topics.go
@@ -233,7 +233,14 @@ func (tt *TopicTracker) load() {
 	}
 	var topics []Topic
 	if err := json.Unmarshal(data, &topics); err != nil {
-		tt.logger.Warn("failed to parse topics", zap.Error(err))
+		// Quarantine for recovery instead of leaving the corrupt file in place
+		// for the next persist to overwrite (see persist.go).
+		if qpath, qerr := quarantineCorrupt(tt.path); qerr == nil {
+			tt.logger.Warn("topics store corrupt; quarantined for recovery",
+				zap.String("quarantine", qpath), zap.Error(err))
+		} else {
+			tt.logger.Warn("topics store corrupt and quarantine failed", zap.Error(qerr))
+		}
 		return
 	}
 	for i := range topics {
@@ -254,5 +261,7 @@ func (tt *TopicTracker) persist() {
 	if err != nil {
 		return
 	}
-	_ = os.WriteFile(tt.path, data, 0o600)
+	if err := atomicWriteFile(tt.path, data, 0o600); err != nil {
+		tt.logger.Warn("failed to write topics store", zap.Error(err))
+	}
 }

--- a/cli/workspace/memory/vector_lifecycle_test.go
+++ b/cli/workspace/memory/vector_lifecycle_test.go
@@ -1,0 +1,73 @@
+package memory
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// The vector index is a cache keyed by fact ID. Every fact-removal path must
+// drop the matching vector: without that, forgotten/compacted facts leave
+// orphan vectors that grow vector_index.json forever, and compaction (which
+// rewrites content hashes) forces a full re-embed while the stale vectors
+// linger unreferenced.
+
+func TestForgetFactAlsoForgetsItsVector(t *testing.T) {
+	dir := t.TempDir()
+	m := NewManager(dir, DefaultConfig(), zap.NewNop())
+	v := NewVectorIndex(dir, &fakeProvider{dim: 128}, nil)
+	m.AttachVectorIndex(v)
+
+	content := "service alpha listens on port 3001 behind nginx"
+	if !m.RememberFact(content, "general") {
+		t.Fatal("fact not added")
+	}
+	id := m.Facts.hashContent(content)
+	if err := v.BackfillFacts(context.Background(), map[string]string{id: content}); err != nil {
+		t.Fatal(err)
+	}
+	if v.Count() != 1 {
+		t.Fatalf("vector not stored: count=%d", v.Count())
+	}
+
+	if n := m.ForgetFacts("port 3001"); n != 1 {
+		t.Fatalf("ForgetFacts removed %d, want 1", n)
+	}
+	if v.Count() != 0 {
+		t.Fatalf("forgotten fact's vector orphaned: count=%d", v.Count())
+	}
+}
+
+func TestReplaceFactsForgetsDroppedVectors(t *testing.T) {
+	dir := t.TempDir()
+	m := NewManager(dir, DefaultConfig(), zap.NewNop())
+	v := NewVectorIndex(dir, &fakeProvider{dim: 128}, nil)
+	m.AttachVectorIndex(v)
+
+	kept := "service alpha listens on port 3001 behind nginx"
+	dropped := "service beta stores queue state in redis db 2"
+	m.RememberFact(kept, "general")
+	m.RememberFact(dropped, "general")
+	keptID := m.Facts.hashContent(kept)
+	droppedID := m.Facts.hashContent(dropped)
+	if err := v.BackfillFacts(context.Background(), map[string]string{keptID: kept, droppedID: dropped}); err != nil {
+		t.Fatal(err)
+	}
+	if v.Count() != 2 {
+		t.Fatalf("vectors not stored: count=%d", v.Count())
+	}
+
+	keptFact, ok := m.Facts.GetByID(keptID)
+	if !ok {
+		t.Fatal("kept fact missing")
+	}
+	m.Facts.ReplaceFacts([]*Fact{keptFact}) // compaction shape: one dropped
+
+	if got := v.MissingFor([]string{keptID}); len(got) != 0 {
+		t.Fatal("kept fact's vector was dropped")
+	}
+	if v.Count() != 1 {
+		t.Fatalf("dropped fact's vector orphaned: count=%d, want 1", v.Count())
+	}
+}

--- a/llm/embedding/vindex/vindex.go
+++ b/llm/embedding/vindex/vindex.go
@@ -356,29 +356,22 @@ func (x *Index) persist() error {
 	}
 	// Atomic replace (same-dir temp + rename): at tens of MB a plain WriteFile
 	// interrupted mid-write leaves a torn file that costs a full re-embed of
-	// the corpus on the next start.
+	// the corpus on the next start. CreateTemp reserves a unique 0600 name;
+	// the write goes through os.WriteFile so there is a single error surface
+	// per step.
 	tmp, err := os.CreateTemp(filepath.Dir(x.path), filepath.Base(x.path)+".*.tmp")
 	if err != nil {
 		return err
 	}
 	tmpName := tmp.Name()
-	if _, werr := tmp.Write(data); werr != nil {
-		_ = tmp.Close()
+	_ = tmp.Close()
+	if err := os.WriteFile(tmpName, data, 0o600); err != nil {
 		_ = os.Remove(tmpName)
-		return werr
+		return err
 	}
-	if cerr := tmp.Chmod(0o600); cerr != nil {
-		_ = tmp.Close()
+	if err := os.Rename(tmpName, x.path); err != nil {
 		_ = os.Remove(tmpName)
-		return cerr
-	}
-	if cerr := tmp.Close(); cerr != nil {
-		_ = os.Remove(tmpName)
-		return cerr
-	}
-	if rerr := os.Rename(tmpName, x.path); rerr != nil {
-		_ = os.Remove(tmpName)
-		return rerr
+		return err
 	}
 	return nil
 }

--- a/llm/embedding/vindex/vindex.go
+++ b/llm/embedding/vindex/vindex.go
@@ -298,7 +298,12 @@ func (x *Index) load() {
 	}
 	var f indexFile
 	if err := json.Unmarshal(data, &f); err != nil {
-		x.logger.Warn("vindex unmarshal failed", zap.Error(err))
+		// A torn/corrupt vector cache has no recovery value (vectors are
+		// re-embeddable), but it must not linger: left in place it would be
+		// reloaded and re-warned about on every start. Discard so the next
+		// Upsert repopulates a clean index.
+		x.logger.Warn("vindex unmarshal failed — discarding corrupt cache for re-embed", zap.Error(err))
+		x.discardStale()
 		return
 	}
 	// Dimension mismatch: cosine across different arities is undefined.
@@ -349,7 +354,33 @@ func (x *Index) persist() error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(x.path, data, 0o600)
+	// Atomic replace (same-dir temp + rename): at tens of MB a plain WriteFile
+	// interrupted mid-write leaves a torn file that costs a full re-embed of
+	// the corpus on the next start.
+	tmp, err := os.CreateTemp(filepath.Dir(x.path), filepath.Base(x.path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	if _, werr := tmp.Write(data); werr != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return werr
+	}
+	if cerr := tmp.Chmod(0o600); cerr != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return cerr
+	}
+	if cerr := tmp.Close(); cerr != nil {
+		_ = os.Remove(tmpName)
+		return cerr
+	}
+	if rerr := os.Rename(tmpName, x.path); rerr != nil {
+		_ = os.Remove(tmpName)
+		return rerr
+	}
+	return nil
 }
 
 // ─── bounded top-K (min-heap) ─────────────────────────────────────────────

--- a/llm/embedding/vindex/vindex_durability_test.go
+++ b/llm/embedding/vindex/vindex_durability_test.go
@@ -1,0 +1,93 @@
+/*
+ * ChatCLI - vindex durability tests: corrupt-cache discard and atomic persist.
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package vindex
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestLoadDiscardsCorruptCache pins the recovery behavior: a torn/corrupt
+// vector cache has no recovery value (vectors are re-embeddable), so load
+// must discard it — never leave it in place to be re-warned about on every
+// start.
+func TestLoadDiscardsCorruptCache(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "vector_index.json")
+	if err := os.WriteFile(path, []byte(`{"dimension":8,"entries":{"a":[0.1,`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	idx := New(path, &oneHotProvider{name: "onehot", dim: 8})
+	if idx.Count() != 0 {
+		t.Fatalf("corrupt cache loaded %d entries, want 0", idx.Count())
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatal("corrupt cache file left in place — it would be re-parsed and re-warned about on every start")
+	}
+
+	// The index stays fully usable: a fresh Upsert repopulates cleanly.
+	if err := idx.Upsert(context.Background(), map[string]string{"a": "alpha text"}); err != nil {
+		t.Fatalf("Upsert after discard: %v", err)
+	}
+	if idx.Count() != 1 {
+		t.Fatalf("Count = %d after re-upsert, want 1", idx.Count())
+	}
+}
+
+// TestPersistLeavesNoTempLitter pins the atomic-write mechanics: after a
+// successful persist the directory holds only the index file — a leftover
+// .tmp would mean the rename path is broken.
+func TestPersistLeavesNoTempLitter(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "vector_index.json")
+	idx := New(path, &oneHotProvider{name: "onehot", dim: 8})
+
+	if err := idx.Upsert(context.Background(), map[string]string{"a": "alpha", "b": "beta"}); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp") {
+			t.Fatalf("temp litter left behind: %s", e.Name())
+		}
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("index file missing after persist: %v", err)
+	}
+}
+
+// TestPersistSurfacesUnwritableDir pins the error path: when the store
+// directory cannot receive the temp file, Upsert must surface the persist
+// failure instead of swallowing it.
+func TestPersistSurfacesUnwritableDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory write permissions are advisory on Windows")
+	}
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "store")
+	if err := os.MkdirAll(sub, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	idx := New(filepath.Join(sub, "vector_index.json"), &oneHotProvider{name: "onehot", dim: 8})
+
+	if err := os.Chmod(sub, 0o500); err != nil { // no write permission
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(sub, 0o750) })
+
+	if err := idx.Upsert(context.Background(), map[string]string{"a": "alpha"}); err == nil {
+		t.Fatal("Upsert on unwritable dir returned nil; persist failure must surface")
+	}
+}


### PR DESCRIPTION
## Summary

Expert review of the memory subsystem (`cli/workspace/memory`, adapter, worker, wiring) following the same method as #1119: every fix landed **red→green**, with the failing test demonstrating the exact failure mode before the fix. The retrieval architecture (pull-first index, blended ranking, HyDE) was sound — the durability layer had **three independent vectors of silent, permanent memory loss**, which is the one failure a memory system must never have.

## P0 — silent memory loss

1. **Non-atomic persistence + no corruption recovery.** Every substore persisted via plain `os.WriteFile`; a crash mid-write tore the JSON, and at the next load the store logged a warn, **started empty, and the next persist overwrote the only copy** — months of accumulated memory erased with zero visible error. All stores (facts, profile, topics, projects, usage stats, MEMORY.md, archive, vector index) now write atomically (same-dir temp + rename), and an unparseable file is **quarantined** as `.corrupt` for recovery instead of being left in place to be clobbered.

2. **Destructive LLM compaction (runs automatically in the background worker).** `ReplaceFacts` applied whatever the model returned; a truncated list (models cut long lists routinely) permanently deleted every fact not echoed. Now: a result keeping under half the facts is **rejected as truncated** (score-based curation runs instead); facts dropped by a legitimate consolidation are **archived first**; and trust metadata — `Confidence`, `Provenance`, `SourceProject` — **survives the rewrite** (previously every compaction silently downgraded user-stated facts to extraction-grade guesses). The last-compaction timestamp is persisted so restarts don't re-trigger the LLM-billed pass.

3. **Multi-process last-writer-wins.** REPL and gateway daemon share the memory directory; each persist rewrote the whole file from that process's in-memory map, clobbering facts the other process learned. Persistence now **reconciles**: each write merges the on-disk state and honors **tombstones** (sidecar) recorded by every deletion path — forget, archive, compaction replace, supersede, cap prune. A tombstone kills copies whose `CreatedAt` predates it, so an explicit forget propagates across processes and is not undone by passive access; only a deliberate re-add resurrects a fact. `MarkAccessed` is debounced (access bumps fold into the next real persist) instead of rewriting the index on every retrieval.

## P1 — correctness

- **Data race**: temporal score recalculation wrote `f.Score` while holding the **read** lock; concurrent retrieval is reachable in production (parallel MoA participants with `@memory recall`, background extraction worker). Scoring is now a pure computation; the stored field is refreshed only under the write lock at persist time. Pinned by a `-race` test that failed before the fix.
- **Orphan vectors**: `VectorIndex.Forget` had **zero callers** (its doc claimed the compactor called it). Every removal path now drops the matching vector via a removal hook wired at `AttachVectorIndex`; previously `vector_index.json` grew forever and each compaction (which rewrites content-hash IDs) forced a full re-embed while stale vectors lingered.
- **Unicode tokenization**: the ASCII-only splitter shredded accented Portuguese words ("configuração" → "configura" + debris), silently degrading the Jaccard dedupe/supersede similarity for exactly the language most facts arrive in.

## P2 — retrieval quality and cost

- Lexical relevance matches **whole tokens** (exact, or prefix for keywords of 4+ runes) instead of raw substrings — "go" no longer fires inside "django" and gets entrenched by the access boost, while "compress" still matches "compression".
- The detached embedding **backfill is single-flighted** — concurrent retrievals used to launch overlapping backfills embedding the same facts (double the bill for zero benefit).
- Bubble sorts in keyword extraction and section parsing replaced with `sort.Slice` (with deterministic tie-breaks); `WriteLongTerm` docs corrected (it merges, never replaces).

## Testing

Red→green tests for every fix: corruption quarantine, truncated-compaction guard, archive-on-consolidation, metadata preservation, compaction-interval restart, cross-process clobber/forget propagation, race detector, orphan vectors on forget and replace, accented tokens, word-boundary relevance, single-flight backfill. Full `go test ./... -short` green; memory package green under `-race`; `go vet` + `gofmt` clean.