### PR TITLE
ci(release): follow the docs language layout inversion in the version bump

### DIFF
--- a/.github/workflows/3-publish-release.yml
+++ b/.github/workflows/3-publish-release.yml
@@ -763,7 +763,9 @@ jobs:
           fi
 
           # 3) "Atualizações recentes" / "Recent updates" Update block
-          #    in introduction.mdx (PT-BR) and en/introduction.mdx (EN).
+          #    in introduction.mdx (EN, site root) and pt/introduction.mdx
+          #    (PT-BR). English moved to the root when it became the
+          #    site's default language.
           #    Driven by release-please's CHANGELOG.md from the chatcli
           #    source repo (checked out above into _chatcli_src). We
           #    extract the latest release section (between the first
@@ -818,7 +820,7 @@ jobs:
 
               # Inject before the FIRST existing <Update label="..."> block.
               # Idempotent: skip if a block with this label already exists.
-              for f in introduction.mdx en/introduction.mdx; do
+              for f in introduction.mdx pt/introduction.mdx; do
                 if [ ! -f "$f" ]; then continue; fi
                 if grep -q "<Update label=\"${MAJOR_MINOR}\"" "$f"; then
                   echo "  ${f}: already has Update label=${MAJOR_MINOR}, skipping"


### PR DESCRIPTION
The docs site (chatcli.ai) was restructured: English now serves from the root and Portuguese moved under `pt/`. The release automation that injects the recent-updates block still targeted `en/introduction.mdx`, which no longer exists — Portuguese readers would silently stop receiving the changelog block on the next release.

- Targets `introduction.mdx` (EN, root) and `pt/introduction.mdx` (PT-BR).
- Comment updated to describe the new layout.
- The `*.mdx` version sed and the docs.json banner regex are layout-agnostic and needed no change (verified against the restructured repo, including the new per-language pt banner which matches the same `🚀 ChatCLI X.Y.Z` pattern).