### PR TITLE
feat(skills): re-activate skills mid-loop in agent and coder modes

### DIFF
--- a/cli/agent/park/snapshot.go
+++ b/cli/agent/park/snapshot.go
@@ -58,6 +58,11 @@ type Snapshot struct {
 	SkillModelHint  string                `json:"skill_model_hint,omitempty"`
 	SkillEffortHint llmclient.SkillEffort `json:"skill_effort_hint,omitempty"`
 
+	// InjectedSkillNames is the mid-loop skill dedup set at park time.
+	// Restored so a skill already delivered to the model before the park
+	// cannot re-fire (and duplicate its prompt block) after resume.
+	InjectedSkillNames []string `json:"injected_skill_names,omitempty"`
+
 	// OriginalQuery is the user's original /coder or /agent prompt,
 	// retained for /parked rendering and audit trails.
 	OriginalQuery string `json:"original_query,omitempty"`

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -121,6 +121,13 @@ type AgentMode struct {
 	skillModelHint  string
 	skillEffortHint llmclient.SkillEffort
 
+	// injectedSkillNames tracks every skill already delivered to the model
+	// during the current Run() — via the startup system-prompt blocks
+	// (pinned/auto/manual) or a mid-loop re-scan injection — so the per-turn
+	// re-scan (skill_rescan.go) never injects the same skill twice. Reset at
+	// the start of each Run() alongside the skill hints.
+	injectedSkillNames map[string]bool
+
 	// Session-scoped flag: true once we have warned the user that the
 	// history is approaching likely corporate-proxy payload limits and
 	// no explicit CHATCLI_MAX_PAYLOAD is configured. Prevents the warning
@@ -776,6 +783,7 @@ func (a *AgentMode) Run(ctx context.Context, query string, additionalContext str
 	// without an active skill does not inherit the old model/effort.
 	a.skillModelHint = ""
 	a.skillEffortHint = llmclient.EffortUnset
+	a.injectedSkillNames = make(map[string]bool)
 	// Block 4 — skills (pinned + auto-activated + manual) and Orchestrator
 	// catalog. Built last because it's the most volatile (changes per query)
 	// and sits at the tail of the system prompt so earlier blocks stay
@@ -788,6 +796,7 @@ func (a *AgentMode) Run(ctx context.Context, query string, additionalContext str
 		manualArgs := a.cli.pendingManualSkillArgs
 		a.cli.pendingManualSkill = nil
 		a.cli.pendingManualSkillArgs = ""
+		a.noteInjectedSkills(manual)
 		if block := renderManualSkillBlock(manual, manualArgs); block != "" {
 			if skillsText != "" {
 				skillsText += "\n\n"
@@ -1372,6 +1381,24 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 		renderer.RenderAssistantResponseTimelineEvent(icon, title, rendered, color)
 	}
 
+	// Mid-loop skill re-activation (skill_rescan.go). pendingSkillBlock holds
+	// a skill block matched against the ASSISTANT's output; it is flushed into
+	// history only at the next turn boundary so the injected user-role message
+	// can never land between an assistant tool_use and its tool_result (which
+	// would corrupt native tool protocols). User follow-ups inject in place —
+	// their slot is already a safe turn boundary.
+	var pendingSkillBlock string
+	notifySkillActivation := func(names []string) {
+		if len(names) == 0 || a.cli.unattended {
+			return
+		}
+		fmt.Printf("\r\033[K  %s %s\n",
+			renderer.Colorize("✨", agent.ColorCyan),
+			renderer.Colorize(
+				i18n.T("agent.skill.rescan_activated", strings.Join(names, ", ")),
+				agent.ColorCyan))
+	}
+
 	// Context recovery state for the session
 	contextRecovery := agent.NewContextRecovery(agent.DefaultContextRecoveryConfig(), a.logger)
 	currentMaxTokens := 0           // 0 = use provider default
@@ -1434,6 +1461,21 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 				Role:    "user",
 				Content: userMsg,
 			})
+			// A type-ahead follow-up is a fresh trigger surface: activate its
+			// skills NOW so they shape the very next turn, not one turn late.
+			if block, names := a.rescanSkillsMidLoop(userMsg); block != "" {
+				a.cli.history = append(a.cli.history, models.Message{Role: "user", Content: block})
+				notifySkillActivation(names)
+			}
+		}
+
+		// Flush the skill block queued by the previous turn's assistant-output
+		// re-scan. This is a turn boundary: the previous turn's tool results
+		// are already in history, so the injection cannot split a tool_use
+		// from its tool_result.
+		if pendingSkillBlock != "" {
+			a.cli.history = append(a.cli.history, models.Message{Role: "user", Content: pendingSkillBlock})
+			pendingSkillBlock = ""
 		}
 
 		// Microcompact (Level 0): cheap, progressive compaction of OLD tool
@@ -1764,6 +1806,18 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 			})
 		} else {
 			a.cli.history = append(a.cli.history, models.Message{Role: "assistant", Content: aiResponse})
+		}
+
+		// Mid-loop skill activation: the model's own <reasoning> text and the
+		// file paths inside its tool_call args are trigger surfaces too. A
+		// skill whose keyword only surfaces in the agent's plan ("I'll write a
+		// Helm chart for this") — or whose path glob matches a file the agent
+		// just started touching — is injected at the next turn boundary, in
+		// time to improve the remaining work. Deduped per Run, so a skill the
+		// user's query already activated never re-fires here.
+		if block, names := a.rescanSkillsMidLoop(aiResponse); block != "" {
+			pendingSkillBlock = block
+			notifySkillActivation(names)
 		}
 
 		// Parsear Tool Calls — native ou XML fallback
@@ -2939,6 +2993,12 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 				Role:    "user",
 				Content: userInput,
 			})
+			// Same contract as the type-ahead path: a mid-session follow-up
+			// activates its skills before the next turn is sent.
+			if block, names := a.rescanSkillsMidLoop(userInput); block != "" {
+				a.cli.history = append(a.cli.history, models.Message{Role: "user", Content: block})
+				notifySkillActivation(names)
+			}
 			continue
 		}
 
@@ -3310,6 +3370,9 @@ func (a *AgentMode) buildAgentSkillBlocks(query, additionalContext string) strin
 
 	merged := append([]*persona.Skill(nil), pinned...)
 	merged = append(merged, autoActivated...)
+	// Seed the mid-loop re-scan dedup set: everything injected here is
+	// already in the model's system prompt for the whole Run.
+	a.noteInjectedSkills(merged...)
 	if len(merged) > 0 {
 		model, effort, _ := pickSkillModelAndEffort(merged)
 		if model != "" {

--- a/cli/agent_park.go
+++ b/cli/agent_park.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -70,7 +71,15 @@ func (a *AgentMode) handleAgentPark(
 		Model:           a.cli.Model,
 		SkillModelHint:  a.skillModelHint,
 		SkillEffortHint: a.skillEffortHint,
-		Park:            req,
+		InjectedSkillNames: func() []string {
+			names := make([]string, 0, len(a.injectedSkillNames))
+			for name := range a.injectedSkillNames {
+				names = append(names, name)
+			}
+			sort.Strings(names)
+			return names
+		}(),
+		Park: req,
 	}
 	// Carry the pending native tool_use ID through the snapshot so
 	// resume can synthesize a matching tool_result and avoid Anthropic's
@@ -304,6 +313,12 @@ func (a *AgentMode) RunResumed(ctx context.Context, snap *park.Snapshot, outcome
 	}
 	if snap.SkillEffortHint != llmclient.EffortUnset {
 		a.skillEffortHint = snap.SkillEffortHint
+	}
+	// Rebuild the mid-loop skill dedup set so skills injected before the
+	// park never duplicate after resume.
+	a.injectedSkillNames = make(map[string]bool, len(snap.InjectedSkillNames))
+	for _, name := range snap.InjectedSkillNames {
+		a.injectedSkillNames[name] = true
 	}
 	a.cli.history = append([]models.Message(nil), snap.History...)
 

--- a/cli/config_env_defaults.go
+++ b/cli/config_env_defaults.go
@@ -109,6 +109,7 @@ var envDefaults = map[string]envDefault{
 
 	// ─── Agent: token efficiency ─────────────────────────────────
 	"CHATCLI_AGENT_EARLY_EXIT":       {Value: "true", IsBool: true, Source: "agent_earlyexit.earlyExitEnabled"},
+	"CHATCLI_AGENT_SKILL_RESCAN":     {Value: "true", IsBool: true, Source: "skill_rescan.skillRescanEnabled"},
 	"CHATCLI_AGENT_EARLY_EXIT_TURNS": {Value: "3", Source: "agent_earlyexit.defaultStagnationThreshold"},
 	"CHATCLI_AGENT_SMART_ROUTE":      {Value: "hint", Source: "agent_routing.smartRouting"},
 

--- a/cli/config_sections.go
+++ b/cli/config_sections.go
@@ -992,6 +992,7 @@ func (cli *ChatCLI) showConfigIntegrations(ctx context.Context) {
 
 	fmt.Println(p)
 	subheader(p, "cfg.sub.integ.skills")
+	kv(p, "CHATCLI_AGENT_SKILL_RESCAN", envBool("CHATCLI_AGENT_SKILL_RESCAN"))
 	kv(p, "CHATCLI_REGISTRY_DISABLE", envBool("CHATCLI_REGISTRY_DISABLE"))
 	kv(p, "CHATCLI_REGISTRY_URLS", envOr("CHATCLI_REGISTRY_URLS"))
 	kv(p, "CHATCLI_SKILL_INSTALL_DIR", envOr("CHATCLI_SKILL_INSTALL_DIR"))

--- a/cli/skill_activation.go
+++ b/cli/skill_activation.go
@@ -104,10 +104,17 @@ func buildSkillInjectionBlock(skills []*persona.Skill) string {
 	b.WriteString("The following skills were automatically activated based on ")
 	b.WriteString("your input (matched via `triggers:` keywords or `paths:` globs ")
 	b.WriteString("in the skill frontmatter). Follow their guidance when relevant.\n\n")
+	renderSkillEntries(&b, skills)
+	return b.String()
+}
+
+// renderSkillEntries writes the shared per-skill markdown section (name,
+// version, description, content) used by every skill injection block.
+func renderSkillEntries(b *strings.Builder, skills []*persona.Skill) {
 	for _, skill := range skills {
-		fmt.Fprintf(&b, "## Skill: %s", skill.Name)
+		fmt.Fprintf(b, "## Skill: %s", skill.Name)
 		if skill.Version != "" {
-			fmt.Fprintf(&b, " (v%s)", skill.Version)
+			fmt.Fprintf(b, " (v%s)", skill.Version)
 		}
 		b.WriteString("\n\n")
 		if skill.Description != "" {
@@ -119,7 +126,6 @@ func buildSkillInjectionBlock(skills []*persona.Skill) string {
 			b.WriteString("\n\n")
 		}
 	}
-	return b.String()
 }
 
 // buildPinnedSkillInjectionBlock formats user-pinned skills (via `/skill pin`)
@@ -139,21 +145,7 @@ func buildPinnedSkillInjectionBlock(skills []*persona.Skill) string {
 	b.WriteString("The user pinned the following skills for this session via ")
 	b.WriteString("`/skill pin <name>`. They apply to every turn regardless of ")
 	b.WriteString("input triggers or file paths — treat them as standing instructions.\n\n")
-	for _, skill := range skills {
-		fmt.Fprintf(&b, "## Skill: %s", skill.Name)
-		if skill.Version != "" {
-			fmt.Fprintf(&b, " (v%s)", skill.Version)
-		}
-		b.WriteString("\n\n")
-		if skill.Description != "" {
-			b.WriteString(skill.Description)
-			b.WriteString("\n\n")
-		}
-		if strings.TrimSpace(skill.Content) != "" {
-			b.WriteString(skill.Content)
-			b.WriteString("\n\n")
-		}
-	}
+	renderSkillEntries(&b, skills)
 	return b.String()
 }
 

--- a/cli/skill_rescan.go
+++ b/cli/skill_rescan.go
@@ -1,0 +1,153 @@
+/*
+ * ChatCLI - Mid-loop skill re-activation for agent/coder mode
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Skills auto-activate once at Run() start against the user's query. That
+ * misses everything the ReAct loop produces afterwards: the model's own
+ * <reasoning> text, the file paths its tool calls start touching, and the
+ * follow-up instructions the user types mid-session (type-ahead queue or the
+ * interactive continuation prompt). This file closes that gap: every turn the
+ * loop re-scans that mid-run text against the skill catalog and injects any
+ * NEWLY matched skill as an append-only history message — so a skill whose
+ * trigger only surfaces in the agent's own plan ("I should write a Helm
+ * chart…") still reaches the model in time to shape the very next action.
+ *
+ * Injection is append-only (a user-role message, like the tool-guard and
+ * payload-recovery hints) so the cached system-prompt prefix is never
+ * invalidated mid-run. A per-Run dedup set guarantees each skill is injected
+ * at most once per session, bounding both token cost and cascade risk.
+ */
+package cli
+
+import (
+	"os"
+	"strings"
+
+	llmclient "github.com/diillson/chatcli/llm/client"
+	"github.com/diillson/chatcli/pkg/persona"
+	"go.uber.org/zap"
+)
+
+// skillRescanEnv toggles mid-loop skill re-activation. Set to "0" or "false"
+// to fall back to the historical behavior (skills only fire on the initial
+// user query). On by default — injection is advisory, append-only, and
+// bounded by the per-Run dedup set.
+const skillRescanEnv = "CHATCLI_AGENT_SKILL_RESCAN"
+
+// skillRescanEnabled reports whether the mid-loop skill re-scan is active.
+// Honors CHATCLI_AGENT_SKILL_RESCAN=0|false|off|no.
+func skillRescanEnabled() bool {
+	switch strings.TrimSpace(strings.ToLower(os.Getenv(skillRescanEnv))) {
+	case "0", "false", "off", "no":
+		return false
+	default:
+		return true
+	}
+}
+
+// rescanNewSkills matches mid-run text (plus any file-path tokens embedded in
+// it — tool_call args count) against the skill catalog and returns only the
+// skills whose Name is NOT yet in injected. Matched names are recorded in
+// injected so a skill fires at most once per agent session.
+//
+// Pure with respect to AgentMode so tests can drive it with just a
+// persona.Manager fixture. A nil injected map means "no dedup state" and is
+// treated as empty (nothing recorded — callers must pass a real map to get
+// dedup, which AgentMode.rescanSkillsMidLoop guarantees).
+func rescanNewSkills(mgr *persona.Manager, injected map[string]bool, text string) []*persona.Skill {
+	if mgr == nil || strings.TrimSpace(text) == "" {
+		return nil
+	}
+	matched := mgr.FindAutoActivatedSkills(text, extractFilePaths(text))
+	if len(matched) == 0 {
+		return nil
+	}
+	out := make([]*persona.Skill, 0, len(matched))
+	for _, s := range matched {
+		if injected != nil && injected[s.Name] {
+			continue
+		}
+		if injected != nil {
+			injected[s.Name] = true
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// buildMidLoopSkillBlock formats skills that fired DURING the ReAct loop into
+// the user-role message injected into history. The header tells the model why
+// new instructions appeared mid-task so it treats them as guidance for the
+// remaining work, not as a new user request.
+func buildMidLoopSkillBlock(skills []*persona.Skill) string {
+	if len(skills) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("[SKILL AUTO-ACTIVATION — MID-TASK]\n\n")
+	b.WriteString("The following skills were automatically activated while you were ")
+	b.WriteString("working (matched against your own reasoning, the files you are ")
+	b.WriteString("touching, or a user follow-up). This is NOT a new user request: ")
+	b.WriteString("apply their guidance to the remainder of the CURRENT task, ")
+	b.WriteString("adjusting your approach if they suggest a better one.\n\n")
+	renderSkillEntries(&b, skills)
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// rescanSkillsMidLoop scans text produced mid-run (assistant reasoning +
+// tool_call args, or a user follow-up) for skills not yet injected in this
+// session. Returns the history message content to append ("" when nothing new
+// fired) and the activated skill names for user-facing notices.
+//
+// Skill model/effort hints are honored only when no earlier skill claimed
+// them (same first-wins rule as pickSkillModelAndEffort) — a mid-task skill
+// must not yank the model out from under a startup skill's explicit choice.
+func (a *AgentMode) rescanSkillsMidLoop(text string) (string, []string) {
+	if !skillRescanEnabled() || a.cli.personaHandler == nil {
+		return "", nil
+	}
+	mgr := a.cli.personaHandler.GetManager()
+	if mgr == nil {
+		return "", nil
+	}
+	if a.injectedSkillNames == nil {
+		a.injectedSkillNames = make(map[string]bool)
+	}
+	fresh := rescanNewSkills(mgr, a.injectedSkillNames, text)
+	if len(fresh) == 0 {
+		return "", nil
+	}
+
+	model, effort, _ := pickSkillModelAndEffort(fresh)
+	if model != "" && a.skillModelHint == "" {
+		a.skillModelHint = model
+	}
+	if effort != "" && a.skillEffortHint == llmclient.EffortUnset {
+		a.skillEffortHint = llmclient.NormalizeEffort(effort)
+	}
+
+	names := make([]string, 0, len(fresh))
+	for _, s := range fresh {
+		names = append(names, s.Name)
+	}
+	a.logger.Info("agent mode: mid-loop skill activation",
+		zap.Strings("skills", names),
+		zap.String("model_hint", a.skillModelHint),
+		zap.String("effort_hint", string(a.skillEffortHint)))
+	return buildMidLoopSkillBlock(fresh), names
+}
+
+// noteInjectedSkills records skill names already delivered to the model (via
+// the system-prompt blocks built at Run() start) so the mid-loop re-scan
+// never injects a duplicate copy of them.
+func (a *AgentMode) noteInjectedSkills(skills ...*persona.Skill) {
+	if a.injectedSkillNames == nil {
+		a.injectedSkillNames = make(map[string]bool)
+	}
+	for _, s := range skills {
+		if s != nil {
+			a.injectedSkillNames[s.Name] = true
+		}
+	}
+}

--- a/cli/skill_rescan_test.go
+++ b/cli/skill_rescan_test.go
@@ -1,0 +1,175 @@
+/*
+ * ChatCLI - Tests for mid-loop skill re-activation (skill_rescan.go)
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Exercises the re-scan that closes the "skills only fire on the initial
+ * user query" gap in agent/coder mode:
+ *   - trigger keywords surfacing only in the ASSISTANT's reasoning
+ *   - path globs matching files named inside tool_call args
+ *   - per-Run dedup (startup-injected skills never re-fire mid-loop)
+ *   - first-wins model/effort hints (mid-loop skills never override startup)
+ *   - env kill switch
+ *
+ * The fixture mirrors skill_pin_test.go: single-file skills in a temp
+ * project dir via Manager.SetProjectDir — fully hermetic.
+ */
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	llmclient "github.com/diillson/chatcli/llm/client"
+	"github.com/diillson/chatcli/pkg/persona"
+	"go.uber.org/zap"
+)
+
+const (
+	rescanFixtureHelm = `---
+name: helm-authoring
+description: guidance for writing Helm charts
+triggers:
+  - helm chart
+effort: high
+---
+Always template image tags and pin chart apiVersion v2.`
+
+	rescanFixtureGoTest = `---
+name: go-test-style
+description: table-driven test conventions
+paths:
+  - "**/*_test.go"
+---
+Prefer table-driven tests with t.Run subtests.`
+
+	rescanFixtureWithModel = `---
+name: perf-audit
+description: performance auditing checklist
+triggers:
+  - profiling
+model: opus
+effort: max
+---
+Collect a pprof profile before optimizing.`
+)
+
+// newRescanFixture builds an AgentMode whose ChatCLI carries an isolated
+// persona manager seeded with the given skills.
+func newRescanFixture(t *testing.T, skills map[string]string) *AgentMode {
+	t.Helper()
+	tmp := t.TempDir()
+	skillsDir := filepath.Join(tmp, ".agent", "skills")
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+		t.Fatalf("mkdir skillsDir: %v", err)
+	}
+	for name, body := range skills {
+		if err := os.WriteFile(filepath.Join(skillsDir, name+".md"), []byte(body), 0o644); err != nil {
+			t.Fatalf("write skill %s: %v", name, err)
+		}
+	}
+	mgr := persona.NewManager(zap.NewNop())
+	mgr.SetProjectDir(tmp)
+	if _, err := mgr.RefreshSkills(); err != nil {
+		t.Fatalf("RefreshSkills: %v", err)
+	}
+	cli := &ChatCLI{personaHandler: &PersonaHandler{manager: mgr, logger: zap.NewNop()}}
+	return &AgentMode{cli: cli, logger: zap.NewNop()}
+}
+
+func TestRescanSkillsMidLoop_TriggerInAssistantReasoning(t *testing.T) {
+	a := newRescanFixture(t, map[string]string{"helm-authoring": rescanFixtureHelm})
+
+	reasoning := "<reasoning>The user wants this deployed; I will write a Helm chart for the service.</reasoning>"
+	block, names := a.rescanSkillsMidLoop(reasoning)
+
+	if len(names) != 1 || names[0] != "helm-authoring" {
+		t.Fatalf("expected helm-authoring to activate, got %v", names)
+	}
+	if !strings.Contains(block, "SKILL AUTO-ACTIVATION — MID-TASK") {
+		t.Fatalf("block missing mid-task header:\n%s", block)
+	}
+	if !strings.Contains(block, "pin chart apiVersion v2") {
+		t.Fatalf("block missing skill content:\n%s", block)
+	}
+	if a.skillEffortHint != llmclient.EffortHigh {
+		t.Fatalf("effort hint = %q, want high", a.skillEffortHint)
+	}
+
+	// Same text again → deduped, nothing new fires.
+	block, names = a.rescanSkillsMidLoop(reasoning)
+	if block != "" || len(names) != 0 {
+		t.Fatalf("dedup failed: second scan returned %v / %q", names, block)
+	}
+}
+
+func TestRescanSkillsMidLoop_PathGlobFromToolCallArgs(t *testing.T) {
+	a := newRescanFixture(t, map[string]string{"go-test-style": rescanFixtureGoTest})
+
+	response := `<reasoning>Fixing the regression.</reasoning>
+<tool_call name="@coder" args="{\"cmd\":\"read\",\"file\":\"pkg/foo/bar_test.go\"}" />`
+	_, names := a.rescanSkillsMidLoop(response)
+
+	if len(names) != 1 || names[0] != "go-test-style" {
+		t.Fatalf("expected go-test-style via path glob, got %v", names)
+	}
+}
+
+func TestRescanSkillsMidLoop_StartupInjectionSeedsDedup(t *testing.T) {
+	a := newRescanFixture(t, map[string]string{"helm-authoring": rescanFixtureHelm})
+
+	// Simulate Run() startup: the skill already fired on the user query and
+	// was recorded via noteInjectedSkills.
+	skill, err := a.cli.personaHandler.GetManager().GetSkill("helm-authoring")
+	if err != nil {
+		t.Fatalf("GetSkill: %v", err)
+	}
+	a.noteInjectedSkills(skill)
+
+	block, names := a.rescanSkillsMidLoop("planning the helm chart layout now")
+	if block != "" || len(names) != 0 {
+		t.Fatalf("startup-injected skill must not re-fire mid-loop; got %v", names)
+	}
+}
+
+func TestRescanSkillsMidLoop_HintsAreFirstWins(t *testing.T) {
+	a := newRescanFixture(t, map[string]string{"perf-audit": rescanFixtureWithModel})
+	a.skillModelHint = "sonnet"
+	a.skillEffortHint = llmclient.EffortLow
+
+	_, names := a.rescanSkillsMidLoop("next I will do some profiling of the hot path")
+	if len(names) != 1 {
+		t.Fatalf("expected perf-audit to activate, got %v", names)
+	}
+	if a.skillModelHint != "sonnet" {
+		t.Fatalf("mid-loop skill must not override startup model hint; got %q", a.skillModelHint)
+	}
+	if a.skillEffortHint != llmclient.EffortLow {
+		t.Fatalf("mid-loop skill must not override startup effort hint; got %q", a.skillEffortHint)
+	}
+}
+
+func TestRescanSkillsMidLoop_NoMatchReturnsEmpty(t *testing.T) {
+	a := newRescanFixture(t, map[string]string{"helm-authoring": rescanFixtureHelm})
+	block, names := a.rescanSkillsMidLoop("just reading some source files")
+	if block != "" || len(names) != 0 {
+		t.Fatalf("no trigger present, expected empty result; got %v / %q", names, block)
+	}
+}
+
+func TestRescanSkillsMidLoop_EnvKillSwitch(t *testing.T) {
+	t.Setenv(skillRescanEnv, "false")
+	a := newRescanFixture(t, map[string]string{"helm-authoring": rescanFixtureHelm})
+	block, names := a.rescanSkillsMidLoop("writing a helm chart")
+	if block != "" || len(names) != 0 {
+		t.Fatalf("rescan disabled by env, expected no activation; got %v", names)
+	}
+}
+
+func TestBuildMidLoopSkillBlock_Empty(t *testing.T) {
+	if got := buildMidLoopSkillBlock(nil); got != "" {
+		t.Fatalf("empty skill slice must render empty block, got %q", got)
+	}
+}

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -1185,6 +1185,7 @@
   "compact.status.truncated": "✓ Truncated (%d → %d msgs)",
   "agent.microcompact.applied": "microcompact: %d truncated, %d summarized, %s freed",
   "agent.queue.new_user_instruction": "New user instruction received",
+  "agent.skill.rescan_activated": "Skill auto-activated mid-task: %s",
   "agent.queue.indicator": "(%d queued)",
   "agent.spinner.executing": "RUNNING: %s %s",
   "agent.spinner.action_placeholder": "action",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1185,6 +1185,7 @@
   "compact.status.truncated": "✓ Truncated (%d → %d msgs)",
   "agent.microcompact.applied": "microcompact: %d truncated, %d summarized, %s freed",
   "agent.queue.new_user_instruction": "New user instruction received",
+  "agent.skill.rescan_activated": "Skill auto-activated mid-task: %s",
   "agent.queue.indicator": "(%d queued)",
   "agent.spinner.executing": "RUNNING: %s %s",
   "agent.spinner.action_placeholder": "action",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -1185,6 +1185,7 @@
   "compact.status.truncated": "✓ Truncado (%d → %d msgs)",
   "agent.microcompact.applied": "microcompact: %d truncados, %d resumidos, %s liberados",
   "agent.queue.new_user_instruction": "Nova instrução do usuário recebida",
+  "agent.skill.rescan_activated": "Skill auto-ativada durante a tarefa: %s",
   "agent.queue.indicator": "(%d na fila)",
   "agent.spinner.executing": "EXECUTANDO: %s %s",
   "agent.spinner.action_placeholder": "ação",


### PR DESCRIPTION
## Problem

Skills auto-activate once at the start of `Run()`, matched only against the user's initial query. Everything the ReAct loop produces afterwards never reaches the trigger matcher:

- the model's own `<reasoning>` text — a plan like *"I'll write a Helm chart for this"* never activates the `helm` skill that would improve exactly that work;
- the file paths inside its `tool_call` args — `paths:` globs can't fire when the agent starts touching matching files;
- mid-session user follow-ups: the type-ahead queue and the coder interactive continuation prompt both append raw to history.

If the agent drifts into an approach a skill could accelerate or correct, the knowledge never arrives.

## Solution

Every turn, `rescanSkillsMidLoop` (new `cli/skill_rescan.go`) re-scans that mid-run text against the same triggers + path-glob catalog:

- **Assistant output** — reasoning and tool_call args (file-path tokens included). Matches are staged in `pendingSkillBlock` and flushed only at the **next turn boundary**, so the injected message can never split a native `tool_use` from its `tool_result`.
- **User follow-ups** — type-ahead drain and interactive continuation inject in place (already a safe boundary).
- Injection is an **append-only user-role message** (`[SKILL AUTO-ACTIVATION — MID-TASK]`) — the cached system-prompt prefix is never invalidated mid-run.
- **Per-Run dedup**: `injectedSkillNames` is seeded with pinned/auto/manual skills at startup; each skill fires at most once per session. The set is persisted in `park.Snapshot` so resume never re-injects.
- **First-wins hints**: mid-loop `model:`/`effort:` never override a startup skill's claim.
- Console notice via i18n (`agent.skill.rescan_activated`, 3 locales); suppressed when unattended.

## Config

`CHATCLI_AGENT_SKILL_RESCAN` (default **true**), listed in `/config` under the skills section and in the env defaults catalog. Set `false` to restore the query-only behavior.

## Tests

7 new tests in `cli/skill_rescan_test.go` (hermetic fixture, same pattern as `skill_pin_test.go`): trigger in assistant reasoning, path glob via tool_call args, startup-injection dedup, first-wins hints, no-match, env kill switch, empty block. Full `cli`, `park`, `i18n`, `persona` suites green; `golangci-lint` zero findings.

Also extracts `renderSkillEntries`, deduplicating the per-skill rendering loop that `buildSkillInjectionBlock` and `buildPinnedSkillInjectionBlock` each carried.