### PR TITLE
fix(plugins): parse the flattened flag argv across builtin tools

### DIFF
--- a/cli/agent_tool_flatten_test.go
+++ b/cli/agent_tool_flatten_test.go
@@ -62,6 +62,325 @@ func (f *flattenFakeSession) Search(_ context.Context, query string, _ int) (str
 }
 func (f *flattenFakeSession) List(context.Context) (string, error) { return "", nil }
 
+// Same chain for @tools describe — the exact shapes a model emits in agent
+// mode. The flattener turns the {cmd,args} envelope into "describe --name X"
+// argv, and the plugin's argv path must parse the flag instead of taking
+// "--name" literally as the tool name.
+type flattenFakeCatalog struct{ described string }
+
+func (f *flattenFakeCatalog) Describe(name string) (string, error) {
+	f.described = name
+	return "DEF " + name, nil
+}
+func (f *flattenFakeCatalog) List() (string, error) { return "INDEX", nil }
+
+func TestAgentFlatten_ToolsDescribeE2E(t *testing.T) {
+	cases := []struct {
+		argLine string
+		want    string
+	}{
+		// Canonical envelope — the shape the system prompt itself teaches.
+		{`{"cmd":"describe","args":{"name":"@graphview"}}`, "@graphview"},
+		// Flat variant models fall back to: name at the top level.
+		{`{"cmd":"describe","name":"graphview"}`, "graphview"},
+		// Raw argv string with a flag.
+		{`describe --name graphview`, "graphview"},
+		// Raw argv string, positional.
+		{`describe @graphview`, "@graphview"},
+	}
+	for _, tc := range cases {
+		f := &flattenFakeCatalog{}
+		plugins.SetToolCatalogAdapter(f)
+		t.Cleanup(func() { plugins.SetToolCatalogAdapter(nil) })
+
+		argv, err := parseToolArgsWithJSON(tc.argLine)
+		if err != nil {
+			t.Fatalf("%s: flatten: %v", tc.argLine, err)
+		}
+		if _, err := plugins.NewBuiltinToolsPlugin().Execute(context.Background(), argv); err != nil {
+			t.Fatalf("%s: @tools via flattened argv failed: %v\nargv=%v", tc.argLine, err, argv)
+		}
+		if f.described != tc.want {
+			t.Errorf("%s: described %q, want %q (argv=%v)", tc.argLine, f.described, tc.want, argv)
+		}
+	}
+}
+
+// flattenExec drives the REAL flattener into the given plugin — the exact
+// path agent mode takes for a <tool_call> envelope.
+func flattenExec(t *testing.T, p plugins.Plugin, argLine string) (string, error) {
+	t.Helper()
+	argv, err := parseToolArgsWithJSON(argLine)
+	if err != nil {
+		t.Fatalf("%s: flatten: %v", argLine, err)
+	}
+	return p.Execute(context.Background(), argv)
+}
+
+type flattenFakeLSP struct {
+	file         string
+	line, column int
+}
+
+func (f *flattenFakeLSP) Diagnostics(file string) (string, error) { f.file = file; return "ok", nil }
+func (f *flattenFakeLSP) Definition(file string, line, column int) (string, error) {
+	f.file, f.line, f.column = file, line, column
+	return "ok", nil
+}
+func (f *flattenFakeLSP) References(file string, line, column int, _ bool, _ int) (string, error) {
+	f.file, f.line, f.column = file, line, column
+	return "ok", nil
+}
+func (f *flattenFakeLSP) Symbols(file string) (string, error) { f.file = file; return "ok", nil }
+func (f *flattenFakeLSP) Hover(file string, line, column int) (string, error) {
+	f.file, f.line, f.column = file, line, column
+	return "ok", nil
+}
+
+func TestAgentFlatten_LSPDefinitionE2E(t *testing.T) {
+	f := &flattenFakeLSP{}
+	plugins.SetLSPAdapter(f)
+	t.Cleanup(func() { plugins.SetLSPAdapter(nil) })
+
+	if _, err := flattenExec(t, plugins.NewBuiltinLSPPlugin(),
+		`{"cmd":"definition","args":{"file":"cli/cli.go","line":128,"column":14}}`); err != nil {
+		t.Fatalf("@lsp definition via flattened argv failed: %v", err)
+	}
+	if f.file != "cli/cli.go" || f.line != 128 || f.column != 14 {
+		t.Fatalf("definition got (%q,%d,%d), want (cli/cli.go,128,14)", f.file, f.line, f.column)
+	}
+
+	if _, err := flattenExec(t, plugins.NewBuiltinLSPPlugin(),
+		`{"cmd":"diagnostics","args":{"file":"cli/agent_mode.go"}}`); err != nil {
+		t.Fatalf("@lsp diagnostics via flattened argv failed: %v", err)
+	}
+	if f.file != "cli/agent_mode.go" {
+		t.Fatalf("diagnostics file = %q", f.file)
+	}
+}
+
+type flattenFakeProc struct {
+	command, dir, id string
+	tail             int
+}
+
+func (f *flattenFakeProc) Start(command, dir string) (string, error) {
+	f.command, f.dir = command, dir
+	return "p1", nil
+}
+func (f *flattenFakeProc) Status(id string) (string, error) { f.id = id; return "ok", nil }
+func (f *flattenFakeProc) Logs(id string, tail int) (string, error) {
+	f.id, f.tail = id, tail
+	return "ok", nil
+}
+func (f *flattenFakeProc) Stop(id string) (string, error)   { f.id = id; return "ok", nil }
+func (f *flattenFakeProc) Remove(id string) (string, error) { f.id = id; return "ok", nil }
+func (f *flattenFakeProc) List() (string, error)            { return "ok", nil }
+
+func TestAgentFlatten_ProcE2E(t *testing.T) {
+	f := &flattenFakeProc{}
+	plugins.SetProcAdapter(f)
+	t.Cleanup(func() { plugins.SetProcAdapter(nil) })
+
+	if _, err := flattenExec(t, plugins.NewBuiltinProcPlugin(),
+		`{"cmd":"start","args":{"command":"npm run dev","dir":"./web"}}`); err != nil {
+		t.Fatalf("@proc start via flattened argv failed: %v", err)
+	}
+	if f.command != "npm run dev" || f.dir != "./web" {
+		t.Fatalf("start got (%q,%q), want (npm run dev,./web)", f.command, f.dir)
+	}
+
+	if _, err := flattenExec(t, plugins.NewBuiltinProcPlugin(),
+		`{"cmd":"status","args":{"id":"p1"}}`); err != nil {
+		t.Fatalf("@proc status via flattened argv failed: %v", err)
+	}
+	if f.id != "p1" {
+		t.Fatalf("status id = %q, want p1", f.id)
+	}
+
+	if _, err := flattenExec(t, plugins.NewBuiltinProcPlugin(),
+		`{"cmd":"logs","args":{"id":"p2","tail":50}}`); err != nil {
+		t.Fatalf("@proc logs via flattened argv failed: %v", err)
+	}
+	if f.id != "p2" || f.tail != 50 {
+		t.Fatalf("logs got (%q,%d), want (p2,50)", f.id, f.tail)
+	}
+}
+
+type flattenFakeTodo struct {
+	items  []plugins.TodoItem
+	id     int
+	status string
+}
+
+func (f *flattenFakeTodo) Write(items []plugins.TodoItem) (string, error) {
+	f.items = items
+	return "ok", nil
+}
+func (f *flattenFakeTodo) List() (string, error) { return "ok", nil }
+func (f *flattenFakeTodo) Mark(id int, status, _ string) (string, error) {
+	f.id, f.status = id, status
+	return "ok", nil
+}
+
+func TestAgentFlatten_TodoE2E(t *testing.T) {
+	f := &flattenFakeTodo{}
+	plugins.SetTodoAdapter(f)
+	t.Cleanup(func() { plugins.SetTodoAdapter(nil) })
+
+	if _, err := flattenExec(t, plugins.NewBuiltinTodoPlugin(),
+		`{"cmd":"write","args":{"todos":[{"description":"map the code"},{"description":"apply fix","status":"in_progress"}]}}`); err != nil {
+		t.Fatalf("@todo write via flattened argv failed: %v", err)
+	}
+	if len(f.items) != 2 || f.items[0].Description != "map the code" || f.items[1].Status != "in_progress" {
+		t.Fatalf("write items = %+v", f.items)
+	}
+
+	if _, err := flattenExec(t, plugins.NewBuiltinTodoPlugin(),
+		`{"cmd":"mark","args":{"id":2,"status":"completed"}}`); err != nil {
+		t.Fatalf("@todo mark via flattened argv failed: %v", err)
+	}
+	if f.id != 2 || f.status != "completed" {
+		t.Fatalf("mark got (%d,%q), want (2,completed)", f.id, f.status)
+	}
+}
+
+type flattenFakeKnowledge struct {
+	query, kb string
+	topK      int
+}
+
+func (f *flattenFakeKnowledge) Search(query, kb string, topK int) (string, error) {
+	f.query, f.kb, f.topK = query, kb, topK
+	return "ok", nil
+}
+func (f *flattenFakeKnowledge) Get(string, string, int) (string, error) { return "ok", nil }
+func (f *flattenFakeKnowledge) TOC(string, string) (string, error)      { return "ok", nil }
+func (f *flattenFakeKnowledge) List() (string, error)                   { return "ok", nil }
+
+func TestAgentFlatten_KnowledgeSearchE2E(t *testing.T) {
+	f := &flattenFakeKnowledge{}
+	plugins.SetKnowledgeAdapter(f)
+	t.Cleanup(func() { plugins.SetKnowledgeAdapter(nil) })
+
+	if _, err := flattenExec(t, plugins.NewBuiltinKnowledgePlugin(),
+		`{"cmd":"search","args":{"query":"gateway voice env vars","top_k":10}}`); err != nil {
+		t.Fatalf("@knowledge search via flattened argv failed: %v", err)
+	}
+	if f.query != "gateway voice env vars" || f.topK != 10 {
+		t.Fatalf("search got (%q,%d), want (gateway voice env vars,10)", f.query, f.topK)
+	}
+}
+
+type flattenFakeCompress struct {
+	statsCalled bool
+	content     string
+}
+
+func (f *flattenFakeCompress) Recall(string) (string, bool) { return "", false }
+func (f *flattenFakeCompress) Compress(_, content string) (string, error) {
+	f.content = content
+	return "ok", nil
+}
+func (f *flattenFakeCompress) Stats() string { f.statsCalled = true; return "stats-ok" }
+
+func TestAgentFlatten_CompressStatsE2E(t *testing.T) {
+	f := &flattenFakeCompress{}
+	plugins.SetCompressionAdapter(f)
+	t.Cleanup(func() { plugins.SetCompressionAdapter(nil) })
+
+	out, err := flattenExec(t, plugins.NewBuiltinCompressPlugin(), `{"cmd":"stats"}`)
+	if err != nil {
+		t.Fatalf("@compress stats via flattened argv failed: %v", err)
+	}
+	if !f.statsCalled || out != "stats-ok" {
+		t.Fatalf("stats not dispatched: out=%q statsCalled=%v content=%q", out, f.statsCalled, f.content)
+	}
+}
+
+type flattenFakeMemory struct{ updates map[string]string }
+
+func (f *flattenFakeMemory) Remember(string, string) (string, error) { return "ok", nil }
+func (f *flattenFakeMemory) UpdateProfile(updates map[string]string) (string, error) {
+	f.updates = updates
+	return "ok", nil
+}
+func (f *flattenFakeMemory) Forget(string) (string, error) { return "ok", nil }
+func (f *flattenFakeMemory) Recall(string) (string, error) { return "ok", nil }
+
+func TestAgentFlatten_MemoryProfileE2E(t *testing.T) {
+	f := &flattenFakeMemory{}
+	plugins.SetMemoryAdapter(f)
+	t.Cleanup(func() { plugins.SetMemoryAdapter(nil) })
+
+	if _, err := flattenExec(t, plugins.NewBuiltinMemoryPlugin(),
+		`{"cmd":"profile","args":{"fields":{"role":"SRE","team":"infra"}}}`); err != nil {
+		t.Fatalf("@memory profile via flattened argv failed: %v", err)
+	}
+	if f.updates["role"] != "SRE" || f.updates["team"] != "infra" {
+		t.Fatalf("profile updates = %+v", f.updates)
+	}
+}
+
+type flattenFakeContext struct {
+	mergeName    string
+	mergeSources []string
+}
+
+func (f *flattenFakeContext) Create(string, string, []string, string, bool) (string, error) {
+	return "ok", nil
+}
+func (f *flattenFakeContext) Update(string, []string, string, string, []string) (string, error) {
+	return "ok", nil
+}
+func (f *flattenFakeContext) Attach(string, int, int) (string, error) { return "ok", nil }
+func (f *flattenFakeContext) Detach(string) (string, error)           { return "ok", nil }
+func (f *flattenFakeContext) List() (string, error)                   { return "ok", nil }
+func (f *flattenFakeContext) Show(string) (string, error)             { return "ok", nil }
+func (f *flattenFakeContext) Inspect(string, int) (string, error)     { return "ok", nil }
+func (f *flattenFakeContext) Merge(name string, sources []string, _ string) (string, error) {
+	f.mergeName, f.mergeSources = name, sources
+	return "ok", nil
+}
+func (f *flattenFakeContext) Status() (string, error)               { return "ok", nil }
+func (f *flattenFakeContext) Export(string, string) (string, error) { return "ok", nil }
+func (f *flattenFakeContext) Import(string) (string, error)         { return "ok", nil }
+func (f *flattenFakeContext) Metrics() (string, error)              { return "ok", nil }
+func (f *flattenFakeContext) Delete(string) (string, error)         { return "ok", nil }
+
+func TestAgentFlatten_ContextMergeE2E(t *testing.T) {
+	f := &flattenFakeContext{}
+	plugins.SetContextAdapter(f)
+	t.Cleanup(func() { plugins.SetContextAdapter(nil) })
+
+	if _, err := flattenExec(t, plugins.NewBuiltinContextPlugin(),
+		`{"cmd":"merge","args":{"name":"all-docs","sources":["react-docs","next-docs"]}}`); err != nil {
+		t.Fatalf("@context merge via flattened argv failed: %v", err)
+	}
+	if f.mergeName != "all-docs" || len(f.mergeSources) != 2 ||
+		f.mergeSources[0] != "react-docs" || f.mergeSources[1] != "next-docs" {
+		t.Fatalf("merge got (%q,%v)", f.mergeName, f.mergeSources)
+	}
+}
+
+// Top-level keys outside the {cmd,args} envelope must reach the plugin as
+// flags, not be silently dropped by the flattener.
+func TestFlatten_TopLevelKeysNotDropped(t *testing.T) {
+	argv, err := parseToolArgsWithJSON(`{"cmd":"describe","name":"graphview"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"describe", "--name", "graphview"}
+	if len(argv) != len(want) {
+		t.Fatalf("argv = %v, want %v", argv, want)
+	}
+	for i := range want {
+		if argv[i] != want[i] {
+			t.Fatalf("argv = %v, want %v", argv, want)
+		}
+	}
+}
+
 func TestAgentFlatten_SessionSearchE2E(t *testing.T) {
 	f := &flattenFakeSession{}
 	plugins.SetSessionAdapter(f)

--- a/cli/agent_tool_sanitizer.go
+++ b/cli/agent_tool_sanitizer.go
@@ -651,30 +651,7 @@ func buildArgvFromJSONMap(m map[string]any) ([]string, bool, error) {
 	}
 
 	argv := []string{cmd}
-	argsMap := map[string]any{}
-
-	if raw, ok := m["args"]; ok {
-		if mm, ok := raw.(map[string]any); ok {
-			for k, v := range mm {
-				if k == "command" {
-					argsMap["cmd"] = v
-					continue
-				}
-				argsMap[k] = v
-			}
-		}
-	}
-	if raw, ok := m["flags"]; ok {
-		if mm, ok := raw.(map[string]any); ok {
-			for k, v := range mm {
-				if k == "command" {
-					argsMap["cmd"] = v
-					continue
-				}
-				argsMap[k] = v
-			}
-		}
-	}
+	argsMap := collectArgsMap(m)
 
 	keys := make([]string, 0, len(argsMap))
 	for k := range argsMap {
@@ -694,6 +671,38 @@ func buildArgvFromJSONMap(m map[string]any) ([]string, bool, error) {
 	}
 
 	return argv, true, nil
+}
+
+// collectArgsMap merges the call's argument sources in precedence order:
+// top-level keys outside the envelope first — models routinely flatten
+// ({"cmd":"describe","name":"x"} instead of nesting under "args") and those
+// keys carry the call's actual arguments, so they must not be dropped —
+// then the explicit args/flags maps, which win on key conflicts. "command"
+// folds onto "cmd" at every level.
+func collectArgsMap(m map[string]any) map[string]any {
+	argsMap := map[string]any{}
+	put := func(k string, v any) {
+		if k == "command" {
+			argsMap["cmd"] = v
+			return
+		}
+		argsMap[k] = v
+	}
+	for k, v := range m {
+		switch k {
+		case "cmd", "argv", "args", "flags", "positional", "_":
+		default:
+			put(k, v)
+		}
+	}
+	for _, envelope := range []string{"args", "flags"} {
+		if mm, ok := m[envelope].(map[string]any); ok {
+			for k, v := range mm {
+				put(k, v)
+			}
+		}
+	}
+	return argsMap
 }
 
 func normalizeFlagName(name string) string {

--- a/cli/plugins/argv_flags.go
+++ b/cli/plugins/argv_flags.go
@@ -42,13 +42,23 @@ func argvToInnerJSON(argv []string, arrayKeys, intKeys map[string]bool) (positio
 		if strings.HasPrefix(a, "--") {
 			seenFlag = true
 			key := strings.TrimLeft(a, "-")
+			var inlineVal string
+			hasInline := false
+			if eq := strings.IndexByte(key, '='); eq >= 0 { // --key=value spelling
+				inlineVal = trimQuotes(key[eq+1:])
+				key = key[:eq]
+				hasInline = true
+			}
 			if _, ok := values[key]; !ok {
 				order = append(order, key)
 			}
-			if i+1 < len(argv) && !strings.HasPrefix(argv[i+1], "--") {
+			switch {
+			case hasInline:
+				values[key] = append(values[key], inlineVal)
+			case i+1 < len(argv) && !strings.HasPrefix(argv[i+1], "--"):
 				values[key] = append(values[key], argv[i+1])
 				i++
-			} else {
+			default:
 				values[key] = append(values[key], "\x00bool") // sentinel for bare flag
 			}
 			continue

--- a/cli/plugins/argv_flatten_parse_test.go
+++ b/cli/plugins/argv_flatten_parse_test.go
@@ -1,0 +1,112 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+/*
+ * Regression tests for the flag-form argv the agent flattener emits: each
+ * case below is byte-for-byte what buildArgvFromJSONMap produces for the
+ * plugin's own schema-taught JSON envelope (subcommand first, then sorted
+ * "--key value" pairs; nested objects JSON-stringified; the "command" key
+ * folded onto "cmd"). Parsers must read these, not treat flags as
+ * positionals.
+ */
+package plugins
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseHTTPInvocation_FlagArgv(t *testing.T) {
+	// {"cmd":"get","args":{"url":"https://api.github.com/zen"}}
+	in, err := parseHTTPInvocation([]string{"get", "--url", "https://api.github.com/zen"})
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if in.Method != "GET" || in.URL != "https://api.github.com/zen" {
+		t.Fatalf("get parsed (%q,%q)", in.Method, in.URL)
+	}
+
+	// {"cmd":"request","args":{"method":"POST","url":"...","body":"{\"a\":1}","headers":{"X-Token":"t"},"timeout_seconds":30}}
+	in, err = parseHTTPInvocation([]string{
+		"request",
+		"--body", `{"a":1}`,
+		"--headers", `{"X-Token":"t"}`,
+		"--method", "POST",
+		"--timeout_seconds", "30",
+		"--url", "https://api.example.com/v1",
+	})
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	if in.Method != "POST" || in.URL != "https://api.example.com/v1" || in.Body != `{"a":1}` {
+		t.Fatalf("request parsed (%q,%q,%q)", in.Method, in.URL, in.Body)
+	}
+	if in.Headers["X-Token"] != "t" {
+		t.Fatalf("headers not decoded from stringified object: %+v", in.Headers)
+	}
+	if in.TimeoutSeconds != 30 {
+		t.Fatalf("timeout_seconds = %d, want 30", in.TimeoutSeconds)
+	}
+
+	// Legacy positional forms must keep working.
+	in, err = parseHTTPInvocation([]string{"get", "https://api.github.com/zen"})
+	if err != nil || in.URL != "https://api.github.com/zen" {
+		t.Fatalf("positional get: %v (%q)", err, in.URL)
+	}
+	in, err = parseHTTPInvocation([]string{"request", "GET", "https://api.github.com/zen"})
+	if err != nil || in.Method != "GET" || in.URL != "https://api.github.com/zen" {
+		t.Fatalf("positional request: %v (%q,%q)", err, in.Method, in.URL)
+	}
+}
+
+func TestParseLSPInvocation_FlagArgv(t *testing.T) {
+	// {"cmd":"definition","args":{"file":"cli/cli.go","line":128,"column":14}}
+	cmd, inner, err := parseLSPInvocation([]string{"definition", "--column", "14", "--file", "cli/cli.go", "--line", "128"})
+	if err != nil {
+		t.Fatalf("definition: %v", err)
+	}
+	if cmd != "definition" {
+		t.Fatalf("cmd = %q", cmd)
+	}
+	for _, want := range []string{`"file":"cli/cli.go"`, `"line":128`, `"column":14`} {
+		if !strings.Contains(inner, want) {
+			t.Fatalf("inner %q missing %s", inner, want)
+		}
+	}
+
+	// Legacy positional form must keep working.
+	_, inner, err = parseLSPInvocation([]string{"definition", "cli/cli.go", "128", "14"})
+	if err != nil || !strings.Contains(inner, `"file":"cli/cli.go"`) || !strings.Contains(inner, `"line":128`) {
+		t.Fatalf("positional: %v inner=%q", err, inner)
+	}
+}
+
+func TestParseProcInvocation_FlagArgv(t *testing.T) {
+	// {"cmd":"start","args":{"command":"npm run dev","dir":"./web"}} — the
+	// flattener folds "command" onto "cmd", so argv carries --cmd.
+	cmd, inner, err := parseProcInvocation([]string{"start", "--cmd", "npm run dev", "--dir", "./web"})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if cmd != "start" || !strings.Contains(inner, `"command":"npm run dev"`) || !strings.Contains(inner, `"dir":"./web"`) {
+		t.Fatalf("start inner = %q", inner)
+	}
+
+	// {"cmd":"status","args":{"id":"p1"}}
+	cmd, inner, err = parseProcInvocation([]string{"status", "--id", "p1"})
+	if err != nil || cmd != "status" || !strings.Contains(inner, `"id":"p1"`) {
+		t.Fatalf("status: %v inner=%q", err, inner)
+	}
+
+	// Legacy positional forms must keep working.
+	_, inner, err = parseProcInvocation([]string{"start", "npm", "run", "dev"})
+	if err != nil || !strings.Contains(inner, `"command":"npm run dev"`) {
+		t.Fatalf("positional start: %v inner=%q", err, inner)
+	}
+	_, inner, err = parseProcInvocation([]string{"logs", "p1"})
+	if err != nil || !strings.Contains(inner, `"id":"p1"`) {
+		t.Fatalf("positional logs: %v inner=%q", err, inner)
+	}
+}

--- a/cli/plugins/builtin_compress.go
+++ b/cli/plugins/builtin_compress.go
@@ -99,6 +99,9 @@ func (p *BuiltinCompressPlugin) ExecuteWithStream(_ context.Context, args []stri
 		if err := json.Unmarshal([]byte(payload), &in); err != nil {
 			return "", fmt.Errorf(`@compress: parse args: %w. Expected {"content":"...","hint":"auto"}`, err)
 		}
+	} else if strings.EqualFold(payload, "stats") {
+		// The agent flattener reduces {"cmd":"stats"} to the bare argv token.
+		in.Cmd = "stats"
 	} else {
 		// Bare text: treat the whole payload as content with auto hint.
 		in.Content = payload

--- a/cli/plugins/builtin_context.go
+++ b/cli/plugins/builtin_context.go
@@ -536,34 +536,52 @@ func trimNonEmpty(in []string) []string {
 // contextArgvToMap converts `--flag value`, `--flag=value` and bare positional
 // names into the raw map the JSON path produces.
 func contextArgvToMap(args []string) map[string]json.RawMessage {
-	raw := map[string]json.RawMessage{}
-	put := func(k, v string) {
-		if b, err := json.Marshal(v); err == nil {
-			raw[k] = b
-		}
-	}
+	// Repeated flags accumulate: the agent flattener emits array fields
+	// (paths, tags, sources) as one "--key value" pair per element, so
+	// overwriting would silently keep only the last element.
+	vals := map[string][]string{}
+	bools := map[string]bool{}
+	add := func(k, v string) { vals[k] = append(vals[k], v) }
 	var positional []string
 	for i := 0; i < len(args); i++ {
 		a := strings.TrimSpace(args[i])
 		switch {
 		case strings.HasPrefix(a, "--") && strings.Contains(a, "="):
 			kv := strings.SplitN(strings.TrimPrefix(a, "--"), "=", 2)
-			put(kv[0], trimQuotes(kv[1]))
+			add(kv[0], trimQuotes(kv[1]))
 		case strings.HasPrefix(a, "--"):
 			key := strings.TrimPrefix(a, "--")
 			if i+1 < len(args) && !strings.HasPrefix(args[i+1], "--") {
-				put(key, trimQuotes(args[i+1]))
+				add(key, trimQuotes(args[i+1]))
 				i++
 			} else {
-				raw[key] = json.RawMessage("true")
+				bools[key] = true
 			}
 		case a != "":
 			positional = append(positional, a)
 		}
 	}
+	raw := map[string]json.RawMessage{}
+	for k := range bools {
+		raw[k] = json.RawMessage("true")
+	}
+	for k, vs := range vals {
+		var b []byte
+		var err error
+		if len(vs) == 1 {
+			b, err = json.Marshal(vs[0])
+		} else {
+			b, err = json.Marshal(vs)
+		}
+		if err == nil {
+			raw[k] = b
+		}
+	}
 	if len(positional) > 0 {
 		if _, ok := raw["name"]; !ok {
-			put("name", positional[0])
+			if b, err := json.Marshal(positional[0]); err == nil {
+				raw["name"] = b
+			}
 		}
 		if len(positional) > 1 {
 			if b, err := json.Marshal(positional[1:]); err == nil {

--- a/cli/plugins/builtin_http.go
+++ b/cli/plugins/builtin_http.go
@@ -137,11 +137,39 @@ func (p *BuiltinHTTPPlugin) ExecuteWithStream(ctx context.Context, args []string
 
 // httpArgs is the parsed request specification.
 type httpArgs struct {
-	Method         string            `json:"method"`
-	URL            string            `json:"url"`
-	Headers        map[string]string `json:"headers"`
-	Body           string            `json:"body"`
-	TimeoutSeconds int               `json:"timeout_seconds"`
+	Method         string    `json:"method"`
+	URL            string    `json:"url"`
+	Headers        headerMap `json:"headers"`
+	Body           string    `json:"body"`
+	TimeoutSeconds int       `json:"timeout_seconds"`
+}
+
+// headerMap unmarshals from an object or from a JSON-encoded object string —
+// the agent flattener stringifies nested objects when it converts the
+// envelope to "--flag value" argv.
+type headerMap map[string]string
+
+func (h *headerMap) UnmarshalJSON(b []byte) error {
+	var direct map[string]string
+	if err := json.Unmarshal(b, &direct); err == nil {
+		*h = direct
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return errors.New(`"headers" must be an object of string values`)
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		*h = nil
+		return nil
+	}
+	var inner map[string]string
+	if err := json.Unmarshal([]byte(s), &inner); err != nil {
+		return fmt.Errorf(`"headers" must be an object of string values: %w`, err)
+	}
+	*h = inner
+	return nil
 }
 
 // perform executes the request through the shared hardened client.
@@ -311,13 +339,21 @@ func parseHTTPInvocation(args []string) (httpArgs, error) {
 		if !ok {
 			return in, fmt.Errorf("unknown cmd %q (valid: request|get|head|options|post|put|patch|delete)", args[0])
 		}
-		in.Method = methodFromCmd
-		if len(args) > 1 {
-			in.URL = args[1]
+		tail := args[1:]
+		// Legacy positional "request GET <url>" before the flag scan.
+		if methodFromCmd == "" && len(tail) >= 2 &&
+			!strings.HasPrefix(tail[0], "-") && httpAllowedMethods[strings.ToUpper(tail[0])] {
+			methodFromCmd = strings.ToUpper(tail[0])
+			tail = tail[1:]
 		}
-		if in.Method == "" && len(args) > 2 { // argv "request GET <url>"
-			in.Method = strings.ToUpper(args[1])
-			in.URL = args[2]
+		// The agent flattener delivers the {cmd,args} envelope as "--flag
+		// value" argv; a bare positional is the URL.
+		inner := argvInner(tail, "url", nil, map[string]bool{"timeout_seconds": true})
+		if err := json.Unmarshal([]byte(inner), &in); err != nil {
+			return in, fmt.Errorf("parse args: %w", err)
+		}
+		if methodFromCmd != "" {
+			in.Method = methodFromCmd
 		}
 	}
 

--- a/cli/plugins/builtin_knowledge.go
+++ b/cli/plugins/builtin_knowledge.go
@@ -243,11 +243,11 @@ func parseKnowledgeInvocation(args []string) (string, string, error) {
 			args[0],
 		)
 	}
-	inner, err := memoryFlagsToJSON(args[1:])
-	if err != nil {
-		return "", "", err
-	}
-	return canon, inner, nil
+	// The agent flattener delivers the {cmd,args} envelope as "--flag value"
+	// pairs; numeric fields (top_k, offset) must come back as numbers, and a
+	// bare positional maps onto the subcommand's primary field.
+	primary := map[string]string{"search": "query", "get": "source", "toc": "prefix"}[canon]
+	return canon, argvInner(args[1:], primary, nil, map[string]bool{"top_k": true, "offset": true}), nil
 }
 
 // canonicalKnowledgeCmd folds aliases into the four canonical names.

--- a/cli/plugins/builtin_lsp.go
+++ b/cli/plugins/builtin_lsp.go
@@ -277,17 +277,33 @@ func parseLSPInvocation(args []string) (string, string, error) {
 	if canon == "" {
 		return "", "", fmt.Errorf("unknown cmd %q (valid: diagnostics|definition|references|symbols|hover)", args[0])
 	}
-	// argv form: positional file [line column]
-	in := map[string]interface{}{}
-	if len(args) > 1 {
-		in["file"] = args[1]
+	// argv form: the agent flattener delivers the {cmd,args} envelope as
+	// "--flag value" pairs; the legacy positional "file [line column]" form
+	// stays supported when no flag token is present.
+	tail := args[1:]
+	if !hasFlagToken(tail) {
+		in := map[string]interface{}{}
+		if len(tail) > 0 {
+			in["file"] = tail[0]
+		}
+		if len(tail) > 2 {
+			in["line"] = atoiSafe(tail[1])
+			in["column"] = atoiSafe(tail[2])
+		}
+		b, _ := json.Marshal(in)
+		return canon, string(b), nil
 	}
-	if len(args) > 3 {
-		in["line"] = atoiSafe(args[2])
-		in["column"] = atoiSafe(args[3])
+	return canon, argvInner(tail, "file", nil, map[string]bool{"line": true, "column": true, "limit": true}), nil
+}
+
+// hasFlagToken reports whether any argv token is flag-shaped.
+func hasFlagToken(args []string) bool {
+	for _, a := range args {
+		if strings.HasPrefix(strings.TrimSpace(a), "-") {
+			return true
+		}
 	}
-	b, _ := json.Marshal(in)
-	return canon, string(b), nil
+	return false
 }
 
 func atoiSafe(s string) int {

--- a/cli/plugins/builtin_memory.go
+++ b/cli/plugins/builtin_memory.go
@@ -343,10 +343,12 @@ func parseProfileFields(inner string) (map[string]string, error) {
 		return nil, nil
 	}
 	var wrapped struct {
-		Fields map[string]interface{} `json:"fields"`
+		Fields json.RawMessage `json:"fields"`
 	}
 	if err := json.Unmarshal([]byte(inner), &wrapped); err == nil && len(wrapped.Fields) > 0 {
-		return stringifyMap(wrapped.Fields), nil
+		if m := decodeFieldsObject(wrapped.Fields); len(m) > 0 {
+			return stringifyMap(m), nil
+		}
 	}
 	var bare map[string]interface{}
 	if err := json.Unmarshal([]byte(inner), &bare); err != nil {
@@ -354,6 +356,25 @@ func parseProfileFields(inner string) (map[string]string, error) {
 	}
 	delete(bare, "fields")
 	return stringifyMap(bare), nil
+}
+
+// decodeFieldsObject reads a JSON object from raw, accepting the direct
+// object form and the JSON-encoded string the agent flattener produces when
+// it stringifies a nested object into a "--fields" argv value.
+func decodeFieldsObject(raw json.RawMessage) map[string]interface{} {
+	var direct map[string]interface{}
+	if err := json.Unmarshal(raw, &direct); err == nil {
+		return direct
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return nil
+	}
+	var inner map[string]interface{}
+	if err := json.Unmarshal([]byte(s), &inner); err != nil {
+		return nil
+	}
+	return inner
 }
 
 // stringifyMap coerces JSON values to strings (numbers/bools become text;

--- a/cli/plugins/builtin_proc.go
+++ b/cli/plugins/builtin_proc.go
@@ -252,16 +252,41 @@ func parseProcInvocation(args []string) (string, string, error) {
 	if canon == "" {
 		return "", "", fmt.Errorf("unknown cmd %q (valid: start|status|logs|stop|remove|list)", args[0])
 	}
-	in := map[string]interface{}{}
-	if len(args) > 1 {
-		if canon == "start" {
-			in["command"] = strings.Join(args[1:], " ")
-		} else {
-			in["id"] = args[1]
+	// The agent flattener delivers the {cmd,args} envelope as "--flag value"
+	// pairs (folding the "command" key onto "cmd"); the legacy positional
+	// forms ("start npm run dev" / "logs p1") stay supported when no flag
+	// token is present.
+	tail := args[1:]
+	if !hasFlagToken(tail) {
+		in := map[string]interface{}{}
+		if len(tail) > 0 {
+			if canon == "start" {
+				in["command"] = strings.Join(tail, " ")
+			} else {
+				in["id"] = tail[0]
+			}
+		}
+		b, _ := json.Marshal(in)
+		return canon, string(b), nil
+	}
+	primary := "id"
+	if canon == "start" {
+		primary = "command"
+	}
+	inner := argvInner(tail, primary, nil, map[string]bool{"tail": true})
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(inner), &m); err == nil {
+		if v, ok := m["cmd"]; ok {
+			if _, has := m["command"]; !has {
+				m["command"] = v
+			}
+			delete(m, "cmd")
+			if b, err := json.Marshal(m); err == nil {
+				inner = string(b)
+			}
 		}
 	}
-	b, _ := json.Marshal(in)
-	return canon, string(b), nil
+	return canon, inner, nil
 }
 
 // canonicalProcCmd folds aliases onto the canonical subcommand names.

--- a/cli/plugins/builtin_todo.go
+++ b/cli/plugins/builtin_todo.go
@@ -222,7 +222,16 @@ func parseTodoInvocation(args []string) (string, map[string]json.RawMessage, err
 		}
 		return sub, inner, nil
 	}
-	// Positional. First token is the subcommand.
+	// Positional/flag argv. First token is the subcommand; the agent
+	// flattener delivers the envelope args as "--flag value" pairs after it
+	// (array fields as repeated flags, objects JSON-stringified).
+	_, innerJSON := argvToInnerJSON(args[1:], map[string]bool{"todos": true}, map[string]bool{"id": true})
+	if innerJSON != "{}" {
+		var inner map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(innerJSON), &inner); err == nil {
+			return first, inner, nil
+		}
+	}
 	return first, nil, nil
 }
 
@@ -236,7 +245,20 @@ func todoItemsFromPayload(payload map[string]json.RawMessage) ([]TodoItem, error
 	}
 	var items []TodoItem
 	if err := json.Unmarshal(raw, &items); err != nil {
-		return nil, fmt.Errorf("@todo write: invalid todos array: %w", err)
+		// The agent flattener JSON-stringifies each object of an array field;
+		// decode string elements as items before giving up.
+		var strs []string
+		if err2 := json.Unmarshal(raw, &strs); err2 != nil {
+			return nil, fmt.Errorf("@todo write: invalid todos array: %w", err)
+		}
+		items = items[:0] // drop the zero-value items the failed decode left behind
+		for _, s := range strs {
+			var it TodoItem
+			if err2 := json.Unmarshal([]byte(s), &it); err2 != nil {
+				return nil, fmt.Errorf("@todo write: invalid todos array: %w", err2)
+			}
+			items = append(items, it)
+		}
 	}
 	if len(items) == 0 {
 		return nil, errors.New("@todo write: todos array cannot be empty")

--- a/cli/plugins/builtin_tools.go
+++ b/cli/plugins/builtin_tools.go
@@ -171,9 +171,30 @@ func parseToolsInvocation(args []string) (string, string, error) {
 	if canon == "" {
 		return "", "", fmt.Errorf("unknown cmd %q (valid: describe|list)", args[0])
 	}
+	// The agent flattener delivers the {cmd,args} envelope as "--flag value"
+	// argv, so both flag and positional spellings must resolve here.
 	in := map[string]interface{}{}
-	if len(args) > 1 {
-		in["name"] = args[1]
+	rest := args[1:]
+	for i := 0; i < len(rest); i++ {
+		a := strings.TrimSpace(rest[i])
+		if a == "" {
+			continue
+		}
+		if strings.HasPrefix(a, "-") {
+			key := strings.TrimLeft(a, "-")
+			if eq := strings.IndexByte(key, '='); eq >= 0 {
+				in[key[:eq]] = trimQuotes(strings.TrimSpace(key[eq+1:]))
+				continue
+			}
+			if i+1 < len(rest) {
+				i++
+				in[key] = trimQuotes(strings.TrimSpace(rest[i]))
+			}
+			continue
+		}
+		if _, ok := in["name"]; !ok {
+			in["name"] = a
+		}
 	}
 	b, _ := json.Marshal(in)
 	return canon, string(b), nil

--- a/cli/plugins/builtin_tools_test.go
+++ b/cli/plugins/builtin_tools_test.go
@@ -60,6 +60,37 @@ func TestToolsListAndAliases(t *testing.T) {
 	}
 }
 
+// The agent-mode flattener converts {"cmd":"describe","args":{"name":"X"}}
+// into argv ["describe","--name","X"]; the argv path must parse flags instead
+// of taking "--name" as the tool name.
+func TestToolsDescribeArgvFlagForms(t *testing.T) {
+	p := NewBuiltinToolsPlugin()
+	cases := []struct {
+		argv []string
+		want string
+	}{
+		{[]string{"describe", "--name", "@graphview"}, "@graphview"},
+		{[]string{"describe", "--name=@graphview"}, "@graphview"},
+		{[]string{"describe", "--name", "graphview"}, "graphview"},
+		{[]string{"describe", "@graphview"}, "@graphview"},
+	}
+	for _, tc := range cases {
+		fake := withFakeCatalog(t)
+		if _, err := p.Execute(context.Background(), tc.argv); err != nil {
+			t.Fatalf("%v: %v", tc.argv, err)
+		}
+		if fake.described != tc.want {
+			t.Errorf("%v: described %q, want %q", tc.argv, fake.described, tc.want)
+		}
+	}
+	// Flag with no value must still fail with the actionable "name" error,
+	// not leak "--name" to the catalog as a tool name.
+	withFakeCatalog(t)
+	if _, err := p.Execute(context.Background(), []string{"describe", "--name"}); err == nil || !strings.Contains(err.Error(), `"name" is required`) {
+		t.Fatalf("dangling flag must error on missing name, got %v", err)
+	}
+}
+
 func TestToolsValidation(t *testing.T) {
 	withFakeCatalog(t)
 	p := NewBuiltinToolsPlugin()


### PR DESCRIPTION
## Problem

In agent mode, the flattener converts the JSON envelope form of a tool call — `{"cmd":"describe","args":{"name":"@graphview"}}` — into flag-style argv (`describe --name @graphview`) before dispatch. Several builtin parsers read that argv **positionally**, so the first flag token was consumed as the value itself:

```
│  Ferramenta: @tools                                        │
│  Comando: {"cmd":"describe","args":{"name":"@graphview"}}  │
❌ unknown tool "--name" — available: @ask, @cmd:help, ...
```

The system prompt teaches exactly the envelope shape that failed, so the model could not recover by rephrasing — every retry variant hit a different hole in the same pipeline.

A full audit of the 34 builtins found the same class of bug beyond `@tools`:

| Tool | Failure in agent mode |
|---|---|
| `@tools` | `describe` read `--name` as the tool name |
| `@http` | every enveloped call misread url/method |
| `@lsp` | file/line/column scrambled by sorted flags |
| `@proc` | `start`/`status`/`logs`/`stop`/`remove` misread command/id |
| `@todo` | `write`/`mark` dropped the whole payload |
| `@compress` | `{"cmd":"stats"}` compressed the literal word "stats" |
| `@context` | `merge` unreachable; multi-element `paths`/`tags`/`sources` kept only the last element |
| `@memory` | `profile` lost the nested `fields` object |
| `@knowledge` | `top_k`/`offset` silently became 0 |

A second flattener bug compounded it: top-level keys outside the envelope (`{"cmd":"describe","name":"graphview"}` — a shape models routinely fall back to) were **silently dropped**.

## Fix

- `buildArgvFromJSONMap`: fold non-envelope top-level keys into the flag map (explicit `args`/`flags` still win on conflicts)
- `@tools`, `@http`, `@lsp`, `@proc`, `@knowledge`: argv branch now parses `--flag value` / `--flag=value` (shared `argvInner` with int coercion), legacy positional spellings preserved
- stringified nested objects decoded: `@todo` todos, `@http` headers, `@memory` profile fields
- `@context`: repeated flags accumulate as arrays; `@compress`: bare `stats` token recognized; `argvToInnerJSON`: `--key=value` spelling supported

## Tests

End-to-end regressions drive the **real** flattener into the **real** plugins (fake adapters) for every shape that failed, plus parse-level tables for `@http`/`@lsp`/`@proc` with byte-exact flattener argv. All were red before the fix, green after. Full suite + golangci-lint clean on both modules.