### PR TITLE
fix(ui): give warnings their own theme role

### DIFF
--- a/ui/kit/glyphs.go
+++ b/ui/kit/glyphs.go
@@ -53,7 +53,7 @@ var glyphTable = [...]struct {
 }{
 	GlyphSuccess:   {"✓", "+", theme.RoleToolSuccess},
 	GlyphError:     {"✗", "x", theme.RoleToolError},
-	GlyphWarn:      {"▲", "!", theme.RoleStatus},
+	GlyphWarn:      {"▲", "!", theme.RoleWarning},
 	GlyphInfo:      {"•", "i", theme.RoleMuted},
 	GlyphBullet:    {"·", "-", theme.RoleMuted},
 	GlyphArrow:     {"❯", ">", theme.RoleModelName},

--- a/ui/kit/kit_test.go
+++ b/ui/kit/kit_test.go
@@ -246,3 +246,19 @@ func TestContentWidthFloor(t *testing.T) {
 		t.Fatalf("margin larger than RightMargin without hitting floor: term=%d content=%d", TermWidth(), w)
 	}
 }
+
+// TestWarnGlyphUsesWarningHue guards the severity contract: the warning
+// glyph must resolve to the palette's Warning color, not Info — the exact
+// mismatch that motivated adding theme.RoleWarning.
+func TestWarnGlyphUsesWarningHue(t *testing.T) {
+	pinTheme(t, theme.ProfileTrueColor)
+	warn := theme.Active().ColorFor(theme.RoleWarning)
+	status := theme.Active().ColorFor(theme.RoleStatus)
+	if warn == status {
+		t.Skip("theme maps warning and info to the same color; nothing to distinguish")
+	}
+	got := Sym(GlyphWarn)
+	if !strings.Contains(got, warn.SGR(theme.ProfileTrueColor)) {
+		t.Fatalf("warn glyph not in Warning hue: %q", got)
+	}
+}

--- a/ui/theme/roles.go
+++ b/ui/theme/roles.go
@@ -43,6 +43,11 @@ const (
 	RoleHeader
 	// RoleMuted: secondary text, metrics, "(default)" hints.
 	RoleMuted
+	// RoleWarning: warnings and partial-success states. Added when the kit's
+	// warning glyph landed: every other severity already had a role, and
+	// without this one warnings rendered in the Info hue while the legacy
+	// yellow path went through Palette.Warning — two colors for one meaning.
+	RoleWarning
 )
 
 // ColorFor resolves a role to its palette color under the active theme.
@@ -71,6 +76,8 @@ func (t Theme) ColorFor(r Role) Color {
 		return p.Accent
 	case RoleMuted:
 		return p.Muted
+	case RoleWarning:
+		return p.Warning
 	default: // RoleBorder
 		return p.Border
 	}


### PR DESCRIPTION
## Summary

Severity-to-hue fix found while auditing the kit vocabulary: every severity had a semantic role except **warnings**. The kit's ▲ glyph and `Notice(LevelWarn)` resolved through `RoleStatus` → palette **Info** color, while the legacy yellow path (`ColorYellow` via `theme.Recolor`) resolves to palette **Warning** — one meaning, two hues depending on which path rendered it.

## Changes

- `theme.RoleWarning` (additive export) mapping straight to `Palette.Warning` across all 11 themes.
- `kit.GlyphWarn` now carries `RoleWarning`, so warn notices/glyphs match the legacy yellow everywhere.
- Guard test pinning the severity-to-hue contract (skips on themes where Warning==Info by design).

## Testing

Full suite green (exit code verified), lint clean, patch coverage 100%.