### PR TITLE
fix(ctxmgr): harden knowledge-mode durability, UTF-8 boundaries and retrieval cost

### DIFF
--- a/cli/ctxmgr/digest.go
+++ b/cli/ctxmgr/digest.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"unicode/utf8"
 )
 
 const (
@@ -120,12 +121,30 @@ func writeDigestTree(b *strings.Builder, sources []digestSource, budget int) {
 func digestLine(s digestSource) string {
 	title := strings.TrimSpace(s.title)
 	if len(title) > digestMaxTitleChars {
-		title = title[:digestMaxTitleChars-1] + "…"
+		// Rune-aligned cut: pt-BR titles are multi-byte, and this line lands
+		// in the CACHED system-prompt prefix — invalid UTF-8 there poisons
+		// every turn.
+		title = title[:alignRuneBefore(title, digestMaxTitleChars-1)] + "…"
 	}
 	if title != "" {
 		return fmt.Sprintf("- %s (%d passages) — %s\n", s.path, s.chunks, title)
 	}
 	return fmt.Sprintf("- %s (%d passages)\n", s.path, s.chunks)
+}
+
+// alignRuneBefore returns the largest index <= i that starts a UTF-8 rune in
+// s (clamped to [0, len(s)]), so byte-budget cuts never split a rune.
+func alignRuneBefore(s string, i int) int {
+	if i <= 0 {
+		return 0
+	}
+	if i >= len(s) {
+		return len(s)
+	}
+	for i > 0 && !utf8.RuneStart(s[i]) {
+		i--
+	}
+	return i
 }
 
 // firstHeading extracts the first markdown heading of a chunk as a

--- a/cli/ctxmgr/fuzz_test.go
+++ b/cli/ctxmgr/fuzz_test.go
@@ -1,0 +1,64 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package ctxmgr
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// FuzzTokenizeLexical hammers the BM25 tokenizer with arbitrary input — it
+// sits on the per-turn retrieval path over user-provided corpora. Invariants:
+// never panics; every token is lowercase and at least 2 bytes.
+func FuzzTokenizeLexical(f *testing.F) {
+	f.Add("getUserName HTTPServer snake_case kebab-case s3 oauth2")
+	f.Add("configuração de autenticação com criptografia homomórfica")
+	f.Add("日本語テキスト mixed with ASCII and 数字123")
+	f.Add(strings.Repeat("→", 500))
+	f.Add("")
+	f.Fuzz(func(t *testing.T, text string) {
+		for _, tok := range tokenizeLexical(text) {
+			if tok != strings.ToLower(tok) {
+				t.Fatalf("token %q not lowercased", tok)
+			}
+			if len(tok) < 2 {
+				t.Fatalf("one-byte token %q emitted (noise filter broken)", tok)
+			}
+		}
+	})
+}
+
+// FuzzSnippetValidUTF8 pins the rune-boundary contract on the search snippet
+// under arbitrary content: valid UTF-8 in ⇒ valid UTF-8 out, and the result
+// never exceeds the byte budget plus the elision marker.
+func FuzzSnippetValidUTF8(f *testing.F) {
+	f.Add("plain ascii content that is fairly short")
+	f.Add("a" + strings.Repeat("→", 400))
+	f.Add(strings.Repeat("ção é açúcar ", 100))
+	f.Fuzz(func(t *testing.T, s string) {
+		out := snippet(s, searchSnippetChars)
+		if utf8.ValidString(s) && !utf8.ValidString(out) {
+			t.Fatal("valid UTF-8 input produced invalid UTF-8 snippet")
+		}
+		if len(out) > searchSnippetChars+len(" […]") {
+			t.Fatalf("snippet exceeds budget: %d bytes", len(out))
+		}
+	})
+}
+
+// FuzzDigestLineValidUTF8 pins the same contract on the TOC line — this text
+// enters the cached system-prompt prefix.
+func FuzzDigestLineValidUTF8(f *testing.F) {
+	f.Add("docs/config.md", "Configuração da integração de autenticação série avançada para produção")
+	f.Add("a#b", strings.Repeat("ç", 200))
+	f.Fuzz(func(t *testing.T, path, title string) {
+		line := digestLine(digestSource{path: path, chunks: 1, title: title})
+		if utf8.ValidString(path) && utf8.ValidString(title) && !utf8.ValidString(line) {
+			t.Fatal("valid UTF-8 inputs produced an invalid UTF-8 digest line")
+		}
+	})
+}

--- a/cli/ctxmgr/knowledge_query.go
+++ b/cli/ctxmgr/knowledge_query.go
@@ -16,6 +16,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"go.uber.org/zap"
 )
 
 const (
@@ -117,7 +119,8 @@ func (m *Manager) KnowledgeSearch(ctx context.Context, sessionID, kb, query stri
 	for _, fc := range targets {
 		segs, err := engine.RetrieveHybrid(ctx, fc, query, k)
 		if err != nil {
-			m.logger.Warn("knowledge search failed for context; skipping")
+			m.logger.Warn("knowledge search failed for context; skipping",
+				zap.String("context", fc.Name), zap.Error(err))
 			continue
 		}
 		for _, s := range segs {
@@ -158,9 +161,16 @@ func (m *Manager) KnowledgeDocument(sessionID, kb, source string, offset int) (p
 		if offset >= total {
 			return "", total, 0, fmt.Errorf("offset %d beyond document end (%d chars)", offset, total)
 		}
+		// Snap both cut points to rune starts: offsets are byte positions the
+		// MODEL echoes back between calls, so a mid-rune page boundary would
+		// both emit invalid UTF-8 and corrupt the next page. nextOffset always
+		// references the actual end used, so pages reassemble exactly.
+		offset = alignRuneBefore(doc, offset)
 		end := offset + docPageChars
 		if end > total {
 			end = total
+		} else {
+			end = alignRuneBefore(doc, end)
 		}
 		next := 0
 		if end < total {
@@ -234,14 +244,15 @@ func FormatKnowledgeHits(query string, hits []KnowledgeHit) string {
 	return b.String()
 }
 
-// snippet trims s to at most limit bytes, cutting at a word boundary and
-// flagging the elision so the model knows there is more behind `get`.
+// snippet trims s to at most limit bytes, preferring a word boundary and
+// always landing on a rune boundary, flagging the elision so the model knows
+// there is more behind `get`.
 func snippet(s string, limit int) string {
 	s = strings.TrimSpace(s)
 	if len(s) <= limit {
 		return s
 	}
-	cut := s[:limit]
+	cut := s[:alignRuneBefore(s, limit)]
 	if i := strings.LastIndexAny(cut, " \n\t"); i > limit/2 {
 		cut = cut[:i]
 	}

--- a/cli/ctxmgr/manager.go
+++ b/cli/ctxmgr/manager.go
@@ -652,7 +652,12 @@ func (m *Manager) BuildPromptMessages(sessionID string, opts FormatOptions) ([]m
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	attachments := m.attachedContexts[sessionID]
+	// Copy before sorting: this method holds only the READ lock, and sorting
+	// the shared slice in place would mutate state other readers iterate.
+	// Today the list arrives pre-sorted (attach keeps it ordered), so the
+	// in-place sort happened to never swap — but that is an invariant of a
+	// different method, not something this read path may lean on.
+	attachments := append([]AttachedContext(nil), m.attachedContexts[sessionID]...)
 	if len(attachments) == 0 {
 		return nil, nil
 	}

--- a/cli/ctxmgr/manager_race_test.go
+++ b/cli/ctxmgr/manager_race_test.go
@@ -1,0 +1,59 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package ctxmgr
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// TestBuildPromptMessagesConcurrentIsRaceFree pins read-path thread safety
+// under the race detector. Prompt assembly runs on every turn, and concurrent
+// turns are reachable (gateway daemon handling a message while a MoA panel
+// builds participant prompts over the same session). BuildPromptMessages used
+// to sort the SHARED attachments slice in place while holding only the READ
+// lock — a latent hazard: it never raced in practice only because attach
+// happens to keep the list pre-sorted, an invariant this read path has no
+// business leaning on. The method now copies before sorting; this test is the
+// guard-rail that keeps concurrent prompt assembly clean under -race.
+func TestBuildPromptMessagesConcurrentIsRaceFree(t *testing.T) {
+	m := newTestManager(t)
+
+	// Several contexts with distinct priorities so the sort actually moves
+	// elements (a pre-sorted list can hide the mutation).
+	for i := 0; i < 6; i++ {
+		fc := &FileContext{
+			ID:        uuid.New().String(),
+			Name:      fmt.Sprintf("ctx-%d", i),
+			Mode:      ModeFull,
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		}
+		m.contexts[fc.ID] = fc
+		if aerr := m.AttachContext("sess", fc.ID, 10-i); aerr != nil { // reversed priorities
+			t.Fatal(aerr)
+		}
+	}
+
+	var wg sync.WaitGroup
+	for w := 0; w < 8; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				if _, berr := m.BuildPromptMessages("sess", FormatOptions{}); berr != nil {
+					t.Error(berr)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/cli/ctxmgr/retrieval.go
+++ b/cli/ctxmgr/retrieval.go
@@ -106,10 +106,13 @@ func (e *RetrievalEngine) Enabled() bool {
 	return e != nil && !embedding.IsNull(e.provider)
 }
 
-// Retrieve returns the top-k passages of fc most relevant to query. It builds
-// the per-context vector cache lazily, embeds only segments not already cached,
-// and evicts vectors for passages that no longer exist (file edited/removed), so
-// repeated calls are cheap and never serve a match against stale text.
+// Retrieve returns the top-k passages of fc most relevant to query. Segments,
+// the vector-index handle and its prune run come from the same fingerprint
+// cache the hybrid path uses — previously this path re-segmented the context
+// and re-parsed the whole persisted vector JSON on EVERY query, the exact
+// per-call cost the cache exists to avoid. It embeds only segments not already
+// cached, so repeated calls are cheap and never serve a match against stale
+// text.
 func (e *RetrievalEngine) Retrieve(ctx context.Context, fc *FileContext, query string, k int) ([]Segment, error) {
 	if !e.Enabled() || fc == nil {
 		return nil, nil
@@ -121,22 +124,20 @@ func (e *RetrievalEngine) Retrieve(ctx context.Context, fc *FileContext, query s
 		return nil, nil
 	}
 
-	segs := SegmentFiles(fc.Files, e.segOpts)
+	entry := e.entryFor(fc)
+	segs := entry.segs
 	if len(segs) == 0 {
 		return nil, nil
 	}
 
 	byID := make(map[string]Segment, len(segs))
-	keep := make(map[string]struct{}, len(segs))
 	allIDs := make([]string, 0, len(segs))
 	for _, s := range segs {
 		byID[s.ID] = s
-		keep[s.ID] = struct{}{}
 		allIDs = append(allIDs, s.ID)
 	}
 
-	idx := vindex.New(e.vectorPath(fc.ID), e.provider, vindex.WithLogger(e.logger))
-	idx.Prune(keep)
+	idx := entry.vec // built and pruned by entryFor when the engine is enabled
 
 	if missing := idx.MissingFor(allIDs); len(missing) > 0 {
 		sub := make(map[string]string, len(missing))

--- a/cli/ctxmgr/storage.go
+++ b/cli/ctxmgr/storage.go
@@ -7,13 +7,42 @@ package ctxmgr
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/diillson/chatcli/utils"
 	"go.uber.org/zap"
 )
+
+// errContextCorrupt marks a context file that exists but cannot be parsed —
+// the signal LoadAllContexts uses to quarantine it instead of skipping it
+// silently on every start.
+var errContextCorrupt = errors.New("context file corrupt")
+
+// atomicWrite persists data via a same-directory temp file and an atomic
+// rename. Context files embed the whole corpus (multi-MB for knowledge
+// bases); a plain WriteFile interrupted mid-write leaves a torn file and the
+// knowledge base silently vanishes from the next load.
+func atomicWrite(path string, data []byte) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	_ = tmp.Close()
+	if err := os.WriteFile(tmpName, data, 0o600); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	return nil
+}
 
 // Storage gerencia a persistência de contextos em disco
 type Storage struct {
@@ -43,12 +72,15 @@ func NewStorage(logger *zap.Logger) (*Storage, error) {
 func (s *Storage) SaveContext(ctx *FileContext) error {
 	filePath := s.getContextPath(ctx.ID)
 
-	data, err := json.MarshalIndent(ctx, "", "  ")
+	// Compact encoding on purpose: a knowledge context embeds its whole corpus
+	// and nobody reads a 50k-chunk JSON by eye — indentation only doubled the
+	// file and the marshal allocation.
+	data, err := json.Marshal(ctx)
 	if err != nil {
 		return fmt.Errorf("erro ao serializar contexto: %w", err)
 	}
 
-	if err := os.WriteFile(filePath, data, 0o600); err != nil {
+	if err := atomicWrite(filePath, data); err != nil {
 		return fmt.Errorf("erro ao salvar contexto: %w", err)
 	}
 
@@ -70,7 +102,7 @@ func (s *Storage) LoadContext(contextID string) (*FileContext, error) {
 
 	var ctx FileContext
 	if err := json.Unmarshal(data, &ctx); err != nil {
-		return nil, fmt.Errorf("erro ao desserializar contexto: %w", err)
+		return nil, fmt.Errorf("erro ao desserializar contexto %s: %w (%w)", contextID, errContextCorrupt, err)
 	}
 
 	// NOVO: Reconstruir ScanOptions a partir dos metadados
@@ -105,6 +137,23 @@ func (s *Storage) LoadAllContexts() ([]*FileContext, error) {
 		contextID := entry.Name()[:len(entry.Name())-5] // Remove .json
 		ctx, err := s.LoadContext(contextID)
 		if err != nil {
+			// Parse failure: quarantine with a visible name instead of skipping
+			// silently forever — a knowledge base that "disappears" from
+			// /context list with only a debug-level trail is undiagnosable.
+			if errors.Is(err, errContextCorrupt) {
+				src := s.getContextPath(contextID)
+				dst := src + ".corrupt"
+				if _, serr := os.Stat(dst); serr == nil {
+					dst = fmt.Sprintf("%s.corrupt-%d", src, time.Now().Unix())
+				}
+				if renameErr := os.Rename(src, dst); renameErr == nil {
+					s.logger.Warn("Contexto corrompido movido para quarentena",
+						zap.String("id", contextID),
+						zap.String("quarantine", dst),
+						zap.Error(err))
+					continue
+				}
+			}
 			s.logger.Warn("Erro ao carregar contexto, pulando",
 				zap.String("id", contextID),
 				zap.Error(err))
@@ -139,12 +188,14 @@ func (s *Storage) GetStoragePath() string {
 
 // ExportContext exporta um contexto para um arquivo específico
 func (s *Storage) ExportContext(ctx *FileContext, targetPath string) error {
+	// Exports keep the indented form: they are the one artifact a human may
+	// open (sharing/reviewing a context definition).
 	data, err := json.MarshalIndent(ctx, "", "  ")
 	if err != nil {
 		return fmt.Errorf("erro ao serializar contexto para exportação: %w", err)
 	}
 
-	if err := os.WriteFile(targetPath, data, 0o600); err != nil {
+	if err := atomicWrite(targetPath, data); err != nil {
 		return fmt.Errorf("erro ao exportar contexto: %w", err)
 	}
 

--- a/cli/ctxmgr/storage_durability_test.go
+++ b/cli/ctxmgr/storage_durability_test.go
@@ -1,0 +1,89 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package ctxmgr
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// TestLoadAllContextsQuarantinesCorruptFile pins the recovery contract for
+// knowledge bases: a torn/corrupt context JSON (multi-MB — it embeds the whole
+// corpus) must be QUARANTINED with a visible name, not silently skipped on
+// every start. Silently skipping is how a knowledge base "disappears" from
+// /context list with no trace, and the corrupt bytes stay in place, reparsed
+// and re-warned about forever.
+func TestLoadAllContextsQuarantinesCorruptFile(t *testing.T) {
+	dir := t.TempDir()
+	s := &Storage{basePath: dir, logger: zap.NewNop()}
+
+	good := &FileContext{ID: "good-ctx", Name: "good", Mode: ModeFull, CreatedAt: time.Now()}
+	if err := s.SaveContext(good); err != nil {
+		t.Fatal(err)
+	}
+	corruptPath := filepath.Join(dir, "broken-ctx.json")
+	if err := os.WriteFile(corruptPath, []byte(`{"id":"broken-ctx","files":[{"content":"trunc`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	contexts, err := s.LoadAllContexts()
+	if err != nil {
+		t.Fatalf("LoadAllContexts: %v", err)
+	}
+	if len(contexts) != 1 || contexts[0].ID != "good-ctx" {
+		t.Fatalf("expected only the good context, got %d", len(contexts))
+	}
+
+	// The corrupt file must be moved aside for inspection…
+	if _, err := os.Stat(corruptPath); !os.IsNotExist(err) {
+		t.Fatal("corrupt context left in place — reparsed and re-warned about on every start")
+	}
+	entries, _ := os.ReadDir(dir)
+	found := false
+	for _, e := range entries {
+		if strings.Contains(e.Name(), "broken-ctx.json.corrupt") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("corrupt context was not quarantined with a recoverable name")
+	}
+}
+
+// TestSaveContextIsAtomic pins the write mechanics: content lands intact on
+// overwrite and no temp litter remains.
+func TestSaveContextIsAtomic(t *testing.T) {
+	dir := t.TempDir()
+	s := &Storage{basePath: dir, logger: zap.NewNop()}
+
+	fc := &FileContext{ID: "ctx-a", Name: "first", Mode: ModeFull, CreatedAt: time.Now()}
+	if err := s.SaveContext(fc); err != nil {
+		t.Fatal(err)
+	}
+	fc.Name = "second"
+	if err := s.SaveContext(fc); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := s.LoadContext("ctx-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Name != "second" {
+		t.Fatalf("Name = %q after overwrite, want %q", loaded.Name, "second")
+	}
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp") {
+			t.Fatalf("temp litter left behind: %s", e.Name())
+		}
+	}
+}

--- a/cli/ctxmgr/utf8_boundary_test.go
+++ b/cli/ctxmgr/utf8_boundary_test.go
@@ -1,0 +1,92 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package ctxmgr
+
+import (
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/diillson/chatcli/utils"
+)
+
+// Knowledge corpora are routinely Portuguese; every byte-sliced boundary in
+// this package must land on a rune start or the prompt receives invalid
+// UTF-8. Three sites cut by byte position: the digest's title truncation
+// (which lands in the CACHED system-prompt prefix), the search snippet, and
+// the paged document read.
+
+// TestDigestLineTruncatesTitleOnRuneBoundary: a 2-byte-rune title cut at the
+// odd byte budget (digestMaxTitleChars-1 = 71) splits a rune.
+func TestDigestLineTruncatesTitleOnRuneBoundary(t *testing.T) {
+	s := digestSource{path: "docs/config.md", chunks: 3, title: strings.Repeat("ç", 100)}
+	line := digestLine(s)
+	if !utf8.ValidString(line) {
+		t.Fatal("digest TOC line contains invalid UTF-8 (title cut mid-rune) — this text enters the cached prompt prefix")
+	}
+}
+
+// TestSnippetCutsOnRuneBoundary: a space-free run of 3-byte runes offset by
+// one ASCII byte guarantees the fallback byte cut at limit=360 lands mid-rune
+// (rune starts sit at 1+3k; 360 is not of that form).
+func TestSnippetCutsOnRuneBoundary(t *testing.T) {
+	out := snippet("a"+strings.Repeat("→", 400), searchSnippetChars)
+	if !utf8.ValidString(out) {
+		t.Fatal("search snippet contains invalid UTF-8 (cut mid-rune)")
+	}
+}
+
+// TestKnowledgeDocumentPagesOnRuneBoundaries: page cuts at byte offsets must
+// snap to rune starts, and the returned nextOffset must reference the actual
+// cut so the follow-up call resumes exactly where the page ended.
+func TestKnowledgeDocumentPagesOnRuneBoundaries(t *testing.T) {
+	m := newTestManager(t)
+	// 1 ASCII byte then 3-byte runes: docPageChars lands mid-rune.
+	content := "a" + strings.Repeat("→", docPageChars)
+	fc := &FileContext{
+		ID: "kb1", Name: "kb", Mode: ModeKnowledge,
+		Files:     []utils.FileInfo{{Path: "docs/guia.md#0001", Content: content, Size: int64(len(content))}},
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	m.contexts[fc.ID] = fc
+	if err := m.AttachContext("sess", fc.ID, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// Walk the full pagination: every page must be valid UTF-8, every
+	// nextOffset must equal the actual cut, and the pages must reassemble the
+	// document byte-identically.
+	var assembled strings.Builder
+	offset, pages := 0, 0
+	for {
+		page, total, next, err := m.KnowledgeDocument("sess", "", "docs/guia.md", offset)
+		if err != nil {
+			t.Fatalf("page at offset %d: %v", offset, err)
+		}
+		if !utf8.ValidString(page) {
+			t.Fatalf("page at offset %d contains invalid UTF-8 (cut mid-rune)", offset)
+		}
+		if next != 0 && next != offset+len(page) {
+			t.Fatalf("nextOffset (%d) does not match the actual page end (%d) — the follow-up call would skip or repeat bytes", next, offset+len(page))
+		}
+		assembled.WriteString(page)
+		pages++
+		if next == 0 {
+			if assembled.Len() != total {
+				t.Fatalf("pages do not reassemble the document: %d != %d", assembled.Len(), total)
+			}
+			break
+		}
+		offset = next
+	}
+	if pages < 2 {
+		t.Fatalf("fixture did not paginate (%d page)", pages)
+	}
+	if assembled.String() != content {
+		t.Fatal("reassembled document differs from the source")
+	}
+}


### PR DESCRIPTION
## Summary

Expert review of knowledge mode (`cli/ctxmgr` ~5.7k lines + adapters), completing the trilogy started with #1119 (compress) and #1121 (memory). Verdict up front: **the hybrid retrieval design is the strongest of the three subsystems** — keyless BM25 recall with embedding rerank bounded by `hybridMaxPool`, correct fingerprint invalidation, graceful degradation on every path. What it repeated were the durability and UTF-8 bug classes fixed in its siblings, plus one cost bug exclusive to the `--rag` path. Same method: red→green for every behavioral fix, verified locally against the repo's own gates before pushing.

## Durability

- **Atomic persistence + quarantine.** A knowledge context embeds its whole corpus in one multi-MB JSON written with plain `os.WriteFile`; a torn write made the knowledge base **silently vanish** from the next load (skipped with a warn, reparsed and re-warned forever). Writes are now same-dir temp + rename, and an unparseable context file is quarantined as `.corrupt` with a visible log line — recoverable and diagnosable instead of a base that just disappears from `/context list`.
- Context JSON is stored **compact** (exports keep indentation for humans): indentation only doubled multi-MB corpus files and the marshal allocation.

## UTF-8 correctness (pt-BR corpora)

Three byte-position cuts could split a rune:
- the digest TOC **title truncation** — that text enters the **cached system-prompt prefix**, so one bad cut poisoned every subsequent turn;
- the `@knowledge search` **snippet**;
- the `get` **page boundaries** — offsets are byte positions the model echoes back between calls, so a mid-rune boundary both emitted invalid UTF-8 and corrupted the next page.

All three now snap to rune starts; `nextOffset` always references the actual cut, pinned by a full pagination-walk test asserting byte-identical reassembly.

## Concurrency & cost

- `BuildPromptMessages` sorted the **shared** attachments slice in place under the read lock. Honest classification: a **latent hazard**, not a live race — it never raced only because attach happens to keep the list pre-sorted, an invariant this read path has no business leaning on (its sibling `BuildRetrievedContextMessages` already copied). Now copies; a concurrent `-race` test guards the path.
- The `--rag` path (`Retrieve`) re-segmented the context and **re-parsed the whole persisted vector JSON on every query** — the exact per-call cost the hybrid path's fingerprint cache exists to avoid. It now reuses the same cache.
- Knowledge search failures log the context name and error again (both fields had been dropped from the warn).

## Testing

Red→green for the quarantine and all three rune-boundary cuts; full pagination-walk contract test; concurrent prompt-assembly guard under `-race`; 3 fuzz targets (BM25 tokenizer, snippet, digest line — valid UTF-8 in ⇒ valid UTF-8 out). Full `go test ./... -short` green; `ctxmgr` green under `-race`; `go vet`/`gofmt` clean; gosec and the patch-coverage gate script verified locally before push.