### PR TITLE
feat(tools): expose MCP tools through the @tools catalog

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -3177,7 +3177,9 @@ func buildMCPToolsSection(tools []models.ToolDefinition, isCoderMode bool) strin
 	var b strings.Builder
 	b.WriteString("MCP Tools (external):\n")
 	b.WriteString("  Para invocar: <tool_call name=\"mcp_<tool>\" args='{\"param\":\"value\"}' />\n")
-	b.WriteString("  Se precisar dos parâmetros exatos, invoque e o sistema retornará o schema.\n")
+	b.WriteString("  Antes do primeiro uso de uma tool MCP, obtenha o schema completo de parâmetros com " +
+		"<tool_call name=\"@tools\" args='{\"cmd\":\"describe\",\"args\":{\"name\":\"mcp_<tool>\"}}' /> — não adivinhe argumentos.\n")
+	b.WriteString("  Se invocar sem os parâmetros obrigatórios, o sistema retornará o schema para você corrigir.\n")
 	if isCoderMode {
 		b.WriteString("\n  " + i18n.T("agent.mcp.routing_hint_coder") + "\n")
 	} else {

--- a/cli/agent_mode_test.go
+++ b/cli/agent_mode_test.go
@@ -310,6 +310,12 @@ func TestBuildMCPToolsSection(t *testing.T) {
 		if !strings.Contains(s, "mcp_read_file") || !strings.Contains(s, "mcp_list_dir") {
 			t.Errorf("missing tool entry in section:\n%s", s)
 		}
+		// The section must route schema discovery through @tools describe —
+		// never blind invocation (a schemaless call to a no-required-params
+		// tool EXECUTES it as a side effect of "discovery").
+		if !strings.Contains(s, `name=\"@tools\"`) && !strings.Contains(s, `name="@tools"`) {
+			t.Errorf("section must teach @tools describe for MCP schemas:\n%s", s)
+		}
 	}
 	// Coder mode must reference @coder fallback; agent mode must not.
 	if !strings.Contains(coder, "@coder") {

--- a/cli/mcp/manager.go
+++ b/cli/mcp/manager.go
@@ -604,6 +604,26 @@ func (m *Manager) GetToolsSummary() []models.ToolDefinition {
 	return defs
 }
 
+// VisibleTools returns value snapshots of every discovered tool the LLM is
+// allowed to see (EnabledTools/DisabledTools honored, same filter as
+// GetTools/GetToolsSummary), sorted by name so consumers render a stable,
+// cache-friendly catalog. Used by the @tools meta-tool to describe MCP tools
+// without re-parsing the display strings GetTools embeds in descriptions.
+func (m *Manager) VisibleTools() []MCPTool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	out := make([]MCPTool, 0, len(m.tools))
+	for _, tool := range m.tools {
+		if !m.isToolVisibleUnlocked(tool) {
+			continue
+		}
+		out = append(out, *tool)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
 // GetToolSchema returns the full JSON schema for a specific MCP tool.
 // Used when the model attempts to invoke a tool and needs parameter details.
 func (m *Manager) GetToolSchema(toolName string) map[string]interface{} {

--- a/cli/mcp/manager_extensions_test.go
+++ b/cli/mcp/manager_extensions_test.go
@@ -148,6 +148,30 @@ func TestManager_GetTools_EnabledToolsTrumpsDisabledTools(t *testing.T) {
 	}
 }
 
+// TestManager_VisibleTools_FilterAndOrder pins the @tools-catalog contract:
+// the snapshot honors the same visibility filter as GetTools/GetToolsSummary
+// and comes back sorted by name so the rendered catalog is stable across
+// turns (map iteration order must not leak into the prompt).
+func TestManager_VisibleTools_FilterAndOrder(t *testing.T) {
+	m := newMgrWithFixture(t,
+		ServerConfig{DisabledTools: []string{"write_file"}},
+		ServerConfig{},
+	)
+	got := m.VisibleTools()
+	names := make([]string, 0, len(got))
+	for _, tool := range got {
+		names = append(names, tool.Name)
+	}
+	want := []string{"exec", "list_files", "query", "read_file"}
+	if !sliceEq(names, want) {
+		t.Errorf("VisibleTools names = %v, want %v (filtered + sorted)", names, want)
+	}
+	// Snapshot carries the fields the catalog renders.
+	if got[0].ServerName == "" || got[0].Description == "" {
+		t.Errorf("snapshot missing ServerName/Description: %+v", got[0])
+	}
+}
+
 func TestManager_ToolCount_MatchesVisibleToolCount(t *testing.T) {
 	m := newMgrWithFixture(t,
 		ServerConfig{DisabledTools: []string{"write_file", "list_files"}},

--- a/cli/plugins/builtin_tools.go
+++ b/cli/plugins/builtin_tools.go
@@ -59,20 +59,21 @@ func (*BuiltinToolsPlugin) Name() string { return "@tools" }
 
 // Description surfaces the tool in /plugin list and the agent tool catalog.
 func (*BuiltinToolsPlugin) Description() string {
-	return "Tool catalog: get the full definition (subcommands, flags, examples) of any tool listed in the index before using it, or list every available tool. Call describe once per unfamiliar tool instead of guessing its arguments."
+	return "Tool catalog: get the full definition of any tool listed in the index before using it — builtins (subcommands, flags, examples) and MCP tools (mcp_* names, full parameter JSON Schema) — or list every available tool. Call describe once per unfamiliar tool instead of guessing its arguments."
 }
 
 // Usage explains the canonical invocation forms.
 func (*BuiltinToolsPlugin) Usage() string {
 	return `<tool_call name="@tools" args='{"cmd":"describe","args":{"name":"@diagram"}}' />
+<tool_call name="@tools" args='{"cmd":"describe","args":{"name":"mcp_read_file"}}' />
 
 Subcommands (cmd + args):
-  describe {name}   full definition of one tool (subcommands, flags, examples)
-  list     {}       one-line index of every available tool`
+  describe {name}   full definition of one tool (builtin: subcommands/flags/examples; mcp_*: parameter JSON Schema)
+  list     {}       one-line index of every available tool, MCP tools included`
 }
 
 // Version is semver; bumped when the surface changes.
-func (*BuiltinToolsPlugin) Version() string { return "1.0.0" }
+func (*BuiltinToolsPlugin) Version() string { return "1.1.0" }
 
 // Path is empty for builtin plugins.
 func (*BuiltinToolsPlugin) Path() string { return "" }
@@ -84,15 +85,15 @@ func (*BuiltinToolsPlugin) Schema() string {
 		"subcommands": []map[string]interface{}{
 			{
 				"name":        "describe",
-				"description": "full definition of one tool: subcommands, flags, examples",
+				"description": "full definition of one tool: subcommands/flags/examples for builtins, parameter JSON Schema for MCP tools (mcp_* names)",
 				"flags": []map[string]interface{}{
-					{"name": "name", "description": "tool name, with or without the @ prefix", "type": "string", "required": true},
+					{"name": "name", "description": "tool name, with or without the @ prefix; MCP tools use their mcp_ prefix", "type": "string", "required": true},
 				},
-				"examples": []string{`{"cmd":"describe","args":{"name":"@diagram"}}`},
+				"examples": []string{`{"cmd":"describe","args":{"name":"@diagram"}}`, `{"cmd":"describe","args":{"name":"mcp_read_file"}}`},
 			},
 			{
 				"name":        "list",
-				"description": "one-line index of every available tool",
+				"description": "one-line index of every available tool, including MCP tools from connected servers",
 				"examples":    []string{`{"cmd":"list"}`},
 			},
 		},

--- a/cli/tool_catalog.go
+++ b/cli/tool_catalog.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/diillson/chatcli/cli/mcp"
 	"github.com/diillson/chatcli/cli/plugins"
 )
 
@@ -163,6 +164,40 @@ func firstSentence(s string) string {
 		return s[:cut] + "…"
 	}
 	return s
+}
+
+// renderMCPToolBlock renders one MCP tool's full prompt block — the MCP
+// counterpart of renderToolBlock. MCP servers describe their tools with a
+// JSON Schema rather than the plugin subcommand/flag shape, so the block
+// carries the schema verbatim (pretty-printed) plus the invocation form.
+// Shared shape with @tools describe so the model learns one format.
+func renderMCPToolBlock(tool mcp.MCPTool) string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("- Ferramenta: mcp_%s (MCP, servidor: %s)\n", tool.Name, tool.ServerName))
+	b.WriteString(fmt.Sprintf("  Descrição: %s\n", tool.Description))
+	b.WriteString(fmt.Sprintf("  Invocação: <tool_call name=\"mcp_%s\" args='{...}' /> (args = JSON validado pelo schema abaixo)\n", tool.Name))
+	if len(tool.Parameters) == 0 {
+		b.WriteString("  Parâmetros: nenhum — invoque com args='{}'\n")
+		return b.String()
+	}
+	schemaJSON, err := json.MarshalIndent(tool.Parameters, "    ", "  ")
+	if err != nil {
+		// A schema that came in over JSON-RPC always re-marshals; guard anyway.
+		b.WriteString("  Parâmetros: schema indisponível — invoque e o sistema retornará o schema\n")
+		return b.String()
+	}
+	b.WriteString("  Parâmetros (JSON Schema):\n    ")
+	b.Write(schemaJSON)
+	b.WriteString("\n")
+	return b.String()
+}
+
+// renderMCPToolIndexLine renders one MCP tool as a single catalog line,
+// mirroring renderToolIndexLine. The [MCP:server] tag matches the format the
+// system-prompt MCP section already uses, so both surfaces name tools the
+// same way.
+func renderMCPToolIndexLine(tool mcp.MCPTool) string {
+	return fmt.Sprintf("- mcp_%s [MCP:%s]: %s\n", tool.Name, tool.ServerName, firstSentence(tool.Description))
 }
 
 // deferredCatalogInstruction tells the model how to pull a full definition.

--- a/cli/tools_catalog_adapter.go
+++ b/cli/tools_catalog_adapter.go
@@ -96,8 +96,18 @@ func (a *toolCatalogPluginAdapter) List() (string, error) {
 	}
 	if len(mcpToolset) > 0 {
 		b.WriteString("MCP tools (external servers — describe before first use):\n")
+		// Cluster by owning server so provenance reads at a glance; the
+		// per-line [MCP:server] tag stays for models that quote lines out
+		// of context. VisibleTools sorts by tool name, so within a server
+		// the name order is preserved by the stable sort.
+		sort.SliceStable(mcpToolset, func(i, j int) bool { return mcpToolset[i].ServerName < mcpToolset[j].ServerName })
+		lastServer := ""
 		for _, t := range mcpToolset {
-			b.WriteString(renderMCPToolIndexLine(t))
+			if t.ServerName != lastServer {
+				fmt.Fprintf(&b, "  Servidor MCP %q:\n", t.ServerName)
+				lastServer = t.ServerName
+			}
+			b.WriteString("  " + renderMCPToolIndexLine(t))
 		}
 	}
 	return strings.TrimRight(b.String(), "\n"), nil

--- a/cli/tools_catalog_adapter.go
+++ b/cli/tools_catalog_adapter.go
@@ -3,10 +3,12 @@
  * Copyright (c) 2024 Edilson Freitas
  * License: Apache-2.0
  *
- * Implements plugins.ToolCatalogAdapter over the live plugin manager:
- * Describe renders one tool's full prompt block through the SAME renderer the
- * agent system prompt uses (an on-demand definition is byte-identical to an
- * inline one), and List renders the one-line index of everything available.
+ * Implements plugins.ToolCatalogAdapter over the live plugin manager AND the
+ * MCP manager: Describe renders one tool's full prompt block through the SAME
+ * renderer the agent system prompt uses (an on-demand definition is
+ * byte-identical to an inline one) — for mcp_* names it renders the tool's
+ * JSON Schema from the connected server instead — and List renders the
+ * one-line index of everything available, builtins and MCP alike.
  * Wired via plugins.SetToolCatalogAdapter at startup.
  */
 package cli
@@ -16,12 +18,28 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/diillson/chatcli/cli/mcp"
 	"github.com/diillson/chatcli/cli/plugins"
 )
 
 // toolCatalogPluginAdapter is the concrete plugins.ToolCatalogAdapter.
+// mcpTools overrides the MCP snapshot source in tests; nil means the live
+// manager (visibility-filtered by mcp.Manager.VisibleTools).
 type toolCatalogPluginAdapter struct {
-	cli *ChatCLI
+	cli      *ChatCLI
+	mcpTools func() []mcp.MCPTool
+}
+
+// visibleMCPTools returns the MCP tools the LLM may see this turn. Empty when
+// MCP is disabled, no server is connected, or every tool is masked.
+func (a *toolCatalogPluginAdapter) visibleMCPTools() []mcp.MCPTool {
+	if a.mcpTools != nil {
+		return a.mcpTools()
+	}
+	if a.cli == nil || a.cli.mcpManager == nil {
+		return nil
+	}
+	return a.cli.mcpManager.VisibleTools()
 }
 
 // Describe implements plugins.ToolCatalogAdapter.
@@ -29,17 +47,35 @@ func (a *toolCatalogPluginAdapter) Describe(name string) (string, error) {
 	if a.cli.pluginManager == nil {
 		return "", fmt.Errorf("plugin manager unavailable in this session")
 	}
-	want := strings.ToLower(strings.TrimSpace(name))
-	if !strings.HasPrefix(want, "@") {
-		want = "@" + want
+	want := strings.TrimSpace(name)
+	want = strings.TrimPrefix(want, "@")
+
+	// MCP names are routed by their canonical mcp_ prefix. Matching is
+	// case-insensitive on our side; the stored name keeps the server's casing.
+	mcpToolset := a.visibleMCPTools()
+	if bare, ok := cutMCPPrefix(want); ok {
+		if tool, ok := findMCPTool(mcpToolset, bare); ok {
+			return renderMCPToolBlock(tool), nil
+		}
 	}
+
 	ps := a.cli.pluginManager.GetPlugins()
-	names := make([]string, 0, len(ps))
+	names := make([]string, 0, len(ps)+len(mcpToolset))
 	for _, p := range ps {
-		if strings.EqualFold(p.Name(), want) {
+		if strings.EqualFold(p.Name(), "@"+want) {
 			return renderToolBlock(p, false), nil
 		}
 		names = append(names, p.Name())
+	}
+
+	// Bare-name fallback: models routinely drop the mcp_ prefix ("describe
+	// read_file"). Only reached when no plugin matched, so a shadowing
+	// builtin still wins.
+	if tool, ok := findMCPTool(mcpToolset, want); ok {
+		return renderMCPToolBlock(tool), nil
+	}
+	for _, t := range mcpToolset {
+		names = append(names, "mcp_"+t.Name)
 	}
 	sort.Strings(names)
 	return "", fmt.Errorf("unknown tool %q — available: %s", name, strings.Join(names, ", "))
@@ -52,12 +88,38 @@ func (a *toolCatalogPluginAdapter) List() (string, error) {
 	}
 	ps := a.cli.pluginManager.GetPlugins()
 	sort.Slice(ps, func(i, j int) bool { return ps[i].Name() < ps[j].Name() })
+	mcpToolset := a.visibleMCPTools()
 	var b strings.Builder
-	fmt.Fprintf(&b, "%d tool(s) available (describe any of them for full usage):\n", len(ps))
+	fmt.Fprintf(&b, "%d tool(s) available (describe any of them for full usage):\n", len(ps)+len(mcpToolset))
 	for _, p := range ps {
 		b.WriteString(renderToolIndexLine(p))
 	}
+	if len(mcpToolset) > 0 {
+		b.WriteString("MCP tools (external servers — describe before first use):\n")
+		for _, t := range mcpToolset {
+			b.WriteString(renderMCPToolIndexLine(t))
+		}
+	}
 	return strings.TrimRight(b.String(), "\n"), nil
+}
+
+// cutMCPPrefix strips the canonical mcp_ prefix, reporting whether it was
+// present. Case-insensitive so "MCP_Read_File" still routes to MCP.
+func cutMCPPrefix(name string) (string, bool) {
+	if len(name) >= 4 && strings.EqualFold(name[:4], "mcp_") {
+		return name[4:], true
+	}
+	return "", false
+}
+
+// findMCPTool looks a tool up by its bare (unprefixed) name.
+func findMCPTool(tools []mcp.MCPTool, bare string) (mcp.MCPTool, bool) {
+	for _, t := range tools {
+		if strings.EqualFold(t.Name, bare) {
+			return t, true
+		}
+	}
+	return mcp.MCPTool{}, false
 }
 
 // compile-time assertion that the adapter satisfies the plugin interface.

--- a/cli/tools_catalog_adapter_test.go
+++ b/cli/tools_catalog_adapter_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/diillson/chatcli/cli/mcp"
 	"github.com/diillson/chatcli/cli/plugins"
 	"go.uber.org/zap"
 )
@@ -64,6 +65,118 @@ func TestToolCatalogAdapterList(t *testing.T) {
 	}
 	if strings.Contains(out, "Subcomandos") {
 		t.Fatal("List must stay one line per tool — no schemas")
+	}
+}
+
+// fakeMCPTools is the test seam for the adapter's MCP snapshot source —
+// the same visibility-filtered shape mcp.Manager.VisibleTools returns.
+func fakeMCPTools() []mcp.MCPTool {
+	return []mcp.MCPTool{
+		{
+			Name:        "read_file",
+			Description: "Reads a file from the sandbox. Paths are server-relative.",
+			ServerName:  "fs",
+			Parameters: map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{"path": map[string]interface{}{"type": "string"}},
+				"required":   []interface{}{"path"},
+			},
+		},
+		{Name: "ping", Description: "Health check", ServerName: "fs"},
+	}
+}
+
+// TestToolCatalogAdapterDescribeMCP pins the fix for the MCP blind spot: the
+// meta-tool must return an MCP tool's full parameter schema instead of
+// "unknown tool", so the model never has to invoke blind to discover args.
+func TestToolCatalogAdapterDescribeMCP(t *testing.T) {
+	cli := newCatalogCLI(t)
+	a := &toolCatalogPluginAdapter{cli: cli, mcpTools: fakeMCPTools}
+
+	out, err := a.Describe("mcp_read_file")
+	if err != nil {
+		t.Fatalf("Describe mcp tool: %v", err)
+	}
+	for _, want := range []string{
+		"- Ferramenta: mcp_read_file (MCP, servidor: fs)",
+		"Reads a file from the sandbox.",
+		`"required"`,
+		`"path"`,
+		`<tool_call name="mcp_read_file"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("Describe(mcp_read_file) missing %q in:\n%s", want, out)
+		}
+	}
+
+	// Models drop prefixes routinely: "@mcp_x" and the bare server-side name
+	// both resolve to the same block.
+	for _, alias := range []string{"@mcp_read_file", "read_file", "MCP_READ_FILE"} {
+		got, err := a.Describe(alias)
+		if err != nil {
+			t.Fatalf("Describe(%q): %v", alias, err)
+		}
+		if got != out {
+			t.Errorf("Describe(%q) diverged from canonical block", alias)
+		}
+	}
+
+	// A tool that legitimately takes no params must say so explicitly.
+	pingOut, err := a.Describe("mcp_ping")
+	if err != nil {
+		t.Fatalf("Describe mcp_ping: %v", err)
+	}
+	if !strings.Contains(pingOut, "args='{}'") {
+		t.Errorf("schemaless tool must instruct empty-args invocation, got:\n%s", pingOut)
+	}
+
+	// Unknown names list MCP tools alongside builtins.
+	if _, err := a.Describe("@nope"); err == nil || !strings.Contains(err.Error(), "mcp_read_file") {
+		t.Fatalf("unknown-tool error must list MCP names, got %v", err)
+	}
+
+	// No MCP wired (chat sessions, MCP disabled): plugin behavior intact,
+	// mcp_ lookups fail cleanly instead of panicking.
+	plain := &toolCatalogPluginAdapter{cli: cli}
+	if _, err := plain.Describe("@diagram"); err != nil {
+		t.Fatalf("plugin describe without MCP: %v", err)
+	}
+	if _, err := plain.Describe("mcp_read_file"); err == nil {
+		t.Fatal("mcp describe without MCP manager must error, not panic")
+	}
+}
+
+// TestToolCatalogAdapterListMCP pins the index: MCP tools appear as one-line
+// entries under their own section, builtin count + MCP count aggregated.
+func TestToolCatalogAdapterListMCP(t *testing.T) {
+	cli := newCatalogCLI(t)
+	a := &toolCatalogPluginAdapter{cli: cli, mcpTools: fakeMCPTools}
+
+	out, err := a.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if !strings.Contains(out, "4 tool(s) available") {
+		t.Errorf("List must count builtins+MCP (2+2), got: %q", out)
+	}
+	if !strings.Contains(out, "- mcp_read_file [MCP:fs]: Reads a file from the sandbox.") {
+		t.Errorf("List missing MCP index line: %q", out)
+	}
+	if !strings.Contains(out, "- mcp_ping [MCP:fs]: Health check") {
+		t.Errorf("List missing schemaless MCP index line: %q", out)
+	}
+	if strings.Contains(out, `"properties"`) {
+		t.Error("List must stay one line per tool — no schemas")
+	}
+
+	// Without MCP the section is absent entirely.
+	plain := &toolCatalogPluginAdapter{cli: cli}
+	plainOut, err := plain.List()
+	if err != nil {
+		t.Fatalf("List without MCP: %v", err)
+	}
+	if strings.Contains(plainOut, "MCP tools (external servers") {
+		t.Errorf("no-MCP list must not render an MCP section: %q", plainOut)
 	}
 }
 

--- a/cli/tools_catalog_adapter_test.go
+++ b/cli/tools_catalog_adapter_test.go
@@ -83,6 +83,7 @@ func fakeMCPTools() []mcp.MCPTool {
 			},
 		},
 		{Name: "ping", Description: "Health check", ServerName: "fs"},
+		{Name: "create_issue", Description: "Opens a GitHub issue", ServerName: "gh"},
 	}
 }
 
@@ -156,8 +157,8 @@ func TestToolCatalogAdapterListMCP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
-	if !strings.Contains(out, "4 tool(s) available") {
-		t.Errorf("List must count builtins+MCP (2+2), got: %q", out)
+	if !strings.Contains(out, "5 tool(s) available") {
+		t.Errorf("List must count builtins+MCP (2+3), got: %q", out)
 	}
 	if !strings.Contains(out, "- mcp_read_file [MCP:fs]: Reads a file from the sandbox.") {
 		t.Errorf("List missing MCP index line: %q", out)
@@ -167,6 +168,15 @@ func TestToolCatalogAdapterListMCP(t *testing.T) {
 	}
 	if strings.Contains(out, `"properties"`) {
 		t.Error("List must stay one line per tool — no schemas")
+	}
+	// Tools cluster under one header per owning server, servers in order.
+	fsHdr := strings.Index(out, `Servidor MCP "fs":`)
+	ghHdr := strings.Index(out, `Servidor MCP "gh":`)
+	if fsHdr < 0 || ghHdr < 0 || fsHdr > ghHdr {
+		t.Errorf("List must group MCP tools under per-server headers in order, got: %q", out)
+	}
+	if issue := strings.Index(out, "- mcp_create_issue [MCP:gh]:"); issue < ghHdr {
+		t.Errorf("gh tool must sit under the gh server header, got: %q", out)
 	}
 
 	// Without MCP the section is absent entirely.


### PR DESCRIPTION
## Problema

O catálogo deferred de tools (`@tools` meta-tool) deixou as tools MCP no escuro no caminho de dispatch textual:

- `@tools describe`/`list` respondiam **unknown tool** para qualquer nome `mcp_*` — o adapter só consultava o plugin registry.
- O system prompt listava só nome+descrição e instruía o modelo a **invocar às cegas** para o sistema devolver o schema. Esse echo só dispara quando a tool declara parâmetros *required* — uma chamada vazia a uma tool só com parâmetros opcionais **executa a tool de verdade** como efeito colateral da "descoberta".
- Em providers sem native tool calling (ex.: StackSpot), esse era o único caminho — a IA não tinha como aprender os parâmetros de uma tool MCP com segurança.

## Solução

O catálogo agora cobre MCP de ponta a ponta:

- **`mcp.Manager.VisibleTools`** — snapshots das tools descobertas honrando `EnabledTools`/`DisabledTools` (mesmo filtro de `GetTools`/`GetToolsSummary`), ordenados por nome para catálogo estável e cache-friendly entre turnos.
- **`@tools describe mcp_<tool>`** — bloco completo: servidor, descrição, JSON Schema de parâmetros e forma de invocação. Aliases resolvem (`@mcp_x`, nome bare, case-insensitive) já que modelos derrubam prefixos rotineiramente; builtin com mesmo nome bare continua vencendo. Tool sem parâmetros instrui explicitamente `args='{}'`.
- **`@tools list`** — seção MCP com entradas de uma linha no mesmo formato `[MCP:server]` que o system prompt já usa; contagem agrega builtins+MCP.
- **Prompt MCP** — descoberta de schema roteada por `@tools describe` em vez de invocação cega; o echo de schema em chamada sem required params permanece como fallback.
- Erro de tool desconhecida agora lista os nomes `mcp_*` disponíveis junto com os builtins.

## Testes

- `TestManager_VisibleTools_FilterAndOrder` — filtro de visibilidade + ordenação estável (ordem de iteração de map não vaza pro prompt).
- `TestToolCatalogAdapterDescribeMCP` — describe com schema completo, aliases, tool schemaless, erro listando nomes MCP, e sessão sem MCP manager (sem panic).
- `TestToolCatalogAdapterListMCP` — seção MCP no index, contagem agregada, ausência da seção sem MCP.
- `TestBuildMCPToolsSection` — pina a nova instrução `@tools describe` no prompt.

`go build ./...`, `go test ./...` e `golangci-lint run` limpos.