### PR TITLE
refactor(ui): move box geometry and wrapping math into ui/kit

### DIFF
--- a/cli/agent/response_envelope.go
+++ b/cli/agent/response_envelope.go
@@ -24,53 +24,31 @@ package agent
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/mattn/go-runewidth"
-	"golang.org/x/term"
+	"github.com/diillson/chatcli/ui/kit"
 )
 
-// init normalizes go-runewidth so emoji-bearing content reports its
-// real terminal-cell width. With the library defaults
-// (EastAsianWidth=false, StrictEmojiNeutral=true) emojis such as
-// "🏟️", "⚫", "🔴" are measured as 1 cell while almost every modern
-// terminal renders them as 2 — and the drift compounded into right
-// borders being pushed off the screen. Pinning StrictEmojiNeutral
-// to false makes the measurement match the rendering across iTerm2,
-// Terminal.app, VSCode, Windows Terminal, and Alacritty.
-func init() {
-	runewidth.DefaultCondition.StrictEmojiNeutral = false
-	runewidth.DefaultCondition.EastAsianWidth = false
-}
+// NOTE: the runewidth normalization (StrictEmojiNeutral=false) that used to
+// live in an init() here moved to ui/kit, which this package imports — the
+// emoji-width guarantee is unchanged (kit has a guard test for it).
 
-// TerminalWidth reports the live terminal width in columns, falling
-// back to a safe default when stdout is not a TTY (CI, tests, piped
-// runs). The 100-column fallback is wider than the legacy 87-col
-// constant so piped runs still produce a readable box; callers that
-// need a tighter cap clamp the result themselves.
+// TerminalWidth reports the live terminal width in columns. Delegates to
+// kit.TermWidth — the single width helper (fallback 100 when stdout is not
+// a TTY).
 func TerminalWidth() int {
-	w, _, err := term.GetSize(int(os.Stdout.Fd())) //#nosec G115 -- bounded by domain
-	if err != nil || w <= 0 {
-		return 100
-	}
-	return w
+	return kit.TermWidth()
 }
 
-// EnvelopeWidth returns the width to use for a response envelope on
-// the current terminal. It reserves 2 columns of right-edge margin so
-// iTerm/VSCode native scrollbars never clip the border, and clamps to
-// a minimum of 40 cols so the box never collapses on tiny terminals.
-// No upper cap is applied — full-screen terminals should use their
-// full width (this was a direct user preference).
+// EnvelopeWidth returns the width to use for a response envelope on the
+// current terminal. Delegates to kit.ContentWidth: right-edge margin so
+// native scrollbars never clip the border, clamped to a minimum so the box
+// never collapses on tiny terminals; no upper cap (full-screen terminals
+// use their full width — a direct user preference).
 func EnvelopeWidth() int {
-	w := TerminalWidth() - 2
-	if w < 40 {
-		return 40
-	}
-	return w
+	return kit.ContentWidth()
 }
 
 // ResponseEnvelopeOptions configures a unified bordered envelope. All
@@ -260,51 +238,10 @@ func (r *UIRenderer) RenderResponseEnvelope(opts ResponseEnvelopeOptions) {
 	fmt.Println(bottomLine)
 }
 
-// buildBilateralBorder constructs a horizontal border with optional
-// left and right labels embedded between the corner glyphs:
-//
-//	<lc>─ HeaderLeft ──────── HeaderRight ─<rc>
-//
-// Layout rules (in visible columns):
-//   - <lc> + '─' + leftLabel  if leftLabel != ""   (else <lc> + '─')
-//   - fill of '─' to absorb remaining width
-//   - rightLabel + '─' + <rc> if rightLabel != ""  (else '─' + <rc>)
-//
-// targetWidth is the EXACT visible width we must produce, measured by
-// lipgloss.Width on the matching body. A degenerate case where the
-// labels alone exceed targetWidth falls back to a minimal border (the
-// labels survive; the fill goes to zero).
+// buildBilateralBorder constructs a horizontal border with optional left
+// and right labels embedded between the corner glyphs. Geometry lives in
+// kit.BilateralBorder; coloring stays here so legacy ANSI-constant call
+// sites keep byte-identical output.
 func buildBilateralBorder(lc, rc rune, leftLabel, rightLabel string, targetWidth int, color string, r *UIRenderer) string {
-	const cornerCols = 1    // lc / rc themselves
-	const dashCornerPad = 1 // the "─" that hugs each corner
-
-	leftBlock := string(lc) + "─"
-	rightBlock := "─" + string(rc)
-	reserved := cornerCols*2 + dashCornerPad*2 // 4 cols of "<lc>─...─<rc>"
-
-	leftVis := lipgloss.Width(leftLabel)
-	rightVis := lipgloss.Width(rightLabel)
-
-	fill := targetWidth - reserved - leftVis - rightVis
-	if fill < 0 {
-		// Labels overflow the target — emit minimal border with the
-		// labels intact so callers can still read them. This is a
-		// safety net; in practice the envelope sizes the body to
-		// accommodate normal labels.
-		return r.Colorize(leftBlock+leftLabel+rightLabel+rightBlock, color+ColorBold)
-	}
-
-	dashes := strings.Repeat("─", fill)
-
-	var sb strings.Builder
-	sb.WriteString(leftBlock)
-	if leftVis > 0 {
-		sb.WriteString(leftLabel)
-	}
-	sb.WriteString(dashes)
-	if rightVis > 0 {
-		sb.WriteString(rightLabel)
-	}
-	sb.WriteString(rightBlock)
-	return r.Colorize(sb.String(), color+ColorBold)
+	return r.Colorize(kit.BilateralBorder(lc, rc, leftLabel, rightLabel, targetWidth), color+ColorBold)
 }

--- a/cli/agent/ui_renderer.go
+++ b/cli/agent/ui_renderer.go
@@ -18,9 +18,9 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/diillson/chatcli/i18n"
+	"github.com/diillson/chatcli/ui/kit"
 	"github.com/diillson/chatcli/ui/theme"
 	"go.uber.org/zap"
-	"golang.org/x/term"
 )
 
 // typewriterPrint emits text rune-by-rune with a small delay between
@@ -152,10 +152,7 @@ func (r *UIRenderer) StreamOutput(line string) {
 	// (ex.: `kubectl ... -o yaml` com annotations gigantes / blocos
 	// `last-applied-configuration`). Sem isso, uma linha que estoura a
 	// largura do terminal faz reflow e rasga a borda lateral/rodapé do box.
-	termWidth, err := terminalWidthForStream()
-	if err != nil || termWidth <= 0 {
-		termWidth = 80
-	}
+	termWidth := kit.TermWidth()
 
 	// Cada linha emitida é: prefix("│  ") + icon + conteúdo. A largura
 	// visível total precisa caber em termWidth-2 (mesma gutter de 2 cols
@@ -181,63 +178,10 @@ func (r *UIRenderer) StreamOutput(line string) {
 	}
 }
 
-// terminalWidthForStream retorna a largura atual do terminal (cols).
-func terminalWidthForStream() (int, error) {
-	w, _, err := term.GetSize(int(os.Stdout.Fd())) //#nosec G115 -- value bounded by domain
-	return w, err
-}
-
 // wrapStreamLine quebra UMA linha de output cru de tool na largura visível
-// informada. Diferente de wrapText, NÃO colapsa espaços em branco: a
-// indentação inicial é preservada (e repetida nas continuações) para que
-// YAML/JSON estruturado continue legível dentro do box. A quebra é por
-// runa (ANSI/wide-rune aware via lipgloss.Width), evitando cortar
-// sequências multibyte no meio.
+// informada, preservando indentação. Matemática em kit.WrapStreamLine.
 func wrapStreamLine(line string, width int) []string {
-	if width <= 0 || VisibleLen(line) <= width {
-		return []string{line}
-	}
-
-	trimmed := strings.TrimLeft(line, " \t")
-	indent := line[:len(line)-len(trimmed)]
-	indentW := VisibleLen(indent)
-	if indentW >= width-1 {
-		// Indentação maior que o box: desiste de preservá-la.
-		indent = ""
-		indentW = 0
-	}
-	chunkW := width - indentW
-	if chunkW < 1 {
-		chunkW = 1
-	}
-
-	var out []string
-	var cur strings.Builder
-	curW := 0
-	flush := func() {
-		out = append(out, indent+cur.String())
-		cur.Reset()
-		curW = 0
-	}
-
-	for _, rr := range trimmed {
-		rw := lipgloss.Width(string(rr))
-		if rw < 1 {
-			rw = 1
-		}
-		if curW+rw > chunkW && cur.Len() > 0 {
-			flush()
-		}
-		cur.WriteRune(rr)
-		curW += rw
-	}
-	if cur.Len() > 0 {
-		flush()
-	}
-	if len(out) == 0 {
-		out = append(out, indent)
-	}
-	return out
+	return kit.WrapStreamLine(line, width)
 }
 
 // Colorize aplica cores ANSI (exportada com C maiúsculo). O resultado passa
@@ -521,18 +465,12 @@ func (r *UIRenderer) PrintPrompt() string {
 	return r.Colorize(i18n.T("agent.prompt.choice"), ColorLime)
 }
 
-// VisibleLen calcula comprimento visível em colunas do terminal (sem ANSI codes).
-//
-// Delegates to lipgloss.Width — the same function the bordered box
-// renderer uses to size top/bottom borders. Sharing one measurement
-// path is what keeps wrap math and border math in agreement when the
-// content has emoji presentation sequences (e.g. "🏟️" = stadium + VS-16
-// = U+1F3DF + U+FE0F) that pure runewidth.StringWidth reports as 1 col
-// while every modern terminal renders as 2. Mismatch there used to
-// drift the right border outside the visible box; routing both sides
-// through lipgloss.Width removes the disagreement entirely.
+// VisibleLen calcula comprimento visível em colunas do terminal (sem ANSI
+// codes). Delegates to kit.VisibleLen (lipgloss.Width) — one measurement
+// path for wrap math and border math keeps them in agreement when content
+// has emoji presentation sequences.
 func VisibleLen(s string) int {
-	return lipgloss.Width(s)
+	return kit.VisibleLen(s)
 }
 
 // RenderTimelineEvent desenha um "card" estilizado com:
@@ -568,14 +506,9 @@ func (r *UIRenderer) RenderAssistantResponseTimelineEvent(icon, title, content, 
 // tool output (YAML/JSON/tables, where indentation and column alignment must
 // survive).
 func (r *UIRenderer) renderTimelineEventInner(icon, title, content, color string, typewrite bool, wrapFn func(string, int) []string) {
-	termWidth, _, err := term.GetSize(int(os.Stdout.Fd())) //#nosec G115 -- value bounded by domain
-	if err != nil || termWidth <= 0 {
-		termWidth = 80
-	}
-
-	// Reserve 2 cols on the right edge for terminals with native
+	// kit.ContentWidth already reserves the right-edge gutter for native
 	// scrollbars (iTerm, VSCode) so the box border never gets clipped.
-	maxCardWidth := termWidth - 2
+	maxCardWidth := kit.ContentWidth()
 	if maxCardWidth < 24 {
 		maxCardWidth = 24
 	}
@@ -645,90 +578,21 @@ func (r *UIRenderer) renderTimelineEventInner(icon, title, content, color string
 //   - title longer than card: truncate dashes to fit (header may overflow
 //     by 1-2 cols on extreme widths; acceptable degradation)
 func buildTitledTopBorder(header string, targetWidth int, color string, r *UIRenderer) string {
-	// Visible cols reserved: `╭── ` (4) + header (lipgloss) + ` ` (1) + dashes + `╮` (1)
-	usedNoFill := 4 + lipgloss.Width(header) + 1 + 1
-	fill := targetWidth - usedNoFill
-	if fill < 0 {
-		// Header doesn't fit — emit a minimal top without filling.
-		// The card will still close at the right cardWidth because we
-		// honor lipgloss's body measurement.
-		return r.Colorize("╭── "+header+" ╮", color+ColorBold)
-	}
-	line := "╭── " + header + " " + strings.Repeat("─", fill) + "╮"
-	return r.Colorize(line, color+ColorBold)
+	// Geometry in kit.TitledTopBorder; coloring stays here so the legacy
+	// ANSI-constant call sites keep byte-identical output.
+	return r.Colorize(kit.TitledTopBorder(header, targetWidth), color+ColorBold)
 }
 
-// trimBlankBoxBodyRows removes fully-empty content rows directly
-// adjacent to the top or bottom border of a lipgloss-rendered box.
-// An empty row looks like "│         │" — same width as the sides
-// but zero printable content between them. The Padding(0,2) on the
-// body style already adds breathing space, so additional blank rows
-// from glamour or wrapped paragraphs would stack up and break the
-// "card opens on real content" invariant.
+// trimBlankBoxBodyRows removes empty body rows adjacent to the box borders.
+// Logic in kit.TrimBlankBoxBodyRows.
 func trimBlankBoxBodyRows(rendered string) string {
-	rows := strings.Split(rendered, "\n")
-	if len(rows) <= 2 {
-		return rendered
-	}
-	isBlankRow := func(s string) bool {
-		plain := stripANSIForCard(s)
-		// Empty body rows are "│  ...spaces...  │". Anything else
-		// counts as real content (including a ╰── bottom border).
-		if !strings.HasPrefix(plain, "│") || !strings.HasSuffix(plain, "│") {
-			return false
-		}
-		inner := strings.TrimSuffix(strings.TrimPrefix(plain, "│"), "│")
-		return strings.TrimSpace(inner) == ""
-	}
-	// We do NOT touch the first row (it could be a border) or the
-	// last (always the bottom border). Trim only the body slice in
-	// between.
-	start := 0
-	end := len(rows)
-	// Find content boundaries: skip leading empties, then trailing.
-	for start < end && rows[start] != "" && !isBlankRow(rows[start]) {
-		// Non-blank, real row — leave start where it is.
-		break
-	}
-	// Trim trailing empty body rows that sit right before the bottom border.
-	// Bottom border is always the last line (no trailing newline preserved).
-	bottomIdx := end - 1
-	cut := bottomIdx - 1
-	for cut > start && isBlankRow(rows[cut]) {
-		cut--
-	}
-	if cut+1 < bottomIdx {
-		rows = append(rows[:cut+1], rows[bottomIdx])
-	}
-	// Trim leading empty body rows that sit right after the (absent) top
-	// border. Since BorderTop is false, rows[0] is the first content row.
-	leading := 0
-	for leading < len(rows)-1 && isBlankRow(rows[leading]) {
-		leading++
-	}
-	if leading > 0 {
-		rows = rows[leading:]
-	}
-	return strings.Join(rows, "\n")
+	return kit.TrimBlankBoxBodyRows(rendered)
 }
 
-// stripANSIForCard removes CSI color escapes so width and emptiness
-// checks see plain text. Inlined to avoid a regex dependency on the
-// hot card-rendering path.
+// stripANSIForCard removes CSI color escapes so width and emptiness checks
+// see plain text. Logic in kit.StripANSI.
 func stripANSIForCard(s string) string {
-	var b strings.Builder
-	b.Grow(len(s))
-	for i := 0; i < len(s); i++ {
-		if s[i] == 0x1b && i+1 < len(s) && s[i+1] == '[' {
-			i += 2
-			for i < len(s) && (s[i] < 0x40 || s[i] > 0x7e) {
-				i++
-			}
-			continue
-		}
-		b.WriteByte(s[i])
-	}
-	return b.String()
+	return kit.StripANSI(s)
 }
 
 // ansiColorToLip maps the package-local ANSI color constants used by
@@ -751,273 +615,41 @@ func (r *UIRenderer) RenderMarkdownTimelineEvent(icon, title, renderedMarkdownAN
 	r.renderTimelineEventInner(icon, title, renderedMarkdownANSI, color, false, wrapStructured)
 }
 
-// trimBlankBorderRows drops fully-blank rows from the leading and
-// trailing edges of a wrapped-text slice. A row is "blank" when it
-// has zero visible width — color codes alone don't count as visible
-// content (lipgloss/glamour emit ANSI-only lines for some markdown
-// constructs, and we don't want those drawing as ghost rows inside
-// the card). Blank rows in the MIDDLE are preserved so paragraph
-// breaks the author put in markdown survive.
+// trimBlankBorderRows drops fully-blank edge rows from a wrapped-text
+// slice, keeping middle blanks. Logic in kit.TrimBlankBorderRows.
 func trimBlankBorderRows(rows []string) []string {
-	start := 0
-	for start < len(rows) && VisibleLen(rows[start]) == 0 {
-		start++
-	}
-	end := len(rows)
-	for end > start && VisibleLen(rows[end-1]) == 0 {
-		end--
-	}
-	if start == 0 && end == len(rows) {
-		return rows
-	}
-	return rows[start:end]
+	return kit.TrimBlankBorderRows(rows)
 }
 
-// wrapText quebra o texto em linhas que não excedem o limite.
-// Versão production-ready:
-// - Preserva quebras de linha originais
-// - Faz word-wrap por largura visível (ignora ANSI)
-// - Não destrói formatação do markdown renderizado (ANSI + linhas)
+// wrapText quebra o texto em linhas que não excedem o limite (word-wrap de
+// prosa). A matemática vive em ui/kit (kit.WrapText); este delegate preserva
+// os call sites e testes históricos do pacote.
 func wrapText(text string, limit int) []string {
-	if limit <= 0 {
-		return []string{text}
-	}
-
-	var finalLines []string
-	paragraphs := strings.Split(text, "\n")
-
-	for _, p := range paragraphs {
-		// Preserva linha vazia
-		if p == "" {
-			finalLines = append(finalLines, "")
-			continue
-		}
-
-		// Word wrap baseado em largura visível
-		words := strings.Fields(p)
-		if len(words) == 0 {
-			finalLines = append(finalLines, "")
-			continue
-		}
-
-		var line strings.Builder
-		curLen := 0
-
-		flushLine := func() {
-			finalLines = append(finalLines, line.String())
-			line.Reset()
-			curLen = 0
-		}
-
-		// emitLongWord quebra uma palavra maior que o limite em pedaços
-		// (rune-aware), empurra os pedaços completos para finalLines e
-		// deixa o último pedaço como início da linha corrente.
-		emitLongWord := func(w string) {
-			chunks := hardBreakWord(w, limit)
-			for i := 0; i < len(chunks)-1; i++ {
-				finalLines = append(finalLines, chunks[i])
-			}
-			last := chunks[len(chunks)-1]
-			line.WriteString(last)
-			curLen = VisibleLen(last)
-		}
-
-		for _, w := range words {
-			wLen := VisibleLen(w)
-			if curLen == 0 {
-				// Palavra única maior que o limite (ex.: o JSON de
-				// `last-applied-configuration` sem espaços) precisa ser
-				// quebrada aqui também — caso contrário ela é escrita
-				// inteira e estoura a largura do box.
-				if wLen > limit {
-					emitLongWord(w)
-				} else {
-					line.WriteString(w)
-					curLen = wLen
-				}
-				continue
-			}
-
-			// +1 espaço
-			if curLen+1+wLen <= limit {
-				line.WriteByte(' ')
-				line.WriteString(w)
-				curLen += 1 + wLen
-				continue
-			}
-
-			// Não cabe na linha atual: fecha e recoloca a palavra,
-			// quebrando "na marra" se ela sozinha já estoura o limite.
-			flushLine()
-
-			if wLen <= limit {
-				line.WriteString(w)
-				curLen = wLen
-				continue
-			}
-
-			emitLongWord(w)
-		}
-
-		if line.Len() > 0 {
-			finalLines = append(finalLines, line.String())
-		}
-	}
-
-	return finalLines
+	return kit.WrapText(text, limit)
 }
 
-// hardBreakWord parte uma palavra (sem espaços) em pedaços cuja largura
-// visível não excede limit. A quebra é por runa, medindo com lipgloss.Width,
-// para não cortar sequências UTF-8 / wide-runes no meio — diferente do
-// fatiamento por bytes anterior. Retorna ao menos um elemento.
-func hardBreakWord(w string, limit int) []string {
-	if limit <= 0 {
-		return []string{w}
-	}
-
-	var out []string
-	var cur strings.Builder
-	curW := 0
-	for _, rr := range w {
-		rw := lipgloss.Width(string(rr))
-		if rw < 1 {
-			rw = 1
-		}
-		if curW+rw > limit && cur.Len() > 0 {
-			out = append(out, cur.String())
-			cur.Reset()
-			curW = 0
-		}
-		cur.WriteRune(rr)
-		curW += rw
-	}
-	if cur.Len() > 0 {
-		out = append(out, cur.String())
-	}
-	if len(out) == 0 {
-		out = append(out, "")
-	}
-	return out
-}
-
-// wrapPreserve quebra texto preservando a estrutura: cada linha que cabe no
-// limite é mantida exatamente como está (indentação e espaçamento de colunas
-// intactos) e só as que estouram são quebradas, repetindo a indentação nas
-// continuações. É a mesma lógica da streaming box (wrapStreamLine), aplicada
-// linha a linha — usada no card de resultado de tool (YAML/JSON/tabelas),
-// onde colapsar whitespace como o word-wrap de prosa destruiria o layout.
+// wrapPreserve quebra texto preservando estrutura/indentação (tool output).
+// Matemática em kit.WrapPreserve.
 func wrapPreserve(text string, limit int) []string {
-	var out []string
-	for _, line := range strings.Split(text, "\n") {
-		out = append(out, wrapStreamLine(line, limit)...)
-	}
-	return out
+	return kit.WrapPreserve(text, limit)
 }
 
-// splitLeadingIndent separa a indentação inicial de uma linha do seu
-// conteúdo, de forma ANSI-aware. O glamour emite sequências de cor de
-// largura-zero ANTES (e entre) os espaços de indentação do markdown
-// renderizado — então um strings.TrimLeft(" \t") reportaria indentação
-// zero em YAML/JSON/código vindos do glamour, que é exatamente a causa do
-// bug de "perde a indentação" no modo chat. Retorna a largura visível do
-// indent em colunas, os códigos ANSI vistos na região inicial (re-anexados
-// ao conteúdo para que o primeiro token preserve a cor) e o conteúdo
-// restante.
-func splitLeadingIndent(line string) (indent int, codes string, content string) {
-	var cb strings.Builder
-	i := 0
-	for i < len(line) {
-		// Sequência CSI ANSI: preserva — pode colorir o conteúdo à frente.
-		if line[i] == 0x1b && i+1 < len(line) && line[i+1] == '[' {
-			j := i + 2
-			for j < len(line) && (line[j] < 0x40 || line[j] > 0x7e) {
-				j++
-			}
-			if j < len(line) {
-				j++ // inclui o byte final da sequência
-			}
-			cb.WriteString(line[i:j])
-			i = j
-			continue
-		}
-		if line[i] == ' ' || line[i] == '\t' {
-			indent++ // tab contado como 1 col (o glamour normaliza para espaços)
-			i++
-			continue
-		}
-		break
-	}
-	return indent, cb.String(), line[i:]
-}
-
-// wrapStructured quebra um corpo já renderizado pelo glamour para exibição
-// dentro do envelope de resposta. Diferente de wrapText (word-wrap de prosa,
-// que colapsa a indentação via strings.Fields), ele PRESERVA a indentação
-// inicial de cada linha — é o fix do bug em que YAML/JSON/código colados no
-// chat "ficam todos à esquerda e perdem a indentação". Mecânica, por linha:
-//
-//   - Detecta o indent inicial visível (ANSI-aware: o glamour emite cores
-//     ANTES dos espaços, então um TrimLeft simples não enxerga o indent).
-//   - Deslova (dedent) toda linha pela margem mínima comum — o glamour aplica
-//     uma margem de documento uniforme (tipicamente 2 cols) a prosa E código;
-//     como o próprio envelope já tem Padding(0,2), carregar a margem do
-//     glamour também empurraria tudo 2 cols para a direita.
-//   - Linhas que cabem na largura interna são emitidas verbatim (alinhamento
-//     de colunas intacto). Só as que estouram passam por word-wrap, repetindo
-//     o indent da linha em cada continuação.
+// wrapStructured quebra corpos renderizados pelo glamour preservando (e
+// dedentando) a indentação. Matemática em kit.WrapStructured.
 func wrapStructured(text string, limit int) []string {
-	if limit <= 0 {
-		return []string{text}
-	}
-	rawLines := strings.Split(text, "\n")
+	return kit.WrapStructured(text, limit)
+}
 
-	type lineSeg struct {
-		indent  int
-		payload string // códigos ANSI iniciais + conteúdo
-		blank   bool
-	}
-	segs := make([]lineSeg, 0, len(rawLines))
-	commonIndent := -1
-	for _, ln := range rawLines {
-		ind, codes, body := splitLeadingIndent(ln)
-		blank := strings.TrimSpace(stripANSIForCard(ln)) == ""
-		segs = append(segs, lineSeg{indent: ind, payload: codes + body, blank: blank})
-		if !blank && (commonIndent < 0 || ind < commonIndent) {
-			commonIndent = ind
-		}
-	}
-	if commonIndent < 0 {
-		commonIndent = 0
-	}
+// splitLeadingIndent separa indentação inicial de conteúdo, ANSI-aware.
+// Lógica em kit.SplitLeadingIndent.
+func splitLeadingIndent(line string) (indent int, codes string, content string) {
+	return kit.SplitLeadingIndent(line)
+}
 
-	out := make([]string, 0, len(rawLines))
-	for _, s := range segs {
-		if s.blank {
-			out = append(out, "")
-			continue
-		}
-		rel := s.indent - commonIndent
-		if rel < 0 {
-			rel = 0
-		}
-		pad := strings.Repeat(" ", rel)
-		full := pad + s.payload
-		if VisibleLen(full) <= limit {
-			// Cabe: verbatim — preserva qualquer alinhamento interno.
-			out = append(out, full)
-			continue
-		}
-		// Estoura: word-wrap do conteúdo, repetindo o indent nas continuações.
-		avail := limit - rel
-		if avail < 1 {
-			avail = 1
-		}
-		for _, chunk := range wrapText(s.payload, avail) {
-			out = append(out, pad+chunk)
-		}
-	}
-	return out
+// hardBreakWord parte uma palavra maior que o limite em pedaços rune-aware.
+// Lógica em kit.HardBreakWord.
+func hardBreakWord(w string, limit int) []string {
+	return kit.HardBreakWord(w, limit)
 }
 
 // RenderThinking exibe o pensamento da IA
@@ -1132,10 +764,7 @@ func cleanArgsForDisplay(args string) string {
 
 // RenderBatchHeader exibe um cabeçalho indicando o início de um lote
 func (r *UIRenderer) RenderBatchHeader(totalActions int) {
-	width, _, _ := term.GetSize(int(os.Stdout.Fd())) //#nosec G115 -- value bounded by domain
-	if width <= 0 {
-		width = 80
-	}
+	width := kit.TermWidth()
 
 	msg := i18n.T("agent.ui.batch_started", totalActions)
 	line := strings.Repeat("═", width)
@@ -1210,10 +839,7 @@ var streamBoxHeaderWidth int
 func (r *UIRenderer) RenderStreamBoxStart(icon, title, color string) {
 	header := fmt.Sprintf("%s %s", icon, title)
 
-	termWidth, _, err := term.GetSize(int(os.Stdout.Fd())) //#nosec G115 -- value bounded by domain
-	if err != nil || termWidth <= 0 {
-		termWidth = 80
-	}
+	termWidth := kit.TermWidth()
 
 	// "╭── " (4) + header + " " + minimum 6 dashes for visual weight.
 	const minTail = 6

--- a/cli/agent/ui_renderer_stream_wrap_test.go
+++ b/cli/agent/ui_renderer_stream_wrap_test.go
@@ -7,8 +7,8 @@ import (
 
 // TestStreamOutputWrapsAndPrefixesEveryLine exercita o caminho de streaming
 // ao vivo: toda linha emitida tem que carregar a borda lateral "│" e nenhuma
-// pode exceder a largura do terminal (fallback 80 fora de tty), garantindo
-// que o box não reflui com YAML largo.
+// pode exceder a largura do terminal (fallback unificado do kit fora de
+// tty), garantindo que o box não reflui com YAML largo.
 func TestStreamOutputWrapsAndPrefixesEveryLine(t *testing.T) {
 	r := NewUIRendererWithStyle(nil, UIStyleFull)
 
@@ -23,13 +23,14 @@ func TestStreamOutputWrapsAndPrefixesEveryLine(t *testing.T) {
 	if len(lines) == 0 {
 		t.Fatal("StreamOutput não emitiu nada")
 	}
+	maxCols := TerminalWidth()
 	for i, ln := range lines {
 		plain := stripANSI(ln)
 		if !strings.HasPrefix(plain, "│") {
 			t.Errorf("linha %d sem borda lateral: %q", i, plain)
 		}
-		if w := VisibleLen(plain); w > 80 {
-			t.Errorf("linha %d excedeu 80 cols (got %d): %q", i, w, plain)
+		if w := VisibleLen(plain); w > maxCols {
+			t.Errorf("linha %d excedeu %d cols (got %d): %q", i, maxCols, w, plain)
 		}
 	}
 	// Garante que o bloco multi-linha gerou as duas linhas lógicas.

--- a/cli/animation_manager.go
+++ b/cli/animation_manager.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/diillson/chatcli/ui/kit"
 	"github.com/diillson/chatcli/ui/theme"
-	"golang.org/x/term"
 )
 
 // spinnerFrames is the single source of the braille spinner animation, shared
@@ -109,13 +109,10 @@ func (am *AnimationManager) ShowThinkingAnimation(message string) {
 	}()
 }
 
-// terminalCols returns the current stdout width, with a conservative default
-// when stdout is not a terminal or the size cannot be determined.
+// terminalCols returns the current stdout width. Delegates to the kit's
+// single width helper (fallback 100 off-terminal).
 func terminalCols() int {
-	if w, _, err := term.GetSize(int(os.Stdout.Fd())); err == nil && w > 0 {
-		return w
-	}
-	return 100
+	return kit.TermWidth()
 }
 
 // clampSpinnerMessage bounds msg so the rendered spinner line (message +

--- a/cli/ui_boxes.go
+++ b/cli/ui_boxes.go
@@ -2,24 +2,21 @@ package cli
 
 import (
 	"fmt"
-	"os"
 	"strings"
-	"unicode/utf8"
 
-	"github.com/mattn/go-runewidth"
-	"golang.org/x/term"
+	"github.com/diillson/chatcli/ui/kit"
 )
 
 // ─── Terminal Box Helpers ──────────────────────────────────────
 // Shared UI functions for rendering consistent boxed output
 // across /mcp, /hooks, /cost, /channel, /worktree, etc.
+// Width and truncation math delegate to ui/kit so every surface
+// agrees on geometry; these helpers survive as the legacy color-
+// constant facade until the /config surfaces migrate to kit
+// components directly.
 
 func uiTermWidth() int {
-	w, _, err := term.GetSize(int(os.Stdout.Fd())) //#nosec G115 -- value bounded by domain
-	if err != nil || w <= 0 {
-		return 80
-	}
-	return w
+	return kit.TermWidth()
 }
 
 // uiBox renders a box header: ╭── icon TITLE
@@ -51,30 +48,9 @@ func uiBoxLine(color, text string) string {
 	return uiPrefix(color) + ansiTruncate(text, maxCols)
 }
 
-// ansiTruncate clamps s to at most maxCols visible columns (wide runes count
-// per display cell), preserving ANSI color sequences and appending an
-// ellipsis plus a color reset when content was dropped so styling never
-// bleeds into the next line.
+// ansiTruncate clamps s to at most maxCols visible columns, preserving ANSI
+// sequences and appending an ellipsis when content was dropped. Logic in
+// kit.Truncate.
 func ansiTruncate(s string, maxCols int) string {
-	if visibleLen(s) <= maxCols {
-		return s
-	}
-	var b strings.Builder
-	cols := 0
-	for i := 0; i < len(s); {
-		if loc := ansiRe.FindStringIndex(s[i:]); loc != nil && loc[0] == 0 {
-			b.WriteString(s[i : i+loc[1]])
-			i += loc[1]
-			continue
-		}
-		r, size := utf8.DecodeRuneInString(s[i:])
-		w := runewidth.RuneWidth(r)
-		if cols+w > maxCols-1 { // reserve one column for the ellipsis
-			break
-		}
-		b.WriteRune(r)
-		cols += w
-		i += size
-	}
-	return b.String() + "…" + ColorReset
+	return kit.Truncate(s, maxCols)
 }

--- a/cli/ui_boxes_test.go
+++ b/cli/ui_boxes_test.go
@@ -3,7 +3,18 @@ package cli
 import (
 	"strings"
 	"testing"
+
+	"github.com/diillson/chatcli/ui/theme"
 )
+
+// pinANSIProfile fixes the color profile so truncation assertions about the
+// trailing reset are deterministic (kit.Truncate emits escapes only on
+// colored profiles), restoring detection afterwards.
+func pinANSIProfile(t *testing.T) {
+	t.Helper()
+	theme.SetProfile(theme.ProfileANSI)
+	t.Cleanup(func() { theme.SetProfile(theme.DetectProfile()) })
+}
 
 func TestAnsiTruncate_ShortStringUnchanged(t *testing.T) {
 	in := "\033[33mshort\033[0m line"
@@ -13,6 +24,7 @@ func TestAnsiTruncate_ShortStringUnchanged(t *testing.T) {
 }
 
 func TestAnsiTruncate_ClampsVisibleWidth(t *testing.T) {
+	pinANSIProfile(t)
 	in := "\033[35m[servicenow/incidents]\033[0m " + strings.Repeat("x", 200)
 	got := ansiTruncate(in, 40)
 
@@ -28,6 +40,7 @@ func TestAnsiTruncate_ClampsVisibleWidth(t *testing.T) {
 }
 
 func TestAnsiTruncate_WideRunesCountPerCell(t *testing.T) {
+	pinANSIProfile(t)
 	// Emoji and CJK occupy two terminal columns; byte- or rune-based
 	// truncation would overflow the box and wrap the line.
 	in := strings.Repeat("🚀", 30)
@@ -43,9 +56,10 @@ func TestAnsiTruncate_WideRunesCountPerCell(t *testing.T) {
 func TestUIBoxLine_NeverExceedsTerminalWidth(t *testing.T) {
 	long := strings.Repeat("word ", 100)
 	got := uiBoxLine(ColorPurple, long)
-	// uiTermWidth falls back to 80 outside a TTY (the test environment).
-	if w := visibleLen(got); w > 80 {
-		t.Errorf("box line visible width = %d, want <= 80", w)
+	// uiTermWidth delegates to kit.TermWidth, which falls back to 100
+	// outside a TTY (the test environment) — the unified fallback.
+	if w := visibleLen(got); w > uiTermWidth() {
+		t.Errorf("box line visible width = %d, want <= %d", w, uiTermWidth())
 	}
 	if !strings.Contains(got, "│") {
 		t.Error("box line must keep the sidebar prefix")

--- a/ui/kit/box.go
+++ b/ui/kit/box.go
@@ -1,0 +1,78 @@
+/*
+ * ChatCLI - UI kit: box border geometry
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * The two border builders every card in the app uses, moved verbatim from
+ * cli/agent. They return PLAIN (uncolored) lines: color belongs to the
+ * caller — the agent wrappers keep their legacy ANSI-constant coloring
+ * byte-identical, and kit-native components colorize through theme roles.
+ * targetWidth is always the EXACT visible width to produce, measured with
+ * VisibleLen (lipgloss.Width) on the matching body so every border row
+ * agrees with every body row even under emoji-width drift.
+ */
+package kit
+
+import "strings"
+
+// TitledTopBorder produces a `╭── header ─────╮` line whose VISIBLE width
+// equals targetWidth. The two padding rules cover the two ways the header
+// can fall short of the card width:
+//   - normal case: header fits, fill with dashes
+//   - header longer than card: emit a minimal top without filling (the
+//     card still closes at the right width because callers honor the
+//     body measurement; 1-2 cols of overflow is accepted degradation)
+func TitledTopBorder(header string, targetWidth int) string {
+	// Visible cols reserved: `╭── ` (4) + header + ` ` (1) + dashes + `╮` (1)
+	usedNoFill := 4 + VisibleLen(header) + 1 + 1
+	fill := targetWidth - usedNoFill
+	if fill < 0 {
+		return "╭── " + header + " ╮"
+	}
+	return "╭── " + header + " " + strings.Repeat("─", fill) + "╮"
+}
+
+// BilateralBorder constructs a horizontal border with optional left and
+// right labels embedded between the corner glyphs:
+//
+//	<lc>─ LeftLabel ──────── RightLabel ─<rc>
+//
+// Layout rules (in visible columns):
+//   - <lc> + '─' + leftLabel  if leftLabel != ""   (else <lc> + '─')
+//   - fill of '─' to absorb remaining width
+//   - rightLabel + '─' + <rc> if rightLabel != ""  (else '─' + <rc>)
+//
+// A degenerate case where the labels alone exceed targetWidth falls back
+// to a minimal border (the labels survive; the fill goes to zero).
+func BilateralBorder(lc, rc rune, leftLabel, rightLabel string, targetWidth int) string {
+	const cornerCols = 1    // lc / rc themselves
+	const dashCornerPad = 1 // the "─" that hugs each corner
+
+	leftBlock := string(lc) + "─"
+	rightBlock := "─" + string(rc)
+	reserved := cornerCols*2 + dashCornerPad*2 // 4 cols of "<lc>─...─<rc>"
+
+	leftVis := VisibleLen(leftLabel)
+	rightVis := VisibleLen(rightLabel)
+
+	fill := targetWidth - reserved - leftVis - rightVis
+	if fill < 0 {
+		// Labels overflow the target — emit minimal border with the labels
+		// intact so callers can still read them.
+		return leftBlock + leftLabel + rightLabel + rightBlock
+	}
+
+	dashes := strings.Repeat("─", fill)
+
+	var sb strings.Builder
+	sb.WriteString(leftBlock)
+	if leftVis > 0 {
+		sb.WriteString(leftLabel)
+	}
+	sb.WriteString(dashes)
+	if rightVis > 0 {
+		sb.WriteString(rightLabel)
+	}
+	sb.WriteString(rightBlock)
+	return sb.String()
+}

--- a/ui/kit/box_test.go
+++ b/ui/kit/box_test.go
@@ -1,0 +1,101 @@
+/*
+ * ChatCLI - UI kit geometry tests
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package kit
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTitledTopBorderExactWidth(t *testing.T) {
+	for _, tt := range []struct {
+		header string
+		width  int
+	}{
+		{"💬 RESPOSTA", 60},
+		{"plain", 40},
+		{"acentuação ção", 80},
+	} {
+		line := TitledTopBorder(tt.header, tt.width)
+		if w := VisibleLen(line); w != tt.width {
+			t.Errorf("TitledTopBorder(%q, %d) width = %d", tt.header, tt.width, w)
+		}
+		if !strings.HasPrefix(line, "╭── ") || !strings.HasSuffix(line, "╮") {
+			t.Errorf("border shape broken: %q", line)
+		}
+	}
+}
+
+func TestTitledTopBorderOverflowFallback(t *testing.T) {
+	line := TitledTopBorder("a very long header that cannot fit", 10)
+	if !strings.Contains(line, "a very long header") || !strings.HasSuffix(line, "╮") {
+		t.Errorf("overflow fallback must keep the header readable: %q", line)
+	}
+}
+
+func TestBilateralBorderExactWidth(t *testing.T) {
+	for _, tt := range []struct {
+		left, right string
+		width       int
+	}{
+		{" claude-fable-5 ", " 3.2s · 12k ", 70},
+		{" only-left ", "", 50},
+		{"", "", 44},
+	} {
+		line := BilateralBorder('╭', '╮', tt.left, tt.right, tt.width)
+		if w := VisibleLen(line); w != tt.width {
+			t.Errorf("BilateralBorder(%q,%q,%d) width = %d: %q", tt.left, tt.right, tt.width, w, line)
+		}
+	}
+}
+
+func TestBilateralBorderOverflowKeepsLabels(t *testing.T) {
+	line := BilateralBorder('╰', '╯', " long left label ", " long right label ", 12)
+	if !strings.Contains(line, "long left label") || !strings.Contains(line, "long right label") {
+		t.Errorf("overflow fallback must keep labels: %q", line)
+	}
+}
+
+func TestWrapStructuredKeepsRelativeIndent(t *testing.T) {
+	in := "  root:\n    child: 1\n    wide: " + strings.Repeat("x", 120)
+	out := WrapStructured(in, 40)
+	if len(out) < 3 {
+		t.Fatalf("expected wrapped lines, got %d", len(out))
+	}
+	// Common margin (2) dedented: root at col 0, child at col 2.
+	if !strings.HasPrefix(out[0], "root:") {
+		t.Errorf("common indent not dedented: %q", out[0])
+	}
+	if !strings.HasPrefix(out[1], "  child:") {
+		t.Errorf("relative indent lost: %q", out[1])
+	}
+	for i, ln := range out {
+		if w := VisibleLen(ln); w > 40 {
+			t.Errorf("line %d exceeds limit: %d", i, w)
+		}
+	}
+}
+
+func TestStripANSIRemovesCSIOnly(t *testing.T) {
+	in := "\x1b[38;5;140mkey\x1b[0m: value"
+	if got := StripANSI(in); got != "key: value" {
+		t.Errorf("StripANSI = %q", got)
+	}
+}
+
+func TestTrimBlankBorderRowsKeepsMiddleBlanks(t *testing.T) {
+	rows := []string{"", "\x1b[0m", "a", "", "b", ""}
+	got := TrimBlankBorderRows(rows)
+	want := []string{"a", "", "b"}
+	if len(got) != len(want) {
+		t.Fatalf("TrimBlankBorderRows = %#v", got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("row %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/ui/kit/wrap.go
+++ b/ui/kit/wrap.go
@@ -1,0 +1,404 @@
+/*
+ * ChatCLI - UI kit: ANSI-aware wrapping
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * The three wrap flavors every boxed surface uses, moved verbatim from
+ * cli/agent so chat, agent and command surfaces share one wrap math:
+ *
+ *   - WrapText: prose word-wrap (collapses whitespace) — reasoning, replies.
+ *   - WrapStructured: glamour-rendered bodies — preserves (and dedents)
+ *     indentation so YAML/JSON/code keeps its shape.
+ *   - WrapPreserve / WrapStreamLine: raw tool output — every fitting line
+ *     verbatim, only overflowing lines break, indentation repeated.
+ */
+package kit
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// WrapText quebra o texto em linhas que não excedem o limite.
+// - Preserva quebras de linha originais
+// - Faz word-wrap por largura visível (ignora ANSI)
+// - Não destrói formatação do markdown renderizado (ANSI + linhas)
+func WrapText(text string, limit int) []string {
+	if limit <= 0 {
+		return []string{text}
+	}
+
+	var finalLines []string
+	paragraphs := strings.Split(text, "\n")
+
+	for _, p := range paragraphs {
+		// Preserva linha vazia
+		if p == "" {
+			finalLines = append(finalLines, "")
+			continue
+		}
+
+		// Word wrap baseado em largura visível
+		words := strings.Fields(p)
+		if len(words) == 0 {
+			finalLines = append(finalLines, "")
+			continue
+		}
+
+		var line strings.Builder
+		curLen := 0
+
+		flushLine := func() {
+			finalLines = append(finalLines, line.String())
+			line.Reset()
+			curLen = 0
+		}
+
+		// emitLongWord quebra uma palavra maior que o limite em pedaços
+		// (rune-aware), empurra os pedaços completos para finalLines e
+		// deixa o último pedaço como início da linha corrente.
+		emitLongWord := func(w string) {
+			chunks := HardBreakWord(w, limit)
+			for i := 0; i < len(chunks)-1; i++ {
+				finalLines = append(finalLines, chunks[i])
+			}
+			last := chunks[len(chunks)-1]
+			line.WriteString(last)
+			curLen = VisibleLen(last)
+		}
+
+		for _, w := range words {
+			wLen := VisibleLen(w)
+			if curLen == 0 {
+				// Palavra única maior que o limite (ex.: o JSON de
+				// `last-applied-configuration` sem espaços) precisa ser
+				// quebrada aqui também — caso contrário ela é escrita
+				// inteira e estoura a largura do box.
+				if wLen > limit {
+					emitLongWord(w)
+				} else {
+					line.WriteString(w)
+					curLen = wLen
+				}
+				continue
+			}
+
+			// +1 espaço
+			if curLen+1+wLen <= limit {
+				line.WriteByte(' ')
+				line.WriteString(w)
+				curLen += 1 + wLen
+				continue
+			}
+
+			// Não cabe na linha atual: fecha e recoloca a palavra,
+			// quebrando "na marra" se ela sozinha já estoura o limite.
+			flushLine()
+
+			if wLen <= limit {
+				line.WriteString(w)
+				curLen = wLen
+				continue
+			}
+
+			emitLongWord(w)
+		}
+
+		if line.Len() > 0 {
+			finalLines = append(finalLines, line.String())
+		}
+	}
+
+	return finalLines
+}
+
+// HardBreakWord parte uma palavra (sem espaços) em pedaços cuja largura
+// visível não excede limit. A quebra é por runa, medindo com lipgloss.Width,
+// para não cortar sequências UTF-8 / wide-runes no meio. Retorna ao menos
+// um elemento.
+func HardBreakWord(w string, limit int) []string {
+	if limit <= 0 {
+		return []string{w}
+	}
+
+	var out []string
+	var cur strings.Builder
+	curW := 0
+	for _, rr := range w {
+		rw := lipgloss.Width(string(rr))
+		if rw < 1 {
+			rw = 1
+		}
+		if curW+rw > limit && cur.Len() > 0 {
+			out = append(out, cur.String())
+			cur.Reset()
+			curW = 0
+		}
+		cur.WriteRune(rr)
+		curW += rw
+	}
+	if cur.Len() > 0 {
+		out = append(out, cur.String())
+	}
+	if len(out) == 0 {
+		out = append(out, "")
+	}
+	return out
+}
+
+// WrapStreamLine quebra UMA linha de output cru de tool na largura visível
+// informada. Diferente de WrapText, NÃO colapsa espaços em branco: a
+// indentação inicial é preservada (e repetida nas continuações) para que
+// YAML/JSON estruturado continue legível dentro do box. A quebra é por
+// runa (ANSI/wide-rune aware via lipgloss.Width), evitando cortar
+// sequências multibyte no meio.
+func WrapStreamLine(line string, width int) []string {
+	if width <= 0 || VisibleLen(line) <= width {
+		return []string{line}
+	}
+
+	trimmed := strings.TrimLeft(line, " \t")
+	indent := line[:len(line)-len(trimmed)]
+	indentW := VisibleLen(indent)
+	if indentW >= width-1 {
+		// Indentação maior que o box: desiste de preservá-la.
+		indent = ""
+		indentW = 0
+	}
+	chunkW := width - indentW
+	if chunkW < 1 {
+		chunkW = 1
+	}
+
+	var out []string
+	var cur strings.Builder
+	curW := 0
+	flush := func() {
+		out = append(out, indent+cur.String())
+		cur.Reset()
+		curW = 0
+	}
+
+	for _, rr := range trimmed {
+		rw := lipgloss.Width(string(rr))
+		if rw < 1 {
+			rw = 1
+		}
+		if curW+rw > chunkW && cur.Len() > 0 {
+			flush()
+		}
+		cur.WriteRune(rr)
+		curW += rw
+	}
+	if cur.Len() > 0 {
+		flush()
+	}
+	if len(out) == 0 {
+		out = append(out, indent)
+	}
+	return out
+}
+
+// WrapPreserve quebra texto preservando a estrutura: cada linha que cabe no
+// limite é mantida exatamente como está (indentação e espaçamento de colunas
+// intactos) e só as que estouram são quebradas, repetindo a indentação nas
+// continuações — usada em output cru de tool (YAML/JSON/tabelas), onde
+// colapsar whitespace como o word-wrap de prosa destruiria o layout.
+func WrapPreserve(text string, limit int) []string {
+	var out []string
+	for _, line := range strings.Split(text, "\n") {
+		out = append(out, WrapStreamLine(line, limit)...)
+	}
+	return out
+}
+
+// SplitLeadingIndent separa a indentação inicial de uma linha do seu
+// conteúdo, de forma ANSI-aware. O glamour emite sequências de cor de
+// largura-zero ANTES (e entre) os espaços de indentação do markdown
+// renderizado — então um strings.TrimLeft(" \t") reportaria indentação
+// zero em YAML/JSON/código vindos do glamour. Retorna a largura visível do
+// indent em colunas, os códigos ANSI vistos na região inicial (re-anexados
+// ao conteúdo para que o primeiro token preserve a cor) e o conteúdo
+// restante.
+func SplitLeadingIndent(line string) (indent int, codes string, content string) {
+	var cb strings.Builder
+	i := 0
+	for i < len(line) {
+		// Sequência CSI ANSI: preserva — pode colorir o conteúdo à frente.
+		if line[i] == 0x1b && i+1 < len(line) && line[i+1] == '[' {
+			j := i + 2
+			for j < len(line) && (line[j] < 0x40 || line[j] > 0x7e) {
+				j++
+			}
+			if j < len(line) {
+				j++ // inclui o byte final da sequência
+			}
+			cb.WriteString(line[i:j])
+			i = j
+			continue
+		}
+		if line[i] == ' ' || line[i] == '\t' {
+			indent++ // tab contado como 1 col (o glamour normaliza para espaços)
+			i++
+			continue
+		}
+		break
+	}
+	return indent, cb.String(), line[i:]
+}
+
+// WrapStructured quebra um corpo já renderizado pelo glamour para exibição
+// dentro de um box. Diferente de WrapText (word-wrap de prosa, que colapsa
+// a indentação via strings.Fields), ele PRESERVA a indentação inicial de
+// cada linha. Mecânica, por linha:
+//
+//   - Detecta o indent inicial visível (ANSI-aware: o glamour emite cores
+//     ANTES dos espaços, então um TrimLeft simples não enxerga o indent).
+//   - Deslova (dedent) toda linha pela margem mínima comum — o glamour aplica
+//     uma margem de documento uniforme (tipicamente 2 cols) a prosa E código;
+//     como o box já tem seu próprio padding, carregar a margem do glamour
+//     também empurraria tudo para a direita.
+//   - Linhas que cabem na largura interna são emitidas verbatim (alinhamento
+//     de colunas intacto). Só as que estouram passam por word-wrap, repetindo
+//     o indent da linha em cada continuação.
+func WrapStructured(text string, limit int) []string {
+	if limit <= 0 {
+		return []string{text}
+	}
+	rawLines := strings.Split(text, "\n")
+
+	type lineSeg struct {
+		indent  int
+		payload string // códigos ANSI iniciais + conteúdo
+		blank   bool
+	}
+	segs := make([]lineSeg, 0, len(rawLines))
+	commonIndent := -1
+	for _, ln := range rawLines {
+		ind, codes, body := SplitLeadingIndent(ln)
+		blank := strings.TrimSpace(StripANSI(ln)) == ""
+		segs = append(segs, lineSeg{indent: ind, payload: codes + body, blank: blank})
+		if !blank && (commonIndent < 0 || ind < commonIndent) {
+			commonIndent = ind
+		}
+	}
+	if commonIndent < 0 {
+		commonIndent = 0
+	}
+
+	out := make([]string, 0, len(rawLines))
+	for _, s := range segs {
+		if s.blank {
+			out = append(out, "")
+			continue
+		}
+		rel := s.indent - commonIndent
+		if rel < 0 {
+			rel = 0
+		}
+		pad := strings.Repeat(" ", rel)
+		full := pad + s.payload
+		if VisibleLen(full) <= limit {
+			// Cabe: verbatim — preserva qualquer alinhamento interno.
+			out = append(out, full)
+			continue
+		}
+		// Estoura: word-wrap do conteúdo, repetindo o indent nas continuações.
+		avail := limit - rel
+		if avail < 1 {
+			avail = 1
+		}
+		for _, chunk := range WrapText(s.payload, avail) {
+			out = append(out, pad+chunk)
+		}
+	}
+	return out
+}
+
+// StripANSI removes CSI color escapes so width and emptiness checks see
+// plain text. Loop-based to avoid a regex dependency on hot render paths.
+func StripANSI(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == 0x1b && i+1 < len(s) && s[i+1] == '[' {
+			i += 2
+			for i < len(s) && (s[i] < 0x40 || s[i] > 0x7e) {
+				i++
+			}
+			continue
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
+// TrimBlankBorderRows drops fully-blank rows from the leading and trailing
+// edges of a wrapped-text slice. A row is "blank" when it has zero visible
+// width — color codes alone don't count as visible content. Blank rows in
+// the MIDDLE are preserved so paragraph breaks the author put in markdown
+// survive.
+func TrimBlankBorderRows(rows []string) []string {
+	start := 0
+	for start < len(rows) && VisibleLen(rows[start]) == 0 {
+		start++
+	}
+	end := len(rows)
+	for end > start && VisibleLen(rows[end-1]) == 0 {
+		end--
+	}
+	if start == 0 && end == len(rows) {
+		return rows
+	}
+	return rows[start:end]
+}
+
+// TrimBlankBoxBodyRows removes fully-empty content rows directly adjacent
+// to the top or bottom border of a lipgloss-rendered box. An empty row
+// looks like "│         │" — same width as the sides but zero printable
+// content between them. Middle blanks are kept (author-intended paragraph
+// breaks survive).
+func TrimBlankBoxBodyRows(rendered string) string {
+	rows := strings.Split(rendered, "\n")
+	if len(rows) <= 2 {
+		return rendered
+	}
+	isBlankRow := func(s string) bool {
+		plain := StripANSI(s)
+		// Empty body rows are "│  ...spaces...  │". Anything else counts
+		// as real content (including a ╰── bottom border).
+		if !strings.HasPrefix(plain, "│") || !strings.HasSuffix(plain, "│") {
+			return false
+		}
+		inner := strings.TrimSuffix(strings.TrimPrefix(plain, "│"), "│")
+		return strings.TrimSpace(inner) == ""
+	}
+	// We do NOT touch the first row (it could be a border) or the last
+	// (always the bottom border). Trim only the body slice in between.
+	start := 0
+	end := len(rows)
+	for start < end && rows[start] != "" && !isBlankRow(rows[start]) {
+		// Non-blank, real row — leave start where it is.
+		break
+	}
+	// Trim trailing empty body rows that sit right before the bottom border.
+	bottomIdx := end - 1
+	cut := bottomIdx - 1
+	for cut > start && isBlankRow(rows[cut]) {
+		cut--
+	}
+	if cut+1 < bottomIdx {
+		rows = append(rows[:cut+1], rows[bottomIdx])
+	}
+	// Trim leading empty body rows that sit right after the (absent) top
+	// border. With BorderTop disabled, rows[0] is the first content row.
+	leading := 0
+	for leading < len(rows)-1 && isBlankRow(rows[leading]) {
+		leading++
+	}
+	if leading > 0 {
+		rows = rows[leading:]
+	}
+	return strings.Join(rows, "\n")
+}


### PR DESCRIPTION
## Summary

Slice 2 of the presentation overhaul (#1164 merged — now based on main; supersedes #1165, auto-closed when its base branch was deleted). Moves ALL box/wrap geometry into `ui/kit` so chat, agent/coder and command surfaces share one math, and unifies the five divergent terminal-width helpers into the kit's single one.

## What moved (verbatim) into `ui/kit`

- `kit/box.go` — `TitledTopBorder` (the `╭── title ───╮` builder) and `BilateralBorder` (the envelope's `╭─ left ──── right ─╮` builder). Both return **plain** lines; coloring stays with callers, so the agent path's output is byte-identical.
- `kit/wrap.go` — `WrapText` (prose), `WrapStructured` (glamour bodies, ANSI-aware indent detection + common-margin dedent), `WrapPreserve`/`WrapStreamLine` (raw tool output), `HardBreakWord`, `SplitLeadingIndent`, `StripANSI`, `TrimBlankBorderRows`, `TrimBlankBoxBodyRows`.
- The `runewidth.StrictEmojiNeutral=false` pin moved from `response_envelope.go` into kit's `init()` (guard test asserts it), same emoji-width guarantee.

`cli/agent/ui_renderer.go` and `response_envelope.go` keep their exact APIs as thin delegates — all ~15 agent call sites and the historical wrap/border test files pass untouched (only the private names now forward to kit).

## Width unification

`agent.TerminalWidth`, `agent.EnvelopeWidth`, `cli.uiTermWidth`, the spinner's `terminalCols` and the three inline `term.GetSize` call sites now delegate to `kit.TermWidth()`/`kit.ContentWidth()`. `cli.ansiTruncate` delegates to `kit.Truncate`.

## Deliberate behavior changes (the only two)

1. **Off-terminal width fallback is 100 everywhere** (was a mix of 80 and 100). Piped/CI output gets slightly wider boxes; three tests updated to assert against the unified helper instead of a hardcoded 80.
2. **Truncation appends its color reset only on color-capable profiles** (via `theme.Reset()`), so piped output no longer carries a stray `\033[0m`. The truncation tests now pin `ProfileANSI` to keep asserting the reset contract.

## Testing

- New kit geometry tests: exact-width invariants for both border builders (incl. emoji headers and overflow fallbacks), `WrapStructured` relative-indent preservation, `StripANSI`, trimmers. Kit at 69.7% direct statement coverage, plus the full agent wrap/border suites exercising it through the delegates.
- `go build ./...`, full `go test ./...` green; `golangci-lint` clean (removed the now-unused `terminalWidthForStream`); ai-smells gate green locally.

