### PR TITLE
feat(skills): match multi-word triggers in any word order

### DIFF
--- a/pkg/persona/types.go
+++ b/pkg/persona/types.go
@@ -9,6 +9,7 @@ package persona
 import (
 	"path/filepath"
 	"strings"
+	"unicode"
 
 	"gopkg.in/yaml.v3"
 )
@@ -127,18 +128,65 @@ type Skill struct {
 	Scripts map[string]string `json:"scripts" yaml:"-"`
 }
 
-// MatchesTrigger checks if the given text contains any of the skill's trigger keywords.
+// MatchesTrigger checks if the given text matches any of the skill's trigger
+// keywords. Matching is case-insensitive and has two tiers:
+//
+//  1. Fast path — the whole trigger appears as a contiguous substring
+//     (historical behavior, always tried first).
+//  2. Multi-word triggers — every word of the trigger appears as a WHOLE
+//     token in the text, in any order. "servicenow login" therefore also
+//     fires on "preciso fazer o login no servicenow".
+//
+// Tier 2 deliberately requires whole tokens, not per-word substrings: short
+// trigger words ("me", "on", "no") hide inside unrelated words far too often
+// (e.g. "message me" would otherwise fire on any text containing the word
+// "message"). Both sides are tokenized with the same splitter, so trigger
+// words carrying punctuation ("unit-tests") match texts the same way.
 func (s *Skill) MatchesTrigger(text string) bool {
 	if len(s.Triggers) == 0 {
 		return false
 	}
 	textLower := strings.ToLower(text)
+	var textTokens map[string]bool // built lazily, only when a tier-2 check runs
 	for _, trigger := range s.Triggers {
-		if strings.Contains(textLower, strings.ToLower(trigger)) {
+		triggerLower := strings.ToLower(trigger)
+		if strings.Contains(textLower, triggerLower) {
+			return true
+		}
+		words := splitTriggerTokens(triggerLower)
+		if len(words) < 2 {
+			continue
+		}
+		if textTokens == nil {
+			textTokens = make(map[string]bool)
+			for _, tok := range splitTriggerTokens(textLower) {
+				textTokens[tok] = true
+			}
+		}
+		if allTokensPresent(textTokens, words) {
 			return true
 		}
 	}
 	return false
+}
+
+// splitTriggerTokens splits lowered text into letter/digit runs. Punctuation,
+// hyphens and symbols are separators, so "unit-tests" and "servicenow.com"
+// yield the tokens their words would produce in prose.
+func splitTriggerTokens(s string) []string {
+	return strings.FieldsFunc(s, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsNumber(r)
+	})
+}
+
+// allTokensPresent reports whether every word is a whole token of the text.
+func allTokensPresent(textTokens map[string]bool, words []string) bool {
+	for _, w := range words {
+		if !textTokens[w] {
+			return false
+		}
+	}
+	return true
 }
 
 // MatchesPath checks if any of the given file paths match any of the skill's

--- a/pkg/persona/types_test.go
+++ b/pkg/persona/types_test.go
@@ -34,6 +34,72 @@ func TestMatchesTrigger(t *testing.T) {
 	}
 }
 
+func TestMatchesTrigger_MultiWordAnyOrder(t *testing.T) {
+	s := &Skill{Triggers: StringList{"servicenow login"}}
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"contiguous phrase (fast path)", "faz o servicenow login pra mim", true},
+		{"reversed order with words between", "preciso fazer o login no servicenow", true},
+		{"reversed order, case-insensitive", "como faço Login no ServiceNow?", true},
+		{"words split across the sentence", "o login da conta corporativa fica no portal servicenow", true},
+		{"only one word present", "preciso acessar o servicenow", false},
+		{"other word only", "esqueci meu login do gmail", false},
+		{"neither word", "abre um chamado pra mim", false},
+		{"empty input", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := s.MatchesTrigger(tc.in); got != tc.want {
+				t.Fatalf("MatchesTrigger(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+
+	// Single-word triggers keep pure substring semantics — no regression.
+	single := &Skill{Triggers: StringList{"servicenow"}}
+	if !single.MatchesTrigger("acessa servicenow.com aí") {
+		t.Fatal("single-word trigger must keep substring matching")
+	}
+}
+
+// Multi-word tier must match on WHOLE tokens: short trigger words ("me",
+// "on", "no") appearing inside other words must not fire. This is the exact
+// false positive that a per-word substring check produces for the builtin
+// send-message skill (trigger "message me" vs input "unrelated user message",
+// where "me" hides inside "message").
+func TestMatchesTrigger_MultiWordNeedsWholeTokens(t *testing.T) {
+	s := &Skill{Triggers: StringList{"message me"}}
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"short word hidden inside another word", "unrelated user message", false},
+		{"both as whole tokens, any order", "can you me... send that message?", true},
+		{"contiguous phrase still works", "please message me when done", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := s.MatchesTrigger(tc.in); got != tc.want {
+				t.Fatalf("MatchesTrigger(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+
+	// Punctuation inside trigger words tokenizes the same way as the text,
+	// so "run unit-tests" fires on "unit-tests run fine" (order-free).
+	hyphen := &Skill{Triggers: StringList{"run unit-tests"}}
+	if !hyphen.MatchesTrigger("the unit-tests only run in CI") {
+		t.Fatal("hyphenated trigger words must tokenize like the text")
+	}
+	if hyphen.MatchesTrigger("run the linter") {
+		t.Fatal("missing trigger tokens must not match")
+	}
+}
+
 func TestMatchesPath_Basic(t *testing.T) {
 	s := &Skill{Paths: StringList{"*_test.go"}}
 	cases := []struct {


### PR DESCRIPTION
## Problem

`MatchesTrigger` is a contiguous, case-insensitive substring check. A skill with:

```yaml
triggers:
  - servicenow login
```

fires on *"do the ServiceNow login"* but **not** on the natural phrasing *"preciso fazer o login no servicenow"* — word order and the words in between break the match. Skill authors had to work around it with single-word triggers.

## Solution

Two-tier matching in `pkg/persona/types.go#MatchesTrigger`:

1. **Fast path (unchanged)** — the whole trigger as a contiguous substring, exactly the historical behavior.
2. **Multi-word tier (new)** — when tier 1 misses and the trigger has 2+ words, it fires if **every word appears as a whole token** in the text, in any order. `servicenow login` now matches *"preciso fazer o login no servicenow"*.

### Why whole tokens, not per-word substrings

Per-word `strings.Contains` was the obvious generalization — and the existing test suite immediately proved it wrong: the builtin **send-message** skill (trigger `message me`) started firing on *"unrelated user message"* because `me` hides inside `message`. Tier 2 therefore tokenizes **both sides** with the same letter/digit splitter (`unicode.IsLetter`/`IsNumber`, so pt-BR accents and `unit-tests`/`servicenow.com` tokenize consistently) and requires whole-token presence. The text token set is built lazily, only when some multi-word trigger reaches tier 2.

Single-word triggers keep pure substring semantics — zero behavior change for them, and since tier 1 always runs first, every match that fired before still fires.

## Tests (red → green)

- `TestMatchesTrigger_MultiWordAnyOrder` — written first; the 3 word-order cases failed on main, pass now. Covers reversed order, words split across the sentence, single-word-only negatives, and the single-word substring regression guard.
- `TestMatchesTrigger_MultiWordNeedsWholeTokens` — pins the `message me` / *"user message"* false positive (caught live by `TestBuildAgentSkillBlocks_NoMatchProducesEmpty` during development) and the hyphenated-trigger tokenization.

Full `./...` suite green, `golangci-lint` zero findings.

Docs (customizable-agents + skill-registry, en+pt, corpus) already updated on chatcli.ai.