### PR TITLE
feat(http): structured HTTP client for the agent as the @http tool

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -506,6 +506,10 @@ func NewChatCLI(ctx context.Context, manager manager.LLMManager, logger *zap.Log
 		// long-running commands (dev servers, watchers). Adapter wired below
 		// over a session supervisor sharing the agent exec validator.
 		pluginMgr.RegisterBuiltinPlugin(plugins.NewBuiltinProcPlugin())
+		// @http — structured HTTP client for testing APIs (pairs with @proc:
+		// start the server, hit its endpoints). Self-contained: shares the
+		// hardened proxy/TLS/SSRF web client with @webfetch.
+		pluginMgr.RegisterBuiltinPlugin(plugins.NewBuiltinHTTPPlugin())
 		// @docs-flatten — push-side companion of @knowledge: flattens a
 		// Markdown/MDX docs tree (local dir or git repo) into the JSONL
 		// corpus /context --mode knowledge ingests. Self-contained.

--- a/cli/plugins/builtin_http.go
+++ b/cli/plugins/builtin_http.go
@@ -1,0 +1,360 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+/*
+ * @http — structured HTTP client for the agent. Where @webfetch turns a page
+ * into readable markdown, @http is for testing APIs: explicit method, headers
+ * and body in; status, timing, relevant headers and a bounded body out. The
+ * natural pair of @proc: start the dev server, hit its endpoints, assert on
+ * what came back.
+ *
+ * Self-contained in this package (the @webfetch precedent): every request
+ * flows through the shared hardened client — corporate-proxy tolerant,
+ * TLS-trust aware, SSRF-guarded (cloud metadata and link-local always
+ * refused; loopback/private allowed by default so local dev servers work,
+ * blockable via CHATCLI_WEBFETCH_BLOCK_PRIVATE) with every redirect hop
+ * re-validated.
+ */
+package plugins
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+const (
+	// httpDefaultTimeout / httpMaxTimeout bound one request.
+	httpDefaultTimeout = 30 * time.Second
+	httpMaxTimeout     = 120 * time.Second
+
+	// httpMaxRequestBody bounds the outgoing body.
+	httpMaxRequestBody = 1 << 20 // 1MiB
+
+	// httpMaxResponseBody bounds how much of the response is read.
+	httpMaxResponseBody = 256 * 1024 // 256KiB read cap
+
+	// httpMaxRenderedBody bounds how much body lands in the conversation.
+	httpMaxRenderedBody = 64 * 1024 // 64KiB rendered
+)
+
+// httpAllowedMethods is the closed set of supported methods; the read-only
+// subset skips the orchestrator's confirmation policy.
+var httpAllowedMethods = map[string]bool{
+	http.MethodGet: true, http.MethodHead: true, http.MethodOptions: true,
+	http.MethodPost: true, http.MethodPut: true, http.MethodPatch: true, http.MethodDelete: true,
+}
+
+var httpReadOnlyMethods = map[string]bool{
+	http.MethodGet: true, http.MethodHead: true, http.MethodOptions: true,
+}
+
+// BuiltinHTTPPlugin is the @http tool.
+type BuiltinHTTPPlugin struct{}
+
+// NewBuiltinHTTPPlugin returns a ready-to-register plugin.
+func NewBuiltinHTTPPlugin() *BuiltinHTTPPlugin { return &BuiltinHTTPPlugin{} }
+
+// Name returns "@http".
+func (*BuiltinHTTPPlugin) Name() string { return "@http" }
+
+// Description surfaces the tool in /plugin list and the agent tool catalog.
+func (*BuiltinHTTPPlugin) Description() string {
+	return "Structured HTTP client for testing APIs: send a request with explicit method, headers and body; get back status, latency, relevant headers and a bounded body. Use it to exercise endpoints (including local dev servers started with @proc) — for reading web PAGES as markdown, use @webfetch instead."
+}
+
+// Usage explains the canonical invocation forms.
+func (*BuiltinHTTPPlugin) Usage() string {
+	return `<tool_call name="@http" args='{"cmd":"request","args":{"method":"POST","url":"http://localhost:8080/api/items","headers":{"Content-Type":"application/json"},"body":"{\"name\":\"x\"}"}}' />
+
+Subcommands (cmd + args):
+  request {method, url, headers?, body?, timeout_seconds?:1-120}
+  get|head|post|put|patch|delete {url, headers?, body?, timeout_seconds?}   method shortcuts
+
+Notes: GET/HEAD/OPTIONS run without confirmation; mutating methods go through
+the approval policy. Response bodies are bounded; JSON bodies come back
+pretty-printed. Cloud-metadata and link-local targets are always refused.`
+}
+
+// Version is semver; bumped when the surface changes.
+func (*BuiltinHTTPPlugin) Version() string { return "1.0.0" }
+
+// Path is empty for builtin plugins.
+func (*BuiltinHTTPPlugin) Path() string { return "" }
+
+// Schema exposes the structured description the agent prompt builder renders.
+func (*BuiltinHTTPPlugin) Schema() string {
+	schema := map[string]interface{}{
+		"argsFormat": "JSON envelope {cmd, args} preferred; argv form also accepted",
+		"subcommands": []map[string]interface{}{
+			{
+				"name":        "request",
+				"description": "send one HTTP request and get status, latency, headers and a bounded body",
+				"flags": []map[string]interface{}{
+					{"name": "method", "description": "GET|HEAD|OPTIONS|POST|PUT|PATCH|DELETE", "type": "string", "required": true},
+					{"name": "url", "description": "http(s) target URL", "type": "string", "required": true},
+					{"name": "headers", "description": "request headers as a string map", "type": "object"},
+					{"name": "body", "description": "request body (string; pair with a Content-Type header)", "type": "string"},
+					{"name": "timeout_seconds", "description": "request timeout", "type": "int", "default": "30"},
+				},
+				"examples": []string{
+					`{"cmd":"request","args":{"method":"GET","url":"http://localhost:8080/healthz"}}`,
+					`{"cmd":"post","args":{"url":"http://localhost:8080/api/items","headers":{"Content-Type":"application/json"},"body":"{\"name\":\"x\"}"}}`,
+				},
+			},
+		},
+	}
+	b, _ := json.Marshal(schema)
+	return string(b)
+}
+
+// Execute implements the plugin contract.
+func (p *BuiltinHTTPPlugin) Execute(ctx context.Context, args []string) (string, error) {
+	return p.ExecuteWithStream(ctx, args, nil)
+}
+
+// ExecuteWithStream mirrors Execute — no incremental output.
+func (p *BuiltinHTTPPlugin) ExecuteWithStream(ctx context.Context, args []string, _ func(string)) (string, error) {
+	if len(args) == 0 {
+		return "", errors.New(`@http: empty args. Example: <tool_call name="@http" args='{"cmd":"get","args":{"url":"http://localhost:8080/healthz"}}' />`)
+	}
+	in, err := parseHTTPInvocation(args)
+	if err != nil {
+		return "", fmt.Errorf("@http: %w", err)
+	}
+	return p.perform(ctx, in)
+}
+
+// httpArgs is the parsed request specification.
+type httpArgs struct {
+	Method         string            `json:"method"`
+	URL            string            `json:"url"`
+	Headers        map[string]string `json:"headers"`
+	Body           string            `json:"body"`
+	TimeoutSeconds int               `json:"timeout_seconds"`
+}
+
+// perform executes the request through the shared hardened client.
+func (p *BuiltinHTTPPlugin) perform(ctx context.Context, in httpArgs) (string, error) {
+	if len(in.Body) > httpMaxRequestBody {
+		return "", fmt.Errorf("@http: request body too large (%d bytes, limit %d)", len(in.Body), httpMaxRequestBody)
+	}
+
+	safeURL, err := validateWebTarget(in.URL)
+	if err != nil {
+		return "", fmt.Errorf("@http: refusing %q: %w", in.URL, err)
+	}
+
+	timeout := httpDefaultTimeout
+	if in.TimeoutSeconds > 0 {
+		timeout = time.Duration(in.TimeoutSeconds) * time.Second
+		if timeout > httpMaxTimeout {
+			timeout = httpMaxTimeout
+		}
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	var bodyReader io.Reader
+	if in.Body != "" {
+		bodyReader = strings.NewReader(in.Body)
+	}
+	req, err := http.NewRequestWithContext(reqCtx, in.Method, safeURL, bodyReader) //#nosec G704 -- URL validated by validateWebTarget + ssrfDialControl (metadata/link-local refused, redirects re-validated)
+	if err != nil {
+		return "", fmt.Errorf("@http: build request: %w", err)
+	}
+	req.Header.Set("User-Agent", fallbackUserAgent)
+	for k, v := range in.Headers {
+		// The proxy credential channel is operator-owned configuration; a tool
+		// argument must never override it.
+		if strings.EqualFold(k, "Proxy-Authorization") {
+			continue
+		}
+		req.Header.Set(k, v)
+	}
+
+	start := time.Now()
+	resp, err := webHTTPClient().Do(req) //#nosec G704 -- see request annotation above
+	if err != nil {
+		return "", fmt.Errorf("@http: %s %s failed after %s: %w", in.Method, in.URL, time.Since(start).Round(time.Millisecond), err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, httpMaxResponseBody+1))
+	if err != nil {
+		return "", fmt.Errorf("@http: read response: %w", err)
+	}
+	elapsed := time.Since(start).Round(time.Millisecond)
+	return renderHTTPResponse(in, resp, raw, elapsed), nil
+}
+
+// renderHTTPResponse formats the model-facing response summary.
+func renderHTTPResponse(in httpArgs, resp *http.Response, raw []byte, elapsed time.Duration) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s %s → %s in %s\n", in.Method, in.URL, resp.Status, elapsed)
+	if final := resp.Request.URL.String(); final != in.URL && final != "" {
+		fmt.Fprintf(&b, "final URL (after redirects): %s\n", final)
+	}
+
+	// Headers the model actually acts on, deterministic order.
+	keys := make([]string, 0, len(resp.Header))
+	for k := range resp.Header {
+		switch strings.ToLower(k) {
+		case "content-type", "content-length", "location", "retry-after",
+			"www-authenticate", "x-request-id", "cache-control", "allow":
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		fmt.Fprintf(&b, "%s: %s\n", k, strings.Join(resp.Header.Values(k), ", "))
+	}
+
+	truncatedRead := false
+	if len(raw) > httpMaxResponseBody {
+		raw, truncatedRead = raw[:httpMaxResponseBody], true
+	}
+	body := renderHTTPBody(raw, resp.Header.Get("Content-Type"))
+	if body == "" {
+		b.WriteString("(empty body)")
+		return strings.TrimRight(b.String(), "\n")
+	}
+	b.WriteString("---\n")
+	b.WriteString(body)
+	if truncatedRead {
+		fmt.Fprintf(&b, "\n… (response larger than %d bytes; truncated)", httpMaxResponseBody)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// renderHTTPBody bounds the body and pretty-prints JSON so the model reads
+// structure instead of a single wrapped line. Cuts land on rune boundaries.
+func renderHTTPBody(raw []byte, contentType string) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	if strings.Contains(strings.ToLower(contentType), "json") && json.Valid(raw) {
+		var pretty bytes.Buffer
+		if err := json.Indent(&pretty, raw, "", "  "); err == nil {
+			return boundRuneSafe(pretty.String(), httpMaxRenderedBody)
+		}
+	}
+	return boundRuneSafe(string(raw), httpMaxRenderedBody)
+}
+
+// boundRuneSafe truncates s to limit bytes on a rune boundary, flagging the cut.
+func boundRuneSafe(s string, limit int) string {
+	if len(s) <= limit {
+		return s
+	}
+	for limit > 0 && !utf8.RuneStart(s[limit]) {
+		limit--
+	}
+	return s[:limit] + "\n… (body truncated)"
+}
+
+// httpInvocationMethod extracts the resolved method for the caps layer.
+func httpInvocationMethod(args []string) string {
+	in, err := parseHTTPInvocation(args)
+	if err != nil {
+		return ""
+	}
+	return in.Method
+}
+
+// parseHTTPInvocation accepts the JSON envelope (cmd request|get|post|...)
+// or the argv form ("get http://..."). Method shortcuts fold into the method
+// field; explicit method wins over the shortcut only when they agree.
+func parseHTTPInvocation(args []string) (httpArgs, error) {
+	payload := strings.TrimSpace(strings.Join(args, " "))
+	var in httpArgs
+
+	if strings.HasPrefix(payload, "{") {
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(payload), &raw); err != nil {
+			return in, fmt.Errorf(`parse envelope: %w. Expected {"cmd":"get","args":{"url":"..."}}`, err)
+		}
+		var cmdStr string
+		if rc, ok := raw["cmd"]; ok {
+			_ = json.Unmarshal(rc, &cmdStr)
+		}
+		methodFromCmd, ok := canonicalHTTPCmd(cmdStr)
+		if !ok {
+			return in, fmt.Errorf("missing or unknown cmd %q (valid: request|get|head|options|post|put|patch|delete)", cmdStr)
+		}
+		var inner string
+		if rargs, ok := raw["args"]; ok && len(rargs) > 0 {
+			inner = string(rargs)
+		} else {
+			delete(raw, "cmd")
+			b, _ := json.Marshal(raw)
+			inner = string(b)
+		}
+		if err := json.Unmarshal([]byte(inner), &in); err != nil {
+			return in, fmt.Errorf("parse args: %w", err)
+		}
+		if methodFromCmd != "" {
+			in.Method = methodFromCmd
+		}
+	} else {
+		methodFromCmd, ok := canonicalHTTPCmd(args[0])
+		if !ok {
+			return in, fmt.Errorf("unknown cmd %q (valid: request|get|head|options|post|put|patch|delete)", args[0])
+		}
+		in.Method = methodFromCmd
+		if len(args) > 1 {
+			in.URL = args[1]
+		}
+		if in.Method == "" && len(args) > 2 { // argv "request GET <url>"
+			in.Method = strings.ToUpper(args[1])
+			in.URL = args[2]
+		}
+	}
+
+	in.Method = strings.ToUpper(strings.TrimSpace(in.Method))
+	if in.Method == "" {
+		return in, errors.New(`"method" is required (or use a method shortcut cmd like "get")`)
+	}
+	if !httpAllowedMethods[in.Method] {
+		return in, fmt.Errorf("method %q not allowed (valid: GET|HEAD|OPTIONS|POST|PUT|PATCH|DELETE)", in.Method)
+	}
+	if strings.TrimSpace(in.URL) == "" {
+		return in, errors.New(`"url" is required`)
+	}
+	return in, nil
+}
+
+// canonicalHTTPCmd resolves a cmd token: "request" keeps the args-supplied
+// method (returns ""); method shortcuts return the concrete method.
+func canonicalHTTPCmd(cmd string) (method string, ok bool) {
+	switch strings.ToLower(strings.TrimSpace(cmd)) {
+	case "request", "req", "call":
+		return "", true
+	case "get":
+		return http.MethodGet, true
+	case "head":
+		return http.MethodHead, true
+	case "options":
+		return http.MethodOptions, true
+	case "post":
+		return http.MethodPost, true
+	case "put":
+		return http.MethodPut, true
+	case "patch":
+		return http.MethodPatch, true
+	case "delete", "del":
+		return http.MethodDelete, true
+	default:
+		return "", false
+	}
+}

--- a/cli/plugins/builtin_http_caps.go
+++ b/cli/plugins/builtin_http_caps.go
@@ -1,0 +1,33 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+package plugins
+
+import (
+	"github.com/diillson/chatcli/i18n"
+)
+
+// Capability advertisements for BuiltinHTTPPlugin.
+
+// IsReadOnly is PER-METHOD: GET/HEAD/OPTIONS only observe the target;
+// POST/PUT/PATCH/DELETE mutate remote state and go through the
+// orchestrator's confirmation policy. Unparseable args fail closed.
+func (p *BuiltinHTTPPlugin) IsReadOnly(args []string) bool {
+	return httpReadOnlyMethods[httpInvocationMethod(args)]
+}
+
+// IsConcurrencySafe reports true: requests are independent; the shared client
+// is safe for concurrent use.
+func (p *BuiltinHTTPPlugin) IsConcurrencySafe(_ []string) bool { return true }
+
+// DescribeCall surfaces the request line in the spinner.
+func (p *BuiltinHTTPPlugin) DescribeCall(args []string) string {
+	in, err := parseHTTPInvocation(args)
+	if err != nil {
+		return i18n.T("plugins.http.describe_generic")
+	}
+	return i18n.T("plugins.http.describe_request", in.Method, describeTrim(in.URL))
+}

--- a/cli/plugins/builtin_http_test.go
+++ b/cli/plugins/builtin_http_test.go
@@ -1,0 +1,193 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * @http tests run against a real httptest server — the tool's whole job is
+ * HTTP semantics (methods, headers, bodies, status), and the loopback path is
+ * also exactly the @proc dev-server workflow it exists to serve.
+ */
+package plugins
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func httpFixture(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Request-Id", "req-123")
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/api/items", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		if r.Header.Get("Content-Type") != "application/json" || !strings.Contains(string(body), `"name"`) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":1,"name":"x","nested":{"deep":true}}`))
+	})
+	mux.HandleFunc("/big", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		chunk := strings.Repeat("é", 64*1024) // multi-byte content past every cap
+		for i := 0; i < 8; i++ {
+			_, _ = w.Write([]byte(chunk))
+		}
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestHTTPGetRoundTrip(t *testing.T) {
+	srv := httpFixture(t)
+	p := NewBuiltinHTTPPlugin()
+
+	out, err := p.Execute(context.Background(),
+		[]string{`{"cmd":"get","args":{"url":"` + srv.URL + `/healthz"}}`})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	for _, want := range []string{"GET " + srv.URL + "/healthz → 200 OK in ", "X-Request-Id: req-123", "ok"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestHTTPPostJSONPrettyPrinted(t *testing.T) {
+	srv := httpFixture(t)
+	p := NewBuiltinHTTPPlugin()
+
+	out, err := p.Execute(context.Background(),
+		[]string{`{"cmd":"post","args":{"url":"` + srv.URL + `/api/items","headers":{"Content-Type":"application/json"},"body":"{\"name\":\"x\"}"}}`})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, "201 Created") {
+		t.Fatalf("status missing: %s", out)
+	}
+	if !strings.Contains(out, "\n  \"nested\": {") {
+		t.Fatalf("JSON body must come back pretty-printed:\n%s", out)
+	}
+}
+
+func TestHTTPResponseBoundsAreRuneSafe(t *testing.T) {
+	srv := httpFixture(t)
+	p := NewBuiltinHTTPPlugin()
+
+	out, err := p.Execute(context.Background(),
+		[]string{`{"cmd":"get","args":{"url":"` + srv.URL + `/big"}}`})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(out) > httpMaxRenderedBody+2048 {
+		t.Fatalf("rendered output not bounded: %d bytes", len(out))
+	}
+	if !strings.Contains(out, "truncated") {
+		t.Fatal("truncation must be flagged, never silent")
+	}
+	for _, r := range out {
+		if r == 0xFFFD {
+			t.Fatal("output contains U+FFFD — body cut mid-rune")
+		}
+	}
+}
+
+func TestHTTPRefusesMetadataAndBadInput(t *testing.T) {
+	p := NewBuiltinHTTPPlugin()
+
+	// Cloud metadata endpoint: always refused by the shared SSRF guard.
+	if _, err := p.Execute(context.Background(),
+		[]string{`{"cmd":"get","args":{"url":"http://169.254.169.254/latest/meta-data/"}}`}); err == nil {
+		t.Fatal("cloud metadata target must be refused")
+	}
+	// Unsupported scheme.
+	if _, err := p.Execute(context.Background(),
+		[]string{`{"cmd":"get","args":{"url":"file:///etc/passwd"}}`}); err == nil {
+		t.Fatal("non-http scheme must be refused")
+	}
+	// Method allowlist.
+	if _, err := p.Execute(context.Background(),
+		[]string{`{"cmd":"request","args":{"method":"TRACE","url":"http://localhost:1/"}}`}); err == nil || !strings.Contains(err.Error(), "not allowed") {
+		t.Fatalf("TRACE must be refused, got %v", err)
+	}
+	// Missing url.
+	if _, err := p.Execute(context.Background(),
+		[]string{`{"cmd":"get","args":{}}`}); err == nil || !strings.Contains(err.Error(), `"url" is required`) {
+		t.Fatalf("missing url must error, got %v", err)
+	}
+	// Oversized request body.
+	big := strings.Repeat("a", httpMaxRequestBody+1)
+	if _, err := p.Execute(context.Background(),
+		[]string{`{"cmd":"post","args":{"url":"http://localhost:1/","body":"` + big + `"}}`}); err == nil || !strings.Contains(err.Error(), "too large") {
+		t.Fatalf("oversized body must be refused, got %v", err)
+	}
+}
+
+func TestHTTPProxyAuthorizationHeaderIsOperatorOwned(t *testing.T) {
+	seen := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen <- r.Header.Get("Proxy-Authorization")
+	}))
+	t.Cleanup(srv.Close)
+
+	p := NewBuiltinHTTPPlugin()
+	if _, err := p.Execute(context.Background(),
+		[]string{`{"cmd":"get","args":{"url":"` + srv.URL + `","headers":{"Proxy-Authorization":"Basic sneaky"}}}`}); err != nil {
+		t.Fatal(err)
+	}
+	if got := <-seen; got != "" {
+		t.Fatalf("tool argument must not set Proxy-Authorization, got %q", got)
+	}
+}
+
+func TestHTTPCapsPerMethod(t *testing.T) {
+	p := NewBuiltinHTTPPlugin()
+
+	readOnly := [][]string{
+		{`{"cmd":"get","args":{"url":"http://x/"}}`},
+		{`{"cmd":"head","args":{"url":"http://x/"}}`},
+		{`{"cmd":"request","args":{"method":"OPTIONS","url":"http://x/"}}`},
+	}
+	for _, args := range readOnly {
+		if !p.IsReadOnly(args) {
+			t.Fatalf("%v must be read-only", args)
+		}
+	}
+	mutating := [][]string{
+		{`{"cmd":"post","args":{"url":"http://x/"}}`},
+		{`{"cmd":"delete","args":{"url":"http://x/"}}`},
+		{`{not json`}, // fail closed
+	}
+	for _, args := range mutating {
+		if p.IsReadOnly(args) {
+			t.Fatalf("%v must NOT be read-only", args)
+		}
+	}
+}
+
+func TestHTTPArgvForm(t *testing.T) {
+	srv := httpFixture(t)
+	p := NewBuiltinHTTPPlugin()
+
+	out, err := p.Execute(context.Background(), []string{"get", srv.URL + "/healthz"})
+	if err != nil {
+		t.Fatalf("argv form: %v", err)
+	}
+	if !strings.Contains(out, "200 OK") {
+		t.Fatalf("argv get failed: %s", out)
+	}
+}

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -1216,6 +1216,8 @@
   "plugins.proc.describe_stop": "Stopping process %s",
   "plugins.proc.describe_remove": "Removing process %s",
   "plugins.proc.describe_list": "Listing background processes",
+  "plugins.http.describe_generic": "Sending HTTP request",
+  "plugins.http.describe_request": "HTTP %s %s",
   "plugins.knowledge.describe_list": "Listing attached knowledge bases",
   "plugins.knowledge.describe_generic": "Querying the knowledge base",
   "plugins.docsflatten.description": "Flatten documentation OR code/infra (Markdown, source code, Terraform, Kubernetes/Argo YAML, shell) from a local directory or git repo into AI-ready chunks (text/jsonl/json/yaml); kind=code chunks by structure; jsonl feeds /context --mode knowledge",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1216,6 +1216,8 @@
   "plugins.proc.describe_stop": "Stopping process %s",
   "plugins.proc.describe_remove": "Removing process %s",
   "plugins.proc.describe_list": "Listing background processes",
+  "plugins.http.describe_generic": "Sending HTTP request",
+  "plugins.http.describe_request": "HTTP %s %s",
   "plugins.knowledge.describe_list": "Listing attached knowledge bases",
   "plugins.knowledge.describe_generic": "Querying the knowledge base",
   "plugins.docsflatten.description": "Flatten documentation OR code/infra (Markdown, source code, Terraform, Kubernetes/Argo YAML, shell) from a local directory or git repo into AI-ready chunks (text/jsonl/json/yaml); kind=code chunks by structure; jsonl feeds /context --mode knowledge",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -1216,6 +1216,8 @@
   "plugins.proc.describe_stop": "Parando processo %s",
   "plugins.proc.describe_remove": "Removendo processo %s",
   "plugins.proc.describe_list": "Listando processos em background",
+  "plugins.http.describe_generic": "Enviando requisição HTTP",
+  "plugins.http.describe_request": "HTTP %s %s",
   "plugins.knowledge.describe_list": "Listando knowledge bases anexadas",
   "plugins.knowledge.describe_generic": "Consultando a knowledge base",
   "plugins.docsflatten.description": "Achata documentação OU código/infra (Markdown, código-fonte, Terraform, YAML Kubernetes/Argo, shell) de diretório local ou repo git em chunks prontos para IA (text/jsonl/json/yaml); kind=code chunka por estrutura; jsonl alimenta /context --mode knowledge",


### PR DESCRIPTION
## Summary

Item C — closing the tool-surface plan (A `@lsp` #1124 → D deferred catalog #1125 → B `@proc` #1126 → C). Where `@webfetch` turns a page into readable markdown, **`@http` is for testing APIs**: explicit method, headers and body in; status, latency, relevant headers and a bounded body out. The natural pair of `@proc`: start the dev server, hit its endpoints, assert on what came back.

## Architecture

**Self-contained in the plugins package** (the `@webfetch` precedent — no adapter seam needed): every request flows through the shared hardened web client, inheriting for free:
- corporate-proxy tolerance (domain logins, special-char passwords, `CHATCLI_PROXY_AUTH`),
- global TLS trust (`CHATCLI_CA_BUNDLE`),
- the SSRF stack — `validateWebTarget` + post-DNS `ssrfDialControl` + per-hop redirect re-validation: **cloud metadata and link-local always refused**, loopback/private allowed by default (the `@proc` dev-loop) and blockable via `CHATCLI_WEBFETCH_BLOCK_PRIVATE`.

## Security posture

- **Closed method allowlist**; capabilities are **per-method**: GET/HEAD/OPTIONS read-only, mutating methods go through the confirmation policy, unparseable args **fail closed**.
- A tool argument can never override `Proxy-Authorization` — the proxy credential channel is operator-owned (**pinned by a test asserting the header does not reach the wire**).
- Request body capped (1MiB), response read capped (256KiB), rendered body capped (64KiB) with **rune-safe truncation** and an explicit marker — never silent.

## Ergonomics

`request` + `get/head/options/post/put/patch/delete` shortcuts, JSON responses pretty-printed (structure instead of one wrapped line), only decision-relevant headers echoed, redirect-final URL shown when it differs. One index line in the deferred catalog until used.

## Verification

Tests against a **real `httptest` server** under `-race`: round-trip with headers, JSON pretty-printing, multi-byte rune-safe truncation past every cap, refusals (metadata IP, `file://`, TRACE, missing url, oversized body), the Proxy-Authorization guard, per-method caps, argv form. Full `-short` suite green; `golangci-lint run ./...` = 0 in both modules (the full-module gate caught an `ineffassign` on this PR's own code — fixed); patch-coverage gate script green locally; docs (pt+en) updated.