### PR TITLE
feat(ui): ui/kit presentation foundation and help header fix

### DIFF
--- a/cli/cli_config.go
+++ b/cli/cli_config.go
@@ -213,7 +213,7 @@ func (cli *ChatCLI) showHelp() {
 		fmt.Printf("    %s    %s\n", colorize(fmt.Sprintf("%-32s", cmd), cmdColor), colorize(desc, descColor))
 	}
 
-	fmt.Println("\n" + colorize(ColorBold, i18n.T("help.header.title")))
+	fmt.Println("\n" + colorize(i18n.T("help.header.title"), ColorBold))
 	fmt.Println(colorize(i18n.T("help.header.subtitle1"), ColorGray))
 	fmt.Println(colorize(i18n.T("help.header.subtitle2"), ColorGray))
 

--- a/cli/cli_llm.go
+++ b/cli/cli_llm.go
@@ -526,7 +526,9 @@ func (cli *ChatCLI) switchProvider() {
 	fmt.Println(i18n.T("cli.switch.available_providers"))
 	availableProviders := cli.manager.GetAvailableProviders()
 	for i, provider := range availableProviders {
-		fmt.Printf("%d. %s\n", i+1, provider)
+		// Two-space indent matches the model listing in listAvailableModels —
+		// adjacent pickers must share the same grid.
+		fmt.Printf("  %d. %s\n", i+1, provider)
 	}
 	cli.interactionState = StateSwitchingProvider
 }

--- a/ui/kit/badge.go
+++ b/ui/kit/badge.go
@@ -1,0 +1,15 @@
+/*
+ * ChatCLI - UI kit: badges
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package kit
+
+import "github.com/diillson/chatcli/ui/theme"
+
+// Badge renders a small bracketed chip — "[text]" — in the given role.
+// Used for value qualifiers like source tags and "(default)" hints where a
+// full component would be noise.
+func Badge(text string, r theme.Role) string {
+	return Colorize("["+text+"]", r)
+}

--- a/ui/kit/doc.go
+++ b/ui/kit/doc.go
@@ -1,0 +1,26 @@
+/*
+ * ChatCLI - UI kit: shared presentation components
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Package kit is the single presentation vocabulary for everything chatcli
+ * prints: one width helper, one style API over ui/theme roles, one status
+ * glyph set, and small pure components (Notice, Rule, Header, Badge, KVTable,
+ * List). It exists because the CLI accreted five terminal-width helpers,
+ * three box idioms and three success glyphs — every surface reinvented
+ * presentation, which is exactly what read as unpolished.
+ *
+ * Contracts:
+ *   - LEAF package: may import ui/theme, lipgloss, runewidth, x/term and the
+ *     stdlib — never i18n or anything under cli/. Components receive
+ *     already-translated strings and only decorate them, so the package can
+ *     be shared by cli and cli/agent and stays out of the i18n gates.
+ *   - Components are pure functions returning strings; printing (and the
+ *     single blank line that separates top-level blocks) belongs to the call
+ *     site.
+ *   - Color always flows through a theme.Role. On colorless profiles every
+ *     escape vanishes (theme.ANSI/Reset return "") so piped output is plain.
+ *   - Spacing grid: 2-space indent, right margin of RightMargin columns,
+ *     components never emit leading/trailing blank lines.
+ */
+package kit

--- a/ui/kit/glyphs.go
+++ b/ui/kit/glyphs.go
@@ -1,0 +1,96 @@
+/*
+ * ChatCLI - UI kit: canonical status glyphs
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * One glyph per meaning, defined once. The audit found three success marks,
+ * four error marks and eight bullet variants in the wild; this file is the
+ * whole vocabulary from now on. Every glyph is deliberately chosen WITHOUT
+ * the Unicode Emoji property, so runewidth (StrictEmojiNeutral=false)
+ * measures them exactly as terminals render them — 1 cell — keeping columns
+ * and box borders aligned on every platform, including Windows. Colored
+ * emoji remains legal only as a box Icon or in the welcome logo; the U+FE0F
+ * variation selector is banned everywhere (it silently flips a glyph from 1
+ * to 2 cells).
+ */
+package kit
+
+import (
+	"strings"
+
+	"github.com/diillson/chatcli/ui/theme"
+)
+
+// Glyph identifies one entry of the canonical status vocabulary.
+type Glyph int
+
+const (
+	// GlyphSuccess marks a completed action.
+	GlyphSuccess Glyph = iota
+	// GlyphError marks a failed action.
+	GlyphError
+	// GlyphWarn marks a warning.
+	GlyphWarn
+	// GlyphInfo marks an informational line.
+	GlyphInfo
+	// GlyphBullet marks a list item.
+	GlyphBullet
+	// GlyphArrow marks user input echoes and drill-downs.
+	GlyphArrow
+	// GlyphRunning marks an in-progress action.
+	GlyphRunning
+	// GlyphAssistant marks assistant text in compact timelines.
+	GlyphAssistant
+	// GlyphEllipsis marks truncation.
+	GlyphEllipsis
+)
+
+// glyphTable maps each glyph to its Unicode form, ASCII fallback and role.
+var glyphTable = [...]struct {
+	unicode string
+	ascii   string
+	role    theme.Role
+}{
+	GlyphSuccess:   {"✓", "+", theme.RoleToolSuccess},
+	GlyphError:     {"✗", "x", theme.RoleToolError},
+	GlyphWarn:      {"▲", "!", theme.RoleStatus},
+	GlyphInfo:      {"•", "i", theme.RoleMuted},
+	GlyphBullet:    {"·", "-", theme.RoleMuted},
+	GlyphArrow:     {"❯", ">", theme.RoleModelName},
+	GlyphRunning:   {"↻", "~", theme.RoleAction},
+	GlyphAssistant: {"◆", "*", theme.RoleResponse},
+	GlyphEllipsis:  {"…", "...", theme.RoleMuted},
+}
+
+// String returns the glyph's textual form under the active profile: Unicode
+// on any capable terminal, the ASCII fallback on dumb terminals and pipes
+// (mirroring how color spans vanish there).
+func (g Glyph) String() string {
+	if theme.ActiveProfile() <= theme.ProfileASCII {
+		return glyphTable[g].ascii
+	}
+	return glyphTable[g].unicode
+}
+
+// unicodeForm returns the Unicode form regardless of profile, for
+// composition inside already-measured strings (e.g. Truncate's ellipsis).
+func (g Glyph) unicodeForm() string {
+	return glyphTable[g].unicode
+}
+
+// Role returns the semantic color role the glyph carries.
+func (g Glyph) Role() theme.Role {
+	return glyphTable[g].role
+}
+
+// Sym renders the glyph in its role color — the everyday call.
+func Sym(g Glyph) string {
+	return Colorize(g.String(), g.Role())
+}
+
+// StripVS16 removes every U+FE0F variation selector from s. Used by
+// renderers to sanitize legacy catalog values during the migration; the
+// selector flips glyph width between terminals and breaks column math.
+func StripVS16(s string) string {
+	return strings.ReplaceAll(s, "️", "")
+}

--- a/ui/kit/kit_test.go
+++ b/ui/kit/kit_test.go
@@ -1,0 +1,227 @@
+/*
+ * ChatCLI - UI kit tests
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package kit
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/ui/theme"
+	"github.com/mattn/go-runewidth"
+)
+
+// pinTheme fixes the theme and color profile so assertions are deterministic
+// and TTY-independent, restoring detection afterwards.
+func pinTheme(t *testing.T, p theme.Profile) {
+	t.Helper()
+	if err := theme.SetActive("dark"); err != nil {
+		t.Fatalf("SetActive(dark): %v", err)
+	}
+	theme.SetProfile(p)
+	t.Cleanup(func() { theme.SetProfile(theme.DetectProfile()) })
+}
+
+func TestRunewidthPinned(t *testing.T) {
+	if runewidth.DefaultCondition.StrictEmojiNeutral {
+		t.Fatal("StrictEmojiNeutral must be false: emoji must measure 2 cells or box borders drift")
+	}
+}
+
+func TestColorizeProfiles(t *testing.T) {
+	pinTheme(t, theme.ProfileANSI)
+	got := Colorize("ok", theme.RoleToolSuccess)
+	if !strings.Contains(got, "ok") || !strings.Contains(got, "\033[") || !strings.HasSuffix(got, "\033[0m") {
+		t.Fatalf("ANSI profile: want colored span, got %q", got)
+	}
+
+	theme.SetProfile(theme.ProfileNoTTY)
+	if got := Colorize("ok", theme.RoleToolSuccess); got != "ok" {
+		t.Fatalf("NoTTY profile: want bare text, got %q", got)
+	}
+}
+
+func TestBoldAndDim(t *testing.T) {
+	pinTheme(t, theme.ProfileANSI)
+	if got := Bold("Title", theme.RoleHeader); !strings.HasPrefix(got, "\033[1m") {
+		t.Fatalf("Bold must lead with SGR 1, got %q", got)
+	}
+	if got := Dim("meta"); !strings.Contains(got, "meta") || !strings.Contains(got, "\033[") {
+		t.Fatalf("Dim must color via RoleMuted, got %q", got)
+	}
+
+	theme.SetProfile(theme.ProfileNoTTY)
+	if got := Bold("Title", theme.RoleHeader); got != "Title" {
+		t.Fatalf("NoTTY Bold must be bare, got %q", got)
+	}
+}
+
+func TestNoEscapesOnNoTTY(t *testing.T) {
+	pinTheme(t, theme.ProfileNoTTY)
+	outputs := []string{
+		Notice(LevelSuccess, "done"),
+		Notice(LevelError, "boom"),
+		Rule(),
+		RuleTitled("Section"),
+		Header("Section"),
+		Badge("default", theme.RoleMuted),
+		KVTable([]KVRow{{Key: "Provider", Value: "CLAUDEAI"}}),
+		List([]string{"a", "b"}),
+		Numbered([]string{"a", "b"}),
+		Sym(GlyphSuccess),
+	}
+	for i, out := range outputs {
+		if strings.Contains(out, "\033") {
+			t.Errorf("output %d contains escapes on NoTTY: %q", i, out)
+		}
+	}
+}
+
+func TestGlyphFallbackASCII(t *testing.T) {
+	pinTheme(t, theme.ProfileASCII)
+	pairs := map[Glyph]string{
+		GlyphSuccess: "+", GlyphError: "x", GlyphWarn: "!",
+		GlyphBullet: "-", GlyphArrow: ">", GlyphEllipsis: "...",
+	}
+	for g, want := range pairs {
+		if got := g.String(); got != want {
+			t.Errorf("glyph %d ASCII fallback = %q, want %q", g, got, want)
+		}
+	}
+
+	theme.SetProfile(theme.ProfileTrueColor)
+	if got := GlyphSuccess.String(); got != "✓" {
+		t.Errorf("truecolor success glyph = %q, want ✓", got)
+	}
+}
+
+func TestGlyphsAreSingleWidth(t *testing.T) {
+	pinTheme(t, theme.ProfileTrueColor)
+	for g := GlyphSuccess; g <= GlyphAssistant; g++ {
+		if w := VisibleLen(g.String()); w != 1 {
+			t.Errorf("glyph %d %q measures %d cells, want 1 (alignment contract)", g, g.String(), w)
+		}
+	}
+}
+
+func TestNoticeShape(t *testing.T) {
+	pinTheme(t, theme.ProfileNoTTY)
+	if got := Notice(LevelSuccess, "saved"); got != "  + saved" {
+		t.Fatalf("Notice success = %q", got)
+	}
+	if got := Notice(LevelError, "failed"); got != "  x failed" {
+		t.Fatalf("Notice error = %q", got)
+	}
+	theme.SetProfile(theme.ProfileANSI)
+	if got := Notice(LevelWarn, "careful"); !strings.Contains(got, "careful") || !strings.Contains(got, "\033[") {
+		t.Fatalf("warn message must be tinted, got %q", got)
+	}
+}
+
+func TestRuleWidths(t *testing.T) {
+	pinTheme(t, theme.ProfileNoTTY) // no TTY → fallback width, deterministic
+	w := ContentWidth()
+	if got := VisibleLen(Rule()); got != w {
+		t.Fatalf("Rule width = %d, want %d", got, w)
+	}
+	for _, title := range []string{"Session", "Configuração de memória", "🚀 launch"} {
+		if got := VisibleLen(RuleTitled(title)); got < w {
+			t.Errorf("RuleTitled(%q) width = %d, want >= %d", title, got, w)
+		}
+	}
+}
+
+func TestKVTableAlignsTranslatedKeys(t *testing.T) {
+	pinTheme(t, theme.ProfileNoTTY)
+	rows := []KVRow{
+		{Key: "Model", Value: "claude-fable-5"},
+		{Key: "Custo da sessão", Value: "$0.004", Note: "(default)"},
+		{Key: "Tokens", Value: "12k", ValueRole: theme.RoleStatus},
+	}
+	out := KVTable(rows)
+	lines := strings.Split(out, "\n")
+	if len(lines) != 3 {
+		t.Fatalf("want 3 lines, got %d: %q", len(lines), out)
+	}
+	// Values must all start at the same column: indent(2) + widest key + gap(2).
+	wantCol := 2 + VisibleLen("Custo da sessão") + 2
+	for i, value := range []string{"claude-fable-5", "$0.004", "12k"} {
+		idx := strings.Index(lines[i], value)
+		if idx < 0 {
+			t.Fatalf("value %q missing in %q", value, lines[i])
+		}
+		if col := VisibleLen(lines[i][:idx]); col != wantCol {
+			t.Errorf("value %q starts at col %d, want %d (%q)", value, col, wantCol, lines[i])
+		}
+	}
+	if !strings.Contains(out, "(default)") {
+		t.Errorf("note missing: %q", out)
+	}
+}
+
+func TestNumberedRightAligns(t *testing.T) {
+	pinTheme(t, theme.ProfileNoTTY)
+	items := make([]string, 10)
+	for i := range items {
+		items[i] = "item"
+	}
+	lines := strings.Split(Numbered(items), "\n")
+	if lines[0] != "   1. item" || lines[9] != "  10. item" {
+		t.Fatalf("numbers not right-aligned: %q vs %q", lines[0], lines[9])
+	}
+}
+
+func TestTruncatePreservesANSIAndWidth(t *testing.T) {
+	pinTheme(t, theme.ProfileANSI)
+	colored := Colorize("abcdefghij", theme.RoleStatus)
+	got := Truncate(colored, 6)
+	if w := VisibleLen(got); w > 6 {
+		t.Fatalf("truncated width %d > 6: %q", w, got)
+	}
+	if !strings.Contains(got, "…") {
+		t.Fatalf("missing ellipsis: %q", got)
+	}
+	if !strings.Contains(got, "\033[") {
+		t.Fatalf("ANSI prefix dropped: %q", got)
+	}
+	// Wide runes never split.
+	if got := Truncate("日本語テスト", 5); VisibleLen(got) > 5 {
+		t.Fatalf("CJK truncation overflows: %q (%d)", got, VisibleLen(got))
+	}
+	// Short input untouched.
+	if got := Truncate("ok", 10); got != "ok" {
+		t.Fatalf("short input mutated: %q", got)
+	}
+}
+
+func TestStripVS16(t *testing.T) {
+	in := "⚠️ atenção ▶️"
+	out := StripVS16(in)
+	if strings.Contains(out, "️") {
+		t.Fatalf("VS16 survived: %q", out)
+	}
+	if !strings.Contains(out, "⚠") || !strings.Contains(out, "atenção") {
+		t.Fatalf("content damaged: %q", out)
+	}
+}
+
+func TestBadge(t *testing.T) {
+	pinTheme(t, theme.ProfileNoTTY)
+	if got := Badge("api", theme.RoleMuted); got != "[api]" {
+		t.Fatalf("Badge = %q", got)
+	}
+}
+
+func TestContentWidthFloor(t *testing.T) {
+	// Under test (piped), TermWidth falls back; ContentWidth must respect
+	// margin and floor invariants regardless.
+	w := ContentWidth()
+	if w < MinContentWidth {
+		t.Fatalf("ContentWidth %d below floor %d", w, MinContentWidth)
+	}
+	if TermWidth()-w > RightMargin && w != MinContentWidth {
+		t.Fatalf("margin larger than RightMargin without hitting floor: term=%d content=%d", TermWidth(), w)
+	}
+}

--- a/ui/kit/kv.go
+++ b/ui/kit/kv.go
@@ -1,0 +1,59 @@
+/*
+ * ChatCLI - UI kit: key/value tables
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package kit
+
+import (
+	"strings"
+
+	"github.com/diillson/chatcli/ui/theme"
+)
+
+// KVRow is one row of a KVTable. Key and Value arrive already translated.
+// ValueRole tints the value; the zero role renders it as plain text (a
+// border-colored value is never what a table wants, so the zero value is
+// repurposed as "unstyled"). Note is an optional dim qualifier appended
+// after the value — e.g. a "(default)" hint.
+type KVRow struct {
+	Key       string
+	Value     string
+	ValueRole theme.Role
+	Note      string
+}
+
+// KVTable renders aligned key/value rows on the grid. The key column width
+// is measured from the TRANSLATED keys at render time (VisibleLen), so
+// alignment holds in every locale — unlike the fixed "%-32s" and the
+// English-tuned literal spaces it replaces. Keys render dim; values in
+// their role (or plain).
+func KVTable(rows []KVRow) string {
+	keyW := 0
+	for _, r := range rows {
+		if w := VisibleLen(r.Key); w > keyW {
+			keyW = w
+		}
+	}
+	var b strings.Builder
+	for i, r := range rows {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		pad := strings.Repeat(" ", keyW-VisibleLen(r.Key))
+		b.WriteString("  ")
+		b.WriteString(Dim(r.Key))
+		b.WriteString(pad)
+		b.WriteString("  ")
+		if r.ValueRole == theme.RoleBorder {
+			b.WriteString(r.Value)
+		} else {
+			b.WriteString(Colorize(r.Value, r.ValueRole))
+		}
+		if r.Note != "" {
+			b.WriteString(" ")
+			b.WriteString(Dim(r.Note))
+		}
+	}
+	return b.String()
+}

--- a/ui/kit/list.go
+++ b/ui/kit/list.go
@@ -1,0 +1,45 @@
+/*
+ * ChatCLI - UI kit: lists
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package kit
+
+import (
+	"fmt"
+	"strings"
+)
+
+// List renders items as a bulleted list on the grid:
+//
+//	· item
+func List(items []string) string {
+	var b strings.Builder
+	for i, it := range items {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString("  ")
+		b.WriteString(Sym(GlyphBullet))
+		b.WriteString(" ")
+		b.WriteString(it)
+	}
+	return b.String()
+}
+
+// Numbered renders items as a numbered list with right-aligned numbers so
+// double-digit lists keep their text column straight:
+//
+//  9. item
+//  10. item
+func Numbered(items []string) string {
+	numW := len(fmt.Sprint(len(items)))
+	var b strings.Builder
+	for i, it := range items {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		fmt.Fprintf(&b, "  %s. %s", Dim(fmt.Sprintf("%*d", numW, i+1)), it)
+	}
+	return b.String()
+}

--- a/ui/kit/notice.go
+++ b/ui/kit/notice.go
@@ -1,0 +1,56 @@
+/*
+ * ChatCLI - UI kit: status notices
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package kit
+
+import "github.com/diillson/chatcli/ui/theme"
+
+// Level classifies a Notice.
+type Level int
+
+const (
+	// LevelSuccess reports a completed action.
+	LevelSuccess Level = iota
+	// LevelError reports a failure.
+	LevelError
+	// LevelWarn reports a warning.
+	LevelWarn
+	// LevelInfo reports neutral information.
+	LevelInfo
+)
+
+// glyphFor maps a level to its canonical glyph.
+func (l Level) glyph() Glyph {
+	switch l {
+	case LevelError:
+		return GlyphError
+	case LevelWarn:
+		return GlyphWarn
+	case LevelInfo:
+		return GlyphInfo
+	default:
+		return GlyphSuccess
+	}
+}
+
+// Notice renders a one-line status message on the grid: two-space indent,
+// role-colored glyph, message. Error and warning messages are tinted with
+// the glyph's role so the whole line reads as one signal; success and info
+// keep the message in default text (the glyph alone carries the state).
+func Notice(l Level, msg string) string {
+	g := l.glyph()
+	body := msg
+	if l == LevelError || l == LevelWarn {
+		body = Colorize(msg, g.Role())
+	}
+	return "  " + Sym(g) + " " + body
+}
+
+// NoticeRole renders a notice-shaped line with an arbitrary glyph and role —
+// the escape hatch for surfaces with domain-specific markers (e.g. the
+// running spinner summary) that still want the grid alignment.
+func NoticeRole(g Glyph, msg string, r theme.Role) string {
+	return "  " + Colorize(g.String(), r) + " " + msg
+}

--- a/ui/kit/rule.go
+++ b/ui/kit/rule.go
@@ -1,0 +1,45 @@
+/*
+ * ChatCLI - UI kit: horizontal rules and headers
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package kit
+
+import (
+	"strings"
+
+	"github.com/diillson/chatcli/ui/theme"
+)
+
+// Rule renders a dim full-content-width horizontal rule — the single
+// replacement for the fixed 39/50/60/70/80-column separators.
+func Rule() string {
+	return Dim(strings.Repeat("─", ContentWidth()))
+}
+
+// RuleTitled renders a rule with an inline title:
+//
+//	── Title ────────────────
+//
+// The title is bold in the header role; the dashes are dim. The line always
+// spans ContentWidth.
+func RuleTitled(title string) string {
+	const lead = 2 // dashes before the title
+	w := ContentWidth()
+	tail := w - lead - VisibleLen(title) - 2 // spaces around the title
+	if tail < 1 {
+		tail = 1
+	}
+	return Dim(strings.Repeat("─", lead)) + " " + Bold(title, theme.RoleHeader) + " " +
+		Dim(strings.Repeat("─", tail))
+}
+
+// Header renders a section title in the title weight of the hierarchy.
+func Header(title string) string {
+	return Bold(title, theme.RoleHeader)
+}
+
+// Subheader renders a secondary title in the metadata weight.
+func Subheader(title string) string {
+	return Dim(title)
+}

--- a/ui/kit/style.go
+++ b/ui/kit/style.go
@@ -1,0 +1,110 @@
+/*
+ * ChatCLI - UI kit: role-based styling
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package kit
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/diillson/chatcli/ui/theme"
+	"github.com/mattn/go-runewidth"
+)
+
+func init() {
+	// Emoji must measure as terminals render them (2 cells) or box borders
+	// drift next to any emoji-bearing content. Identical to the pin in
+	// cli/agent (idempotent while both exist; the agent copy retires when
+	// its geometry moves here).
+	runewidth.DefaultCondition.StrictEmojiNeutral = false
+	runewidth.DefaultCondition.EastAsianWidth = false
+}
+
+const (
+	sgrBold = "\033[1m"
+)
+
+// Style returns a lipgloss style whose foreground is the role's color under
+// the active theme and profile — the lipgloss counterpart of Colorize,
+// mirroring the palette overlay's style(role) pattern.
+func Style(r theme.Role) lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(theme.Lip(r))
+}
+
+// Colorize wraps s in the role's color span. On colorless profiles both the
+// color and the reset are empty strings, so the output is exactly s.
+func Colorize(s string, r theme.Role) string {
+	c := theme.ANSI(r)
+	if c == "" {
+		return s
+	}
+	return c + s + theme.Reset()
+}
+
+// Bold renders s bold in the role's color — the "title weight" of the
+// typographic hierarchy. No escapes are emitted on colorless profiles.
+func Bold(s string, r theme.Role) string {
+	if !theme.ActiveProfile().HasColor() {
+		return s
+	}
+	return sgrBold + theme.ANSI(r) + s + theme.Reset()
+}
+
+// Dim renders s in the muted role — the "metadata weight" of the hierarchy.
+func Dim(s string) string {
+	return Colorize(s, theme.RoleMuted)
+}
+
+// VisibleLen measures the display width of s in terminal cells, ignoring
+// ANSI escapes. This is the kit's single measurement path (lipgloss.Width),
+// shared with the agent renderer so every component agrees on geometry.
+func VisibleLen(s string) int {
+	return lipgloss.Width(s)
+}
+
+// Truncate clamps s to at most maxCols visible columns, preserving ANSI
+// color sequences and appending an ellipsis plus a reset when content was
+// dropped so styling never bleeds into the next line.
+func Truncate(s string, maxCols int) string {
+	if VisibleLen(s) <= maxCols {
+		return s
+	}
+	var b strings.Builder
+	cols := 0
+	for i := 0; i < len(s); {
+		if s[i] == 0x1b {
+			if end := ansiSeqEnd(s[i:]); end > 0 {
+				b.WriteString(s[i : i+end])
+				i += end
+				continue
+			}
+		}
+		r, size := utf8.DecodeRuneInString(s[i:])
+		w := runewidth.RuneWidth(r)
+		if cols+w > maxCols-1 { // reserve one column for the ellipsis
+			break
+		}
+		b.WriteRune(r)
+		cols += w
+		i += size
+	}
+	return b.String() + GlyphEllipsis.unicodeForm() + theme.Reset()
+}
+
+// ansiSeqEnd returns the byte length of the ANSI CSI sequence starting at
+// s[0] (which must be ESC), or 0 when s is not a CSI sequence.
+func ansiSeqEnd(s string) int {
+	if len(s) < 2 || s[1] != '[' {
+		return 0
+	}
+	for i := 2; i < len(s); i++ {
+		c := s[i]
+		if c >= 0x40 && c <= 0x7e { // final byte
+			return i + 1
+		}
+	}
+	return 0
+}

--- a/ui/kit/width.go
+++ b/ui/kit/width.go
@@ -1,0 +1,49 @@
+/*
+ * ChatCLI - UI kit: terminal width
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package kit
+
+import (
+	"os"
+
+	"golang.org/x/term"
+)
+
+const (
+	// RightMargin is the number of columns every full-width component leaves
+	// free on the right so borders never touch the terminal edge (or a
+	// native scrollbar). Previously scattered as ad-hoc "-2" and "-1".
+	RightMargin = 2
+
+	// MinContentWidth is the floor below which components stop shrinking and
+	// accept horizontal overflow — matching the response envelope's historic
+	// minimum so extremely narrow terminals degrade the same way everywhere.
+	MinContentWidth = 40
+
+	// fallbackWidth is used when stdout is not a terminal (pipe, CI) or the
+	// size cannot be determined. 100 is the codebase's most recent deliberate
+	// choice (response envelope); the kit makes it the only one.
+	fallbackWidth = 100
+)
+
+// TermWidth returns the live terminal width in columns, or fallbackWidth
+// when stdout is not a terminal. Queried per call so live resizes are
+// honored by the next render.
+func TermWidth() int {
+	if w, _, err := term.GetSize(int(os.Stdout.Fd())); err == nil && w > 0 {
+		return w
+	}
+	return fallbackWidth
+}
+
+// ContentWidth is the width components should actually occupy: the terminal
+// width minus the right margin, clamped to MinContentWidth.
+func ContentWidth() int {
+	w := TermWidth() - RightMargin
+	if w < MinContentWidth {
+		return MinContentWidth
+	}
+	return w
+}


### PR DESCRIPTION
## Summary

First slice of the presentation-layer overhaul (professional UX/UI): introduces **`ui/kit`**, the single presentation vocabulary all printed surfaces will migrate onto, plus two audit-found presentation bugs fixed.

An audit of the output layer found 4 competing visual systems: 5 box vocabularies, separators fixed at 39/50/60/70/80 columns, 5 terminal-width helpers with divergent fallbacks, 3 success glyphs (✅/✓/✔), 4 error glyphs, 96 distinct symbols in code + 62 in the i18n catalogs, and column alignment tuned to English label widths. `ui/kit` is the foundation that ends that drift; follow-up PRs migrate surfaces onto it.

## What's in `ui/kit`

A leaf package (imports `ui/theme` + lipgloss + runewidth + x/term only — never `i18n` or `cli/`), pure functions returning strings:

- **`width.go`** — `TermWidth()` / `ContentWidth()`: the one responsive width helper (fallback 100, right margin 2, floor 40).
- **`style.go`** — `Style` / `Colorize` / `Bold` / `Dim` over `theme.Role`, `VisibleLen` (lipgloss.Width) and ANSI-aware `Truncate`. Pins `runewidth.StrictEmojiNeutral=false` (identical to the agent's pin; idempotent until geometry moves here).
- **`glyphs.go`** — the canonical status vocabulary (✓ ✗ ▲ • · ❯ ↻ ◆ …), one glyph per meaning, all **without the Unicode Emoji property** so they measure 1 cell everywhere (incl. Windows); ASCII degradation on dumb terminals/pipes; `StripVS16` for migrating legacy catalog values.
- **`notice.go` / `rule.go` / `header.go` / `badge.go`** — grid-aligned status lines, responsive rules (plain and titled), typographic hierarchy helpers, chips.
- **`kv.go`** — `KVTable`: key column measured from **translated** labels at render time, so alignment holds in pt-BR (replaces `%-32s` and English-tuned literal spaces).
- **`list.go`** — bulleted and right-aligned numbered lists.

Contracts documented in `doc.go`: colorless profiles emit zero escapes; components never emit leading/trailing blank lines (the call site owns block separation).

## Bug fixes

- `cli/cli_config.go`: the `/help` header called `colorize(ColorBold, i18n.T(...))` with **swapped arguments** (signature is `colorize(text, color)`), printing a malformed escape sequence instead of a bold title. Only inverted call site in the codebase.
- `cli/cli_llm.go`: the provider picker printed its numbered list at column 0 while the adjacent model listing indents by 2 — both now on the 2-space grid.

## Testing

- `ui/kit` at **91.7% statement coverage**: golden assertions with pinned theme/profile, profile matrix (NoTTY → zero escapes; ASCII → fallback glyphs), single-width contract for every glyph, KVTable alignment with accented pt-BR keys, CJK-safe truncation, right-aligned numbering.
- `go build ./...`, full `go test ./cli/... ./ui/...`, `golangci-lint` clean, ai-smells gate green locally.

## Follow-ups (planned slices)

Geometry/width unification into kit → command surfaces (`/config`, `/cost`, `/help`, `/session`) → agent/coder timeline glyph sweep → welcome screen → i18n catalog normalization → legacy `Color*` retirement.
