### PR TITLE
fix(cli): restore spinner, type-ahead queue and AltGr input in the Windows chat REPL

### DIFF
--- a/cli/chat_ask.go
+++ b/cli/chat_ask.go
@@ -18,7 +18,6 @@ package cli
 import (
 	"context"
 	"os"
-	"runtime"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -356,9 +355,7 @@ func (cli *ChatCLI) chatAskFollowup(
 	cli.interactionState = StateProcessing
 	cli.isExecuting.Store(true)
 	spinnerDone := make(chan struct{})
-	if runtime.GOOS != "windows" {
-		go cli.runPrefixSpinner(spinnerDone)
-	}
+	go cli.runPrefixSpinner(spinnerDone)
 
 	resp, err := activeClient.SendPrompt(ctx, prompt, follow, effectiveMaxTokens)
 	if cli.refreshClientOnAuthError(err) {

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -988,15 +988,11 @@ func (cli *ChatCLI) executor(in string) {
 	}
 
 	cli.interactionState = StateProcessing
-	if runtime.GOOS == "windows" {
-		// On Windows, run synchronously so go-prompt naturally redraws the prompt
-		// after the response completes. SIGWINCH doesn't exist on Windows, so the
-		// async approach leaves go-prompt waiting for a keypress before redrawing.
-		// Ctrl+C still works via the OS signal handler (SIGINT) in a separate goroutine.
-		cli.processLLMRequest(context.Background(), in)
-	} else {
-		go cli.processLLMRequest(context.Background(), in)
-	}
+	// Async on every platform: go-prompt keeps reading while the turn runs,
+	// which is what makes the type-ahead queue and the prefix spinner work.
+	// The post-turn prompt redraw is driven by forceRefreshPrompt — SIGWINCH
+	// self-signal on Unix, injected no-op key event on Windows.
+	go cli.processLLMRequest(context.Background(), in)
 }
 
 // IsExecuting retorna true se uma operação está em andamento
@@ -1064,8 +1060,16 @@ func (cli *ChatCLI) Start(ctx context.Context) {
 				}
 			}()
 
+			// On Windows, go-tty turns AltGr characters ("/" on ABNT2, "@"
+			// on German, …) into ESC+rune, which go-prompt would insert
+			// verbatim into the buffer as a stray glyph. Sanitize before the
+			// paste detector sees the stream. See wininput.go.
+			var inputParser prompt.ConsoleParser = prompt.NewStandardInputParser()
+			if runtime.GOOS == "windows" {
+				inputParser = newAltGrParser(inputParser)
+			}
 			pasteParser := paste.NewBracketedPasteParser(
-				prompt.NewStandardInputParser(),
+				inputParser,
 				func(info paste.Info) {
 					cli.lastPasteInfo = &info
 				},

--- a/cli/cli_llm.go
+++ b/cli/cli_llm.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -86,9 +85,7 @@ func (cli *ChatCLI) startProcessingLifecycle() func() {
 			atomic.StoreInt32(&cli.prefixSpinnerIdx, 0)
 		}
 	}
-	if runtime.GOOS != "windows" {
-		go cli.runPrefixSpinner(spinnerDone)
-	}
+	go cli.runPrefixSpinner(spinnerDone)
 	cli.isExecuting.Store(true)
 	return stopSpinner
 }

--- a/cli/signal_windows.go
+++ b/cli/signal_windows.go
@@ -10,11 +10,25 @@ package cli
 import (
 	"fmt"
 	"os"
+
+	"go.uber.org/zap"
 )
 
-// forceRefreshPrompt no Windows usa sequências de escape ANSI para limpar a linha.
+// forceRefreshPrompt limpa a linha atual e força o go-prompt a repintar o
+// prompt. No Unix isso é feito com um SIGWINCH auto-enviado; o Windows não
+// tem SIGWINCH, então o equivalente é injetar um key event no-op no buffer
+// do console (WriteConsoleInputW) — o mesmo mecanismo do park auto-resume.
+// O evento acorda o loop de leitura do go-prompt, que re-renderiza o prompt
+// e re-avalia o live prefix (é isso que anima o spinner de prefixo e redesenha
+// o prompt após um turno assíncrono terminar).
 func (cli *ChatCLI) forceRefreshPrompt() {
 	// Limpar linha e resetar cores
 	fmt.Print("\r\033[K\033[0m")
-	os.Stdout.Sync()
+	_ = os.Stdout.Sync()
+
+	if err := injectPromptWake(); err != nil {
+		// Sem console anexado (pipe/CI/daemon): o refresh vira só o
+		// clear-line acima — mesma degradação do caminho Unix sem TTY.
+		cli.logger.Debug("forceRefreshPrompt: wake injection unavailable", zap.Error(err))
+	}
 }

--- a/cli/tty_inject_windows.go
+++ b/cli/tty_inject_windows.go
@@ -51,6 +51,7 @@ const (
 	stdInputHandle = ^uintptr(0) - 9 // STD_INPUT_HANDLE = -10
 	keyEventType   = 0x0001          // KEY_EVENT
 	vkReturn       = 0x0D            // VK_RETURN
+	vkPageUp       = 0x21            // VK_PRIOR (PageUp)
 )
 
 // keyEventRecord mirrors the Win32 KEY_EVENT_RECORD struct used inside
@@ -74,6 +75,47 @@ type inputRecord struct {
 	EventType uint16
 	_         [2]byte // padding for ABI alignment
 	Event     keyEventRecord
+}
+
+// injectPromptWake writes a single no-op key event into the console input
+// buffer so a live go-prompt wakes from ReadConsoleInput and repaints the
+// prompt (re-evaluating the animated live prefix). This is the Windows dual
+// of the SIGWINCH self-signal used on Unix: there is no SIGWINCH here, and
+// go-prompt drops single NUL bytes, so we synthesize a PageUp key press —
+// go-tty translates VK_PRIOR into the full "ESC [ 5 ~" batch, which
+// go-prompt maps to the PageUp key that neither go-prompt nor chatcli binds
+// to any action. Net effect: one render pass, zero buffer mutation.
+//
+// Only a key-down record is sent: go-tty ignores key-up events anyway, and
+// each extra record costs one wasted read cycle on the prompt loop.
+func injectPromptWake() error {
+	hStdin, _, _ := procGetStdHandle.Call(stdInputHandle)
+	if hStdin == 0 || hStdin == ^uintptr(0) {
+		return errTTYInjectUnsupported
+	}
+
+	event := inputRecord{
+		EventType: keyEventType,
+		Event: keyEventRecord{
+			KeyDown:        1,
+			RepeatCount:    1,
+			VirtualKeyCode: vkPageUp,
+		},
+	}
+
+	var written uint32
+	// #nosec G103 -- same contract as injectTTYLine: the kernel copies the
+	// record before the synchronous syscall returns.
+	r1, _, callErr := procWriteConsoleInputW.Call(
+		hStdin,
+		uintptr(unsafe.Pointer(&event)),
+		1,
+		uintptr(unsafe.Pointer(&written)),
+	)
+	if r1 == 0 {
+		return fmt.Errorf("WriteConsoleInputW failed: %v", callErr)
+	}
+	return nil
 }
 
 // injectTTYLine writes line + Enter to the controlling console's input

--- a/cli/tty_inject_windows.go
+++ b/cli/tty_inject_windows.go
@@ -113,7 +113,7 @@ func injectPromptWake() error {
 		uintptr(unsafe.Pointer(&written)),
 	)
 	if r1 == 0 {
-		return fmt.Errorf("WriteConsoleInputW failed: %v", callErr)
+		return fmt.Errorf("wake injection via WriteConsoleInputW: %v", callErr)
 	}
 	return nil
 }

--- a/cli/wininput.go
+++ b/cli/wininput.go
@@ -1,0 +1,89 @@
+/*
+ * ChatCLI - Windows console input sanitizer.
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * On Windows, go-prompt reads keys through go-tty, which translates any key
+ * pressed with Alt held — INCLUDING AltGr (right Alt), which Windows reports
+ * as Ctrl+Alt — into an ESC prefix followed by the character. That is correct
+ * for Alt-as-Meta shortcuts, but AltGr is how several layouts type everyday
+ * characters: "/" is AltGr+Q on Brazilian ABNT2, "@"/"{"/"[" need AltGr on
+ * German and Nordic layouts, and so on. go-prompt doesn't recognize
+ * ESC+<printable> sequences, so it inserts the raw ESC byte into the edit
+ * buffer, which the terminal renders as a stray "?"-like glyph before the
+ * character the user actually typed.
+ *
+ * altGrParser wraps the platform ConsoleParser and strips that spurious ESC
+ * when — and only when — the batch is ESC followed by exactly one printable
+ * rune. Real escape sequences (CSI "ESC [", SS3 "ESC O", double-ESC) and the
+ * Alt shortcuts chatcli itself binds (ESC f / ESC b word navigation,
+ * ESC DEL / ESC BS delete-word) pass through untouched. The logic is
+ * platform-neutral (and unit-tested everywhere); the wrapper is only wired
+ * into the prompt on Windows, where the go-tty translation exists.
+ */
+package cli
+
+import (
+	"unicode"
+	"unicode/utf8"
+
+	prompt "github.com/c-bata/go-prompt"
+)
+
+// altGrParser is a pass-through prompt.ConsoleParser that rewrites AltGr
+// key batches (ESC + printable rune) into the bare rune. See the file
+// header for the full rationale.
+type altGrParser struct {
+	inner prompt.ConsoleParser
+}
+
+// newAltGrParser wraps inner with the AltGr ESC-prefix sanitizer.
+func newAltGrParser(inner prompt.ConsoleParser) *altGrParser {
+	return &altGrParser{inner: inner}
+}
+
+// Setup delegates to the wrapped parser.
+func (p *altGrParser) Setup() error { return p.inner.Setup() }
+
+// TearDown delegates to the wrapped parser.
+func (p *altGrParser) TearDown() error { return p.inner.TearDown() }
+
+// GetWinSize delegates to the wrapped parser.
+func (p *altGrParser) GetWinSize() *prompt.WinSize { return p.inner.GetWinSize() }
+
+// Read sanitizes each batch produced by the wrapped parser.
+func (p *altGrParser) Read() ([]byte, error) {
+	data, err := p.inner.Read()
+	if err != nil {
+		return data, err
+	}
+	return stripAltGrEscape(data), nil
+}
+
+// stripAltGrEscape rewrites an "ESC + one printable rune" batch into the bare
+// rune, leaving every other batch (real escape sequences, bound Alt
+// shortcuts, plain text, lone ESC) unchanged.
+func stripAltGrEscape(data []byte) []byte {
+	if len(data) < 2 || data[0] != 0x1b {
+		return data
+	}
+	rest := data[1:]
+	switch rest[0] {
+	case '[', 'O', 0x1b:
+		// CSI / SS3 / double-ESC: genuine terminal escape sequences.
+		return data
+	}
+	if len(rest) == 1 {
+		switch rest[0] {
+		case 'f', 'b', 0x7f, 0x08:
+			// Alt shortcuts chatcli binds via ASCIICodeBind (word
+			// navigation, delete word) — must keep the ESC prefix.
+			return data
+		}
+	}
+	r, size := utf8.DecodeRune(rest)
+	if r == utf8.RuneError || size != len(rest) || !unicode.IsPrint(r) {
+		return data
+	}
+	return rest
+}

--- a/cli/wininput_test.go
+++ b/cli/wininput_test.go
@@ -1,0 +1,166 @@
+/*
+ * ChatCLI - Windows console input sanitizer tests.
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"bytes"
+	"testing"
+
+	prompt "github.com/c-bata/go-prompt"
+)
+
+func TestStripAltGrEscape(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []byte
+		want []byte
+	}{
+		{
+			name: "altgr slash (ABNT2 AltGr+Q) drops the ESC",
+			in:   []byte{0x1b, '/'},
+			want: []byte{'/'},
+		},
+		{
+			name: "altgr at-sign (German AltGr+Q) drops the ESC",
+			in:   []byte{0x1b, '@'},
+			want: []byte{'@'},
+		},
+		{
+			name: "altgr euro sign (multi-byte rune) drops the ESC",
+			in:   append([]byte{0x1b}, []byte("€")...),
+			want: []byte("€"),
+		},
+		{
+			name: "altgr question mark (ABNT2 AltGr+W) drops the ESC",
+			in:   []byte{0x1b, '?'},
+			want: []byte{'?'},
+		},
+		{
+			name: "lone ESC (Escape key) passes through",
+			in:   []byte{0x1b},
+			want: []byte{0x1b},
+		},
+		{
+			name: "CSI arrow sequence passes through",
+			in:   []byte{0x1b, '[', 'D'},
+			want: []byte{0x1b, '[', 'D'},
+		},
+		{
+			name: "SS3 home sequence passes through",
+			in:   []byte{0x1b, 'O', 'H'},
+			want: []byte{0x1b, 'O', 'H'},
+		},
+		{
+			name: "double-ESC arrow variant passes through",
+			in:   []byte{0x1b, 0x1b, '[', 'C'},
+			want: []byte{0x1b, 0x1b, '[', 'C'},
+		},
+		{
+			name: "bound alt+f word navigation passes through",
+			in:   []byte{0x1b, 'f'},
+			want: []byte{0x1b, 'f'},
+		},
+		{
+			name: "bound alt+b word navigation passes through",
+			in:   []byte{0x1b, 'b'},
+			want: []byte{0x1b, 'b'},
+		},
+		{
+			name: "bound alt+backspace (DEL) passes through",
+			in:   []byte{0x1b, 0x7f},
+			want: []byte{0x1b, 0x7f},
+		},
+		{
+			name: "bound alt+backspace (BS) passes through",
+			in:   []byte{0x1b, 0x08},
+			want: []byte{0x1b, 0x08},
+		},
+		{
+			name: "ESC + control rune (alt+enter) passes through",
+			in:   []byte{0x1b, '\r'},
+			want: []byte{0x1b, '\r'},
+		},
+		{
+			name: "ESC + more than one rune passes through",
+			in:   []byte{0x1b, '/', '/'},
+			want: []byte{0x1b, '/', '/'},
+		},
+		{
+			name: "ESC + truncated multi-byte rune passes through",
+			in:   []byte{0x1b, 0xe2, 0x82},
+			want: []byte{0x1b, 0xe2, 0x82},
+		},
+		{
+			name: "plain text passes through",
+			in:   []byte("hello"),
+			want: []byte("hello"),
+		},
+		{
+			name: "single printable byte passes through",
+			in:   []byte{'/'},
+			want: []byte{'/'},
+		},
+		{
+			name: "NUL wake byte passes through",
+			in:   []byte{0x00},
+			want: []byte{0x00},
+		},
+		{
+			name: "empty batch passes through",
+			in:   []byte{},
+			want: []byte{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripAltGrEscape(tt.in)
+			if !bytes.Equal(got, tt.want) {
+				t.Errorf("stripAltGrEscape(%v) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// fakeConsoleParser feeds canned batches to the sanitizer wrapper.
+type fakeConsoleParser struct {
+	batches [][]byte
+	idx     int
+}
+
+func (f *fakeConsoleParser) Setup() error                { return nil }
+func (f *fakeConsoleParser) TearDown() error             { return nil }
+func (f *fakeConsoleParser) GetWinSize() *prompt.WinSize { return &prompt.WinSize{Row: 24, Col: 80} }
+func (f *fakeConsoleParser) Read() ([]byte, error) {
+	if f.idx >= len(f.batches) {
+		return nil, nil
+	}
+	b := f.batches[f.idx]
+	f.idx++
+	return b, nil
+}
+
+func TestAltGrParserReadSanitizes(t *testing.T) {
+	inner := &fakeConsoleParser{batches: [][]byte{
+		{0x1b, '/'},      // AltGr+Q on ABNT2 → "/"
+		{0x1b, '[', 'A'}, // Up arrow → untouched
+		[]byte("plain"),  // plain text → untouched
+	}}
+	p := newAltGrParser(inner)
+
+	got1, err := p.Read()
+	if err != nil || !bytes.Equal(got1, []byte{'/'}) {
+		t.Fatalf("Read #1 = (%v, %v), want (['/'], nil)", got1, err)
+	}
+	got2, _ := p.Read()
+	if !bytes.Equal(got2, []byte{0x1b, '[', 'A'}) {
+		t.Fatalf("Read #2 = %v, want untouched CSI", got2)
+	}
+	got3, _ := p.Read()
+	if !bytes.Equal(got3, []byte("plain")) {
+		t.Fatalf("Read #3 = %q, want %q", got3, "plain")
+	}
+}

--- a/cli/wininput_test.go
+++ b/cli/wininput_test.go
@@ -7,6 +7,7 @@ package cli
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
 	prompt "github.com/c-bata/go-prompt"
@@ -127,14 +128,20 @@ func TestStripAltGrEscape(t *testing.T) {
 
 // fakeConsoleParser feeds canned batches to the sanitizer wrapper.
 type fakeConsoleParser struct {
-	batches [][]byte
-	idx     int
+	batches  [][]byte
+	idx      int
+	readErr  error
+	setupped bool
+	toredown bool
 }
 
-func (f *fakeConsoleParser) Setup() error                { return nil }
-func (f *fakeConsoleParser) TearDown() error             { return nil }
+func (f *fakeConsoleParser) Setup() error                { f.setupped = true; return nil }
+func (f *fakeConsoleParser) TearDown() error             { f.toredown = true; return nil }
 func (f *fakeConsoleParser) GetWinSize() *prompt.WinSize { return &prompt.WinSize{Row: 24, Col: 80} }
 func (f *fakeConsoleParser) Read() ([]byte, error) {
+	if f.readErr != nil {
+		return nil, f.readErr
+	}
 	if f.idx >= len(f.batches) {
 		return nil, nil
 	}
@@ -162,5 +169,33 @@ func TestAltGrParserReadSanitizes(t *testing.T) {
 	got3, _ := p.Read()
 	if !bytes.Equal(got3, []byte("plain")) {
 		t.Fatalf("Read #3 = %q, want %q", got3, "plain")
+	}
+}
+
+func TestAltGrParserDelegates(t *testing.T) {
+	inner := &fakeConsoleParser{}
+	p := newAltGrParser(inner)
+
+	if err := p.Setup(); err != nil || !inner.setupped {
+		t.Fatalf("Setup: err=%v, delegated=%v", err, inner.setupped)
+	}
+	if ws := p.GetWinSize(); ws == nil || ws.Col != 80 || ws.Row != 24 {
+		t.Fatalf("GetWinSize = %+v, want 80x24", ws)
+	}
+	if err := p.TearDown(); err != nil || !inner.toredown {
+		t.Fatalf("TearDown: err=%v, delegated=%v", err, inner.toredown)
+	}
+}
+
+func TestAltGrParserReadPropagatesError(t *testing.T) {
+	wantErr := errors.New("EAGAIN")
+	p := newAltGrParser(&fakeConsoleParser{readErr: wantErr})
+
+	data, err := p.Read()
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Read error = %v, want %v", err, wantErr)
+	}
+	if data != nil {
+		t.Fatalf("Read data = %v, want nil on error", data)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -122,6 +122,11 @@ func installSignalHandlers(isExecuting func() bool, cancelOperation, cancelRoot 
 }
 
 func main() {
+	// Opt the legacy Windows console into ANSI/VT processing before anything
+	// prints (spinners, colors, \r repaints). No-op elsewhere and on handles
+	// that are not a console.
+	utils.EnableVirtualTerminal()
+
 	// Check for subcommands (server, connect) before processing standard flags.
 	// These subcommands have their own flag sets and should not go through cli.Parse().
 	if dispatchSubcommand() {

--- a/utils/console_other.go
+++ b/utils/console_other.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+/*
+ * ChatCLI - Console bootstrap (non-Windows no-op).
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package utils
+
+// EnableVirtualTerminal is a no-op outside Windows: Unix terminals process
+// ANSI escapes natively. See console_windows.go for the Windows opt-in.
+func EnableVirtualTerminal() {}

--- a/utils/console_test.go
+++ b/utils/console_test.go
@@ -1,0 +1,17 @@
+/*
+ * ChatCLI - Console bootstrap tests.
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package utils
+
+import "testing"
+
+// TestEnableVirtualTerminalIsSafe exercises the console opt-in on every
+// platform: a no-op on Unix, and on Windows it must tolerate redirected
+// handles (the test binary's stdout is usually a pipe) without panicking
+// or returning anything — the contract is "best effort, never fails".
+func TestEnableVirtualTerminalIsSafe(t *testing.T) {
+	EnableVirtualTerminal()
+	EnableVirtualTerminal() // idempotent by contract
+}

--- a/utils/console_windows.go
+++ b/utils/console_windows.go
@@ -1,0 +1,37 @@
+//go:build windows
+
+/*
+ * ChatCLI - Windows console bootstrap.
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * ChatCLI paints its UI with raw ANSI escapes (spinners, colors, \r\033[K
+ * repaints). Windows Terminal interprets them natively, but the legacy
+ * console host (cmd.exe / PowerShell outside WT) only does so after the
+ * process opts in via ENABLE_VIRTUAL_TERMINAL_PROCESSING. Without the opt-in
+ * every escape renders as literal garbage. Enabling it is idempotent and
+ * harmless where VT is already on, so main() calls this unconditionally at
+ * boot.
+ */
+package utils
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// EnableVirtualTerminal turns on ANSI/VT escape processing for stdout and
+// stderr when they are attached to a Windows console. Redirected handles
+// (pipes, files) and consoles that reject the mode (pre-Win10) are skipped
+// silently — output degrades exactly as it did before the opt-in existed.
+func EnableVirtualTerminal() {
+	for _, f := range []*os.File{os.Stdout, os.Stderr} {
+		h := windows.Handle(f.Fd())
+		var mode uint32
+		if err := windows.GetConsoleMode(h, &mode); err != nil {
+			continue // not a console
+		}
+		_ = windows.SetConsoleMode(h, mode|windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes two Windows-only bugs reported while testing the chat REPL in a Windows VM:

1. **No spinner while waiting for a response, and the type-ahead message queue never worked with streaming.**
2. **Typing `/` inserted a stray `?`-like glyph before the character.**

Both were real defects in our Windows code paths, not emulation artifacts.

## Root causes and fixes

### Spinner + queue (async parity)

- `cli.go` ran `processLLMRequest` **synchronously** inside the go-prompt executor on Windows. With the executor blocked, go-prompt stops reading the keyboard, so typed-ahead messages could never reach the queue; and `cli_llm.go` / `chat_ask.go` skipped `runPrefixSpinner` behind `runtime.GOOS != "windows"` guards while the classic thinking animation stays suppressed in chat mode — net result: a frozen cursor.
- The sync path existed because the prompt refresh relies on a self-sent SIGWINCH, which Windows doesn't have. This PR gives Windows a real wake: `forceRefreshPrompt` now injects a **no-op PageUp key event via `WriteConsoleInputW`** (`injectPromptWake`, same mechanism as park auto-resume). go-tty translates VK_PRIOR into a single `ESC [ 5 ~` batch that go-prompt maps to the unbound PageUp key — a pure re-render with zero buffer mutation.
  - Why PageUp: go-prompt **drops** single-NUL batches (`readBuffer` filters `[0x00]`), and its Windows build never listens for resize events, so neither a NUL key nor a `WINDOW_BUFFER_SIZE_EVENT` can wake it.
- With the wake in place, the Windows sync special case and the platform guards are removed: Windows now runs the same async flow as Unix — animated prefix spinner, working type-ahead queue during streaming, and Ctrl+C cancel through the go-prompt keybind.

### `?` before `/` (AltGr input)

- Windows reports AltGr as Ctrl+Alt; go-tty translates any Alt-modified key into `ESC` + character; go-prompt doesn't recognize `ESC` + printable and inserts the raw ESC into the edit buffer, which renders as a stray glyph. `/` is AltGr+Q on ABNT2 — the same bug breaks `@ { [` on German/Nordic layouts.
- New `altGrParser` (`cli/wininput.go`) wraps the console parser (Windows only, beneath the bracketed-paste detector) and strips the spurious ESC when the batch is ESC followed by exactly one printable rune. Real escape sequences (`ESC [`, `ESC O`, double-ESC) and the Alt shortcuts chatcli binds (`ESC f`/`ESC b`, Alt+Backspace) pass through untouched.

### Legacy console ANSI

- chatcli prints raw ANSI (`\r\033[K`, colors, spinner frames) but never opted into `ENABLE_VIRTUAL_TERMINAL_PROCESSING`, so those bytes render as garbage in cmd.exe/PowerShell outside Windows Terminal. `utils.EnableVirtualTerminal()` now runs at the top of `main()` (no-op on other platforms and on redirected handles).

## Testing

- `go build ./...` and `GOOS=windows go build ./...` pass; `GOOS=windows go vet ./cli/ ./utils/` (compiles Windows test files) passes.
- Full `go test ./... -count=1` green; new table-driven unit tests for the AltGr sanitizer (`cli/wininput_test.go`) run on all platforms.
- `golangci-lint run ./cli/... ./utils/...` clean.
- Caveat: runtime behavior on a real Windows console was not exercised in CI/dev (built and vetted via cross-compile); validated by design against go-prompt v0.2.6 and go-tty v0.0.3 sources. Manual retest on Windows: spinner animating in the prompt prefix, "message queued" while a response streams, and clean `/` input on ABNT2.
