### PR TITLE
feat(ui): align command surfaces on kit padding, rules and notices

### DIFF
--- a/cli/agent_command_blocks.go
+++ b/cli/agent_command_blocks.go
@@ -21,6 +21,7 @@ import (
 	"github.com/diillson/chatcli/i18n"
 	"github.com/diillson/chatcli/llm/openaiassistant"
 	"github.com/diillson/chatcli/models"
+	"github.com/diillson/chatcli/ui/kit"
 	"github.com/diillson/chatcli/utils"
 )
 
@@ -492,11 +493,11 @@ func (a *AgentMode) cmdBatchExecute(ctx context.Context, renderer *agent.UIRende
 	fmt.Println(i18n.T("agent.status.all_commands_executed"))
 	fmt.Println(i18n.T("agent.status.summary"))
 	for i, out := range outputs {
-		status := "OK"
 		if out == nil || strings.TrimSpace(out.ErrorMsg) != "" {
-			status = "ERRO"
+			fmt.Println(kit.Notice(kit.LevelError, i18n.T("agent.summary.block_failed", i+1)))
+			continue
 		}
-		fmt.Printf("- #%d: %s\n", i+1, status)
+		fmt.Println(kit.Notice(kit.LevelSuccess, i18n.T("agent.summary.block_ok", i+1)))
 	}
 	_ = a.getInput(renderer.Colorize(i18n.T("agent.status.press_enter"), agent.ColorGray))
 }
@@ -579,9 +580,9 @@ func (a *AgentMode) cmdAddContextContinue(ctx context.Context, renderer *agent.U
 	}
 
 	fmt.Println(i18n.T("agent.output_header"))
-	fmt.Println("---------------------------------------")
+	fmt.Println(kit.Rule())
 	fmt.Print(outputs[cmdNum-1].Output)
-	fmt.Println("---------------------------------------")
+	fmt.Println(kit.Rule())
 
 	userContext := a.getMultilineInput(i18n.T("agent.prompt.additional_context"))
 
@@ -946,7 +947,7 @@ func (a *AgentMode) askUserIfInteractive(cmd string, contextInfo agent.CommandCo
 // simulateCommandBlock simula execução (dry-run)
 func (a *AgentMode) simulateCommandBlock(ctx context.Context, block agent.CommandBlock) {
 	fmt.Printf(i18n.T("agent.status.simulating_commands", block.Language)+"\n", block.Language)
-	fmt.Println("---------------------------------------")
+	fmt.Println(kit.Rule())
 
 	shell := os.Getenv("SHELL")
 	if shell == "" {
@@ -979,7 +980,7 @@ func (a *AgentMode) simulateCommandBlock(ctx context.Context, block agent.Comman
 			fmt.Println(string(out))
 		}
 	}
-	fmt.Println("---------------------------------------")
+	fmt.Println(kit.Rule())
 }
 
 // editCommandBlock abre comandos em editor

--- a/cli/cli_config.go
+++ b/cli/cli_config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/diillson/chatcli/config"
 	"github.com/diillson/chatcli/i18n"
 	"github.com/diillson/chatcli/llm/manager"
+	"github.com/diillson/chatcli/ui/kit"
 	"github.com/diillson/chatcli/ui/theme"
 	"github.com/diillson/chatcli/utils"
 	"github.com/diillson/chatcli/version"
@@ -210,7 +211,7 @@ func (cli *ChatCLI) showHelp() {
 			cmdColor = ColorGray
 			descColor = ColorGray
 		}
-		fmt.Printf("    %s    %s\n", colorize(fmt.Sprintf("%-32s", cmd), cmdColor), colorize(desc, descColor))
+		fmt.Printf("    %s    %s\n", colorize(kit.PadRight(cmd, 32), cmdColor), colorize(desc, descColor))
 	}
 
 	fmt.Println("\n" + colorize(i18n.T("help.header.title"), ColorBold))

--- a/cli/command_handler_plugins.go
+++ b/cli/command_handler_plugins.go
@@ -18,6 +18,7 @@ import (
 	"github.com/diillson/chatcli/auth"
 	"github.com/diillson/chatcli/config"
 	"github.com/diillson/chatcli/i18n"
+	"github.com/diillson/chatcli/ui/kit"
 	"github.com/diillson/chatcli/utils"
 )
 
@@ -41,10 +42,10 @@ func (ch *CommandHandler) handleAuthCommand(ctx context.Context, userInput strin
 		case "anthropic", "claude", "claudeai":
 			id, err := auth.LoginAnthropicOAuth(ctx, ch.cli.logger)
 			if err != nil {
-				fmt.Println(i18n.T("auth.login.failed", err))
+				fmt.Println(kit.Notice(kit.LevelError, i18n.T("auth.login.failed", err)))
 				return
 			}
-			fmt.Println(i18n.T("auth.login.success", "Anthropic", id))
+			fmt.Println(kit.Notice(kit.LevelSuccess, i18n.T("auth.login.success", "Anthropic", id)))
 			ch.cli.manager.RefreshProviders()
 			ch.autoSwitchProvider(ctx, "CLAUDEAI",
 				utils.GetEnvOrDefault("ANTHROPIC_MODEL", config.DefaultClaudeAIModel))
@@ -52,10 +53,10 @@ func (ch *CommandHandler) handleAuthCommand(ctx context.Context, userInput strin
 		case "openai-codex", "codex":
 			id, err := auth.LoginOpenAICodexOAuth(ctx, ch.cli.logger)
 			if err != nil {
-				fmt.Println(i18n.T("auth.login.failed", err))
+				fmt.Println(kit.Notice(kit.LevelError, i18n.T("auth.login.failed", err)))
 				return
 			}
-			fmt.Println(i18n.T("auth.login.success", "OpenAI Codex", id))
+			fmt.Println(kit.Notice(kit.LevelSuccess, i18n.T("auth.login.success", "OpenAI Codex", id)))
 			ch.cli.manager.RefreshProviders()
 			ch.autoSwitchProvider(ctx, "OPENAI",
 				utils.GetEnvOrDefault("OPENAI_MODEL", config.DefaultOpenAIModel))
@@ -63,10 +64,10 @@ func (ch *CommandHandler) handleAuthCommand(ctx context.Context, userInput strin
 		case "github-copilot", "copilot", "gh-copilot":
 			id, err := auth.LoginGitHubCopilotOAuth(ctx, ch.cli.logger)
 			if err != nil {
-				fmt.Println(i18n.T("auth.login.failed", err))
+				fmt.Println(kit.Notice(kit.LevelError, i18n.T("auth.login.failed", err)))
 				return
 			}
-			fmt.Println(i18n.T("auth.login.success", "GitHub Copilot", id))
+			fmt.Println(kit.Notice(kit.LevelSuccess, i18n.T("auth.login.success", "GitHub Copilot", id)))
 			ch.cli.manager.RefreshProviders()
 			ch.autoSwitchProvider(ctx, "COPILOT",
 				utils.GetEnvOrDefault("COPILOT_MODEL", config.DefaultCopilotModel))
@@ -74,10 +75,10 @@ func (ch *CommandHandler) handleAuthCommand(ctx context.Context, userInput strin
 		case "github-models", "gh-models":
 			id, err := auth.LoginGitHubModelsPAT(ctx, ch.cli.logger)
 			if err != nil {
-				fmt.Println(i18n.T("auth.login.failed", err))
+				fmt.Println(kit.Notice(kit.LevelError, i18n.T("auth.login.failed", err)))
 				return
 			}
-			fmt.Println(i18n.T("auth.login.success", "GitHub Models", id))
+			fmt.Println(kit.Notice(kit.LevelSuccess, i18n.T("auth.login.success", "GitHub Models", id)))
 			ch.cli.manager.RefreshProviders()
 			ch.autoSwitchProvider(ctx, "GITHUB_MODELS",
 				utils.GetEnvOrDefault("GITHUB_MODELS_MODEL", config.DefaultGitHubModelsModel))

--- a/cli/config_sections.go
+++ b/cli/config_sections.go
@@ -46,6 +46,7 @@ import (
 	"github.com/diillson/chatcli/llm/imagegen"
 	"github.com/diillson/chatcli/llm/transcription"
 	"github.com/diillson/chatcli/llm/tts"
+	"github.com/diillson/chatcli/ui/kit"
 )
 
 // ─── Routing ───────────────────────────────────────────────────
@@ -209,7 +210,7 @@ func kv(prefix, key, value string) {
 		display = strings.TrimPrefix(display, defaultMarker)
 		fmt.Printf("%s%s  %s %s\n",
 			prefix,
-			colorize(fmt.Sprintf("%-32s", key+":"), ColorCyan),
+			colorize(kit.PadRight(key+":", 32), ColorCyan),
 			colorize(display, ColorCyan),
 			colorize(defaultTag, ColorGray))
 		return
@@ -227,9 +228,11 @@ func kv(prefix, key, value string) {
 		display == i18n.T("cfg.val.off"):
 		valueColor = ColorYellow
 	}
+	// kit.PadRight mede largura VISÍVEL — o "%-32s" antigo contava bytes e
+	// desalinhava qualquer label acentuado (pt-BR) nesta coluna.
 	fmt.Printf("%s%s  %s\n",
 		prefix,
-		colorize(fmt.Sprintf("%-32s", key+":"), ColorCyan),
+		colorize(kit.PadRight(key+":", 32), ColorCyan),
 		colorize(display, valueColor))
 }
 

--- a/cli/cost_command.go
+++ b/cli/cost_command.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/diillson/chatcli/i18n"
+	"github.com/diillson/chatcli/ui/kit"
 )
 
 func (cli *ChatCLI) handleCostCommand() {
@@ -36,10 +37,33 @@ func (cli *ChatCLI) handleCostCommand() {
 	duration := time.Since(ct.sessionStart).Truncate(time.Second)
 	totalTokens := ct.totalPromptTokens + ct.totalCompletionTokens
 
-	fmt.Println(p + fmt.Sprintf("  %s%s:%s    %s", ColorGray, i18n.T("cost.cmd.provider"), ColorReset, provider))
-	fmt.Println(p + fmt.Sprintf("  %s%s:%s       %s", ColorGray, i18n.T("cost.cmd.model"), ColorReset, model))
-	fmt.Println(p + fmt.Sprintf("  %s%s:%s    %s", ColorGray, i18n.T("cost.cmd.duration"), ColorReset, duration))
-	fmt.Println(p + fmt.Sprintf("  %s%s:%s    %d", ColorGray, i18n.T("cost.cmd.requests"), ColorReset, ct.totalRequests))
+	// Aligned key/value rows: the label column is measured from the
+	// TRANSLATED labels of each group (kit.PadRight is visible-width
+	// aware), replacing the literal spaces that were hand-tuned to the
+	// English label lengths and drifted in pt-BR.
+	row := func(labelW int, label, value string) {
+		fmt.Println(p + "  " + colorize(kit.PadRight(label+":", labelW+1), ColorGray) + "  " + value)
+	}
+	groupWidth := func(labels ...string) int {
+		w := 0
+		for _, l := range labels {
+			if lw := kit.VisibleLen(l); lw > w {
+				w = lw
+			}
+		}
+		return w
+	}
+
+	topLabels := []string{
+		i18n.T("cost.cmd.provider"), i18n.T("cost.cmd.model"),
+		i18n.T("cost.cmd.duration"), i18n.T("cost.cmd.requests"),
+		i18n.T("cost.cmd.source"),
+	}
+	topW := groupWidth(topLabels...)
+	row(topW, i18n.T("cost.cmd.provider"), provider)
+	row(topW, i18n.T("cost.cmd.model"), model)
+	row(topW, i18n.T("cost.cmd.duration"), duration.String())
+	row(topW, i18n.T("cost.cmd.requests"), fmt.Sprintf("%d", ct.totalRequests))
 
 	// Data source indicator
 	hasReal := false
@@ -50,9 +74,9 @@ func (cli *ChatCLI) handleCostCommand() {
 		}
 	}
 	if hasReal {
-		fmt.Println(p + fmt.Sprintf("  %s%s:%s      %s%s%s", ColorGray, i18n.T("cost.cmd.source"), ColorReset, ColorGreen, i18n.T("cost.cmd.source_api"), ColorReset))
+		row(topW, i18n.T("cost.cmd.source"), colorize(i18n.T("cost.cmd.source_api"), ColorGreen))
 	} else {
-		fmt.Println(p + fmt.Sprintf("  %s%s:%s      %s%s%s", ColorGray, i18n.T("cost.cmd.source"), ColorReset, ColorYellow, i18n.T("cost.cmd.source_estimate"), ColorReset))
+		row(topW, i18n.T("cost.cmd.source"), colorize(i18n.T("cost.cmd.source_estimate"), ColorYellow))
 	}
 	fmt.Println(p)
 
@@ -69,30 +93,29 @@ func (cli *ChatCLI) handleCostCommand() {
 		completionBar = strings.Repeat("\u2588", int(ct.totalCompletionTokens*20/maxToken))
 	}
 
+	tokenW := groupWidth(i18n.T("cost.cmd.input"), i18n.T("cost.cmd.output"), i18n.T("cost.cmd.total"))
+	tokenRow := func(label, count, bar string) {
+		line := "    " + kit.PadRight(label, tokenW+2) + ColorBold + kit.PadRight(count, 8) + ColorReset
+		if bar != "" {
+			line += " " + bar
+		}
+		fmt.Println(p + line)
+	}
 	fmt.Println(p + colorize("  "+i18n.T("cost.cmd.tokens_label"), ColorCyan))
-	fmt.Println(p + fmt.Sprintf("    %s      %s%-8s%s %s%s%s",
-		i18n.T("cost.cmd.input"),
-		ColorBold, formatTokenCount64(ct.totalPromptTokens), ColorReset,
-		ColorGreen, promptBar, ColorReset))
-	fmt.Println(p + fmt.Sprintf("    %s     %s%-8s%s %s%s%s",
-		i18n.T("cost.cmd.output"),
-		ColorBold, formatTokenCount64(ct.totalCompletionTokens), ColorReset,
-		ColorPurple, completionBar, ColorReset))
-	fmt.Println(p + fmt.Sprintf("    %s      %s%s%s",
-		i18n.T("cost.cmd.total"),
-		ColorBold, formatTokenCount64(totalTokens), ColorReset))
+	tokenRow(i18n.T("cost.cmd.input"), formatTokenCount64(ct.totalPromptTokens), ColorGreen+promptBar+ColorReset)
+	tokenRow(i18n.T("cost.cmd.output"), formatTokenCount64(ct.totalCompletionTokens), ColorPurple+completionBar+ColorReset)
+	tokenRow(i18n.T("cost.cmd.total"), formatTokenCount64(totalTokens), "")
 
 	// Cache tokens (Anthropic only)
 	if ct.totalCacheCreation > 0 || ct.totalCacheRead > 0 {
+		cacheW := groupWidth(i18n.T("cost.cmd.cache_created"), i18n.T("cost.cmd.cache_read"))
 		fmt.Println(p)
 		fmt.Println(p + colorize("  "+i18n.T("cost.cmd.cache_tokens_label"), ColorCyan))
-		fmt.Println(p + fmt.Sprintf("    %s    %s%s%s",
-			i18n.T("cost.cmd.cache_created"),
-			ColorBold, formatTokenCount64(ct.totalCacheCreation), ColorReset))
-		fmt.Println(p + fmt.Sprintf("    %s       %s%s%s  %s%s%s",
-			i18n.T("cost.cmd.cache_read"),
-			ColorBold, formatTokenCount64(ct.totalCacheRead), ColorReset,
-			ColorGray, i18n.T("cost.cmd.cache_savings"), ColorReset))
+		fmt.Println(p + "    " + kit.PadRight(i18n.T("cost.cmd.cache_created"), cacheW+2) +
+			ColorBold + formatTokenCount64(ct.totalCacheCreation) + ColorReset)
+		fmt.Println(p + "    " + kit.PadRight(i18n.T("cost.cmd.cache_read"), cacheW+2) +
+			ColorBold + formatTokenCount64(ct.totalCacheRead) + ColorReset + "  " +
+			colorize(i18n.T("cost.cmd.cache_savings"), ColorGray))
 	}
 	fmt.Println(p)
 
@@ -101,21 +124,21 @@ func (cli *ChatCLI) handleCostCommand() {
 		fmt.Println(p + colorize("  "+i18n.T("cost.cmd.cost_label"), ColorCyan))
 
 		// Show per-model cost breakdown
+		costW := groupWidth(i18n.T("cost.cmd.input_cost"), i18n.T("cost.cmd.output_cost"), i18n.T("cost.cmd.cache_cost"))
 		for _, rec := range ct.modelUsage {
 			if rec.TotalCostUSD <= 0 {
 				continue
 			}
 			fmt.Println(p + fmt.Sprintf("    %s/%s:", rec.Provider, rec.Model))
-			fmt.Println(p + fmt.Sprintf("      %s    $%.4f", i18n.T("cost.cmd.input_cost"), rec.InputCostUSD))
-			fmt.Println(p + fmt.Sprintf("      %s   $%.4f", i18n.T("cost.cmd.output_cost"), rec.OutputCostUSD))
+			fmt.Println(p + "      " + kit.PadRight(i18n.T("cost.cmd.input_cost"), costW+2) + fmt.Sprintf("$%.4f", rec.InputCostUSD))
+			fmt.Println(p + "      " + kit.PadRight(i18n.T("cost.cmd.output_cost"), costW+2) + fmt.Sprintf("$%.4f", rec.OutputCostUSD))
 			if rec.CacheCostUSD > 0 {
-				fmt.Println(p + fmt.Sprintf("      %s    $%.4f", i18n.T("cost.cmd.cache_cost"), rec.CacheCostUSD))
+				fmt.Println(p + "      " + kit.PadRight(i18n.T("cost.cmd.cache_cost"), costW+2) + fmt.Sprintf("$%.4f", rec.CacheCostUSD))
 			}
 		}
 
 		fmt.Println(p)
-		fmt.Println(p + fmt.Sprintf("    %s%s      %s$%.4f%s",
-			ColorBold, i18n.T("cost.cmd.total"), ColorLime, ct.totalCostUSD, ColorReset))
+		fmt.Println(p + "    " + ColorBold + kit.PadRight(i18n.T("cost.cmd.total"), costW+2) + ColorLime + fmt.Sprintf("$%.4f", ct.totalCostUSD) + ColorReset)
 	} else {
 		fmt.Println(p + colorize("  "+i18n.T("cost.cmd.pricing_unavailable"), ColorGray))
 	}

--- a/cli/cost_command_render_test.go
+++ b/cli/cost_command_render_test.go
@@ -1,0 +1,132 @@
+package cli
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/ui/kit"
+	"github.com/diillson/chatcli/ui/theme"
+)
+
+// captureCommandStdout runs fn with os.Stdout redirected to a pipe and
+// returns everything it printed. Local to the render tests so they can
+// assert on the exact lines the user sees.
+func captureCommandStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+
+	fn()
+	_ = w.Close()
+	out, _ := io.ReadAll(r)
+	return string(out)
+}
+
+// pinPlainProfile strips all color so line assertions see plain text.
+func pinPlainProfile(t *testing.T) {
+	t.Helper()
+	theme.SetProfile(theme.ProfileNoTTY)
+	t.Cleanup(func() { theme.SetProfile(theme.DetectProfile()) })
+}
+
+// newCostTrackerFixture builds a tracker exercising every /cost section:
+// top group, token bars, cache group, per-model costs and budget notice.
+func newCostTrackerFixture() *CostTracker {
+	ct := NewCostTracker()
+	ct.totalPromptTokens = 1200
+	ct.totalCompletionTokens = 800
+	ct.totalCacheCreation = 300
+	ct.totalCacheRead = 500
+	ct.totalRequests = 3
+	ct.totalCostUSD = 0.1234
+	ct.budgetLimitUSD = 0.2
+	ct.modelUsage["claudeai:model-a"] = &ModelUsageRecord{
+		Provider:      "CLAUDEAI",
+		Model:         "model-a",
+		HasRealData:   true,
+		InputCostUSD:  0.08,
+		OutputCostUSD: 0.04,
+		CacheCostUSD:  0.003,
+		TotalCostUSD:  0.1234,
+	}
+	return ct
+}
+
+// TestHandleCostCommandRendersAllSections drives the full /cost render and
+// asserts every section reaches the screen with its values formatted.
+func TestHandleCostCommandRendersAllSections(t *testing.T) {
+	pinPlainProfile(t)
+	c := &ChatCLI{costTracker: newCostTrackerFixture(), Provider: "CLAUDEAI"}
+
+	out := captureCommandStdout(t, func() { c.handleCostCommand() })
+
+	for _, want := range []string{
+		"CLAUDEAI",     // provider row
+		"model-a",      // per-model cost header
+		"$0.0800",      // input cost
+		"$0.0400",      // output cost
+		"$0.0030",      // cache cost
+		"$0.1234",      // total cost
+		"╭", "╰", "│", // box frame survives
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("/cost output missing %q\n%s", want, out)
+		}
+	}
+}
+
+// TestHandleCostCommandAlignsTopGroup proves the label column is measured
+// from the translated labels: every value of the top group starts at the
+// same visible column, which the old English-tuned literal spaces could
+// not guarantee in pt-BR.
+func TestHandleCostCommandAlignsTopGroup(t *testing.T) {
+	pinPlainProfile(t)
+	c := &ChatCLI{costTracker: newCostTrackerFixture(), Provider: "CLAUDEAI"}
+
+	out := captureCommandStdout(t, func() { c.handleCostCommand() })
+
+	cols := map[int]bool{}
+	for _, ln := range strings.Split(out, "\n") {
+		// Top-group rows carry "<label>:" then two-space gap then value.
+		idx := strings.Index(ln, ":")
+		if idx < 0 || !strings.Contains(ln, "CLAUDEAI") && !strings.Contains(ln, "model") {
+			continue
+		}
+		rest := ln[idx+1:]
+		pad := len(rest) - len(strings.TrimLeft(rest, " "))
+		cols[kit.VisibleLen(ln[:idx+1+pad])] = true
+	}
+	if len(cols) > 2 { // provider/model rows share the group column
+		t.Errorf("top-group values start at %d distinct columns, want aligned: %v\n%s", len(cols), cols, out)
+	}
+}
+
+// TestHandleCostCommandWithoutTracker covers the guard path.
+func TestHandleCostCommandWithoutTracker(t *testing.T) {
+	pinPlainProfile(t)
+	c := &ChatCLI{}
+	out := captureCommandStdout(t, func() { c.handleCostCommand() })
+	if strings.TrimSpace(out) == "" {
+		t.Fatal("missing not-initialized notice")
+	}
+}
+
+// TestShowHelpRendersCommandColumns smoke-covers the /help table path,
+// including the visible-width padded command column.
+func TestShowHelpRendersCommandColumns(t *testing.T) {
+	pinPlainProfile(t)
+	c := &ChatCLI{}
+	out := captureCommandStdout(t, func() { c.showHelp() })
+	for _, want := range []string{"/help", "/exit", "/switch"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("/help output missing %q", want)
+		}
+	}
+}

--- a/cli/cost_command_render_test.go
+++ b/cli/cost_command_render_test.go
@@ -68,12 +68,12 @@ func TestHandleCostCommandRendersAllSections(t *testing.T) {
 	out := captureCommandStdout(t, func() { c.handleCostCommand() })
 
 	for _, want := range []string{
-		"CLAUDEAI",     // provider row
-		"model-a",      // per-model cost header
-		"$0.0800",      // input cost
-		"$0.0400",      // output cost
-		"$0.0030",      // cache cost
-		"$0.1234",      // total cost
+		"CLAUDEAI",    // provider row
+		"model-a",     // per-model cost header
+		"$0.0800",     // input cost
+		"$0.0400",     // output cost
+		"$0.0030",     // cache cost
+		"$0.1234",     // total cost
 		"╭", "╰", "│", // box frame survives
 	} {
 		if !strings.Contains(out, want) {

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -3216,5 +3216,8 @@
   "complete.configimage.models": "List the model catalog",
   "complete.configimage.reset": "Clear image overrides",
   "complete.configimage.val": "value",
-  "agent.spinner.working": "working"
+  "agent.spinner.working": "working",
+
+  "agent.summary.block_ok": "Block #%d completed",
+  "agent.summary.block_failed": "Block #%d failed"
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -3216,5 +3216,8 @@
   "complete.configimage.models": "List the model catalog",
   "complete.configimage.reset": "Clear image overrides",
   "complete.configimage.val": "value",
-  "agent.spinner.working": "working"
+  "agent.spinner.working": "working",
+
+  "agent.summary.block_ok": "Block #%d completed",
+  "agent.summary.block_failed": "Block #%d failed"
 }

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -3216,5 +3216,8 @@
   "complete.configimage.models": "Lista o catálogo de modelos",
   "complete.configimage.reset": "Limpa os overrides de imagem",
   "complete.configimage.val": "valor",
-  "agent.spinner.working": "processando"
+  "agent.spinner.working": "processando",
+
+  "agent.summary.block_ok": "Bloco #%d concluído",
+  "agent.summary.block_failed": "Bloco #%d falhou"
 }

--- a/ui/kit/kit_test.go
+++ b/ui/kit/kit_test.go
@@ -207,6 +207,27 @@ func TestStripVS16(t *testing.T) {
 	}
 }
 
+func TestPadRightIsVisibleWidthAware(t *testing.T) {
+	// "Custo da sessão" is 15 visible cols but 17 bytes — fmt's %-16s would
+	// pad it short. PadRight must land both labels on the same column.
+	a := PadRight("Custo da sessão", 20)
+	b := PadRight("Model", 20)
+	if VisibleLen(a) != 20 || VisibleLen(b) != 20 {
+		t.Fatalf("PadRight widths: %d vs %d, want 20", VisibleLen(a), VisibleLen(b))
+	}
+	// At-or-past width: unchanged.
+	if got := PadRight("longer-than-width", 5); got != "longer-than-width" {
+		t.Fatalf("PadRight must not truncate: %q", got)
+	}
+	// ANSI-colored input: escapes don't count toward the width.
+	theme.SetProfile(theme.ProfileANSI)
+	t.Cleanup(func() { theme.SetProfile(theme.DetectProfile()) })
+	colored := Colorize("key", theme.RoleStatus)
+	if VisibleLen(PadRight(colored, 10)) != 10 {
+		t.Fatalf("ANSI-aware padding failed: %q", PadRight(colored, 10))
+	}
+}
+
 func TestBadge(t *testing.T) {
 	pinTheme(t, theme.ProfileNoTTY)
 	if got := Badge("api", theme.RoleMuted); got != "[api]" {

--- a/ui/kit/style.go
+++ b/ui/kit/style.go
@@ -65,6 +65,19 @@ func VisibleLen(s string) int {
 	return lipgloss.Width(s)
 }
 
+// PadRight pads s with spaces to the given visible width. Measurement is
+// ANSI/emoji-aware (VisibleLen), unlike fmt's "%-Ns" which counts BYTES and
+// silently misaligns any accented or multibyte label — the root cause of
+// column drift in pt-BR surfaces. Strings already at or past the width are
+// returned unchanged.
+func PadRight(s string, cols int) string {
+	gap := cols - VisibleLen(s)
+	if gap <= 0 {
+		return s
+	}
+	return s + strings.Repeat(" ", gap)
+}
+
 // Truncate clamps s to at most maxCols visible columns, preserving ANSI
 // color sequences and appending an ellipsis plus a reset when content was
 // dropped so styling never bleeds into the next line.


### PR DESCRIPTION
## Summary

Slice 3 of the presentation overhaul (**stacked on #1165**, which stacks on #1164 — merge in order). First slice where visuals actually change: command surfaces align correctly in both locales and lose their rawest output.

## Changes

### i18n-safe column alignment (`kit.PadRight`)

New `kit.PadRight(s, cols)` pads by **visible width** (ANSI/emoji-aware). The previous idioms counted bytes:

- `cli/config_sections.go` `kv()` — the `%-32s` key column used by **every** `/config` section (17 files inherit the fix with zero edits). Any accented pt-BR label ("Custo da sessão", "Duração da sessão") was drifting its value column today.
- `cli/cli_config.go` `showHelp` — same `%-32s` fix for the command column.
- `cli/cost_command.go` — replaced the literal spaces hand-tuned to English label widths (`":%s    "`, `":%s       "`…) with per-group dynamic columns measured from the translated labels: top group (provider/model/duration/requests/source), token group, cache group, per-model cost group. pt-BR and en now align identically.

### Glyphs and rules

- `cli/agent_command_blocks.go`: the four raw `"---------------------------------------"` separators → `kit.Rule()` (responsive, dim).
- Command-batch task summary: the untranslated `- #%d: OK` / `- #%d: ERRO` lines → `kit.Notice(LevelSuccess/LevelError, …)` with two new catalog keys (`agent.summary.block_ok/block_failed`) added to `en`, `en-US` and `pt-BR` (hand-appended; catalogs otherwise untouched — 12-line diff).
- `cli/command_handler_plugins.go`: OAuth login success/failure prints → `kit.Notice` (✓/✗ on the grid).

## Testing

- New `kit.PadRight` unit test proves the byte-vs-visible-width failure mode (accented label + ANSI-colored input) and the no-truncate contract.
- `go build ./...`, `go test ./cli/ ./ui/kit/` green; `golangci-lint` clean; `qg-i18n-parity` reports `missing_keys=0`; ai-smells green locally.
- Manual check pending on the stacked branch: `/config all`, `/cost` and `/help` in `CHATCLI_LANG=pt-BR` and `en` (columns should match), one agent batch run for the summary notices.
