### PR TITLE
fix(lint): zero both module baselines and enforce full-module linting

### DIFF
--- a/.github/workflows/1-ci.yml
+++ b/.github/workflows/1-ci.yml
@@ -17,11 +17,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
-        with:
-          # Deep clone so --new-from-rev can resolve origin/<base>.
-          # Without this, golangci-lint cannot enumerate the diff and
-          # would fail to apply diff-only enforcement.
-          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -29,16 +24,16 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: golangci-lint (diff-only)
-        # The stricter .golangci.yml introduced in feat/quality-gate-overhaul
-        # would flag thousands of pre-existing violations across legacy code.
-        # --new-from-rev keeps enforcement scoped to lines this PR adds or
-        # modifies, matching what the Quality Gate Floor 1 does.
+      - name: golangci-lint (full module)
+        # The legacy backlog that once required --new-from-rev diff-only
+        # enforcement was fully paid down (misspell in PR #1055, the five
+        # heavy linters in #1056, the remainder here), so the whole module
+        # is enforced: debt can no longer accumulate outside PR diffs.
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.64.8
           install-mode: goinstall
-          args: --timeout=5m --new-from-rev=origin/${{ github.base_ref }}
+          args: --timeout=8m
 
       - name: Check gofmt
         run: |

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -116,12 +116,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-        with:
-          # Deep clone — golangci-lint --new-from-rev needs origin/<base>
-          # available locally to compute the diff. Default checkout is
-          # shallow (depth=1) and the linter falls back to flagging the
-          # whole tree, which would block on legacy code.
-          fetch-depth: 0
       - uses: actions/setup-go@v6
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
@@ -150,23 +144,25 @@ jobs:
             exit 1
           fi
 
-      - name: golangci-lint (root, diff-only)
-        # --new-from-rev gates the stricter linters in .golangci.yml to
-        # lines this PR touched. Without it, enabling `revive` would
-        # block every PR over pre-existing doc-comment violations.
+      - name: golangci-lint (root, full module)
+        # Both module baselines are at zero (misspell in PR #1055, the five
+        # heavy linters in #1056, the remainder — including the operator
+        # module — in the change that flipped this), so enforcement covers
+        # the whole tree: pre-existing debt can no longer accumulate
+        # silently outside PR diffs.
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.64.8
           install-mode: goinstall
-          args: --timeout=5m --new-from-rev=origin/${{ github.base_ref }}
+          args: --timeout=8m
 
-      - name: golangci-lint (operator, diff-only)
+      - name: golangci-lint (operator, full module)
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.64.8
           install-mode: goinstall
           working-directory: operator
-          args: --timeout=5m --new-from-rev=origin/${{ github.base_ref }}
+          args: --timeout=8m
 
   # ---------------------------------------------------------------------
   # Floor 2 — total coverage ratchet (unit tests with -race)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,12 +2,13 @@
 #
 # Strategy: enable the linters whose findings have caught real bugs in
 # the past (errcheck/govet/staticcheck/revive) plus a few quality-of-life
-# ones (misspell, unconvert, prealloc). Existing legacy code is
-# grandfathered via the workflow's `--new-from-rev=origin/main` flag —
-# every linter listed here runs on PRs, but only flags lines the PR
-# actually added or modified. The Quality Gate Floor 1 calls this file
-# without --new-from-rev for new branches off main to ensure the
-# baseline is enforceable.
+# ones (misspell, unconvert, prealloc). The legacy backlog is fully paid
+# down (misspell in PR #1055, errorlint/prealloc/gocyclo/revive/
+# contextcheck in #1056, the remainder — root and operator — in the
+# change that removed --new-from-rev), so CI enforces the FULL module on
+# every PR: `golangci-lint run ./...` must stay at zero findings in both
+# modules. New debt fails the gate immediately instead of accumulating
+# outside PR diffs.
 
 run:
   timeout: 5m

--- a/deploy/helm/chatcli-operator/crds/platform.chatcli.io_issues.yaml
+++ b/deploy/helm/chatcli-operator/crds/platform.chatcli.io_issues.yaml
@@ -55,7 +55,7 @@ spec:
             description: IssueSpec defines the desired state of an Issue.
             properties:
               correlationId:
-                description: CorrelationId links correlated anomaly signals.
+                description: CorrelationID links correlated anomaly signals.
                 type: string
               description:
                 description: Description of the issue.

--- a/deploy/helm/chatcli/crds/platform.chatcli.io_issues.yaml
+++ b/deploy/helm/chatcli/crds/platform.chatcli.io_issues.yaml
@@ -55,7 +55,7 @@ spec:
             description: IssueSpec defines the desired state of an Issue.
             properties:
               correlationId:
-                description: CorrelationId links correlated anomaly signals.
+                description: CorrelationID links correlated anomaly signals.
                 type: string
               description:
                 description: Description of the issue.

--- a/operator/api/rest/middleware.go
+++ b/operator/api/rest/middleware.go
@@ -66,19 +66,6 @@ func (s *APIServer) authMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-// requireRole returns a middleware that checks the role meets the minimum requirement.
-// Role hierarchy: admin > operator > viewer.
-func requireRole(minRole string, next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		role := roleFromContext(r.Context())
-		if !hasMinRole(role, minRole) {
-			writeError(w, http.StatusForbidden, "insufficient permissions: requires "+minRole+" role")
-			return
-		}
-		next.ServeHTTP(w, r)
-	})
-}
-
 // hasMinRole checks if the given role meets the minimum role requirement.
 func hasMinRole(role, minRole string) bool {
 	roleLevel := map[string]int{
@@ -252,21 +239,4 @@ func pathSegments(path string) []string {
 		return nil
 	}
 	return strings.Split(path, "/")
-}
-
-// matchRoute checks if segments match a pattern like ["api", "v1", "incidents", ":name"].
-// Returns extracted parameters or nil if no match.
-func matchRoute(segments []string, pattern []string) map[string]string {
-	if len(segments) != len(pattern) {
-		return nil
-	}
-	params := make(map[string]string)
-	for i, p := range pattern {
-		if strings.HasPrefix(p, ":") {
-			params[p[1:]] = segments[i]
-		} else if p != segments[i] {
-			return nil
-		}
-	}
-	return params
 }

--- a/operator/api/rest/server.go
+++ b/operator/api/rest/server.go
@@ -1582,7 +1582,7 @@ func (s *APIServer) handleAnalyticsCapacity(w http.ResponseWriter, r *http.Reque
 	}
 
 	seen := make(map[string]bool)
-	var forecasts []interface{}
+	forecasts := make([]interface{}, 0, len(issues.Items))
 	for _, iss := range issues.Items {
 		key := fmt.Sprintf("%s/%s/%s", iss.Spec.Resource.Kind, iss.Spec.Resource.Namespace, iss.Spec.Resource.Name)
 		if seen[key] {
@@ -2568,7 +2568,7 @@ func (s *APIServer) handleFederationClusters(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	var clusters []ClusterItem
+	clusters := make([]ClusterItem, 0, len(items))
 	for _, item := range items {
 		ci := unstructuredToCluster(item)
 		if tier != "" && ci.Tier != tier {
@@ -2589,7 +2589,7 @@ func (s *APIServer) handleFederationCorrelations(w http.ResponseWriter, r *http.
 		return
 	}
 
-	var correlations []map[string]interface{}
+	correlations := make([]map[string]interface{}, 0, len(issues.Items))
 	seen := make(map[string]bool)
 	for _, iss := range issues.Items {
 		if iss.Annotations == nil {
@@ -2662,7 +2662,7 @@ func (s *APIServer) handleListAIInsights(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	var items []AIInsightItem
+	items := make([]AIInsightItem, 0, len(insights.Items))
 	for _, ai := range insights.Items {
 		if issueFilter != "" && ai.Spec.IssueRef.Name != issueFilter {
 			continue
@@ -2780,7 +2780,7 @@ func (s *APIServer) handleListRemediations(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	var items []RemediationItem
+	items := make([]RemediationItem, 0, len(remediations.Items))
 	for _, rp := range remediations.Items {
 		if stateFilter != "" && !strings.EqualFold(string(rp.Status.State), stateFilter) {
 			continue

--- a/operator/api/rest/types.go
+++ b/operator/api/rest/types.go
@@ -451,12 +451,6 @@ type HealthResponse struct {
 	Timestamp string `json:"timestamp"`
 }
 
-// requestContext holds parsed authentication info for a request.
-type requestContext struct {
-	Role   string
-	APIKey string
-}
-
 // paginationParams holds parsed pagination parameters.
 type paginationParams struct {
 	Page     int

--- a/operator/api/v1alpha1/issue_types.go
+++ b/operator/api/v1alpha1/issue_types.go
@@ -75,9 +75,9 @@ type IssueSpec struct {
 	// Description of the issue.
 	Description string `json:"description"`
 
-	// CorrelationId links correlated anomaly signals.
+	// CorrelationID links correlated anomaly signals.
 	// +optional
-	CorrelationId string `json:"correlationId,omitempty"`
+	CorrelationID string `json:"correlationId,omitempty"`
 
 	// RiskScore is an AI-calculated risk score (0-100).
 	// +kubebuilder:validation:Minimum=0

--- a/operator/config/crd/bases/platform.chatcli.io_issues.yaml
+++ b/operator/config/crd/bases/platform.chatcli.io_issues.yaml
@@ -55,7 +55,7 @@ spec:
             description: IssueSpec defines the desired state of an Issue.
             properties:
               correlationId:
-                description: CorrelationId links correlated anomaly signals.
+                description: CorrelationID links correlated anomaly signals.
                 type: string
               description:
                 description: Description of the issue.

--- a/operator/controllers/aiinsight_controller.go
+++ b/operator/controllers/aiinsight_controller.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -90,125 +91,7 @@ func (r *AIInsightReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 	}
 
-	// Build Kubernetes context for AI enrichment
-	var kubeCtx string
-	if r.ContextBuilder != nil {
-		var ctxErr error
-		kubeCtx, ctxErr = r.ContextBuilder.BuildContext(ctx, issue.Spec.Resource)
-		if ctxErr != nil {
-			logger.Info("Failed to build K8s context, continuing without it", "error", ctxErr)
-		}
-	}
-
-	// Determine incident time for contextual enrichment
-	incidentTime := issue.CreationTimestamp.Time
-	if issue.Status.DetectedAt != nil {
-		incidentTime = issue.Status.DetectedAt.Time
-	}
-
-	// Build enriched context from all sources
-	var enrichedContext strings.Builder
-	enrichedContext.WriteString(kubeCtx)
-
-	// Log analysis
-	if r.LogAnalyzer != nil {
-		if logResult, err := r.LogAnalyzer.AnalyzePodLogs(ctx, issue.Spec.Resource, incidentTime); err == nil && logResult != nil {
-			logText := logResult.FormatForAI()
-			if logText != "" {
-				enrichedContext.WriteString("\n")
-				enrichedContext.WriteString(logText)
-			}
-			insight.Status.LogAnalysis = logResult.Summary
-		}
-	}
-
-	// Prometheus metrics
-	if r.MetricsCollector != nil {
-		if metricsResult, err := r.MetricsCollector.CollectIncidentMetrics(ctx, issue.Spec.Resource, incidentTime); err == nil && metricsResult != nil {
-			metricsText := metricsResult.FormatForAI()
-			if metricsText != "" {
-				enrichedContext.WriteString("\n")
-				enrichedContext.WriteString(metricsText)
-			}
-			insight.Status.MetricsContext = metricsResult.Summary
-		}
-	}
-
-	// GitOps context (Helm/ArgoCD/Flux)
-	if r.GitOpsDetector != nil {
-		if gitopsCtx, err := r.GitOpsDetector.DetectGitOpsContext(ctx, issue.Spec.Resource); err == nil && gitopsCtx != nil {
-			gitopsText := gitopsCtx.FormatForAI()
-			if gitopsText != "" {
-				enrichedContext.WriteString("\n")
-				enrichedContext.WriteString(gitopsText)
-			}
-			insight.Status.GitOpsContext = gitopsCtx.Summary
-		}
-	}
-
-	// Source code correlation
-	var stackTraces []StackTrace
-	if r.LogAnalyzer != nil {
-		if logResult, err := r.LogAnalyzer.AnalyzePodLogs(ctx, issue.Spec.Resource, incidentTime); err == nil && logResult != nil {
-			stackTraces = logResult.StackTraces
-		}
-	}
-	if r.SourceCodeAnalyzer != nil {
-		if srcCtx, err := r.SourceCodeAnalyzer.BuildSourceContext(ctx, issue.Spec.Resource, incidentTime, stackTraces); err == nil && srcCtx != nil {
-			srcText := srcCtx.FormatForAI()
-			if srcText != "" {
-				enrichedContext.WriteString("\n")
-				enrichedContext.WriteString(srcText)
-			}
-			insight.Status.SourceCodeContext = srcCtx.Summary
-		}
-	}
-
-	// Cascade / cross-service analysis
-	if r.CascadeAnalyzer != nil {
-		if cascadeResult, err := r.CascadeAnalyzer.AnalyzeCascade(ctx, &issue); err == nil && cascadeResult != nil {
-			cascadeText := cascadeResult.FormatForAI()
-			if cascadeText != "" {
-				enrichedContext.WriteString("\n")
-				enrichedContext.WriteString(cascadeText)
-			}
-			insight.Status.CascadeAnalysis = cascadeResult.Summary
-		}
-	}
-
-	// RCA enrichment
-	rcaEnricher := NewRCAEnricher(r.Client)
-	if rcaCtx, err := rcaEnricher.EnrichIssueContext(ctx, &issue); err == nil && rcaCtx != nil {
-		rcaText := rcaCtx.FormatForAI()
-		if rcaText != "" {
-			enrichedContext.WriteString("\n")
-			enrichedContext.WriteString(rcaText)
-		}
-	}
-
-	// Security (M1): Scrub sensitive data from logs before sending to LLM
-	scrubber := NewLogScrubber(os.Getenv("CHATCLI_LOG_SCRUB_PATTERNS"))
-	combinedContext := scrubber.ScrubText(enrichedContext.String())
-	if len(combinedContext) > 30000 {
-		combinedContext = combinedContext[:30000] + "\n... (context truncated)"
-	}
-
-	// Read failure context from annotation (set by retry re-analysis flow)
-	var failureCtx string
-	if insight.Annotations != nil {
-		failureCtx = insight.Annotations["platform.chatcli.io/failure-context"]
-	}
-
-	// Inject candidate runbook context for AI validation (if present)
-	if insight.Annotations != nil {
-		if rbCtx := insight.Annotations["platform.chatcli.io/runbook-context"]; rbCtx != "" {
-			combinedContext = combinedContext + "\n\n--- RUNBOOK VALIDATION ---\n" + rbCtx
-			// Re-truncate if needed
-			if len(combinedContext) > 32000 {
-				combinedContext = combinedContext[:32000] + "\n... (context truncated)"
-			}
-		}
-	}
+	combinedContext, failureCtx := r.buildAnalysisContext(ctx, &insight, &issue)
 
 	// Call AnalyzeIssue RPC
 	analyzeReq := &pb.AnalyzeIssueRequest{
@@ -277,6 +160,135 @@ func (r *AIInsightReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		"model", resp.Model)
 
 	return ctrl.Result{}, nil
+}
+
+// buildAnalysisContext assembles, scrubs and bounds the enrichment context an
+// analysis call sends to the LLM, and returns the failure context of a prior
+// attempt (set by the retry re-analysis flow) alongside it.
+func (r *AIInsightReconciler) buildAnalysisContext(ctx context.Context, insight *platformv1alpha1.AIInsight, issue *platformv1alpha1.Issue) (combined, failureCtx string) {
+	// Determine incident time for contextual enrichment
+	incidentTime := issue.CreationTimestamp.Time
+	if issue.Status.DetectedAt != nil {
+		incidentTime = issue.Status.DetectedAt.Time
+	}
+
+	raw := r.gatherEnrichmentSources(ctx, insight, issue, incidentTime)
+
+	// Security (M1): Scrub sensitive data from logs before sending to LLM
+	scrubber := NewLogScrubber(os.Getenv("CHATCLI_LOG_SCRUB_PATTERNS"))
+	combined = truncateContextRuneSafe(scrubber.ScrubText(raw), 30000)
+
+	// Read failure context from annotation (set by retry re-analysis flow)
+	if insight.Annotations != nil {
+		failureCtx = insight.Annotations["platform.chatcli.io/failure-context"]
+	}
+
+	// Inject candidate runbook context for AI validation (if present)
+	if insight.Annotations != nil {
+		if rbCtx := insight.Annotations["platform.chatcli.io/runbook-context"]; rbCtx != "" {
+			combined = truncateContextRuneSafe(combined+"\n\n--- RUNBOOK VALIDATION ---\n"+rbCtx, 32000)
+		}
+	}
+	return combined, failureCtx
+}
+
+// gatherEnrichmentSources runs every wired enrichment collector — Kubernetes
+// context, log analysis, Prometheus metrics, GitOps, source-code correlation,
+// cascade analysis and RCA — appending each non-empty block and recording the
+// per-source summaries on the insight status. Every collector is optional and
+// failure-tolerant: enrichment must never block the analysis itself.
+func (r *AIInsightReconciler) gatherEnrichmentSources(ctx context.Context, insight *platformv1alpha1.AIInsight, issue *platformv1alpha1.Issue, incidentTime time.Time) string {
+	logger := log.FromContext(ctx)
+	var enrichedContext strings.Builder
+
+	if r.ContextBuilder != nil {
+		kubeCtx, ctxErr := r.ContextBuilder.BuildContext(ctx, issue.Spec.Resource)
+		if ctxErr != nil {
+			logger.Info("Failed to build K8s context, continuing without it", "error", ctxErr)
+		}
+		enrichedContext.WriteString(kubeCtx)
+	}
+
+	// Log analysis — analyzed once; the stack traces feed source correlation
+	// below (this used to run AnalyzePodLogs a second time for the same data).
+	var stackTraces []StackTrace
+	if r.LogAnalyzer != nil {
+		if logResult, err := r.LogAnalyzer.AnalyzePodLogs(ctx, issue.Spec.Resource, incidentTime); err == nil && logResult != nil {
+			if logText := logResult.FormatForAI(); logText != "" {
+				enrichedContext.WriteString("\n")
+				enrichedContext.WriteString(logText)
+			}
+			insight.Status.LogAnalysis = logResult.Summary
+			stackTraces = logResult.StackTraces
+		}
+	}
+
+	// Prometheus metrics
+	if r.MetricsCollector != nil {
+		if metricsResult, err := r.MetricsCollector.CollectIncidentMetrics(ctx, issue.Spec.Resource, incidentTime); err == nil && metricsResult != nil {
+			if metricsText := metricsResult.FormatForAI(); metricsText != "" {
+				enrichedContext.WriteString("\n")
+				enrichedContext.WriteString(metricsText)
+			}
+			insight.Status.MetricsContext = metricsResult.Summary
+		}
+	}
+
+	// GitOps context (Helm/ArgoCD/Flux)
+	if r.GitOpsDetector != nil {
+		if gitopsCtx, err := r.GitOpsDetector.DetectGitOpsContext(ctx, issue.Spec.Resource); err == nil && gitopsCtx != nil {
+			if gitopsText := gitopsCtx.FormatForAI(); gitopsText != "" {
+				enrichedContext.WriteString("\n")
+				enrichedContext.WriteString(gitopsText)
+			}
+			insight.Status.GitOpsContext = gitopsCtx.Summary
+		}
+	}
+
+	// Source code correlation
+	if r.SourceCodeAnalyzer != nil {
+		if srcCtx, err := r.SourceCodeAnalyzer.BuildSourceContext(ctx, issue.Spec.Resource, incidentTime, stackTraces); err == nil && srcCtx != nil {
+			if srcText := srcCtx.FormatForAI(); srcText != "" {
+				enrichedContext.WriteString("\n")
+				enrichedContext.WriteString(srcText)
+			}
+			insight.Status.SourceCodeContext = srcCtx.Summary
+		}
+	}
+
+	// Cascade / cross-service analysis
+	if r.CascadeAnalyzer != nil {
+		if cascadeResult, err := r.CascadeAnalyzer.AnalyzeCascade(ctx, issue); err == nil && cascadeResult != nil {
+			if cascadeText := cascadeResult.FormatForAI(); cascadeText != "" {
+				enrichedContext.WriteString("\n")
+				enrichedContext.WriteString(cascadeText)
+			}
+			insight.Status.CascadeAnalysis = cascadeResult.Summary
+		}
+	}
+
+	// RCA enrichment
+	rcaEnricher := NewRCAEnricher(r.Client)
+	if rcaCtx, err := rcaEnricher.EnrichIssueContext(ctx, issue); err == nil && rcaCtx != nil {
+		if rcaText := rcaCtx.FormatForAI(); rcaText != "" {
+			enrichedContext.WriteString("\n")
+			enrichedContext.WriteString(rcaText)
+		}
+	}
+
+	return enrichedContext.String()
+}
+
+// truncateContextRuneSafe bounds s to limit bytes, cutting on a rune boundary
+// — log content is arbitrary UTF-8 and this text goes to the LLM.
+func truncateContextRuneSafe(s string, limit int) string {
+	if len(s) <= limit {
+		return s
+	}
+	for limit > 0 && !utf8.RuneStart(s[limit]) {
+		limit--
+	}
+	return s[:limit] + "\n... (context truncated)"
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/operator/controllers/anomaly_controller_test.go
+++ b/operator/controllers/anomaly_controller_test.go
@@ -78,7 +78,7 @@ func TestAnomalyReconcile_AlreadyCorrelated(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if result.Requeue {
+	if result.RequeueAfter > 0 {
 		t.Error("expected no requeue for already correlated anomaly")
 	}
 }

--- a/operator/controllers/approval_controller.go
+++ b/operator/controllers/approval_controller.go
@@ -599,11 +599,6 @@ func severityMaxRank(sev platformv1alpha1.IssueSeverity) int {
 	}
 }
 
-// severityToRank returns the numeric rank for a given severity level (used externally).
-func severityToRank(sev platformv1alpha1.IssueSeverity) int {
-	return severityMaxRank(sev)
-}
-
 // findRemediationPlan finds the RemediationPlan associated with an ApprovalRequest.
 func (r *ApprovalReconciler) findRemediationPlan(ctx context.Context, ar *platformv1alpha1.ApprovalRequest) (*platformv1alpha1.RemediationPlan, error) {
 	if ar.Spec.RemediationPlanRef == "" {

--- a/operator/controllers/audit_recorder.go
+++ b/operator/controllers/audit_recorder.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"time"
+	"unicode/utf8"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -215,9 +216,14 @@ func randomSuffix(n int) string {
 	return string(b)
 }
 
-func truncate(s string, max int) string {
-	if len(s) <= max {
+func truncate(s string, limit int) string {
+	if len(s) <= limit {
 		return s
 	}
-	return s[:max] + "..."
+	// Cut on a rune boundary: audit detail is arbitrary UTF-8, and a mid-rune
+	// byte slice would store invalid text in the audit record.
+	for limit > 0 && !utf8.RuneStart(s[limit]) {
+		limit--
+	}
+	return s[:limit] + "..."
 }

--- a/operator/controllers/blast_radius.go
+++ b/operator/controllers/blast_radius.go
@@ -534,45 +534,49 @@ func (bp *BlastRadiusPredictor) checkQuota(ctx context.Context, res platformv1al
 		return
 	}
 
-	for _, q := range quotas.Items {
-		result := &QuotaCheckResult{
-			QuotaName: q.Name,
-		}
-
-		cpuUsed := q.Status.Used[corev1.ResourceRequestsCPU]
-		cpuHard := q.Status.Hard[corev1.ResourceRequestsCPU]
-		memUsed := q.Status.Used[corev1.ResourceRequestsMemory]
-		memHard := q.Status.Hard[corev1.ResourceRequestsMemory]
-
-		if !cpuHard.IsZero() {
-			remaining := cpuHard.DeepCopy()
-			remaining.Sub(cpuUsed)
-			result.CPURemaining = remaining.String()
-		}
-		if !memHard.IsZero() {
-			remaining := memHard.DeepCopy()
-			remaining.Sub(memUsed)
-			result.MemRemaining = remaining.String()
-		}
-
-		// Check if quota is near limit (>90% used)
-		if !cpuHard.IsZero() && cpuUsed.AsApproximateFloat64() > cpuHard.AsApproximateFloat64()*0.9 {
-			prediction.Warnings = append(prediction.Warnings,
-				fmt.Sprintf("CPU quota %s is >90%% used (used=%s hard=%s)",
-					q.Name, cpuUsed.String(), cpuHard.String()))
-		}
-		if !memHard.IsZero() && memUsed.AsApproximateFloat64() > memHard.AsApproximateFloat64()*0.9 {
-			prediction.Warnings = append(prediction.Warnings,
-				fmt.Sprintf("Memory quota %s is >90%% used (used=%s hard=%s)",
-					q.Name, memUsed.String(), memHard.String()))
-		}
-
-		result.Detail = fmt.Sprintf("Quota %s: CPU remaining=%s, Memory remaining=%s",
-			q.Name, result.CPURemaining, result.MemRemaining)
-
-		prediction.QuotaCheck = result
-		break
+	// Only the first quota informs the prediction (a namespace rarely carries
+	// more than one) — an explicit head take, where a loop with an
+	// unconditional break disguised the intent.
+	if len(quotas.Items) == 0 {
+		return
 	}
+	q := quotas.Items[0]
+	result := &QuotaCheckResult{
+		QuotaName: q.Name,
+	}
+
+	cpuUsed := q.Status.Used[corev1.ResourceRequestsCPU]
+	cpuHard := q.Status.Hard[corev1.ResourceRequestsCPU]
+	memUsed := q.Status.Used[corev1.ResourceRequestsMemory]
+	memHard := q.Status.Hard[corev1.ResourceRequestsMemory]
+
+	if !cpuHard.IsZero() {
+		remaining := cpuHard.DeepCopy()
+		remaining.Sub(cpuUsed)
+		result.CPURemaining = remaining.String()
+	}
+	if !memHard.IsZero() {
+		remaining := memHard.DeepCopy()
+		remaining.Sub(memUsed)
+		result.MemRemaining = remaining.String()
+	}
+
+	// Check if quota is near limit (>90% used)
+	if !cpuHard.IsZero() && cpuUsed.AsApproximateFloat64() > cpuHard.AsApproximateFloat64()*0.9 {
+		prediction.Warnings = append(prediction.Warnings,
+			fmt.Sprintf("CPU quota %s is >90%% used (used=%s hard=%s)",
+				q.Name, cpuUsed.String(), cpuHard.String()))
+	}
+	if !memHard.IsZero() && memUsed.AsApproximateFloat64() > memHard.AsApproximateFloat64()*0.9 {
+		prediction.Warnings = append(prediction.Warnings,
+			fmt.Sprintf("Memory quota %s is >90%% used (used=%s hard=%s)",
+				q.Name, memUsed.String(), memHard.String()))
+	}
+
+	result.Detail = fmt.Sprintf("Quota %s: CPU remaining=%s, Memory remaining=%s",
+		q.Name, result.CPURemaining, result.MemRemaining)
+
+	prediction.QuotaCheck = result
 }
 
 // findAffectedServices discovers services that depend on the resource.

--- a/operator/controllers/capacity_planner.go
+++ b/operator/controllers/capacity_planner.go
@@ -74,34 +74,7 @@ func (cp *CapacityPlanner) AnalyzeResourceTrends(ctx context.Context, resource p
 		return nil, err
 	}
 
-	if len(deploy.Spec.Template.Spec.Containers) > 0 {
-		c := deploy.Spec.Template.Spec.Containers[0]
-		if c.Resources.Limits != nil {
-			if cpu, ok := c.Resources.Limits[corev1.ResourceCPU]; ok {
-				forecast.Limits.CPUMillicores = cpu.MilliValue()
-			}
-			if mem, ok := c.Resources.Limits[corev1.ResourceMemory]; ok {
-				forecast.Limits.MemoryBytes = mem.Value()
-			}
-		}
-		// Use requests as current usage proxy
-		if c.Resources.Requests != nil {
-			if cpu, ok := c.Resources.Requests[corev1.ResourceCPU]; ok {
-				forecast.CurrentUsage.CPUMillicores = cpu.MilliValue()
-			}
-			if mem, ok := c.Resources.Requests[corev1.ResourceMemory]; ok {
-				forecast.CurrentUsage.MemoryBytes = mem.Value()
-			}
-		}
-	}
-
-	// Calculate usage percentage
-	if forecast.Limits.CPUMillicores > 0 {
-		forecast.UsagePercentage.CPU = float64(forecast.CurrentUsage.CPUMillicores) / float64(forecast.Limits.CPUMillicores) * 100
-	}
-	if forecast.Limits.MemoryBytes > 0 {
-		forecast.UsagePercentage.Memory = float64(forecast.CurrentUsage.MemoryBytes) / float64(forecast.Limits.MemoryBytes) * 100
-	}
+	fillUsageFromDeployment(forecast, &deploy)
 
 	// Query anomalies for trend analysis
 	var anomalies platformv1alpha1.AnomalyList
@@ -143,7 +116,51 @@ func (cp *CapacityPlanner) AnalyzeResourceTrends(ctx context.Context, resource p
 		forecast.Trend.Direction = "stable"
 	}
 
-	// Forecast exhaustion
+	fillExhaustionForecast(forecast)
+
+	// Recommendation
+	forecast.Forecast.Recommendation = cp.generateRecommendation(forecast)
+
+	cp.fillIncidentCorrelation(ctx, forecast, resource, cutoff)
+
+	return forecast, nil
+}
+
+// fillUsageFromDeployment extracts limits and request-based current usage from
+// the deployment's first container and derives the usage percentages.
+func fillUsageFromDeployment(forecast *CapacityForecast, deploy *appsv1.Deployment) {
+	if len(deploy.Spec.Template.Spec.Containers) > 0 {
+		c := deploy.Spec.Template.Spec.Containers[0]
+		if c.Resources.Limits != nil {
+			if cpu, ok := c.Resources.Limits[corev1.ResourceCPU]; ok {
+				forecast.Limits.CPUMillicores = cpu.MilliValue()
+			}
+			if mem, ok := c.Resources.Limits[corev1.ResourceMemory]; ok {
+				forecast.Limits.MemoryBytes = mem.Value()
+			}
+		}
+		// Use requests as current usage proxy
+		if c.Resources.Requests != nil {
+			if cpu, ok := c.Resources.Requests[corev1.ResourceCPU]; ok {
+				forecast.CurrentUsage.CPUMillicores = cpu.MilliValue()
+			}
+			if mem, ok := c.Resources.Requests[corev1.ResourceMemory]; ok {
+				forecast.CurrentUsage.MemoryBytes = mem.Value()
+			}
+		}
+	}
+
+	if forecast.Limits.CPUMillicores > 0 {
+		forecast.UsagePercentage.CPU = float64(forecast.CurrentUsage.CPUMillicores) / float64(forecast.Limits.CPUMillicores) * 100
+	}
+	if forecast.Limits.MemoryBytes > 0 {
+		forecast.UsagePercentage.Memory = float64(forecast.CurrentUsage.MemoryBytes) / float64(forecast.Limits.MemoryBytes) * 100
+	}
+}
+
+// fillExhaustionForecast projects when CPU/memory hit 100% given the current
+// usage and per-day trend, ignoring horizons beyond a year.
+func fillExhaustionForecast(forecast *CapacityForecast) {
 	now := time.Now()
 	if forecast.Trend.CPUTrendPerDay > 0 && forecast.UsagePercentage.CPU < 100 {
 		daysLeft := (100 - forecast.UsagePercentage.CPU) / forecast.Trend.CPUTrendPerDay
@@ -161,28 +178,27 @@ func (cp *CapacityPlanner) AnalyzeResourceTrends(ctx context.Context, resource p
 			forecast.Forecast.DaysUntilMemoryExhaustion = int(daysLeft)
 		}
 	}
+}
 
-	// Recommendation
-	forecast.Forecast.Recommendation = cp.generateRecommendation(forecast)
-
-	// Incident correlation
+// fillIncidentCorrelation counts window incidents and flags the resource as a
+// bottleneck when it is tied to more than two of them.
+func (cp *CapacityPlanner) fillIncidentCorrelation(ctx context.Context, forecast *CapacityForecast, resource platformv1alpha1.ResourceRef, cutoff time.Time) {
 	var issues platformv1alpha1.IssueList
-	if err := cp.client.List(ctx, &issues, client.InNamespace(resource.Namespace)); err == nil {
-		for _, iss := range issues.Items {
-			if iss.CreationTimestamp.Time.Before(cutoff) {
-				continue
-			}
-			forecast.IncidentCorrelation.IncidentsInWindow++
-			if iss.Spec.Resource.Name == resource.Name {
-				forecast.IncidentCorrelation.ResourceRelatedIncidents++
-			}
+	if err := cp.client.List(ctx, &issues, client.InNamespace(resource.Namespace)); err != nil {
+		return
+	}
+	for _, iss := range issues.Items {
+		if iss.CreationTimestamp.Time.Before(cutoff) {
+			continue
 		}
-		if forecast.IncidentCorrelation.ResourceRelatedIncidents > 2 {
-			forecast.IncidentCorrelation.ResourceIsBottleneck = true
+		forecast.IncidentCorrelation.IncidentsInWindow++
+		if iss.Spec.Resource.Name == resource.Name {
+			forecast.IncidentCorrelation.ResourceRelatedIncidents++
 		}
 	}
-
-	return forecast, nil
+	if forecast.IncidentCorrelation.ResourceRelatedIncidents > 2 {
+		forecast.IncidentCorrelation.ResourceIsBottleneck = true
+	}
 }
 
 func (cp *CapacityPlanner) generateRecommendation(f *CapacityForecast) string {

--- a/operator/controllers/cascade_analyzer.go
+++ b/operator/controllers/cascade_analyzer.go
@@ -247,7 +247,7 @@ func (ca *CascadeAnalyzer) buildCascadeChain(currentIssue *platformv1alpha1.Issu
 	}
 
 	// Build nodes from all correlated issues + current
-	var allNodes []CascadeNode
+	allNodes := make([]CascadeNode, 0, len(correlatedIssues))
 
 	for _, iss := range correlatedIssues {
 		detected := iss.CreationTimestamp.Time

--- a/operator/controllers/compliance_reporter.go
+++ b/operator/controllers/compliance_reporter.go
@@ -75,7 +75,6 @@ func (cr *ComplianceReporter) GenerateReport(ctx context.Context, namespace stri
 	start := now.Add(-window)
 	report := &ComplianceReport{Period: ReportPeriod{Start: start, End: now}}
 
-	// Issues
 	var issues platformv1alpha1.IssueList
 	opts := []client.ListOption{}
 	if namespace != "" {
@@ -85,10 +84,23 @@ func (cr *ComplianceReporter) GenerateReport(ctx context.Context, namespace stri
 		return nil, err
 	}
 
+	detectCount, resolveCount := fillIncidentMetrics(report, &issues, start)
+	if err := cr.fillRemediationMetrics(ctx, report, opts, start); err != nil {
+		return nil, err
+	}
+	cr.fillApprovalMetrics(ctx, report, opts, start)
+	fillSLAMetrics(report, &issues, start, detectCount, resolveCount)
+	cr.fillAuditSummary(ctx, report, opts, start)
+
+	return report, nil
+}
+
+// fillIncidentMetrics aggregates incident counts, MTTD and MTTR over the
+// window, returning the detect/resolve sample sizes the SLA section reuses.
+func fillIncidentMetrics(report *ComplianceReport, issues *platformv1alpha1.IssueList, start time.Time) (detectCount, resolveCount int) {
 	report.IncidentMetrics.BySeverity = make(map[string]int64)
 	report.IncidentMetrics.ByState = make(map[string]int64)
 	var totalDetectDur, totalResolveDur time.Duration
-	var detectCount, resolveCount int
 	var totalAttempts int64
 
 	for _, iss := range issues.Items {
@@ -118,11 +130,15 @@ func (cr *ComplianceReporter) GenerateReport(ctx context.Context, namespace stri
 	if report.IncidentMetrics.TotalIncidents > 0 {
 		report.IncidentMetrics.MeanRemediationAttempts = float64(totalAttempts) / float64(report.IncidentMetrics.TotalIncidents)
 	}
+	return detectCount, resolveCount
+}
 
-	// Remediations
+// fillRemediationMetrics aggregates remediation-plan outcomes and per-action
+// success/failure stats over the window.
+func (cr *ComplianceReporter) fillRemediationMetrics(ctx context.Context, report *ComplianceReport, opts []client.ListOption, start time.Time) error {
 	var plans platformv1alpha1.RemediationPlanList
 	if err := cr.client.List(ctx, &plans, opts...); err != nil {
-		return nil, err
+		return err
 	}
 
 	report.RemediationMetrics.ByActionType = make(map[string]ActionStats)
@@ -156,90 +172,99 @@ func (cr *ComplianceReporter) GenerateReport(ctx context.Context, namespace stri
 	if completed+failed > 0 {
 		report.RemediationMetrics.SuccessRate = float64(completed) / float64(completed+failed) * 100
 	}
+	return nil
+}
 
-	// Approvals
+// fillApprovalMetrics aggregates approval outcomes and mean decision time.
+// List failures leave the section empty — approvals are optional data.
+func (cr *ComplianceReporter) fillApprovalMetrics(ctx context.Context, report *ComplianceReport, opts []client.ListOption, start time.Time) {
 	var approvals platformv1alpha1.ApprovalRequestList
-	if err := cr.client.List(ctx, &approvals, opts...); err == nil {
-		var totalDecisionDur time.Duration
-		var decisionCount int
-		for _, ar := range approvals.Items {
-			if ar.CreationTimestamp.Time.Before(start) {
-				continue
-			}
-			report.ApprovalMetrics.TotalRequests++
-			switch ar.Status.State {
-			case platformv1alpha1.ApprovalStateApproved:
-				if ar.Status.AutoApproved {
-					report.ApprovalMetrics.AutoApproved++
-				} else {
-					report.ApprovalMetrics.ManualApproved++
-				}
-				if ar.Status.ApprovedAt != nil {
-					totalDecisionDur += ar.Status.ApprovedAt.Time.Sub(ar.CreationTimestamp.Time)
-					decisionCount++
-				}
-			case platformv1alpha1.ApprovalStateRejected:
-				report.ApprovalMetrics.Rejected++
-			case platformv1alpha1.ApprovalStateExpired:
-				report.ApprovalMetrics.Expired++
-			}
+	if err := cr.client.List(ctx, &approvals, opts...); err != nil {
+		return
+	}
+	var totalDecisionDur time.Duration
+	var decisionCount int
+	for _, ar := range approvals.Items {
+		if ar.CreationTimestamp.Time.Before(start) {
+			continue
 		}
-		if decisionCount > 0 {
-			report.ApprovalMetrics.AverageDecisionTime = totalDecisionDur / time.Duration(decisionCount)
+		report.ApprovalMetrics.TotalRequests++
+		switch ar.Status.State {
+		case platformv1alpha1.ApprovalStateApproved:
+			if ar.Status.AutoApproved {
+				report.ApprovalMetrics.AutoApproved++
+			} else {
+				report.ApprovalMetrics.ManualApproved++
+			}
+			if ar.Status.ApprovedAt != nil {
+				totalDecisionDur += ar.Status.ApprovedAt.Time.Sub(ar.CreationTimestamp.Time)
+				decisionCount++
+			}
+		case platformv1alpha1.ApprovalStateRejected:
+			report.ApprovalMetrics.Rejected++
+		case platformv1alpha1.ApprovalStateExpired:
+			report.ApprovalMetrics.Expired++
 		}
 	}
+	if decisionCount > 0 {
+		report.ApprovalMetrics.AverageDecisionTime = totalDecisionDur / time.Duration(decisionCount)
+	}
+}
 
-	// SLA Compliance — calculate from issues and SLA definitions
-	// CompliancePercentage = ((totalIncidents - slaViolations) / totalIncidents) * 100
+// fillSLAMetrics derives SLA compliance from the incident set:
+// CompliancePercentage = ((totalIncidents - slaViolations) / totalIncidents) * 100.
+func fillSLAMetrics(report *ComplianceReport, issues *platformv1alpha1.IssueList, start time.Time, detectCount, resolveCount int) {
 	totalIncidents := report.IncidentMetrics.TotalIncidents
-	if totalIncidents > 0 {
-		// Count SLA violations: issues that were escalated (indicates SLA breach)
-		// or have SLA-related annotations
-		var violations int64
-		for _, iss := range issues.Items {
-			if iss.CreationTimestamp.Time.Before(start) {
-				continue
-			}
-			// Escalated = SLA resolution time exceeded
-			if iss.Status.State == platformv1alpha1.IssueStateEscalated {
-				report.SLAMetrics.ResolutionSLAViolations++
-				violations++
-			}
-			// Check if response SLA was violated (DetectedAt too late)
-			if iss.Status.DetectedAt != nil {
-				detectTime := iss.Status.DetectedAt.Time.Sub(iss.CreationTimestamp.Time)
-				report.SLAMetrics.AverageResponseTime += detectTime
-			}
-			if iss.Status.ResolvedAt != nil {
-				resolveTime := iss.Status.ResolvedAt.Time.Sub(iss.CreationTimestamp.Time)
-				report.SLAMetrics.AverageResolutionTime += resolveTime
-			}
-		}
-		if detectCount > 0 {
-			report.SLAMetrics.AverageResponseTime = report.SLAMetrics.AverageResponseTime / time.Duration(detectCount)
-		}
-		if resolveCount > 0 {
-			report.SLAMetrics.AverageResolutionTime = report.SLAMetrics.AverageResolutionTime / time.Duration(resolveCount)
-		}
-		report.SLAMetrics.CompliancePercentage = float64(totalIncidents-violations) / float64(totalIncidents) * 100
-	} else {
+	if totalIncidents == 0 {
 		report.SLAMetrics.CompliancePercentage = 100 // No incidents = 100% compliance
+		return
 	}
-
-	// Audit events
-	var auditEvents platformv1alpha1.AuditEventList
-	if err := cr.client.List(ctx, &auditEvents, opts...); err == nil {
-		report.AuditSummary.BySeverity = make(map[string]int64)
-		report.AuditSummary.ByEventType = make(map[string]int64)
-		for _, ae := range auditEvents.Items {
-			if ae.CreationTimestamp.Time.Before(start) {
-				continue
-			}
-			report.AuditSummary.TotalEvents++
-			report.AuditSummary.BySeverity[ae.Spec.Severity]++
-			report.AuditSummary.ByEventType[ae.Spec.EventType]++
+	// Count SLA violations: issues that were escalated (indicates SLA breach)
+	// or have SLA-related annotations.
+	var violations int64
+	for _, iss := range issues.Items {
+		if iss.CreationTimestamp.Time.Before(start) {
+			continue
+		}
+		// Escalated = SLA resolution time exceeded
+		if iss.Status.State == platformv1alpha1.IssueStateEscalated {
+			report.SLAMetrics.ResolutionSLAViolations++
+			violations++
+		}
+		// Check if response SLA was violated (DetectedAt too late)
+		if iss.Status.DetectedAt != nil {
+			detectTime := iss.Status.DetectedAt.Time.Sub(iss.CreationTimestamp.Time)
+			report.SLAMetrics.AverageResponseTime += detectTime
+		}
+		if iss.Status.ResolvedAt != nil {
+			resolveTime := iss.Status.ResolvedAt.Time.Sub(iss.CreationTimestamp.Time)
+			report.SLAMetrics.AverageResolutionTime += resolveTime
 		}
 	}
+	if detectCount > 0 {
+		report.SLAMetrics.AverageResponseTime = report.SLAMetrics.AverageResponseTime / time.Duration(detectCount)
+	}
+	if resolveCount > 0 {
+		report.SLAMetrics.AverageResolutionTime = report.SLAMetrics.AverageResolutionTime / time.Duration(resolveCount)
+	}
+	report.SLAMetrics.CompliancePercentage = float64(totalIncidents-violations) / float64(totalIncidents) * 100
+}
 
-	return report, nil
+// fillAuditSummary aggregates audit events by severity and type. List
+// failures leave the section empty — audit data is optional.
+func (cr *ComplianceReporter) fillAuditSummary(ctx context.Context, report *ComplianceReport, opts []client.ListOption, start time.Time) {
+	var auditEvents platformv1alpha1.AuditEventList
+	if err := cr.client.List(ctx, &auditEvents, opts...); err != nil {
+		return
+	}
+	report.AuditSummary.BySeverity = make(map[string]int64)
+	report.AuditSummary.ByEventType = make(map[string]int64)
+	for _, ae := range auditEvents.Items {
+		if ae.CreationTimestamp.Time.Before(start) {
+			continue
+		}
+		report.AuditSummary.TotalEvents++
+		report.AuditSummary.BySeverity[ae.Spec.Severity]++
+		report.AuditSummary.ByEventType[ae.Spec.EventType]++
+	}
 }

--- a/operator/controllers/correlation.go
+++ b/operator/controllers/correlation.go
@@ -89,7 +89,7 @@ func (ce *CorrelationEngine) FindRelatedAnomalies(ctx context.Context, resource 
 	}
 
 	cutoff := time.Now().Add(-window)
-	var related []platformv1alpha1.Anomaly
+	related := make([]platformv1alpha1.Anomaly, 0, len(list.Items))
 	for _, a := range list.Items {
 		if a.Status.Correlated {
 			continue

--- a/operator/controllers/extracted_helpers_test.go
+++ b/operator/controllers/extracted_helpers_test.go
@@ -1,0 +1,382 @@
+/*
+ * ChatCLI Operator - tests for the phase/section helpers extracted by the
+ * gocyclo decomposition (PR: lint baseline zero). Each helper is a pure (or
+ * nearly pure) function encoding report/forecast/formatting business logic
+ * that previously lived untested inside oversized functions.
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package controllers
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	platformv1alpha1 "github.com/diillson/chatcli/operator/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// --- compliance_reporter helpers ---
+
+func mkIssue(created time.Time, sev platformv1alpha1.IssueSeverity, state platformv1alpha1.IssueState, detectedAfter, resolvedAfter time.Duration, attempts int32) platformv1alpha1.Issue {
+	iss := platformv1alpha1.Issue{
+		ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(created)},
+		Spec:       platformv1alpha1.IssueSpec{Severity: sev},
+		Status:     platformv1alpha1.IssueStatus{State: state, RemediationAttempts: attempts},
+	}
+	if detectedAfter > 0 {
+		d := metav1.NewTime(created.Add(detectedAfter))
+		iss.Status.DetectedAt = &d
+	}
+	if resolvedAfter > 0 {
+		r := metav1.NewTime(created.Add(resolvedAfter))
+		iss.Status.ResolvedAt = &r
+	}
+	return iss
+}
+
+func TestFillIncidentMetrics(t *testing.T) {
+	now := time.Now()
+	start := now.Add(-24 * time.Hour)
+	issues := &platformv1alpha1.IssueList{Items: []platformv1alpha1.Issue{
+		// In window: detected in 2m, resolved 10m after detection, 2 attempts.
+		mkIssue(now.Add(-2*time.Hour), platformv1alpha1.IssueSeverityHigh, platformv1alpha1.IssueStateResolved, 2*time.Minute, 12*time.Minute, 2),
+		// In window: detected in 4m, never resolved, 1 attempt.
+		mkIssue(now.Add(-1*time.Hour), platformv1alpha1.IssueSeverityLow, platformv1alpha1.IssueStateRemediating, 4*time.Minute, 0, 1),
+		// Out of window: must be ignored entirely.
+		mkIssue(now.Add(-48*time.Hour), platformv1alpha1.IssueSeverityHigh, platformv1alpha1.IssueStateResolved, time.Minute, 2*time.Minute, 5),
+	}}
+
+	report := &ComplianceReport{}
+	detectCount, resolveCount := fillIncidentMetrics(report, issues, start)
+
+	if report.IncidentMetrics.TotalIncidents != 2 {
+		t.Fatalf("TotalIncidents = %d, want 2 (window filter)", report.IncidentMetrics.TotalIncidents)
+	}
+	if detectCount != 2 || resolveCount != 1 {
+		t.Fatalf("counts = (%d, %d), want (2, 1)", detectCount, resolveCount)
+	}
+	if got := report.IncidentMetrics.MTTD; got != 3*time.Minute {
+		t.Fatalf("MTTD = %v, want 3m (mean of 2m and 4m)", got)
+	}
+	if got := report.IncidentMetrics.MTTR; got != 10*time.Minute {
+		t.Fatalf("MTTR = %v, want 10m (resolution minus detection)", got)
+	}
+	if got := report.IncidentMetrics.MeanRemediationAttempts; got != 1.5 {
+		t.Fatalf("MeanRemediationAttempts = %v, want 1.5", got)
+	}
+	if report.IncidentMetrics.BySeverity[string(platformv1alpha1.IssueSeverityHigh)] != 1 {
+		t.Fatalf("BySeverity[high] = %d, want 1", report.IncidentMetrics.BySeverity[string(platformv1alpha1.IssueSeverityHigh)])
+	}
+}
+
+func TestFillSLAMetricsNoIncidentsIsFullCompliance(t *testing.T) {
+	report := &ComplianceReport{}
+	fillSLAMetrics(report, &platformv1alpha1.IssueList{}, time.Now().Add(-time.Hour), 0, 0)
+	if report.SLAMetrics.CompliancePercentage != 100 {
+		t.Fatalf("CompliancePercentage = %v, want 100 for zero incidents", report.SLAMetrics.CompliancePercentage)
+	}
+}
+
+func TestFillSLAMetricsCountsEscalationsAsViolations(t *testing.T) {
+	now := time.Now()
+	start := now.Add(-24 * time.Hour)
+	issues := &platformv1alpha1.IssueList{Items: []platformv1alpha1.Issue{
+		mkIssue(now.Add(-2*time.Hour), platformv1alpha1.IssueSeverityHigh, platformv1alpha1.IssueStateEscalated, 2*time.Minute, 0, 1),
+		mkIssue(now.Add(-1*time.Hour), platformv1alpha1.IssueSeverityLow, platformv1alpha1.IssueStateResolved, 4*time.Minute, 20*time.Minute, 1),
+	}}
+	report := &ComplianceReport{}
+	detectCount, resolveCount := fillIncidentMetrics(report, issues, start)
+	fillSLAMetrics(report, issues, start, detectCount, resolveCount)
+
+	if report.SLAMetrics.ResolutionSLAViolations != 1 {
+		t.Fatalf("ResolutionSLAViolations = %d, want 1 (the escalated issue)", report.SLAMetrics.ResolutionSLAViolations)
+	}
+	if report.SLAMetrics.CompliancePercentage != 50 {
+		t.Fatalf("CompliancePercentage = %v, want 50 (1 violation / 2 incidents)", report.SLAMetrics.CompliancePercentage)
+	}
+}
+
+// --- capacity_planner helpers ---
+
+func TestFillUsageFromDeployment(t *testing.T) {
+	deploy := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("512Mi"),
+					},
+				},
+			}},
+		}}},
+	}
+	forecast := &CapacityForecast{}
+	fillUsageFromDeployment(forecast, deploy)
+
+	if forecast.Limits.CPUMillicores != 2000 {
+		t.Fatalf("Limits.CPUMillicores = %d, want 2000", forecast.Limits.CPUMillicores)
+	}
+	if forecast.UsagePercentage.CPU != 25 {
+		t.Fatalf("UsagePercentage.CPU = %v, want 25 (500m of 2)", forecast.UsagePercentage.CPU)
+	}
+	if forecast.UsagePercentage.Memory != 50 {
+		t.Fatalf("UsagePercentage.Memory = %v, want 50 (512Mi of 1Gi)", forecast.UsagePercentage.Memory)
+	}
+}
+
+func TestFillExhaustionForecast(t *testing.T) {
+	forecast := &CapacityForecast{}
+	forecast.UsagePercentage.CPU = 80
+	forecast.Trend.CPUTrendPerDay = 5 // +5%/day → 4 days to 100%
+	forecast.UsagePercentage.Memory = 90
+	forecast.Trend.MemoryTrendPerDay = -1 // decreasing → no exhaustion
+
+	fillExhaustionForecast(forecast)
+
+	if forecast.Forecast.DaysUntilCPUExhaustion != 4 {
+		t.Fatalf("DaysUntilCPUExhaustion = %d, want 4", forecast.Forecast.DaysUntilCPUExhaustion)
+	}
+	if forecast.Forecast.CPUExhaustionDate == nil {
+		t.Fatal("CPUExhaustionDate not set")
+	}
+	if forecast.Forecast.MemoryExhaustionDate != nil {
+		t.Fatal("decreasing memory trend must not forecast exhaustion")
+	}
+}
+
+func TestFillExhaustionForecastIgnoresBeyondOneYear(t *testing.T) {
+	forecast := &CapacityForecast{}
+	forecast.UsagePercentage.CPU = 10
+	forecast.Trend.CPUTrendPerDay = 0.01 // 9000 days → ignored
+	fillExhaustionForecast(forecast)
+	if forecast.Forecast.CPUExhaustionDate != nil {
+		t.Fatal("horizons beyond a year must be ignored")
+	}
+}
+
+// --- rune-safe truncation helpers ---
+
+func TestTruncateContextRuneSafe(t *testing.T) {
+	if got := truncateContextRuneSafe("short", 100); got != "short" {
+		t.Fatalf("under-limit content must pass through, got %q", got)
+	}
+	// 1 ASCII byte + 3-byte runes: the limit lands mid-rune.
+	s := "a" + strings.Repeat("→", 200)
+	got := truncateContextRuneSafe(s, 300)
+	if !utf8.ValidString(got) {
+		t.Fatal("truncation produced invalid UTF-8")
+	}
+	if !strings.HasSuffix(got, "(context truncated)") {
+		t.Fatalf("missing truncation marker: %q", got[len(got)-30:])
+	}
+}
+
+func TestAuditTruncateRuneSafe(t *testing.T) {
+	s := "x" + strings.Repeat("ç", 100)
+	got := truncate(s, 51) // mid-rune position for 2-byte runes offset by 1
+	if !utf8.ValidString(got) {
+		t.Fatal("audit truncate produced invalid UTF-8")
+	}
+	if got := truncate("ok", 10); got != "ok" {
+		t.Fatalf("under-limit input must pass through, got %q", got)
+	}
+}
+
+// --- log_analyzer section writers (exercised through FormatForAI) ---
+
+func TestFormatForAIRendersAllSections(t *testing.T) {
+	r := &LogAnalysisResult{
+		StackTraces: []StackTrace{{
+			Language: "go", ExceptionType: "panic", Message: "nil deref",
+			PodName: "api-0", ContainerName: "api", OccurrenceCount: 3,
+			Frames: []string{"main.go:10", "svc.go:22"},
+		}},
+		ErrorPatterns: []ErrorPattern{{
+			Severity: "error", Category: "db", SampleLines: []string{"conn refused"}, Count: 7,
+		}},
+		StructuredErrors: []StructuredLogEntry{{
+			Level: "error", Message: "query failed", Error: "timeout", Logger: "repo",
+		}},
+		CriticalLines: []CriticalLogLine{{
+			PodName: "api-0", ContainerName: "api",
+			LinesBefore: []string{"before"}, Line: "FATAL boom", LinesAfter: []string{"after"},
+		}},
+		InitContainerLogs: []ContainerLogSummary{{
+			PodName: "api-0", ContainerName: "init-db", ErrorCount: 1, KeyFindings: []string{"migration failed"},
+		}},
+		SidecarLogs: []ContainerLogSummary{{
+			PodName: "api-0", ContainerName: "envoy", ErrorCount: 2, KeyFindings: []string{"upstream timeout"},
+		}},
+	}
+	out := r.FormatForAI()
+
+	for _, want := range []string{
+		"Stack Traces Found", "panic", "main.go:10",
+		"Error Patterns Detected", "conn refused",
+		"Structured Log Errors", "query failed",
+		"Critical Log Lines", "FATAL boom",
+		"Init Container Findings", "migration failed",
+		"Sidecar api-0/envoy", "upstream timeout",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("FormatForAI missing %q in output", want)
+		}
+	}
+	if (&LogAnalysisResult{}).FormatForAI() == "" {
+		t.Fatal("empty result should still render the header")
+	}
+	var nilResult *LogAnalysisResult
+	if nilResult.FormatForAI() != "" {
+		t.Fatal("nil result must render empty")
+	}
+}
+
+func TestFormatForAITruncatesOnRuneBoundary(t *testing.T) {
+	frames := make([]string, 0, 10)
+	for i := 0; i < 10; i++ {
+		frames = append(frames, strings.Repeat("ção", 40))
+	}
+	r := &LogAnalysisResult{}
+	for i := 0; i < 30; i++ {
+		r.StackTraces = append(r.StackTraces, StackTrace{
+			Language: "go", ExceptionType: "erro", Message: strings.Repeat("çã", 60),
+			Frames: frames,
+		})
+	}
+	out := r.FormatForAI()
+	if len(out) > 6000+len("...") {
+		t.Fatalf("FormatForAI exceeded budget: %d bytes", len(out))
+	}
+	if !utf8.ValidString(out) {
+		t.Fatal("FormatForAI truncation produced invalid UTF-8")
+	}
+}
+
+// --- resources: buildInstanceVolumes (exercised through buildPodSpec) ---
+
+func TestBuildPodSpecAssemblesFeatureVolumes(t *testing.T) {
+	r := &InstanceReconciler{}
+	enabled := true
+	pvcPlugins := "plugins-pvc"
+	agentsCM := "agents-cm"
+	skillsCM := "skills-cm"
+	instance := &platformv1alpha1.Instance{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo"},
+		Spec: platformv1alpha1.InstanceSpec{
+			Persistence: &platformv1alpha1.PersistenceSpec{Enabled: enabled},
+			Server: platformv1alpha1.ServerSpec{
+				TLS: &platformv1alpha1.TLSSpec{Enabled: true, SecretName: "demo-tls"},
+			},
+			Agents:  &platformv1alpha1.AgentProvisionSpec{ConfigMapRef: &agentsCM, SkillsConfigMapRef: &skillsCM},
+			MCP:     &platformv1alpha1.MCPSpec{Enabled: true},
+			Plugins: &platformv1alpha1.PluginProvisionSpec{PVCName: pvcPlugins},
+		},
+	}
+
+	spec := r.buildPodSpec(instance)
+	if len(spec.Containers) != 1 {
+		t.Fatalf("containers = %d, want 1", len(spec.Containers))
+	}
+
+	wantVolumes := []string{"tmp", "data", "sessions", "tls", "agents", "skills", "mcp-config", "plugins"}
+	names := map[string]bool{}
+	for _, v := range spec.Volumes {
+		names[v.Name] = true
+	}
+	for _, w := range wantVolumes {
+		if !names[w] {
+			t.Fatalf("volume %q missing (got %v)", w, names)
+		}
+	}
+	mounts := map[string]bool{}
+	for _, m := range spec.Containers[0].VolumeMounts {
+		mounts[m.Name] = true
+	}
+	for _, w := range wantVolumes {
+		if !mounts[w] {
+			t.Fatalf("volume mount %q missing", w)
+		}
+	}
+	if spec.SecurityContext == nil || spec.SecurityContext.RunAsNonRoot == nil || !*spec.SecurityContext.RunAsNonRoot {
+		t.Fatal("default pod security context must enforce runAsNonRoot")
+	}
+}
+
+func TestBuildPodSpecPluginInitContainer(t *testing.T) {
+	r := &InstanceReconciler{}
+	instance := &platformv1alpha1.Instance{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo"},
+		Spec: platformv1alpha1.InstanceSpec{
+			Plugins: &platformv1alpha1.PluginProvisionSpec{Image: "ghcr.io/x/plugins:v1"},
+		},
+	}
+	spec := r.buildPodSpec(instance)
+	if len(spec.InitContainers) != 1 || spec.InitContainers[0].Name != "plugin-loader" {
+		t.Fatalf("expected plugin-loader init container, got %+v", spec.InitContainers)
+	}
+}
+
+// --- blast_radius: checkQuota (the SA4004 loop→head-take rewrite) ---
+
+func TestCheckQuotaUsesFirstQuotaAndWarnsNearLimit(t *testing.T) {
+	quota := &corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: "team-quota", Namespace: "prod"},
+		Status: corev1.ResourceQuotaStatus{
+			Hard: corev1.ResourceList{
+				corev1.ResourceRequestsCPU:    resource.MustParse("10"),
+				corev1.ResourceRequestsMemory: resource.MustParse("10Gi"),
+			},
+			Used: corev1.ResourceList{
+				corev1.ResourceRequestsCPU:    resource.MustParse("9500m"), // >90%
+				corev1.ResourceRequestsMemory: resource.MustParse("4Gi"),   // <90%
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(quota).Build()
+	bp := NewBlastRadiusPredictor(c)
+
+	prediction := &BlastRadiusPrediction{}
+	bp.checkQuota(context.Background(), platformv1alpha1.ResourceRef{Namespace: "prod", Name: "api", Kind: "Deployment"}, prediction)
+
+	if prediction.QuotaCheck == nil || prediction.QuotaCheck.QuotaName != "team-quota" {
+		t.Fatalf("QuotaCheck = %+v, want the first quota", prediction.QuotaCheck)
+	}
+	if prediction.QuotaCheck.CPURemaining != "500m" {
+		t.Fatalf("CPURemaining = %q, want 500m", prediction.QuotaCheck.CPURemaining)
+	}
+	warned := false
+	for _, w := range prediction.Warnings {
+		if strings.Contains(w, "CPU quota team-quota is >90%") {
+			warned = true
+		}
+		if strings.Contains(w, "Memory quota") {
+			t.Fatalf("memory under 90%% must not warn: %v", prediction.Warnings)
+		}
+	}
+	if !warned {
+		t.Fatalf("expected CPU >90%% warning, got %v", prediction.Warnings)
+	}
+}
+
+func TestCheckQuotaNoQuotasIsNoOp(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(newScheme()).Build()
+	bp := NewBlastRadiusPredictor(c)
+	prediction := &BlastRadiusPrediction{}
+	bp.checkQuota(context.Background(), platformv1alpha1.ResourceRef{Namespace: "prod", Name: "api"}, prediction)
+	if prediction.QuotaCheck != nil {
+		t.Fatal("no quotas in namespace must leave QuotaCheck nil")
+	}
+}

--- a/operator/controllers/gitops_detector.go
+++ b/operator/controllers/gitops_detector.go
@@ -124,7 +124,7 @@ func (g *GitOpsDetector) detectHelmRelease(ctx context.Context, resource platfor
 	}
 
 	// Find secrets matching the resource name
-	var candidates []releaseEntry
+	candidates := make([]releaseEntry, 0, len(secrets.Items))
 	for i := range secrets.Items {
 		s := &secrets.Items[i]
 		releaseName := s.Labels["name"]

--- a/operator/controllers/instance_controller_test.go
+++ b/operator/controllers/instance_controller_test.go
@@ -293,7 +293,7 @@ func TestReconcile_NotFound(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if result.Requeue {
+	if result.RequeueAfter > 0 {
 		t.Error("expected no requeue")
 	}
 }

--- a/operator/controllers/issue_controller.go
+++ b/operator/controllers/issue_controller.go
@@ -624,7 +624,7 @@ func (r *IssueReconciler) createRemediationPlan(ctx context.Context, issue *plat
 	planName := fmt.Sprintf("%s-plan-%d", issue.Name, attempt)
 
 	// Build actions from runbook steps — use mapActionType for consistent mapping
-	var actions []platformv1alpha1.RemediationAction
+	actions := make([]platformv1alpha1.RemediationAction, 0, len(runbook.Spec.Steps))
 	for _, step := range runbook.Spec.Steps {
 		actionType := mapActionType(step.Action)
 		actions = append(actions, platformv1alpha1.RemediationAction{
@@ -682,15 +682,10 @@ func (r *IssueReconciler) generateRunbookFromAI(ctx context.Context, issue *plat
 	rbName := sanitizeRunbookName(fmt.Sprintf("auto-%s-%s-%s-%s",
 		signalType, issue.Spec.Severity, strings.ToLower(issue.Spec.Resource.Kind), analysisHash))
 
-	// Convert AI suggested actions to runbook steps
-	var steps []platformv1alpha1.RunbookStep
+	// Convert AI suggested actions to runbook steps (field-identical types).
+	steps := make([]platformv1alpha1.RunbookStep, 0, len(insight.Status.SuggestedActions))
 	for _, sa := range insight.Status.SuggestedActions {
-		steps = append(steps, platformv1alpha1.RunbookStep{
-			Name:        sa.Name,
-			Action:      sa.Action,
-			Description: sa.Description,
-			Params:      sa.Params,
-		})
+		steps = append(steps, platformv1alpha1.RunbookStep(sa))
 	}
 
 	// Build full description from AI analysis (no truncation)
@@ -1694,7 +1689,7 @@ func (r *IssueReconciler) generateAgenticRunbook(ctx context.Context, issue *pla
 	rbName := sanitizeRunbookName(fmt.Sprintf("agentic-%s-%s-%s",
 		signalType, issue.Spec.Severity, strings.ToLower(issue.Spec.Resource.Kind)))
 
-	var steps []platformv1alpha1.RunbookStep
+	steps := make([]platformv1alpha1.RunbookStep, 0, len(plan.Spec.AgenticHistory))
 	for _, step := range plan.Spec.AgenticHistory {
 		if step.Action == nil || strings.HasPrefix(step.Observation, "FAILED:") {
 			continue
@@ -1752,7 +1747,7 @@ func (r *IssueReconciler) buildTrendingInfo(ctx context.Context, issue *platform
 	windowDays := int32(30)
 	cutoff := time.Now().AddDate(0, 0, -int(windowDays))
 
-	var related []string
+	related := make([]string, 0, len(pms.Items))
 	for _, pm := range pms.Items {
 		if pm.Spec.Resource.Name != issue.Spec.Resource.Name {
 			continue

--- a/operator/controllers/issue_controller_test.go
+++ b/operator/controllers/issue_controller_test.go
@@ -88,7 +88,7 @@ func TestIssueReconcile_NotFound(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if result.Requeue {
+	if result.RequeueAfter > 0 {
 		t.Error("expected no requeue")
 	}
 }
@@ -473,9 +473,10 @@ func TestIssueReconcile_AnalyzingToRemediatingFromAI(t *testing.T) {
 		t.Error("expected non-empty strategy")
 	}
 	if len(plan.Spec.Strategy) > 0 && len(plan.Spec.Strategy) <= 256 {
-		// Strategy should contain the full AI analysis, not be truncated
+		// A short strategy must at least reference the auto-generated runbook —
+		// this branch used to be empty, silently asserting nothing.
 		if !strings.Contains(plan.Spec.Strategy, "auto-") {
-			// It should reference the auto-generated runbook
+			t.Errorf("expected short strategy to reference the auto-generated runbook, got %q", plan.Spec.Strategy)
 		}
 	}
 

--- a/operator/controllers/log_analyzer.go
+++ b/operator/controllers/log_analyzer.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -579,7 +580,7 @@ func detectErrorPatterns(lines []string) []ErrorPattern {
 		}
 	}
 
-	var patterns []ErrorPattern
+	patterns := make([]ErrorPattern, 0, len(patternCounts))
 	for _, p := range patternCounts {
 		patterns = append(patterns, *p)
 	}
@@ -598,7 +599,7 @@ func detectErrorPatterns(lines []string) []ErrorPattern {
 
 // parseStructuredLogs extracts error-level entries from JSON-formatted logs.
 func parseStructuredLogs(lines []string) []StructuredLogEntry {
-	var entries []StructuredLogEntry
+	entries := make([]StructuredLogEntry, 0, len(lines))
 
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
@@ -683,7 +684,7 @@ func parseStructuredLogs(lines []string) []StructuredLogEntry {
 
 // extractCriticalLines extracts FATAL/PANIC/ERROR lines with surrounding context.
 func extractCriticalLines(lines []string, podName, containerName string) []CriticalLogLine {
-	var critical []CriticalLogLine
+	critical := make([]CriticalLogLine, 0, len(lines))
 	critRegex := regexp.MustCompile(`(?i)\b(FATAL|PANIC|CRITICAL)\b`)
 
 	for i, line := range lines {
@@ -799,7 +800,9 @@ func aggregateErrorPatterns(patterns []ErrorPattern) []ErrorPattern {
 	return result
 }
 
-// FormatForAI formats the log analysis result as a text block suitable for LLM context.
+// FormatForAI formats the log analysis result as a text block suitable for
+// LLM context. Each section renders through its own writer, ordered by
+// diagnostic value (stack traces first).
 func (r *LogAnalysisResult) FormatForAI() string {
 	if r == nil {
 		return ""
@@ -807,117 +810,147 @@ func (r *LogAnalysisResult) FormatForAI() string {
 
 	var sb strings.Builder
 	sb.WriteString("## Application Log Analysis\n\n")
-
-	// Stack traces (most valuable for root cause)
-	if len(r.StackTraces) > 0 {
-		sb.WriteString("### Stack Traces Found\n")
-		for i, t := range r.StackTraces {
-			if i >= 5 {
-				sb.WriteString(fmt.Sprintf("... and %d more stack traces\n", len(r.StackTraces)-5))
-				break
-			}
-			sb.WriteString(fmt.Sprintf("\n**[%s] %s: %s** (pod=%s, container=%s, occurrences=%d)\n",
-				t.Language, t.ExceptionType, t.Message, t.PodName, t.ContainerName, t.OccurrenceCount))
-			// Show top 10 frames
-			maxFrames := 10
-			if len(t.Frames) < maxFrames {
-				maxFrames = len(t.Frames)
-			}
-			for _, f := range t.Frames[:maxFrames] {
-				sb.WriteString(fmt.Sprintf("  %s\n", f))
-			}
-			if len(t.Frames) > 10 {
-				sb.WriteString(fmt.Sprintf("  ... %d more frames\n", len(t.Frames)-10))
-			}
-		}
-		sb.WriteString("\n")
-	}
-
-	// Error patterns
-	if len(r.ErrorPatterns) > 0 {
-		sb.WriteString("### Error Patterns Detected\n")
-		for i, p := range r.ErrorPatterns {
-			if i >= 10 {
-				break
-			}
-			sb.WriteString(fmt.Sprintf("- [%s/%s] %s (count=%d)\n",
-				p.Severity, p.Category, p.SampleLines[0], p.Count))
-		}
-		sb.WriteString("\n")
-	}
-
-	// Structured log errors
-	if len(r.StructuredErrors) > 0 {
-		sb.WriteString("### Structured Log Errors\n")
-		for i, e := range r.StructuredErrors {
-			if i >= 10 {
-				break
-			}
-			sb.WriteString(fmt.Sprintf("- [%s] %s", e.Level, e.Message))
-			if e.Error != "" {
-				sb.WriteString(fmt.Sprintf(" error=%s", truncateLine(e.Error, 150)))
-			}
-			if e.Logger != "" {
-				sb.WriteString(fmt.Sprintf(" logger=%s", e.Logger))
-			}
-			sb.WriteString("\n")
-		}
-		sb.WriteString("\n")
-	}
-
-	// Critical lines
-	if len(r.CriticalLines) > 0 {
-		sb.WriteString("### Critical Log Lines\n")
-		for i, cl := range r.CriticalLines {
-			if i >= 5 {
-				break
-			}
-			sb.WriteString(fmt.Sprintf("Pod=%s Container=%s:\n", cl.PodName, cl.ContainerName))
-			for _, b := range cl.LinesBefore {
-				sb.WriteString(fmt.Sprintf("    %s\n", b))
-			}
-			sb.WriteString(fmt.Sprintf(" >> %s\n", cl.Line))
-			for _, a := range cl.LinesAfter {
-				sb.WriteString(fmt.Sprintf("    %s\n", a))
-			}
-			sb.WriteString("\n")
-		}
-	}
-
-	// Init container findings
-	if len(r.InitContainerLogs) > 0 {
-		sb.WriteString("### Init Container Findings\n")
-		for _, s := range r.InitContainerLogs {
-			if s.ErrorCount > 0 || len(s.KeyFindings) > 0 {
-				sb.WriteString(fmt.Sprintf("- %s/%s: errors=%d warnings=%d\n",
-					s.PodName, s.ContainerName, s.ErrorCount, s.WarnCount))
-				for _, f := range s.KeyFindings {
-					sb.WriteString(fmt.Sprintf("  - %s\n", f))
-				}
-			}
-		}
-		sb.WriteString("\n")
-	}
-
-	// Sidecar findings
-	if len(r.SidecarLogs) > 0 {
-		for _, s := range r.SidecarLogs {
-			if s.ErrorCount > 0 {
-				sb.WriteString(fmt.Sprintf("### Sidecar %s/%s: errors=%d\n",
-					s.PodName, s.ContainerName, s.ErrorCount))
-				for _, f := range s.KeyFindings {
-					sb.WriteString(fmt.Sprintf("- %s\n", f))
-				}
-			}
-		}
-		sb.WriteString("\n")
-	}
+	r.writeStackTraces(&sb)
+	r.writeErrorPatterns(&sb)
+	r.writeStructuredErrors(&sb)
+	r.writeCriticalLines(&sb)
+	r.writeInitContainerFindings(&sb)
+	r.writeSidecarFindings(&sb)
 
 	result := sb.String()
 	if len(result) > 6000 {
-		result = result[:5997] + "..."
+		// Cut on a rune boundary: log content is arbitrary UTF-8 and this
+		// text is injected into the LLM context.
+		cut := 5997
+		for cut > 0 && !utf8.RuneStart(result[cut]) {
+			cut--
+		}
+		result = result[:cut] + "..."
 	}
 	return result
+}
+
+// writeStackTraces renders the stack-trace section (most valuable for root cause).
+func (r *LogAnalysisResult) writeStackTraces(sb *strings.Builder) {
+	if len(r.StackTraces) == 0 {
+		return
+	}
+	sb.WriteString("### Stack Traces Found\n")
+	for i, t := range r.StackTraces {
+		if i >= 5 {
+			sb.WriteString(fmt.Sprintf("... and %d more stack traces\n", len(r.StackTraces)-5))
+			break
+		}
+		sb.WriteString(fmt.Sprintf("\n**[%s] %s: %s** (pod=%s, container=%s, occurrences=%d)\n",
+			t.Language, t.ExceptionType, t.Message, t.PodName, t.ContainerName, t.OccurrenceCount))
+		// Show top 10 frames
+		maxFrames := 10
+		if len(t.Frames) < maxFrames {
+			maxFrames = len(t.Frames)
+		}
+		for _, f := range t.Frames[:maxFrames] {
+			sb.WriteString(fmt.Sprintf("  %s\n", f))
+		}
+		if len(t.Frames) > 10 {
+			sb.WriteString(fmt.Sprintf("  ... %d more frames\n", len(t.Frames)-10))
+		}
+	}
+	sb.WriteString("\n")
+}
+
+// writeErrorPatterns renders the detected error-pattern section.
+func (r *LogAnalysisResult) writeErrorPatterns(sb *strings.Builder) {
+	if len(r.ErrorPatterns) == 0 {
+		return
+	}
+	sb.WriteString("### Error Patterns Detected\n")
+	for i, p := range r.ErrorPatterns {
+		if i >= 10 {
+			break
+		}
+		sb.WriteString(fmt.Sprintf("- [%s/%s] %s (count=%d)\n",
+			p.Severity, p.Category, p.SampleLines[0], p.Count))
+	}
+	sb.WriteString("\n")
+}
+
+// writeStructuredErrors renders the structured-log-error section.
+func (r *LogAnalysisResult) writeStructuredErrors(sb *strings.Builder) {
+	if len(r.StructuredErrors) == 0 {
+		return
+	}
+	sb.WriteString("### Structured Log Errors\n")
+	for i, e := range r.StructuredErrors {
+		if i >= 10 {
+			break
+		}
+		sb.WriteString(fmt.Sprintf("- [%s] %s", e.Level, e.Message))
+		if e.Error != "" {
+			sb.WriteString(fmt.Sprintf(" error=%s", truncateLine(e.Error, 150)))
+		}
+		if e.Logger != "" {
+			sb.WriteString(fmt.Sprintf(" logger=%s", e.Logger))
+		}
+		sb.WriteString("\n")
+	}
+	sb.WriteString("\n")
+}
+
+// writeCriticalLines renders critical lines with their surrounding context.
+func (r *LogAnalysisResult) writeCriticalLines(sb *strings.Builder) {
+	if len(r.CriticalLines) == 0 {
+		return
+	}
+	sb.WriteString("### Critical Log Lines\n")
+	for i, cl := range r.CriticalLines {
+		if i >= 5 {
+			break
+		}
+		sb.WriteString(fmt.Sprintf("Pod=%s Container=%s:\n", cl.PodName, cl.ContainerName))
+		for _, b := range cl.LinesBefore {
+			sb.WriteString(fmt.Sprintf("    %s\n", b))
+		}
+		sb.WriteString(fmt.Sprintf(" >> %s\n", cl.Line))
+		for _, a := range cl.LinesAfter {
+			sb.WriteString(fmt.Sprintf("    %s\n", a))
+		}
+		sb.WriteString("\n")
+	}
+}
+
+// writeInitContainerFindings renders init-container findings.
+func (r *LogAnalysisResult) writeInitContainerFindings(sb *strings.Builder) {
+	if len(r.InitContainerLogs) == 0 {
+		return
+	}
+	sb.WriteString("### Init Container Findings\n")
+	for _, s := range r.InitContainerLogs {
+		if s.ErrorCount > 0 || len(s.KeyFindings) > 0 {
+			sb.WriteString(fmt.Sprintf("- %s/%s: errors=%d warnings=%d\n",
+				s.PodName, s.ContainerName, s.ErrorCount, s.WarnCount))
+			for _, f := range s.KeyFindings {
+				sb.WriteString(fmt.Sprintf("  - %s\n", f))
+			}
+		}
+	}
+	sb.WriteString("\n")
+}
+
+// writeSidecarFindings renders sidecar findings (only containers with errors).
+func (r *LogAnalysisResult) writeSidecarFindings(sb *strings.Builder) {
+	if len(r.SidecarLogs) == 0 {
+		return
+	}
+	for _, s := range r.SidecarLogs {
+		if s.ErrorCount > 0 {
+			sb.WriteString(fmt.Sprintf("### Sidecar %s/%s: errors=%d\n",
+				s.PodName, s.ContainerName, s.ErrorCount))
+			for _, f := range s.KeyFindings {
+				sb.WriteString(fmt.Sprintf("- %s\n", f))
+			}
+		}
+	}
+	sb.WriteString("\n")
 }
 
 // isResourcePod checks if a pod belongs to the given resource (Deployment, StatefulSet, DaemonSet, Job).

--- a/operator/controllers/metrics_collector.go
+++ b/operator/controllers/metrics_collector.go
@@ -394,7 +394,7 @@ func (mc *MetricsCollector) buildMetricsSummary(snapshot *MetricsSnapshot) strin
 		return ""
 	}
 
-	var parts []string
+	parts := make([]string, 0, len(snapshot.Trends))
 
 	for _, t := range snapshot.Trends {
 		parts = append(parts, fmt.Sprintf("%s: %s (%.1f%% change, before=%.4f, during=%.4f, after=%.4f) [%s]",

--- a/operator/controllers/notification_controller.go
+++ b/operator/controllers/notification_controller.go
@@ -421,8 +421,8 @@ func (r *NotificationReconciler) buildMessage(issue *platformv1alpha1.Issue, pol
 		"SignalType": issue.Spec.SignalType,
 		"RiskScore":  fmt.Sprintf("%d", issue.Spec.RiskScore),
 	}
-	if issue.Spec.CorrelationId != "" {
-		fields["CorrelationID"] = issue.Spec.CorrelationId
+	if issue.Spec.CorrelationID != "" {
+		fields["CorrelationID"] = issue.Spec.CorrelationID
 	}
 	if issue.Status.RemediationAttempts > 0 {
 		fields["RemediationAttempts"] = fmt.Sprintf("%d/%d",

--- a/operator/controllers/postmortem_controller_test.go
+++ b/operator/controllers/postmortem_controller_test.go
@@ -82,7 +82,7 @@ func TestPostMortem_TerminalClosed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconcile failed: %v", err)
 	}
-	if result.Requeue || result.RequeueAfter > 0 {
+	if result.RequeueAfter > 0 {
 		t.Error("expected no requeue for terminal state")
 	}
 

--- a/operator/controllers/remediation_actions_extended.go
+++ b/operator/controllers/remediation_actions_extended.go
@@ -502,12 +502,10 @@ func (r *RemediationReconciler) executeResizePVC(ctx context.Context, resource p
 		return fmt.Errorf("new size (%s) must be larger than current size (%s)", newSize, currentSize.String())
 	}
 
-	// Check if storage class supports expansion
-	if pvc.Spec.StorageClassName != nil {
-		// The CSI driver and StorageClass must support expansion,
-		// but we can't easily check this at runtime without the StorageClass API.
-		// The API server will reject the request if expansion is not supported.
-	}
+	// Storage-class expansion support is not checked here: the CSI driver and
+	// StorageClass must support it, but that cannot be verified at runtime
+	// without the StorageClass API — the API server rejects the request when
+	// expansion is unsupported.
 
 	pvc.Spec.Resources.Requests[corev1.ResourceStorage] = qty
 	return r.Update(ctx, &pvc)

--- a/operator/controllers/remediation_actions_extended_test.go
+++ b/operator/controllers/remediation_actions_extended_test.go
@@ -52,7 +52,7 @@ func TestDiagnosticAllowlist_Defaults(t *testing.T) {
 }
 
 func TestDiagnosticAllowlist_EnvOverride(t *testing.T) {
-	// Reset the sync.Once so we can re-initialise with the env var set. This is the
+	// Reset the sync.Once so we can re-initialize with the env var set. This is the
 	// only place we intentionally break cache encapsulation; every other call site
 	// uses the cached singleton.
 	resetDiagnosticAllowlistCache()

--- a/operator/controllers/remediation_controller.go
+++ b/operator/controllers/remediation_controller.go
@@ -146,7 +146,7 @@ func (r *RemediationReconciler) handleWaitingApproval(ctx context.Context, plan 
 		plan.Status.State = platformv1alpha1.RemediationStateExecuting
 		plan.Status.StartedAt = &now
 		plan.Status.Result = ""
-		return ctrl.Result{Requeue: true}, r.Status().Update(ctx, plan)
+		return ctrl.Result{RequeueAfter: conflictRetryDelay}, r.Status().Update(ctx, plan)
 
 	case platformv1alpha1.ApprovalStateRejected:
 		rejectedBy, reason := lastDecision(ar.Status.Decisions)
@@ -223,7 +223,7 @@ func (r *RemediationReconciler) handlePending(ctx context.Context, plan *platfor
 		}
 	}
 
-	return ctrl.Result{Requeue: true}, nil
+	return ctrl.Result{RequeueAfter: conflictRetryDelay}, nil
 }
 
 func (r *RemediationReconciler) handleExecuting(ctx context.Context, plan *platformv1alpha1.RemediationPlan) (ctrl.Result, error) {
@@ -244,7 +244,7 @@ func (r *RemediationReconciler) handleExecuting(ctx context.Context, plan *platf
 	rollbackEngine := NewRollbackEngine(r.Client)
 
 	// Capture full restorable pre-flight snapshot (structured, not just text)
-	var evidence []platformv1alpha1.EvidenceItem
+	evidence := make([]platformv1alpha1.EvidenceItem, 0, 4)
 	preflightSnapshot, err := rollbackEngine.CaptureSnapshot(ctx, resource)
 	if err != nil {
 		log.Info("Failed to capture structured snapshot, falling back to text", "error", err)
@@ -263,7 +263,7 @@ func (r *RemediationReconciler) handleExecuting(ctx context.Context, plan *platf
 	}
 
 	// Execute each action with ReAct loop: Act → Observe → decide if resource is healthy (early exit)
-	var checkpoints []platformv1alpha1.ActionCheckpoint
+	checkpoints := make([]platformv1alpha1.ActionCheckpoint, 0, len(plan.Spec.Actions))
 	for i, action := range plan.Spec.Actions {
 		// ReAct: OBSERVE — check if resource is already healthy before running next action
 		if i > 0 {
@@ -811,7 +811,7 @@ func (r *RemediationReconciler) handleAgenticResolved(ctx context.Context, plan 
 
 	if err := r.Update(ctx, plan); err != nil {
 		if errors.IsConflict(err) {
-			return ctrl.Result{Requeue: true}, nil
+			return ctrl.Result{RequeueAfter: conflictRetryDelay}, nil
 		}
 		return ctrl.Result{}, err
 	}
@@ -973,7 +973,7 @@ func (r *RemediationReconciler) rejectDivergentAgenticAction(ctx context.Context
 	needStartedAt := plan.Status.AgenticStartedAt == nil
 	if err := r.Update(ctx, plan); err != nil {
 		if errors.IsConflict(err) {
-			return ctrl.Result{Requeue: true}, nil
+			return ctrl.Result{RequeueAfter: conflictRetryDelay}, nil
 		}
 		return ctrl.Result{}, err
 	}

--- a/operator/controllers/remediation_controller_test.go
+++ b/operator/controllers/remediation_controller_test.go
@@ -101,7 +101,7 @@ func TestRemediationReconcile_NotFound(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if result.Requeue {
+	if result.RequeueAfter > 0 {
 		t.Error("expected no requeue")
 	}
 }
@@ -117,7 +117,7 @@ func TestRemediationReconcile_PendingToExecuting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconcile failed: %v", err)
 	}
-	if !result.Requeue {
+	if result.RequeueAfter == 0 {
 		t.Error("expected requeue after transitioning to Executing")
 	}
 
@@ -908,7 +908,7 @@ func TestRemediationReconcile_TerminalStateNoop(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if result.Requeue {
+	if result.RequeueAfter > 0 {
 		t.Error("expected no requeue for terminal state")
 	}
 }

--- a/operator/controllers/resources.go
+++ b/operator/controllers/resources.go
@@ -235,7 +235,37 @@ func (r *InstanceReconciler) buildPodSpec(instance *platformv1alpha1.Instance) c
 		})
 	}
 
-	// Volume mounts
+	volumeMounts, volumes, initContainers := r.buildInstanceVolumes(instance)
+	container.VolumeMounts = volumeMounts
+
+	podSpec := corev1.PodSpec{
+		ServiceAccountName: instance.Name,
+		InitContainers:     initContainers,
+		Containers:         []corev1.Container{container},
+		Volumes:            volumes,
+	}
+
+	if instance.Spec.SecurityContext != nil {
+		podSpec.SecurityContext = instance.Spec.SecurityContext
+	} else {
+		// Default security context
+		podSpec.SecurityContext = &corev1.PodSecurityContext{
+			RunAsNonRoot: boolPtr(true),
+			RunAsUser:    int64Ptr(1000),
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			},
+		}
+	}
+
+	return podSpec
+}
+
+// buildInstanceVolumes assembles the volume mounts, volumes and init
+// containers an Instance pod needs: the writable tmp/data dirs required by
+// the read-only root filesystem, then one optional block per feature
+// (sessions PVC, TLS, watcher config, agents, skills, MCP, plugins).
+func (r *InstanceReconciler) buildInstanceVolumes(instance *platformv1alpha1.Instance) ([]corev1.VolumeMount, []corev1.Volume, []corev1.Container) {
 	var volumeMounts []corev1.VolumeMount
 	var volumes []corev1.Volume
 
@@ -427,29 +457,7 @@ func (r *InstanceReconciler) buildPodSpec(instance *platformv1alpha1.Instance) c
 		}
 	}
 
-	container.VolumeMounts = volumeMounts
-
-	podSpec := corev1.PodSpec{
-		ServiceAccountName: instance.Name,
-		InitContainers:     initContainers,
-		Containers:         []corev1.Container{container},
-		Volumes:            volumes,
-	}
-
-	if instance.Spec.SecurityContext != nil {
-		podSpec.SecurityContext = instance.Spec.SecurityContext
-	} else {
-		// Default security context
-		podSpec.SecurityContext = &corev1.PodSecurityContext{
-			RunAsNonRoot: boolPtr(true),
-			RunAsUser:    int64Ptr(1000),
-			SeccompProfile: &corev1.SeccompProfile{
-				Type: corev1.SeccompProfileTypeRuntimeDefault,
-			},
-		}
-	}
-
-	return podSpec
+	return volumeMounts, volumes, initContainers
 }
 
 func (r *InstanceReconciler) buildContainerArgs(instance *platformv1alpha1.Instance) []string {

--- a/operator/controllers/rollback_engine.go
+++ b/operator/controllers/rollback_engine.go
@@ -275,8 +275,8 @@ func (re *RollbackEngine) captureHPASnapshot(ctx context.Context, resource platf
 			if hpa.Spec.MinReplicas != nil {
 				snapshot.HPAMinReplicas = hpa.Spec.MinReplicas
 			}
-			max := hpa.Spec.MaxReplicas
-			snapshot.HPAMaxReplicas = &max
+			maxReplicas := hpa.Spec.MaxReplicas
+			snapshot.HPAMaxReplicas = &maxReplicas
 			break
 		}
 	}

--- a/operator/controllers/slo_controller.go
+++ b/operator/controllers/slo_controller.go
@@ -115,13 +115,13 @@ func (r *SLOReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		remaining = math.Max(0, 1.0-consumed)
 		consumedPercentage = consumed * 100.0
 	} else {
-		// 100% target means zero error budget
+		// 100% target means zero error budget. Only remaining and
+		// consumedPercentage feed the status below; consumed is read solely
+		// in the errorBudgetTotal > 0 branch above.
 		if currentValue < 1.0 {
-			consumed = 1.0
 			remaining = 0.0
 			consumedPercentage = 100.0
 		} else {
-			consumed = 0.0
 			remaining = 1.0
 			consumedPercentage = 0.0
 		}

--- a/operator/controllers/source_controller.go
+++ b/operator/controllers/source_controller.go
@@ -143,7 +143,7 @@ func (r *SourceRepositoryReconciler) resolveAuth(ctx context.Context, repo *plat
 			return nil, fmt.Errorf("secret %s missing 'token' key", repo.Spec.SecretRef)
 		}
 		// For HTTPS URLs, inject token into URL via credential helper
-		env = append(env, fmt.Sprintf("GIT_ASKPASS=echo"), fmt.Sprintf("GIT_TOKEN=%s", token))
+		env = append(env, "GIT_ASKPASS=echo", fmt.Sprintf("GIT_TOKEN=%s", token))
 
 	case platformv1alpha1.SourceRepoAuthSSH:
 		sshKey := secret.Data["ssh-key"]
@@ -401,13 +401,13 @@ func detectLanguages(localPath string) []string {
 		name  string
 		count int
 	}
-	var sorted []langEntry
+	sorted := make([]langEntry, 0, len(langCount))
 	for name, count := range langCount {
 		sorted = append(sorted, langEntry{name, count})
 	}
 	sort.Slice(sorted, func(i, j int) bool { return sorted[i].count > sorted[j].count })
 
-	var result []string
+	result := make([]string, 0, 5)
 	for i, e := range sorted {
 		if i >= 5 {
 			break
@@ -595,7 +595,7 @@ func findSuspectedCommit(recentChanges []platformv1alpha1.GitCommitInfo, inciden
 		score  float64
 	}
 
-	var candidates []scored
+	candidates := make([]scored, 0, len(recentChanges))
 	for _, c := range recentChanges {
 		diff := incidentTime.Sub(c.Timestamp.Time)
 		if diff < 0 {
@@ -805,7 +805,7 @@ func readLinesAround(rootDir, filePath string, targetLine, contextLines int) (st
 
 // readConfigFiles reads deployment-related config files.
 func readConfigFiles(localPath string, configFiles []string) []ConfigFileContent {
-	var configs []ConfigFileContent
+	configs := make([]ConfigFileContent, 0, len(configFiles))
 
 	important := []string{"Dockerfile", "values.yaml", "Chart.yaml"}
 	for _, cf := range configFiles {

--- a/pkg/coder/engine/commands_exec.go
+++ b/pkg/coder/engine/commands_exec.go
@@ -216,10 +216,6 @@ func IsUnsafeCommand(cmd string, allowSudo bool) (bool, string) {
 	return false, ""
 }
 
-func runCommand(dir, cmd string, args ...string) (string, error) {
-	return runCommandCtx(context.Background(), dir, cmd, args...)
-}
-
 func runCommandCtx(ctx context.Context, dir, cmd string, args ...string) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()


### PR DESCRIPTION
## Summary

Closes the lint backlog for good. The CI has linted **diff-only** (`--new-from-rev`) since the strict `.golangci.yml` landed — PRs stayed clean, but pre-existing debt never shrank on its own. #1055 (misspell) and #1056 (errorlint/prealloc/gocyclo/revive/contextcheck) paid most of it; this PR pays the remainder — **1 finding in root, 49 in the operator module** (never covered by the earlier passes) — and then **removes `--new-from-rev` from all three lint invocations** (1-ci.yml + quality-gate root/operator), so `golangci-lint run ./...` is enforced at zero on the full tree of both modules from here on. Debt can no longer accumulate outside PR diffs.

## Root (1)
- Deleted the dead `runCommand` wrapper left behind by the #1056 contextcheck migration.

## Operator (49 → 0)

**Mechanical** — 22 `prealloc` preallocations; 4 unused symbols deleted; struct-literal copy → type conversion; needless `Sprintf`; dead assignments; empty blocks resolved (the empty test branch became the assertion it always intended to be); misspelling; builtin-shadowing `max` identifiers renamed; `CorrelationId` → `CorrelationID` with the **JSON tag unchanged** (CRD schema identical — description regenerated with the pinned controller-gen v0.17.2 and synced to both Helm chart `crds/` copies, so Floor 11 sees no drift).

**Deprecation** — the four `ctrl.Result{Requeue: true}` controller sites migrated to `RequeueAfter` using the file's own `conflictRetryDelay` — the exact pattern `persistAgenticStep` already documents as "controller-runtime's non-deprecated equivalent" — plus the six test assertions. Controller test suite green after the migration.

**Complexity** — five functions over the gocyclo threshold decomposed into cohesive phase/section helpers (**threshold untouched**, per project policy):
| Function | Was | Approach |
|---|---|---|
| `AIInsightReconciler.Reconcile` | 51 | enrichment gathering + context finalization extracted; **bonus: the duplicate `AnalyzePodLogs` call is gone** (one analysis feeds both the context block and source correlation) |
| `ComplianceReporter.GenerateReport` | 41 | one filler per report section |
| `CapacityPlanner.AnalyzeResourceTrends` | 36 | usage / exhaustion / incident-correlation phases |
| `LogAnalysisResult.FormatForAI` | 31 | one writer per section |
| `InstanceReconciler.buildPodSpec` | 31 | volume/mount/init-container assembly extracted |

**Boy-scout** — three byte-position truncations found along the way (audit detail, log-analysis block, LLM context) now cut on UTF-8 rune boundaries, matching the hardening pattern applied across compress (#1119), memory (#1121) and knowledge (#1122).

## Verification

`golangci-lint run ./...` = **0 findings in both modules** (v1.64.8, the CI-pinned version); full test suites green in root and operator; gofmt clean; CRDs regenerated with the gate's pinned controller-gen and flags.