### PR TITLE
test(scheduler): settle the whole post-fire bookkeeping before asserting

### DIFF
--- a/cli/scheduler/scheduler_test.go
+++ b/cli/scheduler/scheduler_test.go
@@ -249,19 +249,35 @@ func TestScheduler_RecurringInterval_RearmsInPlace(t *testing.T) {
 
 	// Poll briefly for the scheduler's post-fire bookkeeping to settle.
 	// fa.calls is incremented inside the action callback BEFORE the
-	// scheduler advances NextFireAt for the next cycle, so a query that
-	// runs immediately after `fa.calls.Load() >= wantFires` can race the
-	// re-arm path and observe a stale NextFireAt. On Ubuntu CI with the
-	// race detector the gap can exceed 200ms, which used to flake the
-	// assertion below. The poll preserves the invariant (NextFireAt
-	// must be within 200ms of now) while waiting up to 1s for it to
-	// become observable; if it never settles, the post-loop assertion
-	// still surfaces the failure.
+	// scheduler persists the cycle's history entry and advances NextFireAt,
+	// so a query that runs immediately after `fa.calls.Load() >= wantFires`
+	// can race the re-arm path and observe stale state. On Ubuntu CI with
+	// the race detector the gap can exceed 200ms — this used to flake the
+	// NextFireAt assertion, and later (PR #1126's Floor 2 run) the HISTORY
+	// assertions: 3 fires counted but only 2 history entries persisted yet.
+	// The poll therefore waits for the WHOLE post-fire bookkeeping —
+	// NextFireAt re-armed AND one history entry per fired cycle — up to 2s.
+	// Every invariant is still enforced by the assertions below; the poll
+	// only waits for them to become observable, and if they never settle the
+	// assertions surface the failure exactly as before.
+	settled := func(j *Job) bool {
+		if j.NextFireAt.Before(time.Now().Add(-200 * time.Millisecond)) {
+			return false
+		}
+		if len(j.History) < wantFires {
+			return false
+		}
+		cycles := map[int]bool{}
+		for _, h := range j.History {
+			cycles[h.CycleNum] = true
+		}
+		return len(cycles) >= wantFires
+	}
 	var q *Job
 	var queryErr error
-	for end := time.Now().Add(1 * time.Second); time.Now().Before(end); {
+	for end := time.Now().Add(2 * time.Second); time.Now().Before(end); {
 		q, queryErr = s.Query(created.ID)
-		if queryErr == nil && !q.NextFireAt.Before(time.Now().Add(-200*time.Millisecond)) {
+		if queryErr == nil && settled(q) {
 			break
 		}
 		time.Sleep(20 * time.Millisecond)


### PR DESCRIPTION
## Summary

`TestScheduler_RecurringInterval_RearmsInPlace` flaked on #1126's Floor 2 run — and the failure log corrects the easy diagnosis: it was **not** runner slowness. The test finished in 0.25s with **3 fires counted but only 2 history entries persisted** at assertion time:

```
scheduler_test.go:290: history entries=2, want >=3 (one per cycle)
scheduler_test.go:300: only 2 distinct CycleNums in history, want >=3
```

That is the exact bookkeeping race the test already documents for `NextFireAt`: `fa.calls` increments inside the action callback **before** the scheduler persists the cycle's history entry and re-arms. The existing settle-poll only waited for `NextFireAt`; the history assertions raced the same window.

## Fix

Extend the settle-poll to the **whole** post-fire bookkeeping — `NextFireAt` re-armed **and** one history entry per fired cycle with distinct `CycleNum`s — bounded at 2s. **No invariant is loosened**: every assertion below the poll is unchanged and still fails on a real regression; the poll only waits for asynchronous bookkeeping to become observable, exactly the pattern the test already established.

## Verification

50 consecutive runs under `-race`, zero failures; full scheduler suite green ×3; lint clean. Bookkeeping-race lesson recorded: when Floor 2 fails, read the job log — a broken test (not a percentage) skips Floor 3 in cascade and masquerades as a coverage problem.