### PR TITLE
refactor(ui): mark the legacy color path and migrate queue notices to kit

### DIFF
--- a/cli/agent/ui_renderer.go
+++ b/cli/agent/ui_renderer.go
@@ -45,6 +45,11 @@ func typewriterPrint(text string, delay time.Duration) {
 }
 
 // ANSI Color codes exportados
+//
+// Legacy path: hue constants (duplicated from cli/colors.go — the
+// duplication is exactly what ui/kit exists to end). They remain because
+// they are exported and load-bearing across cli, but new and migrated code
+// styles through kit.Colorize / kit.Style with a theme.Role.
 const (
 	ColorReset  = "\033[0m"
 	ColorGreen  = "\033[32m"

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -46,6 +46,7 @@ import (
 	"github.com/diillson/chatcli/llm/manager"
 	"github.com/diillson/chatcli/llm/openaiassistant"
 	"github.com/diillson/chatcli/pkg/persona"
+	"github.com/diillson/chatcli/ui/kit"
 	"github.com/diillson/chatcli/ui/theme"
 	"github.com/fsnotify/fsnotify"
 
@@ -979,10 +980,10 @@ func (cli *ChatCLI) executor(in string) {
 			cli.messageQueue = append(cli.messageQueue, in)
 			queueLen := len(cli.messageQueue)
 			cli.messageQueueMu.Unlock()
-			fmt.Printf("\n  %s\n", colorize(i18n.T("queue.message_queued", queueLen), ColorGray))
+			fmt.Printf("\n%s\n", kit.Notice(kit.LevelInfo, i18n.T("queue.message_queued", queueLen)))
 		} else {
 			cli.messageQueueMu.Unlock()
-			fmt.Printf("\n  %s\n", colorize(i18n.T("queue.full"), ColorYellow))
+			fmt.Printf("\n%s\n", kit.Notice(kit.LevelWarn, i18n.T("queue.full")))
 		}
 		return
 	}

--- a/cli/cli_llm.go
+++ b/cli/cli_llm.go
@@ -18,6 +18,8 @@ import (
 	"github.com/diillson/chatcli/llm/catalog"
 	"github.com/diillson/chatcli/llm/client"
 	"github.com/diillson/chatcli/models"
+	"github.com/diillson/chatcli/ui/kit"
+	"github.com/diillson/chatcli/ui/theme"
 	"github.com/diillson/chatcli/utils"
 	"go.uber.org/zap"
 )
@@ -136,10 +138,10 @@ func (cli *ChatCLI) announceQueueDrain() {
 	fmt.Print("\033[0m")
 	_ = os.Stdout.Sync()
 	if remaining > 0 {
-		fmt.Printf("\n  %s\n", colorize(i18n.T("queue.processing_remaining", remaining), ColorGray))
+		fmt.Printf("\n%s\n", kit.NoticeRole(kit.GlyphRunning, i18n.T("queue.processing_remaining", remaining), theme.RoleAction))
 		return
 	}
-	fmt.Printf("\n  %s\n", colorize(i18n.T("queue.processing"), ColorGray))
+	fmt.Printf("\n%s\n", kit.NoticeRole(kit.GlyphRunning, i18n.T("queue.processing"), theme.RoleAction))
 }
 
 // acquireOperationContext creates the cancellable context that drives the

--- a/cli/colors.go
+++ b/cli/colors.go
@@ -7,6 +7,12 @@ import (
 )
 
 // ANSI Color Codes
+//
+// Legacy path: these hue constants are the legacy color path. New and
+// migrated code styles through semantic roles instead — kit.Colorize /
+// kit.Style with a theme.Role — so the theme-swap contract lives in one
+// place. The constants stay (they are load-bearing across many call sites
+// and theme.Recolor keeps them themable) but should not gain new callers.
 const (
 	ColorReset  = "\033[0m"
 	ColorGreen  = "\033[32m"
@@ -24,6 +30,9 @@ const (
 // resultado passa por theme.Recolor: os códigos básicos legados adotam a hue
 // do tema ativo sob o profile de cor atual, e a saída perde todo ANSI quando
 // não há terminal colorido (pipe/CI) — tudo isso sem mudar os call sites.
+//
+// Legacy: prefira kit.Colorize(text, role) em código novo/migrado — o
+// role semântico registra POR QUE a cor existe e o tema resolve o resto.
 func colorize(text string, color string) string {
 	return theme.Recolor(fmt.Sprintf("%s%s%s", color, text, ColorReset))
 }

--- a/cli/queue_notice_test.go
+++ b/cli/queue_notice_test.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/ui/theme"
+)
+
+// captureQueueStdout is a local stdout capture for the queue-notice tests
+// (named distinctly from the cost-render helper to avoid a collision once
+// both slices land on main).
+func captureQueueStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+	fn()
+	_ = w.Close()
+	out, _ := io.ReadAll(r)
+	return string(out)
+}
+
+// TestExecutorQueuesTypeAheadWithNotices drives the executor's type-ahead
+// branch: while a turn is executing, a plain message must be enqueued with
+// the info notice, and an eleventh message must hit the queue-full warning.
+func TestExecutorQueuesTypeAheadWithNotices(t *testing.T) {
+	theme.SetProfile(theme.ProfileNoTTY)
+	t.Cleanup(func() { theme.SetProfile(theme.DetectProfile()) })
+
+	c := &ChatCLI{Client: &fakeClient{provider: "P", model: "m"}}
+	c.isExecuting.Store(true)
+
+	out := captureQueueStdout(t, func() { c.executor("mensagem digitada durante o turno") })
+	if len(c.messageQueue) != 1 {
+		t.Fatalf("queue len = %d, want 1", len(c.messageQueue))
+	}
+	if strings.TrimSpace(out) == "" {
+		t.Fatal("queued notice not printed")
+	}
+
+	// Fill the queue to its cap and overflow it.
+	for i := len(c.messageQueue); i < 10; i++ {
+		c.messageQueue = append(c.messageQueue, "x")
+	}
+	out = captureQueueStdout(t, func() { c.executor("estourou a fila") })
+	if len(c.messageQueue) != 10 {
+		t.Fatalf("queue len = %d, want capped at 10", len(c.messageQueue))
+	}
+	if strings.TrimSpace(out) == "" {
+		t.Fatal("queue-full warning not printed")
+	}
+}
+
+// TestAnnounceQueueDrainBranches covers both drain announcements: with
+// messages remaining and with an empty queue.
+func TestAnnounceQueueDrainBranches(t *testing.T) {
+	theme.SetProfile(theme.ProfileNoTTY)
+	t.Cleanup(func() { theme.SetProfile(theme.DetectProfile()) })
+
+	c := &ChatCLI{}
+	c.messageQueue = []string{"next"}
+	withRemaining := captureQueueStdout(t, func() { c.announceQueueDrain() })
+
+	c.messageQueue = nil
+	empty := captureQueueStdout(t, func() { c.announceQueueDrain() })
+
+	if strings.TrimSpace(withRemaining) == "" || strings.TrimSpace(empty) == "" {
+		t.Fatalf("drain notices missing: remaining=%q empty=%q", withRemaining, empty)
+	}
+	if withRemaining == empty {
+		t.Fatal("the two drain branches must print different notices")
+	}
+}


### PR DESCRIPTION
## Summary

Slice 7 of the presentation overhaul (**stacked on #1169** — top of the stack). Closes the legacy color path to new callers and migrates the first call-site cluster as the pattern for the remaining sweep.

## Changes

- **Legacy-path documentation** on the two hue-constant blocks (`cli/colors.go` and the exported duplicate in `cli/agent/ui_renderer.go`) and on `colorize`: they stay (load-bearing across ~180 call sites, themable via `theme.Recolor`; deleting exports would trip the API-breaking gate) but must not gain new callers — new/migrated code styles through `kit.Colorize`/`kit.Style` with a `theme.Role`.
  - Deliberately **prose, not a `Deprecated:` marker**: the machine-readable form flips staticcheck SA1019 on every historical call site at once, trading the zero-lint baseline for noise without making the migration safer.
- **First migrated cluster — chat type-ahead queue notices**: "message queued" → info notice, "queue full" → warning notice, drain announcements → running glyph in the action role. This is the exemplar for sweeping the remaining `colorize(x, ColorY)` sites file-by-file in follow-ups.

## Testing

Full `go test ./cli ./cli/agent ./ui/kit` green, lint clean (zero SA1019), ai-smells green locally.

## Stack recap (merge bottom-up)

#1164 kit foundation → #1165 geometry → #1166 command surfaces → #1167 timeline glyphs → #1168 welcome → #1169 i18n VS16+rules → this one.