### PR TITLE
fix(windows): repair coder mode input, path validation, prompt rendering and version info

### DIFF
--- a/cli/agent/command_allowlist.go
+++ b/cli/agent/command_allowlist.go
@@ -244,11 +244,7 @@ func extractBaseCommand(fullCommand string) string {
 		return ""
 	}
 
-	baseCmd := fields[0]
-	// Strip path prefix (e.g., /usr/bin/git -> git)
-	if idx := strings.LastIndex(baseCmd, "/"); idx >= 0 {
-		baseCmd = baseCmd[idx+1:]
-	}
-
-	return baseCmd
+	// Strip path prefix and Windows executable extension
+	// (e.g., /usr/bin/git -> git, C:\Git\git.exe -> git)
+	return baseName(fields[0])
 }

--- a/cli/agent/path_validator.go
+++ b/cli/agent/path_validator.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/diillson/chatcli/pkg/fspath"
 	"go.uber.org/zap"
 )
 
@@ -30,7 +31,9 @@ var systemBinPaths = []string{
 	"/opt/homebrew/bin/",
 }
 
-var pathTraversalPattern = regexp.MustCompile(`(?:^|/)\.\.(?:/|$)`)
+// Matches "..", delimited by either separator: Windows commands use "\"
+// (e.g. "..\..\secret"), and a slash-only pattern would let those through.
+var pathTraversalPattern = regexp.MustCompile(`(?:^|[/\\])\.\.(?:[/\\]|$)`)
 
 // NewPathValidator creates a new path validator.
 func NewPathValidator(workspace string, logger *zap.Logger) *PathValidator {
@@ -75,6 +78,11 @@ func (pv *PathValidator) DetectPathTraversal(command string) (bool, string) {
 				return true, fmt.Sprintf("command accesses sensitive path: %s", sensitive)
 			}
 		}
+		for _, sensitive := range fspath.WindowsSystemRoots() {
+			if fspath.WithinBoundary(resolved, sensitive) {
+				return true, fmt.Sprintf("command accesses sensitive path: %s", sensitive)
+			}
+		}
 	}
 
 	return false, ""
@@ -103,7 +111,7 @@ func (pv *PathValidator) IsWithinWorkspace(targetPath string) bool {
 		}
 	}
 
-	return strings.HasPrefix(resolved, boundary+"/") || resolved == boundary
+	return fspath.WithinBoundary(resolved, boundary)
 }
 
 // ValidateFilePaths validates all paths in a command against safety rules.

--- a/cli/agent/read_path_validator.go
+++ b/cli/agent/read_path_validator.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/diillson/chatcli/pkg/fspath"
 )
 
 // SensitiveReadPaths enforces read access control in agent mode.
@@ -27,9 +29,10 @@ func NewSensitiveReadPaths() *SensitiveReadPaths {
 		allowKubeconfig: strings.EqualFold(os.Getenv("CHATCLI_AGENT_ALLOW_KUBECONFIG"), "true"),
 	}
 
-	// Parse extra allowed read paths (colon-separated)
+	// Parse extra allowed read paths (separated by os.PathListSeparator:
+	// ':' on Unix, ';' on Windows — ':' would split drive letters apart)
 	if extra := os.Getenv("CHATCLI_AGENT_EXTRA_READ_PATHS"); extra != "" {
-		for _, p := range strings.Split(extra, ":") {
+		for _, p := range filepath.SplitList(extra) {
 			p = strings.TrimSpace(p)
 			if p != "" {
 				s.extraReadPaths = append(s.extraReadPaths, p)
@@ -72,7 +75,7 @@ func (s *SensitiveReadPaths) IsReadAllowed(path, workspace string) (bool, string
 			}
 
 			// Check if path is within workspace
-			if strings.HasPrefix(resolvedPath, absWorkspace+string(filepath.Separator)) || resolvedPath == absWorkspace {
+			if fspath.WithinBoundary(resolvedPath, absWorkspace) {
 				return true, ""
 			}
 
@@ -82,7 +85,7 @@ func (s *SensitiveReadPaths) IsReadAllowed(path, workspace string) (bool, string
 				if err != nil {
 					continue
 				}
-				if strings.HasPrefix(resolvedPath, extraAbs+string(filepath.Separator)) || resolvedPath == extraAbs {
+				if fspath.WithinBoundary(resolvedPath, extraAbs) {
 					return true, ""
 				}
 			}
@@ -95,7 +98,7 @@ func (s *SensitiveReadPaths) IsReadAllowed(path, workspace string) (bool, string
 				if evalAux, errEval := filepath.EvalSymlinks(aux); errEval == nil {
 					aux = evalAux
 				}
-				if strings.HasPrefix(resolvedPath, aux+string(filepath.Separator)) || resolvedPath == aux {
+				if fspath.WithinBoundary(resolvedPath, aux) {
 					return true, ""
 				}
 			}
@@ -103,10 +106,11 @@ func (s *SensitiveReadPaths) IsReadAllowed(path, workspace string) (bool, string
 			// Allow Go module cache and standard library
 			gopath := os.Getenv("GOPATH")
 			if gopath == "" {
-				gopath = filepath.Join(os.Getenv("HOME"), "go")
+				home, _ := os.UserHomeDir()
+				gopath = filepath.Join(home, "go")
 			}
 			goModCache := filepath.Join(gopath, "pkg", "mod")
-			if strings.HasPrefix(resolvedPath, goModCache) {
+			if strings.HasPrefix(resolvedPath, goModCache+string(filepath.Separator)) {
 				return true, ""
 			}
 
@@ -126,8 +130,11 @@ func (s *SensitiveReadPaths) IsReadAllowed(path, workspace string) (bool, string
 
 // isSensitivePath checks if a path matches known sensitive file patterns.
 func (s *SensitiveReadPaths) isSensitivePath(path string) (bool, string) {
-	home := os.Getenv("HOME")
-	if home == "" {
+	// os.UserHomeDir handles USERPROFILE on Windows; a raw $HOME lookup would
+	// come back empty there and anchor every sensitive-dir check to a path
+	// that never matches, disabling credential-file protection entirely.
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
 		home = "/root"
 	}
 
@@ -154,14 +161,14 @@ func (s *SensitiveReadPaths) isSensitivePath(path string) (bool, string) {
 	}
 
 	for dir, reason := range sensitiveGlobs {
-		if strings.HasPrefix(path, dir+string(filepath.Separator)) || path == dir {
+		if fspath.WithinBoundary(path, dir) {
 			return true, reason
 		}
 	}
 
 	// kubeconfig (controlled by CHATCLI_AGENT_ALLOW_KUBECONFIG)
 	kubeconfigPath := filepath.Join(home, ".kube", "config")
-	if !s.allowKubeconfig && path == kubeconfigPath {
+	if !s.allowKubeconfig && fspath.Equal(path, kubeconfigPath) {
 		return true, "kubeconfig access is blocked (set CHATCLI_AGENT_ALLOW_KUBECONFIG=true to allow)"
 	}
 
@@ -176,7 +183,7 @@ func (s *SensitiveReadPaths) isSensitivePath(path string) (bool, string) {
 		filepath.Join(home, ".gradle", "gradle.properties"): "Gradle properties may contain credentials",
 	}
 	for fp, reason := range sensitiveFiles {
-		if path == fp {
+		if fspath.Equal(path, fp) {
 			return true, reason
 		}
 	}
@@ -193,7 +200,7 @@ func (s *SensitiveReadPaths) isSensitivePath(path string) (bool, string) {
 		".pfx": true, ".jks": true, ".keystore": true,
 		".p8": true, ".der": true,
 	}
-	if sensitiveExts[ext] && !strings.HasPrefix(path, home) {
+	if sensitiveExts[ext] && !fspath.WithinBoundary(path, home) {
 		// Only block sensitive extensions outside home directory
 		// (within project they might be test fixtures)
 		return true, "files with extension " + ext + " outside home directory are blocked"

--- a/cli/agent/shell_parser.go
+++ b/cli/agent/shell_parser.go
@@ -238,10 +238,15 @@ func (s ShellSegment) InlineSource(flagPos int) string {
 }
 
 // baseName strips a directory prefix from an executable path so
-// `/usr/bin/python3` and `python3` are treated identically.
+// `/usr/bin/python3` and `python3` are treated identically. Both separators
+// are handled (`C:\Python\python.exe`), and a Windows executable extension is
+// dropped so `python.exe` matches the same table entry as `python`.
 func baseName(p string) string {
-	if i := strings.LastIndex(p, "/"); i >= 0 {
-		return p[i+1:]
+	p = p[strings.LastIndexAny(p, `/\`)+1:]
+	for _, ext := range []string{".exe", ".bat", ".cmd"} {
+		if len(p) > len(ext) && strings.EqualFold(p[len(p)-len(ext):], ext) {
+			return p[:len(p)-len(ext)]
+		}
 	}
 	return p
 }

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -96,8 +96,9 @@ type AgentMode struct {
 	qualityPipeline *quality.Pipeline
 	qualityConfig   quality.Config
 	// Centralized stdin reader for type-ahead queue support
-	stdinLines   chan string   // all stdin lines flow through here
-	stdinDone    chan struct{} // signals reader goroutine to stop
+	stdinLines   chan string        // all stdin lines flow through here
+	stdinDone    chan struct{}      // signals reader goroutine to stop
+	stdinCancel  *stdinReadCanceler // aborts a blocking console read (Windows)
 	stdinWg      sync.WaitGroup
 	multilineBuf MultilineBuffer // ``` delimited multiline input
 
@@ -187,10 +188,16 @@ func splitStdinChunk(chunk []byte, lineBuf *strings.Builder) []string {
 func (a *AgentMode) startStdinReader() {
 	a.stdinLines = make(chan string, 10)
 	a.stdinDone = make(chan struct{})
+	a.stdinCancel = newStdinReadCanceler()
 	a.stdinWg.Add(1)
 
 	go func() {
 		defer a.stdinWg.Done()
+		// Pin to an OS thread and publish its handle so stopStdinReader can
+		// abort a blocking console read via CancelSynchronousIo (Windows;
+		// no-op elsewhere).
+		a.stdinCancel.bind()
+		defer a.stdinCancel.unbind()
 		var lineBuf strings.Builder
 		buf := make([]byte, 512)
 		for {
@@ -238,32 +245,64 @@ func (a *AgentMode) startStdinReader() {
 	}()
 }
 
+// Reader shutdown pacing: the clean-exit window covers one full poll cycle
+// with slack; the cancel-retry window gives each CancelSynchronousIo attempt
+// time to land before retrying (retries close the race where the blocking
+// read starts right after a cancel that found no I/O in flight).
+const (
+	stdinStopGrace       = 150 * time.Millisecond
+	stdinCancelRetryWait = 100 * time.Millisecond
+	stdinCancelRetries   = 4
+)
+
 // stopStdinReader signals the stdin reader goroutine to stop and waits for it
 // to exit. On Unix (Linux/macOS), the goroutine exits within ~50ms (one poll
-// cycle). On Windows, it may be blocked in os.Stdin.Read after a
-// WaitForSingleObject false positive; a safety timeout prevents indefinite
-// blocking.
+// cycle). On Windows it may be inside a blocking os.Stdin.Read (console reads
+// have no deadline); left orphaned it would steal the next prompt's
+// keystrokes (no echo until Enter), so the pending read is aborted with
+// CancelSynchronousIo on the reader's thread — the documented mechanism for
+// cancelling synchronous console I/O.
 func (a *AgentMode) stopStdinReader() {
 	if a.stdinDone != nil {
 		close(a.stdinDone)
 
-		// Wait with safety timeout. On Unix the goroutine exits in ~50ms.
-		// On Windows it might be stuck in a blocking Read; don't wait forever.
 		done := make(chan struct{})
 		go func() {
 			a.stdinWg.Wait()
 			close(done)
 		}()
+
 		select {
 		case <-done:
-			// Clean exit
-		case <-time.After(500 * time.Millisecond):
-			// Goroutine stuck on blocking read (Windows edge case).
-			// It will discard any data and exit on the next stdin input.
+			// Clean exit within one poll cycle.
+		case <-time.After(stdinStopGrace):
+			a.abortBlockedStdinRead(done)
 		}
 
 		a.stdinLines = nil
 		a.stdinDone = nil
+	}
+}
+
+// abortBlockedStdinRead unblocks a reader goroutine parked in a blocking
+// console read. On platforms without cancellable synchronous I/O it just
+// waits out the poll cycle; if every attempt fails the goroutine degrades to
+// the old behavior (discards data and exits on the next stdin input).
+func (a *AgentMode) abortBlockedStdinRead(done <-chan struct{}) {
+	for attempt := 0; attempt < stdinCancelRetries; attempt++ {
+		if !a.stdinCancel.cancel() {
+			// No cancellation on this platform; one bounded wait.
+			select {
+			case <-done:
+			case <-time.After(stdinCancelRetryWait * stdinCancelRetries):
+			}
+			return
+		}
+		select {
+		case <-done:
+			return
+		case <-time.After(stdinCancelRetryWait):
+		}
 	}
 }
 
@@ -479,8 +518,15 @@ func readLinePlainFromReader(reader *bufio.Reader) string {
 // not calling readLineWithEditing directly; production code uses it
 // as the one go-prompt-touching path.
 func (a *AgentMode) readLineFromGoPrompt() string {
+	// Same Windows input sanitation as the main REPL (see cli.go): AltGr
+	// chars arrive as ESC+rune and would land as a stray glyph without the
+	// altGrParser wrapper.
+	var inputParser prompt.ConsoleParser = prompt.NewStandardInputParser()
+	if runtime.GOOS == "windows" {
+		inputParser = newAltGrParser(inputParser)
+	}
 	pasteParser := paste.NewBracketedPasteParser(
-		prompt.NewStandardInputParser(),
+		inputParser,
 		func(info paste.Info) {
 			a.cli.lastPasteInfo = &info
 		},
@@ -490,6 +536,7 @@ func (a *AgentMode) readLineFromGoPrompt() string {
 		"  > ",
 		noopCompleter,
 		prompt.OptionParser(pasteParser),
+		prompt.OptionWriter(newPlatformPromptWriter()),
 		prompt.OptionPrefixTextColor(prompt.Green),
 		prompt.OptionInputTextColor(prompt.White),
 	)

--- a/cli/agent_tool_sanitizer.go
+++ b/cli/agent_tool_sanitizer.go
@@ -578,7 +578,16 @@ func parseToolArgsMaybeJSON(argLine string) ([]string, bool, error) {
 
 	var payload any
 	if err := json.Unmarshal([]byte(trimmed), &payload); err != nil {
-		return nil, true, err
+		// Salvage pass: models emit Windows paths with single backslashes
+		// ("C:\Users\x"), which are invalid JSON escapes. Repair and retry
+		// before surfacing the error (lenient parsing keeps the loop moving).
+		repaired := utils.RepairJSONInvalidEscapes(trimmed)
+		if repaired == trimmed {
+			return nil, true, err
+		}
+		if err2 := json.Unmarshal([]byte(repaired), &payload); err2 != nil {
+			return nil, true, err
+		}
 	}
 
 	switch v := payload.(type) {
@@ -696,13 +705,44 @@ func collectArgsMap(m map[string]any) map[string]any {
 		}
 	}
 	for _, envelope := range []string{"args", "flags"} {
-		if mm, ok := m[envelope].(map[string]any); ok {
+		switch mm := m[envelope].(type) {
+		case map[string]any:
 			for k, v := range mm {
 				put(k, v)
+			}
+		case string:
+			// Models sometimes double-encode the envelope as a JSON string
+			// ({"cmd":"write","args":"{\"file\":...}"}); recover it instead
+			// of dropping every argument.
+			if obj, ok := decodeJSONObjectLenient(mm); ok {
+				for k, v := range obj {
+					put(k, v)
+				}
 			}
 		}
 	}
 	return argsMap
+}
+
+// decodeJSONObjectLenient parses a string that should contain a JSON object,
+// repairing invalid backslash escapes (Windows paths) when a strict parse
+// fails.
+func decodeJSONObjectLenient(s string) (map[string]any, bool) {
+	trimmed := strings.TrimSpace(s)
+	if !strings.HasPrefix(trimmed, "{") {
+		return nil, false
+	}
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(trimmed), &obj); err != nil {
+		repaired := utils.RepairJSONInvalidEscapes(trimmed)
+		if repaired == trimmed {
+			return nil, false
+		}
+		if err2 := json.Unmarshal([]byte(repaired), &obj); err2 != nil {
+			return nil, false
+		}
+	}
+	return obj, true
 }
 
 func normalizeFlagName(name string) string {

--- a/cli/agent_tool_windows_args_test.go
+++ b/cli/agent_tool_windows_args_test.go
@@ -1,0 +1,73 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"testing"
+)
+
+// findFlagValue returns the token following the given flag in argv, or "".
+func findFlagValue(argv []string, flag string) string {
+	for i, a := range argv {
+		if a == flag && i+1 < len(argv) {
+			return argv[i+1]
+		}
+	}
+	return ""
+}
+
+// Regression for the field failure on Windows: the model emitted the args
+// envelope double-encoded as a JSON STRING whose content carries unescaped
+// Windows-path backslashes (invalid JSON escapes like \U). The flattener used
+// to drop every argument ("falta --file"); it must recover the envelope.
+func TestParseToolArgs_WindowsPathStringEnvelope(t *testing.T) {
+	argLine := `{"args":"{\"file\":\"C:\\Users\\builder\\deployment.yaml\",\"content\":\"QQ==\",\"encoding\":\"base64\"}","cmd":"write"}`
+
+	argv, err := parseToolArgsWithJSON(argLine)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(argv) == 0 || argv[0] != "write" {
+		t.Fatalf("unexpected argv: %v", argv)
+	}
+	if got := findFlagValue(argv, "--file"); got != `C:\Users\builder\deployment.yaml` {
+		t.Errorf("--file = %q, want the Windows path; argv=%v", got, argv)
+	}
+	if got := findFlagValue(argv, "--content"); got != "QQ==" {
+		t.Errorf("--content = %q, want QQ==", got)
+	}
+}
+
+// Same failure one level up: the whole args attribute arrives with raw
+// single-backslash Windows paths, which is invalid JSON. The lenient repair
+// pass must recover it instead of surfacing "Args parsing error".
+func TestParseToolArgs_WindowsPathInvalidEscapesTopLevel(t *testing.T) {
+	argLine := `{"cmd":"write","args":{"file":"C:\Users\builder\deployment.yaml","content":"QQ==","encoding":"base64"}}`
+
+	argv, err := parseToolArgsWithJSON(argLine)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(argv) == 0 || argv[0] != "write" {
+		t.Fatalf("unexpected argv: %v", argv)
+	}
+	if got := findFlagValue(argv, "--file"); got != `C:\Users\builder\deployment.yaml` {
+		t.Errorf("--file = %q, want the Windows path; argv=%v", got, argv)
+	}
+}
+
+// The guard-rail that fired in the field ("falta --file") must accept the
+// recovered argv end-to-end.
+func TestCoderArgsGuardRail_WindowsPathStringEnvelope(t *testing.T) {
+	argLine := `{"args":"{\"file\":\"C:\\Users\\builder\\deployment.yaml\",\"content\":\"QQ==\",\"encoding\":\"base64\"}","cmd":"write"}`
+	argv, err := parseToolArgsWithJSON(argLine)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if missing, which := isCoderArgsMissingRequiredValue(argv); missing {
+		t.Errorf("guard-rail flagged %q as missing; argv=%v", which, argv)
+	}
+}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1080,6 +1080,10 @@ func (cli *ChatCLI) Start(ctx context.Context) {
 				cli.executor,
 				cli.completer,
 				prompt.OptionParser(pasteParser),
+				// On Windows+VT the writer compensates the deferred EOL wrap
+				// go-prompt's renderer doesn't expect; elsewhere it is the
+				// standard writer. See promptwrap.go.
+				prompt.OptionWriter(newPlatformPromptWriter()),
 				prompt.OptionTitle("ChatCLI - LLM no seu Terminal"),
 				prompt.OptionLivePrefix(cli.changeLivePrefix),
 				prompt.OptionPrefixTextColor(prompt.Green),
@@ -1286,6 +1290,14 @@ func (cli *ChatCLI) runRequestedPalette() bool {
 		m = palette.NewRoot(cli.paletteSuggest)
 	} else {
 		m = palette.NewScoped(cli.paletteSuggest, target)
+	}
+	// go-prompt's BreakLine committed the trigger line ("❯ /") to the main
+	// buffer right before this runs. On Windows the alt-screen exit does not
+	// reconcile the main buffer the way xterm does, so that line survives as
+	// a ghost above the palette result — erase it before the overlay opens.
+	// The cursor sits at column 0 of the line just below it.
+	if runtime.GOOS == "windows" {
+		fmt.Print("\033[A\033[2K\r")
 	}
 	sel, err := palette.Run(context.Background(), m)
 	if err != nil {

--- a/cli/cli_config.go
+++ b/cli/cli_config.go
@@ -425,13 +425,8 @@ func (cli *ChatCLI) getEnvFilePath() string {
 }
 
 func (ch *CommandHandler) handleVersionCommand(ctx context.Context) {
-	versionInfo := version.GetCurrentVersion()
-
 	// Checagem com timeout
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	latest, hasUpdate, err := version.CheckLatestVersionWithContext(ctx)
-
-	// Exibir as informações formatadas
-	fmt.Println(version.FormatVersionInfo(versionInfo, latest, hasUpdate, err))
+	fmt.Println(version.GetReport(ctx).Format())
 }

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -11,19 +11,8 @@ import (
 
 	"github.com/diillson/chatcli/version"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"
 )
-
-// Mock para a função de checagem de versão
-type mockVersionChecker struct {
-	mock.Mock
-}
-
-func (m *mockVersionChecker) Check(ctx context.Context) (string, bool, error) {
-	args := m.Called(ctx)
-	return args.String(0), args.Bool(1), args.Error(2)
-}
 
 // stripANSI remove códigos ANSI de uma string
 func stripANSI(s string) string {
@@ -41,37 +30,38 @@ func TestHandleVersionCommand(t *testing.T) {
 	cliInstance := &ChatCLI{logger: logger}
 	handler := NewCommandHandler(cliInstance)
 
-	originalCheckImpl := version.CheckLatestVersionImpl
+	originalFetchImpl := version.FetchLatestReleaseImpl
 	originalBuildImpl := version.GetBuildInfoImpl
 
-	mockChecker := new(mockVersionChecker)
-
-	version.CheckLatestVersionImpl = func(ctx context.Context) (string, bool, error) {
-		return mockChecker.Check(ctx)
-	}
 	version.GetBuildInfoImpl = func() (string, string, string) {
 		return "1.25.0", "abc1234", "2024-09-15"
 	}
 	defer func() {
-		version.CheckLatestVersionImpl = originalCheckImpl
+		version.FetchLatestReleaseImpl = originalFetchImpl
 		version.GetBuildInfoImpl = originalBuildImpl
 	}()
 
+	// mockLatest alimenta o seam de fetch; "precisa atualizar" é decidido
+	// pela lógica REAL de comparação contra a versão mockada 1.25.0.
 	testCases := []struct {
 		name       string
 		mockLatest string
-		mockUpdate bool
 		mockErr    error
 		expectOut  string
 	}{
-		{"Update available", "1.26.0", true, nil, "Disponível! Atualize"},
-		{"No update", "1.25.0", false, nil, "Você está na versão mais recente."},
-		{"With error", "", false, errors.New("network error"), "Não foi possível verificar: network error"},
+		{"Update available", "1.26.0", nil, "Disponível! Atualize"},
+		{"No update", "1.25.0", nil, "Você está na versão mais recente."},
+		{"With error", "", errors.New("network error"), "Não foi possível verificar: network error"},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			mockChecker.On("Check", mock.Anything).Return(tc.mockLatest, tc.mockUpdate, tc.mockErr).Once()
+			version.FetchLatestReleaseImpl = func(ctx context.Context) (version.ReleaseInfo, error) {
+				if tc.mockErr != nil {
+					return version.ReleaseInfo{}, tc.mockErr
+				}
+				return version.ReleaseInfo{TagName: "v" + tc.mockLatest}, nil
+			}
 
 			oldStdout := os.Stdout
 			r, w, _ := os.Pipe()
@@ -87,7 +77,6 @@ func TestHandleVersionCommand(t *testing.T) {
 			normalized := normalizeSpaces(cleanOut)
 
 			assert.Contains(t, normalized, tc.expectOut)
-			mockChecker.AssertExpectations(t)
 		})
 	}
 }

--- a/cli/coder/normalize.go
+++ b/cli/coder/normalize.go
@@ -52,7 +52,16 @@ func NormalizeCoderArgs(args string) (subcommand string, normalized string) {
 func normalizeJSON(trimmed string) (string, string) {
 	var payload any
 	if err := json.Unmarshal([]byte(trimmed), &payload); err != nil {
-		return "", ""
+		// Windows paths with single backslashes ("C:\Users\x") are invalid
+		// JSON escapes; repair and retry so policy matching still sees the
+		// real subcommand and flags.
+		repaired := utils.RepairJSONInvalidEscapes(trimmed)
+		if repaired == trimmed {
+			return "", ""
+		}
+		if err2 := json.Unmarshal([]byte(repaired), &payload); err2 != nil {
+			return "", ""
+		}
 	}
 
 	switch v := payload.(type) {
@@ -98,26 +107,40 @@ func normalizeJSONMap(m map[string]any) (string, string) {
 	// Build from args/flags maps
 	argsMap := make(map[string]any)
 
-	if raw, ok := m["args"]; ok {
-		if mm, ok := raw.(map[string]any); ok {
-			for k, v := range mm {
-				if k == "command" {
-					argsMap["cmd"] = v
+	for _, envelope := range []string{"args", "flags"} {
+		raw, ok := m[envelope]
+		if !ok {
+			continue
+		}
+		mm, ok := raw.(map[string]any)
+		if !ok {
+			// Models sometimes double-encode the envelope as a JSON string
+			// ({"cmd":"write","args":"{\"file\":...}"}); recover it so the
+			// policy prompt still shows the real flags.
+			s, isStr := raw.(string)
+			if !isStr {
+				continue
+			}
+			trimmed := strings.TrimSpace(s)
+			if !strings.HasPrefix(trimmed, "{") {
+				continue
+			}
+			if err := json.Unmarshal([]byte(trimmed), &mm); err != nil {
+				repaired := utils.RepairJSONInvalidEscapes(trimmed)
+				if repaired == trimmed {
 					continue
 				}
-				argsMap[k] = v
+				if err2 := json.Unmarshal([]byte(repaired), &mm); err2 != nil {
+					continue
+				}
 			}
 		}
-	}
-	if raw, ok := m["flags"]; ok {
-		if mm, ok := raw.(map[string]any); ok {
-			for k, v := range mm {
-				if k == "command" {
-					argsMap["cmd"] = v
-					continue
-				}
-				argsMap[k] = v
+		for k, v := range mm {
+			if k == "command" {
+				argsMap["cmd"] = v
+				continue
 			}
+			argsMap[k] = v
 		}
 	}
 

--- a/cli/coder/normalize_windows_args_test.go
+++ b/cli/coder/normalize_windows_args_test.go
@@ -1,0 +1,49 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package coder
+
+import (
+	"testing"
+)
+
+// Regression for the Windows field failure: the policy normalizer must still
+// extract the subcommand and flags when the args envelope is double-encoded
+// as a JSON string and/or carries unescaped Windows-path backslashes —
+// otherwise the security prompt degrades to a raw JSON blob and rules like
+// "@coder write" never match.
+func TestNormalizeCoderArgs_WindowsPaths(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     string
+		wantSub  string
+		wantNorm string
+	}{
+		{
+			name:     "string envelope with invalid escapes",
+			args:     `{"args":"{\"file\":\"C:\\Users\\builder\\deployment.yaml\",\"content\":\"QQ==\",\"encoding\":\"base64\"}","cmd":"write"}`,
+			wantSub:  "write",
+			wantNorm: `write --file C:\Users\builder\deployment.yaml`,
+		},
+		{
+			name:     "top-level invalid escapes",
+			args:     `{"cmd":"write","args":{"file":"C:\Users\builder\deployment.yaml","content":"QQ==","encoding":"base64"}}`,
+			wantSub:  "write",
+			wantNorm: `write --file C:\Users\builder\deployment.yaml`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sub, norm := NormalizeCoderArgs(tt.args)
+			if sub != tt.wantSub {
+				t.Errorf("subcommand = %q, want %q", sub, tt.wantSub)
+			}
+			if norm != tt.wantNorm {
+				t.Errorf("normalized = %q, want %q", norm, tt.wantNorm)
+			}
+		})
+	}
+}

--- a/cli/coder/readonly_allowlist.go
+++ b/cli/coder/readonly_allowlist.go
@@ -150,12 +150,9 @@ func IsReadOnlyCommand(cmdLine string) bool {
 
 	// Parse the base command and arguments
 	parts := strings.Fields(cmdLine)
-	baseCmd := parts[0]
-
-	// Strip path prefix (e.g., "/usr/bin/git" → "git")
-	if idx := strings.LastIndex(baseCmd, "/"); idx >= 0 {
-		baseCmd = baseCmd[idx+1:]
-	}
+	// Strip path prefix and Windows executable extension
+	// (e.g., "/usr/bin/git" → "git", `C:\Git\git.exe` → "git")
+	baseCmd := stripCommandPath(parts[0])
 
 	for _, entry := range readOnlyAllowlist {
 		if !strings.EqualFold(entry.Name, baseCmd) {
@@ -215,11 +212,20 @@ func containsDangerousPipeTarget(cmdLine string) bool {
 		"sudo":  true,
 	}
 
-	cmd := parts[0]
-	if idx := strings.LastIndex(cmd, "/"); idx >= 0 {
-		cmd = cmd[idx+1:]
+	return dangerousTargets[strings.ToLower(stripCommandPath(parts[0]))]
+}
+
+// stripCommandPath reduces an executable invocation to its bare command name:
+// directory prefixes with either separator are removed, along with a Windows
+// executable extension, so `C:\Git\git.exe` and `/usr/bin/git` both yield "git".
+func stripCommandPath(cmd string) string {
+	cmd = cmd[strings.LastIndexAny(cmd, `/\`)+1:]
+	for _, ext := range []string{".exe", ".bat", ".cmd"} {
+		if len(cmd) > len(ext) && strings.EqualFold(cmd[len(cmd)-len(ext):], ext) {
+			return cmd[:len(cmd)-len(ext)]
+		}
 	}
-	return dangerousTargets[strings.ToLower(cmd)]
+	return cmd
 }
 
 // containsOutputRedirect checks if the command redirects output to a file.

--- a/cli/coder/security_ui.go
+++ b/cli/coder/security_ui.go
@@ -84,7 +84,10 @@ func detectTerminalWidth() int {
 // swallowed: the prompt is best-effort UX and any failure here just
 // degrades to the previous (broken-on-resume) behavior.
 func resetTTYToSane() bool {
-	if runtime.GOOS == "windows" || sttyPath == "" {
+	if runtime.GOOS == "windows" {
+		return restoreCookedModeWindows()
+	}
+	if sttyPath == "" {
 		return false
 	}
 	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)

--- a/cli/coder/tty_reset.go
+++ b/cli/coder/tty_reset.go
@@ -38,7 +38,10 @@ import (
 // (occasionally-broken-on-resume) behavior, which is what we are
 // trying to improve.
 func RestoreCookedMode() bool {
-	if runtime.GOOS == "windows" || sttyPath == "" {
+	if runtime.GOOS == "windows" {
+		return restoreCookedModeWindows()
+	}
+	if sttyPath == "" {
 		return false
 	}
 	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)

--- a/cli/coder/tty_reset_other.go
+++ b/cli/coder/tty_reset_other.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+package coder
+
+// restoreCookedModeWindows only has an implementation on Windows; the Unix
+// paths reset the terminal via `stty sane` instead.
+func restoreCookedModeWindows() bool { return false }

--- a/cli/coder/tty_reset_windows.go
+++ b/cli/coder/tty_reset_windows.go
@@ -1,0 +1,40 @@
+//go:build windows
+
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+package coder
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+// restoreCookedModeWindows is the Windows counterpart of `stty sane`: it
+// resets the console input buffer to canonical (cooked, echo-on) mode. The
+// console mode is a property of the shared input buffer, not of a single
+// handle, so a raw mode left behind by a dirty go-prompt / Bubble Tea
+// teardown persists for every subsequent reader — in cooked-reader flows
+// (security confirmations, the centralized stdin reader) that surfaces as
+// keystrokes that never echo and lines that never complete.
+func restoreCookedModeWindows() bool {
+	h, err := windows.GetStdHandle(windows.STD_INPUT_HANDLE)
+	if err != nil || h == windows.InvalidHandle {
+		return false
+	}
+	var mode uint32
+	if err := windows.GetConsoleMode(h, &mode); err != nil {
+		// Not a console (piped/redirected stdin) — nothing to restore.
+		return false
+	}
+	cooked := mode | windows.ENABLE_PROCESSED_INPUT | windows.ENABLE_LINE_INPUT | windows.ENABLE_ECHO_INPUT
+	// VT input turns keys into escape sequences, which the cooked line
+	// editor would insert literally; raw-mode readers re-enable it themselves.
+	cooked &^= windows.ENABLE_VIRTUAL_TERMINAL_INPUT
+	if cooked == mode {
+		return true
+	}
+	return windows.SetConsoleMode(h, cooked) == nil
+}

--- a/cli/path_mentions.go
+++ b/cli/path_mentions.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -20,8 +21,9 @@ var knownAtCommands = map[string]bool{
 // - @src/file.go
 // - @~/home/file
 // - @/absolute/path
+// - @C:\Users\x\file and other backslash/drive-letter forms on Windows
 // Does NOT match @word (no path separators) or known commands.
-var pathMentionRe = regexp.MustCompile(`@((?:\./|~/|/|[a-zA-Z0-9_-]+/)[\w./_~-]+)`)
+var pathMentionRe = regexp.MustCompile(`@((?:\.[/\\]|~[/\\]|[/\\]|[A-Za-z]:[/\\]|[a-zA-Z0-9_-]+[/\\])[\w./\\_~-]+)`)
 
 // expandPathMentions converts @path/to/file patterns into @file path/to/file.
 // This allows users to type @src/main.go directly instead of @file src/main.go.
@@ -31,16 +33,19 @@ func expandPathMentions(input string) string {
 		path := match[1:] // strip leading @
 
 		// Skip known @ commands
-		atWord := "@" + strings.SplitN(path, "/", 2)[0]
-		if knownAtCommands[strings.ToLower(atWord)] {
+		first := path
+		if sepIdx := strings.IndexAny(path, `/\`); sepIdx >= 0 {
+			first = path[:sepIdx]
+		}
+		if knownAtCommands[strings.ToLower("@"+first)] {
 			return match
 		}
 
 		// Expand ~ to home dir
 		expandedPath := path
-		if strings.HasPrefix(expandedPath, "~/") {
+		if strings.HasPrefix(expandedPath, "~/") || strings.HasPrefix(expandedPath, `~\`) {
 			if home, err := os.UserHomeDir(); err == nil {
-				expandedPath = home + expandedPath[1:]
+				expandedPath = filepath.Join(home, expandedPath[2:])
 			}
 		}
 

--- a/cli/promptwrap.go
+++ b/cli/promptwrap.go
@@ -1,0 +1,164 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	prompt "github.com/c-bata/go-prompt"
+	runewidth "github.com/mattn/go-runewidth"
+)
+
+// wrapAwareWriter aligns a deferred-EOL-wrap console with go-prompt's Windows
+// renderer, which assumes legacy immediate wrap.
+//
+// go-prompt models the cursor as y = cells/width (render.go toPos) and, on
+// Unix, materializes the wrap pending at an exact column boundary by emitting
+// "\n" (render.go lineWrap). On Windows that "\n" is skipped on the assumption
+// that the legacy conhost wraps immediately — but with VT processing enabled
+// (Windows Terminal, or conhost after EnableVirtualTerminal) the console uses
+// xterm-style DEFERRED wrap, so the software model drifts one row for every
+// render that ends exactly on a column boundary. The renderer's CursorUp then
+// overshoots and the prompt climbs, leaving ghost copies of the input line —
+// worst with the animated live prefix re-rendering ~4×/s and with the
+// completion dropdown (whose rows go through the same lineWrap).
+//
+// This wrapper re-introduces the newline at the writer level: it tracks the
+// cursor column across writer calls and, whenever a text write lands exactly
+// on the terminal's right edge, emits the "\n" that materializes the wrap —
+// making the console behave the way go-prompt's Windows math expects.
+type wrapAwareWriter struct {
+	prompt.ConsoleWriter
+	width func() int // terminal width in cells; re-queried on every Flush
+	w     int        // cached width for the current render pass (0 = passthrough)
+	col   int        // tracked cursor column, 0-based
+}
+
+// newWrapAwareWriter wraps inner. width is consulted at construction and on
+// every Flush (one render pass = one flush); returning 0 disables injection.
+func newWrapAwareWriter(inner prompt.ConsoleWriter, width func() int) *wrapAwareWriter {
+	return &wrapAwareWriter{
+		ConsoleWriter: inner,
+		width:         width,
+		w:             width(),
+	}
+}
+
+// writeCells scans text, tracking the column and flushing through emit; when
+// a rune lands exactly on the right edge it emits the pending segment plus a
+// raw "\n" so the terminal wraps NOW, exactly as go-prompt's model assumes.
+func (w *wrapAwareWriter) writeCells(text string, emit func(string)) {
+	if w.w <= 0 {
+		emit(text)
+		return
+	}
+	start := 0
+	for i, r := range text {
+		if r == '\n' || r == '\r' {
+			w.col = 0
+			continue
+		}
+		w.col += runewidth.RuneWidth(r)
+		if w.col >= w.w {
+			end := i + len(string(r))
+			emit(text[start:end])
+			w.ConsoleWriter.WriteRawStr("\n")
+			w.col = 0
+			start = end
+		}
+	}
+	if start < len(text) {
+		emit(text[start:])
+	}
+}
+
+func (w *wrapAwareWriter) WriteStr(data string) {
+	w.writeCells(data, w.ConsoleWriter.WriteStr)
+}
+
+func (w *wrapAwareWriter) Write(data []byte) {
+	w.writeCells(string(data), func(s string) { w.ConsoleWriter.Write([]byte(s)) })
+}
+
+// WriteRawStr carries go-prompt's own control sequences (colors, erases,
+// moves); nothing to inject, but the column must stay tracked.
+func (w *wrapAwareWriter) WriteRawStr(data string) {
+	w.trackRaw(data)
+	w.ConsoleWriter.WriteRawStr(data)
+}
+
+func (w *wrapAwareWriter) WriteRaw(data []byte) {
+	w.trackRaw(string(data))
+	w.ConsoleWriter.WriteRaw(data)
+}
+
+// trackRaw advances the column model over a raw byte stream, skipping ANSI
+// escape sequences (which do not print) and resetting on \r / \n. Cursor
+// movement is not expected through raw writes — go-prompt uses the dedicated
+// Cursor* methods, which are tracked below.
+func (w *wrapAwareWriter) trackRaw(data string) {
+	if w.w <= 0 {
+		return
+	}
+	inEsc := false
+	for _, r := range data {
+		switch {
+		case inEsc:
+			// CSI sequences end on a final byte in @-~ (0x40-0x7e); the
+			// bracket and parameter bytes fall below that range.
+			if r >= 0x40 && r <= 0x7e && r != '[' {
+				inEsc = false
+			}
+		case r == 0x1b:
+			inEsc = true
+		case r == '\n' || r == '\r':
+			w.col = 0
+		default:
+			w.col += runewidth.RuneWidth(r)
+			if w.col >= w.w {
+				// Raw text is not wrap-compensated (only tracked); model the
+				// deferred state as "at the edge" so the next tracked write
+				// resolves it.
+				w.col = 0
+			}
+		}
+	}
+}
+
+func (w *wrapAwareWriter) Flush() error {
+	err := w.ConsoleWriter.Flush()
+	if next := w.width(); next > 0 {
+		w.w = next
+	}
+	return err
+}
+
+func (w *wrapAwareWriter) CursorGoTo(row, col int) {
+	if col <= 1 {
+		w.col = 0
+	} else {
+		w.col = col - 1 // ANSI CUP is 1-based
+	}
+	w.ConsoleWriter.CursorGoTo(row, col)
+}
+
+func (w *wrapAwareWriter) CursorForward(n int) {
+	if n > 0 {
+		w.col += n
+		if w.w > 0 && w.col > w.w-1 {
+			w.col = w.w - 1 // terminals clamp at the right edge
+		}
+	}
+	w.ConsoleWriter.CursorForward(n)
+}
+
+func (w *wrapAwareWriter) CursorBackward(n int) {
+	if n > 0 {
+		w.col -= n
+		if w.col < 0 {
+			w.col = 0
+		}
+	}
+	w.ConsoleWriter.CursorBackward(n)
+}

--- a/cli/promptwrap_other.go
+++ b/cli/promptwrap_other.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	prompt "github.com/c-bata/go-prompt"
+)
+
+// newPlatformPromptWriter returns the standard writer on Unix: go-prompt's
+// own lineWrap already materializes deferred wraps there, so no compensation
+// is needed (see promptwrap_windows.go for the Windows story).
+func newPlatformPromptWriter() prompt.ConsoleWriter {
+	return prompt.NewStandardOutputWriter()
+}

--- a/cli/promptwrap_test.go
+++ b/cli/promptwrap_test.go
@@ -1,0 +1,165 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	prompt "github.com/c-bata/go-prompt"
+)
+
+// recordingWriter captures every call so tests can assert exactly what the
+// wrapper forwards, including injected raw newlines.
+type recordingWriter struct {
+	log []string
+}
+
+func (r *recordingWriter) WriteRaw(data []byte)    { r.log = append(r.log, "raw:"+string(data)) }
+func (r *recordingWriter) Write(data []byte)       { r.log = append(r.log, "str:"+string(data)) }
+func (r *recordingWriter) WriteRawStr(data string) { r.log = append(r.log, "raw:"+data) }
+func (r *recordingWriter) WriteStr(data string)    { r.log = append(r.log, "str:"+data) }
+func (r *recordingWriter) Flush() error            { return nil }
+func (r *recordingWriter) EraseScreen()            {}
+func (r *recordingWriter) EraseUp()                {}
+func (r *recordingWriter) EraseDown()              {}
+func (r *recordingWriter) EraseStartOfLine()       {}
+func (r *recordingWriter) EraseEndOfLine()         {}
+func (r *recordingWriter) EraseLine()              {}
+func (r *recordingWriter) ShowCursor()             {}
+func (r *recordingWriter) HideCursor()             {}
+func (r *recordingWriter) CursorGoTo(row, col int) {}
+func (r *recordingWriter) CursorUp(n int)          {}
+func (r *recordingWriter) CursorDown(n int)        {}
+func (r *recordingWriter) CursorForward(n int)     {}
+func (r *recordingWriter) CursorBackward(n int)    {}
+func (r *recordingWriter) AskForCPR()              {}
+func (r *recordingWriter) SaveCursor()             {}
+func (r *recordingWriter) UnSaveCursor()           {}
+func (r *recordingWriter) ScrollDown()             {}
+func (r *recordingWriter) ScrollUp()               {}
+func (r *recordingWriter) SetTitle(title string)   {}
+func (r *recordingWriter) ClearTitle()             {}
+func (r *recordingWriter) SetColor(fg, bg prompt.Color, bold bool) {
+	r.log = append(r.log, "color")
+}
+
+func (r *recordingWriter) joined() string { return strings.Join(r.log, "|") }
+
+var _ prompt.ConsoleWriter = (*recordingWriter)(nil)
+
+func newTestWrapWriter(width int) (*wrapAwareWriter, *recordingWriter) {
+	rec := &recordingWriter{}
+	return newWrapAwareWriter(rec, func() int { return width }), rec
+}
+
+func TestWrapAwareWriter_InjectsNewlineAtExactBoundary(t *testing.T) {
+	w, rec := newTestWrapWriter(10)
+	w.WriteStr("0123456789")
+	want := "str:0123456789|raw:\n"
+	if got := rec.joined(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if w.col != 0 {
+		t.Errorf("col = %d, want 0 after wrap", w.col)
+	}
+}
+
+func TestWrapAwareWriter_NoInjectionShortOfBoundary(t *testing.T) {
+	w, rec := newTestWrapWriter(10)
+	w.WriteStr("012345678")
+	if got := rec.joined(); got != "str:012345678" {
+		t.Errorf("got %q, want no injected newline", got)
+	}
+	if w.col != 9 {
+		t.Errorf("col = %d, want 9", w.col)
+	}
+}
+
+func TestWrapAwareWriter_AccumulatesAcrossWrites(t *testing.T) {
+	w, rec := newTestWrapWriter(10)
+	w.WriteStr("01234")
+	w.WriteStr("56789xy")
+	// The boundary falls mid-second-write: segment up to "9", newline, rest.
+	want := "str:01234|str:56789|raw:\n|str:xy"
+	if got := rec.joined(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if w.col != 2 {
+		t.Errorf("col = %d, want 2", w.col)
+	}
+}
+
+func TestWrapAwareWriter_WideRunes(t *testing.T) {
+	w, rec := newTestWrapWriter(10)
+	w.WriteStr("ああああああ") // 6 runes × 2 cells = 12 → boundary after the 5th
+	want := "str:あああああ|raw:\n|str:あ"
+	if got := rec.joined(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWrapAwareWriter_NewlineResetsColumn(t *testing.T) {
+	w, rec := newTestWrapWriter(10)
+	w.WriteStr("01234\r\n0123456789")
+	// Explicit newline resets the column; the second line hits the boundary.
+	want := "str:01234\r\n0123456789|raw:\n"
+	if got := rec.joined(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWrapAwareWriter_CursorMovesAdjustColumn(t *testing.T) {
+	w, rec := newTestWrapWriter(10)
+	w.WriteStr("01234567") // col 8
+	w.CursorBackward(3)    // col 5
+	w.WriteStr("56789")    // hits boundary at 10
+	want := "str:01234567|str:56789|raw:\n"
+	if got := rec.joined(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	w2, _ := newTestWrapWriter(10)
+	w2.WriteStr("0123")
+	w2.CursorGoTo(0, 0)
+	if w2.col != 0 {
+		t.Errorf("col after CursorGoTo home = %d, want 0", w2.col)
+	}
+}
+
+func TestWrapAwareWriter_RawEscapesDoNotCount(t *testing.T) {
+	w, _ := newTestWrapWriter(10)
+	w.WriteRawStr("\x1b[32m") // color: zero cells
+	if w.col != 0 {
+		t.Errorf("col after SGR = %d, want 0", w.col)
+	}
+	w.WriteRawStr("ab\x1b[0mc")
+	if w.col != 3 {
+		t.Errorf("col after mixed raw = %d, want 3", w.col)
+	}
+}
+
+func TestWrapAwareWriter_ZeroWidthPassthrough(t *testing.T) {
+	w, rec := newTestWrapWriter(0)
+	w.WriteStr("0123456789012345")
+	if got := rec.joined(); got != "str:0123456789012345" {
+		t.Errorf("got %q, want untouched passthrough", got)
+	}
+}
+
+func TestWrapAwareWriter_FlushRefreshesWidth(t *testing.T) {
+	width := 10
+	rec := &recordingWriter{}
+	w := newWrapAwareWriter(rec, func() int { return width })
+	width = 5
+	if err := w.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	w.WriteStr("01234")
+	want := "str:01234|raw:\n"
+	if got := rec.joined(); got != want {
+		t.Errorf("got %q, want %q (width must refresh on Flush)", got, want)
+	}
+}

--- a/cli/promptwrap_windows.go
+++ b/cli/promptwrap_windows.go
@@ -1,0 +1,48 @@
+//go:build windows
+
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"os"
+
+	prompt "github.com/c-bata/go-prompt"
+	"golang.org/x/sys/windows"
+	"golang.org/x/term"
+)
+
+// newPlatformPromptWriter returns the ConsoleWriter go-prompt should use.
+//
+// When the console has VT processing enabled (Windows Terminal, or conhost
+// after EnableVirtualTerminal at boot) it wraps the standard writer with the
+// deferred-wrap compensator — see wrapAwareWriter. On a legacy console
+// without VT the immediate-wrap behavior already matches go-prompt's Windows
+// math, and injecting extra newlines would break it, so the default writer is
+// returned untouched.
+func newPlatformPromptWriter() prompt.ConsoleWriter {
+	if !stdoutHasVTProcessing() {
+		return prompt.NewStandardOutputWriter()
+	}
+	return newWrapAwareWriter(prompt.NewStandardOutputWriter(), func() int {
+		if w, _, err := term.GetSize(int(os.Stdout.Fd())); err == nil && w > 0 {
+			return w
+		}
+		return 0
+	})
+}
+
+// stdoutHasVTProcessing reports whether stdout is a console with
+// ENABLE_VIRTUAL_TERMINAL_PROCESSING set — i.e. xterm-style deferred EOL
+// wrap semantics.
+func stdoutHasVTProcessing() bool {
+	h := windows.Handle(os.Stdout.Fd())
+	var mode uint32
+	if err := windows.GetConsoleMode(h, &mode); err != nil {
+		return false
+	}
+	return mode&windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING != 0
+}

--- a/cli/slash_tool_handlers.go
+++ b/cli/slash_tool_handlers.go
@@ -68,9 +68,7 @@ func (cli *ChatCLI) helpText() string {
 // network; we layer an extra 2s timeout on top in case the caller's ctx
 // is the long-lived agent loop ctx.
 func (cli *ChatCLI) versionText(parent context.Context) string {
-	versionInfo := version.GetCurrentVersion()
 	ctx, cancel := context.WithTimeout(parent, 2*time.Second)
 	defer cancel()
-	latest, hasUpdate, err := version.CheckLatestVersionWithContext(ctx)
-	return version.FormatVersionInfo(versionInfo, latest, hasUpdate, err)
+	return version.GetReport(ctx).Format()
 }

--- a/cli/stdin_cancel_other.go
+++ b/cli/stdin_cancel_other.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+// stdinReadCanceler is a no-op outside Windows: stdinPollReady uses poll(2),
+// which has no false positives, so the reader goroutine never sits in a
+// blocking os.Stdin.Read — it exits within one poll cycle of stdinDone
+// closing. See stdin_cancel_windows.go for the Windows implementation.
+type stdinReadCanceler struct{}
+
+func newStdinReadCanceler() *stdinReadCanceler { return &stdinReadCanceler{} }
+
+func (c *stdinReadCanceler) bind()   {}
+func (c *stdinReadCanceler) unbind() {}
+
+// cancel reports false: there is no cancellable read on this platform, so
+// the caller falls back to plainly waiting out the poll cycle.
+func (c *stdinReadCanceler) cancel() bool { return false }

--- a/cli/stdin_cancel_windows.go
+++ b/cli/stdin_cancel_windows.go
@@ -1,0 +1,78 @@
+//go:build windows
+
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"runtime"
+	"sync"
+
+	"golang.org/x/sys/windows"
+)
+
+var procCancelSynchronousIo = kernel32.NewProc("CancelSynchronousIo")
+
+// stdinReadCanceler aborts a pending blocking os.Stdin.Read on Windows.
+//
+// A console read has no cancellable deadline: once the reader goroutine is
+// inside ReadFile, closing a channel cannot unblock it. The documented API
+// for this is CancelSynchronousIo, which targets the OS *thread* issuing the
+// synchronous I/O. The reader goroutine therefore locks itself to its OS
+// thread (bind) and publishes a duplicated thread handle; stopStdinReader
+// calls cancel to make the in-flight ReadFile return ERROR_OPERATION_ABORTED,
+// letting the goroutine observe stdinDone and exit cleanly — no synthetic
+// input, no console-buffer mutation.
+type stdinReadCanceler struct {
+	mu     sync.Mutex
+	thread windows.Handle
+}
+
+func newStdinReadCanceler() *stdinReadCanceler { return &stdinReadCanceler{} }
+
+// bind must be called from the reader goroutine before its first read. It
+// pins the goroutine to its OS thread (so every subsequent Read syscall is
+// issued from a known thread) and publishes that thread's handle.
+func (c *stdinReadCanceler) bind() {
+	runtime.LockOSThread()
+	cp := windows.CurrentProcess()
+	var h windows.Handle
+	if err := windows.DuplicateHandle(cp, windows.CurrentThread(), cp, &h, 0, false, windows.DUPLICATE_SAME_ACCESS); err != nil {
+		return // cancel() degrades to a no-op attempt; the retry loop still waits
+	}
+	c.mu.Lock()
+	c.thread = h
+	c.mu.Unlock()
+}
+
+// unbind releases the thread handle and the OS-thread pin. Must be called
+// from the reader goroutine on exit.
+func (c *stdinReadCanceler) unbind() {
+	c.mu.Lock()
+	h := c.thread
+	c.thread = 0
+	c.mu.Unlock()
+	if h != 0 {
+		_ = windows.CloseHandle(h)
+	}
+	runtime.UnlockOSThread()
+}
+
+// cancel aborts the reader thread's in-flight synchronous I/O, if any.
+// Returns true because the platform supports cancellation (the caller uses
+// this to pick between the cancel-retry path and the plain-wait fallback).
+// ERROR_NOT_FOUND — no I/O in flight at this instant — is expected: the
+// caller retries, which closes the race where the read starts right after a
+// cancel that found nothing.
+func (c *stdinReadCanceler) cancel() bool {
+	c.mu.Lock()
+	h := c.thread
+	c.mu.Unlock()
+	if h != 0 {
+		_, _, _ = procCancelSynchronousIo.Call(uintptr(h))
+	}
+	return true
+}

--- a/cli/stdin_ready_windows.go
+++ b/cli/stdin_ready_windows.go
@@ -11,18 +11,83 @@ import (
 	"os"
 	"syscall"
 	"time"
+	"unsafe"
 )
 
-// stdinPollReady waits up to timeout for stdin to have input events available.
-// On Windows this uses WaitForSingleObject on the console input handle.
+var (
+	procPeekConsoleInputW = kernel32.NewProc("PeekConsoleInputW")
+	procReadConsoleInputW = kernel32.NewProc("ReadConsoleInputW")
+)
+
+// stdinPollReady waits up to timeout for stdin to have TEXT input available.
+// On Windows this uses WaitForSingleObject on the console input handle plus a
+// PeekConsoleInput classification pass.
 //
-// Note: WaitForSingleObject may return true for non-key console events (e.g.,
-// window resize). In that case the subsequent os.Stdin.Read may block until
-// actual text input arrives. This is acceptable because:
-//   - Non-key events are infrequent in typical CLI usage.
-//   - The stopStdinReader timeout ensures we don't block indefinitely on exit.
+// WaitForSingleObject alone is not enough: a console input handle is signaled
+// by ANY pending event — window resize, focus changes, mouse movement — not
+// just keystrokes. Treating those as "ready" sends the caller into a blocking
+// os.Stdin.Read that only returns when the user actually types, and
+// stopStdinReader cannot cancel that read (the root cause of the coder-mode
+// "typing shows nothing until Enter" hang). So after the wait we peek the
+// queue: only a key-down event carrying a character counts as ready, and the
+// non-text records in front of it are consumed so they stop re-signaling the
+// wait on every poll cycle.
 func stdinPollReady(timeout time.Duration) bool {
 	h := syscall.Handle(os.Stdin.Fd())
 	r, _ := syscall.WaitForSingleObject(h, uint32(timeout.Milliseconds()))
-	return r == syscall.WAIT_OBJECT_0
+	if r != syscall.WAIT_OBJECT_0 {
+		return false
+	}
+	return consoleHasPendingText(h)
+}
+
+// consoleHasPendingText reports whether the console input queue holds a
+// key-down event with a character, discarding the non-text events (resize,
+// focus, mouse, key-up) queued in front of it. The reader goroutine is the
+// only console consumer while it runs, so dropping those records is safe.
+func consoleHasPendingText(h syscall.Handle) bool {
+	const maxRecords = 64
+	var recs [maxRecords]inputRecord
+	var n uint32
+
+	// #nosec G103 -- the kernel fills the record array before the synchronous
+	// syscall returns; recs outlives the call.
+	r1, _, _ := procPeekConsoleInputW.Call(
+		uintptr(h),
+		uintptr(unsafe.Pointer(&recs[0])),
+		maxRecords,
+		uintptr(unsafe.Pointer(&n)),
+	)
+	if r1 == 0 {
+		// Peek unavailable (e.g. stdin is a pipe, not a console). Fall back
+		// to the pre-classification behavior: assume the wait meant data.
+		return true
+	}
+	if n == 0 {
+		return false
+	}
+
+	textAt := -1
+	for i := 0; i < int(n); i++ {
+		if recs[i].EventType == keyEventType && recs[i].Event.KeyDown == 1 && recs[i].Event.UnicodeChar != 0 {
+			textAt = i
+			break
+		}
+	}
+
+	discard := int(n)
+	if textAt >= 0 {
+		discard = textAt
+	}
+	if discard > 0 {
+		var read uint32
+		// #nosec G103 -- same contract as the peek above.
+		_, _, _ = procReadConsoleInputW.Call(
+			uintptr(h),
+			uintptr(unsafe.Pointer(&recs[0])),
+			uintptr(discard),
+			uintptr(unsafe.Pointer(&read)),
+		)
+	}
+	return textAt >= 0
 }

--- a/cli/tty_inject_windows.go
+++ b/cli/tty_inject_windows.go
@@ -113,7 +113,7 @@ func injectPromptWake() error {
 		uintptr(unsafe.Pointer(&written)),
 	)
 	if r1 == 0 {
-		return fmt.Errorf("wake injection via WriteConsoleInputW: %v", callErr)
+		return fmt.Errorf("wake injection via WriteConsoleInputW: %w", callErr)
 	}
 	return nil
 }
@@ -212,7 +212,7 @@ func injectTTYLine(line string) error {
 		uintptr(unsafe.Pointer(&written)),
 	)
 	if r1 == 0 {
-		return fmt.Errorf("WriteConsoleInputW failed: %v", callErr)
+		return fmt.Errorf("WriteConsoleInputW failed: %w", callErr)
 	}
 	if written != uint32(len(events)) {
 		return fmt.Errorf("WriteConsoleInputW: short write (%d/%d events)", written, len(events))

--- a/cli/tty_inject_windows.go
+++ b/cli/tty_inject_windows.go
@@ -212,7 +212,7 @@ func injectTTYLine(line string) error {
 		uintptr(unsafe.Pointer(&written)),
 	)
 	if r1 == 0 {
-		return fmt.Errorf("WriteConsoleInputW failed: %w", callErr)
+		return fmt.Errorf("line injection via WriteConsoleInputW: %w", callErr)
 	}
 	if written != uint32(len(events)) {
 		return fmt.Errorf("WriteConsoleInputW: short write (%d/%d events)", written, len(events))

--- a/main.go
+++ b/main.go
@@ -96,11 +96,9 @@ func reportDotenvBootstrap(b dotenvBootstrap) {
 // printVersionInfo prints version details (including update check) and is used
 // for the -version flag.
 func printVersionInfo() {
-	versionInfo := version.GetCurrentVersion()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	latest, hasUpdate, err := version.CheckLatestVersionWithContext(ctx)
-	fmt.Println(version.FormatVersionInfo(versionInfo, latest, hasUpdate, err))
+	fmt.Println(version.GetReport(ctx).Format())
 }
 
 // applyStackSpotFlags applies StackSpot realm/agent overrides when the target

--- a/pkg/coder/engine/engine.go
+++ b/pkg/coder/engine/engine.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"github.com/diillson/chatcli/pkg/fspath"
 )
 
 const (
@@ -151,6 +153,11 @@ func (e *Engine) validatePath(target string) error {
 			return fmt.Errorf("access to sensitive path %q is blocked", target)
 		}
 	}
+	for _, sp := range fspath.WindowsSystemRoots() {
+		if fspath.WithinBoundary(resolved, sp) {
+			return fmt.Errorf("access to sensitive path %q is blocked", target)
+		}
+	}
 
 	// Enforce workspace boundary
 	if e.WorkspaceRoot != "" {
@@ -169,7 +176,7 @@ func (e *Engine) validatePath(target string) error {
 			}
 		}
 
-		if !isSystemBin && resolved != boundary && !strings.HasPrefix(resolved, boundary+"/") {
+		if !isSystemBin && !fspath.WithinBoundary(resolved, boundary) {
 			// Check aux allowlist (e.g. session scratch dir, tool-result
 			// overflow). These are registered only by the CLI itself, so
 			// they're trusted.
@@ -177,7 +184,7 @@ func (e *Engine) validatePath(target string) error {
 				if evalAux, err := filepath.EvalSymlinks(aux); err == nil {
 					aux = evalAux
 				}
-				if resolved == aux || strings.HasPrefix(resolved, aux+string(filepath.Separator)) {
+				if fspath.WithinBoundary(resolved, aux) {
 					return nil
 				}
 			}

--- a/pkg/fspath/fspath.go
+++ b/pkg/fspath/fspath.go
@@ -1,0 +1,76 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+// Package fspath provides filesystem path comparison helpers that are correct
+// across operating systems. It is stdlib-only so that leaf packages with a
+// no-external-dependency contract (e.g. pkg/coder/engine) can import it.
+package fspath
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// normalize cleans a path and puts it in canonical comparison form: forward
+// slashes everywhere, lowercased on Windows (whose filesystems are
+// case-insensitive).
+func normalize(p string) string {
+	p = filepath.ToSlash(filepath.Clean(p))
+	if runtime.GOOS == "windows" {
+		p = strings.ToLower(p)
+	}
+	return p
+}
+
+// WithinBoundary reports whether target is root itself or a path contained
+// inside root. Both are cleaned and compared with normalized separators, so a
+// target like "C:/Users/x/file" matches a root of "C:\Users\x". On Windows the
+// comparison is case-insensitive, matching filesystem semantics.
+//
+// Callers must pass absolute (and, where relevant, symlink-resolved) paths;
+// this function does not resolve them.
+func WithinBoundary(target, root string) bool {
+	if target == "" || root == "" {
+		return false
+	}
+	t := normalize(target)
+	r := normalize(root)
+	if t == r {
+		return true
+	}
+	if !strings.HasSuffix(r, "/") {
+		r += "/"
+	}
+	return strings.HasPrefix(t, r)
+}
+
+// Equal reports whether two paths refer to the same location after cleaning,
+// separator normalization and — on Windows — case folding. It does not touch
+// the filesystem (no symlink resolution).
+func Equal(a, b string) bool {
+	if a == "" || b == "" {
+		return a == b
+	}
+	return normalize(a) == normalize(b)
+}
+
+// WindowsSystemRoots returns OS-critical directories that automated tools
+// must never touch on Windows — the counterpart of the unix /etc, /proc &co.
+// blocklists, which never match backslashed paths. Resolved from the
+// environment so non-standard installs are still covered. Empty on other
+// operating systems.
+func WindowsSystemRoots() []string {
+	if runtime.GOOS != "windows" {
+		return nil
+	}
+	root := os.Getenv("SystemRoot")
+	if root == "" {
+		root = `C:\Windows`
+	}
+	return []string{root}
+}

--- a/pkg/fspath/fspath_test.go
+++ b/pkg/fspath/fspath_test.go
@@ -1,0 +1,85 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package fspath
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestWithinBoundary(t *testing.T) {
+	tests := []struct {
+		name        string
+		target      string
+		root        string
+		want        bool
+		windowsOnly bool
+	}{
+		{name: "unix inside", target: "/home/u/proj/main.go", root: "/home/u/proj", want: true},
+		{name: "unix equals root", target: "/home/u/proj", root: "/home/u/proj", want: true},
+		{name: "unix outside", target: "/home/u/other/main.go", root: "/home/u/proj", want: false},
+		{name: "unix sibling prefix is not inside", target: "/home/u/projext/f.go", root: "/home/u/proj", want: false},
+		{name: "unix root boundary", target: "/etc/passwd", root: "/", want: true},
+		{name: "trailing separator on root", target: "/home/u/proj/f.go", root: "/home/u/proj/", want: true},
+		{name: "empty target", target: "", root: "/home/u", want: false},
+		{name: "empty root", target: "/home/u", root: "", want: false},
+
+		// The exact failure from the field: LLM sends forward slashes, the
+		// workspace root is backslashed.
+		{name: "win forward slash target", target: "C:/Users/x/deployment.yaml", root: `C:\Users\x`, want: true, windowsOnly: true},
+		{name: "win backslash target", target: `C:\Users\x\deployment.yaml`, root: `C:\Users\x`, want: true, windowsOnly: true},
+		{name: "win case-insensitive", target: `c:\users\X\f.yaml`, root: `C:\Users\x`, want: true, windowsOnly: true},
+		{name: "win equals root mixed slashes", target: "C:/Users/x", root: `C:\Users\x`, want: true, windowsOnly: true},
+		{name: "win outside", target: `C:\Users\alt\f.yaml`, root: `C:\Users\x`, want: false, windowsOnly: true},
+		{name: "win sibling prefix", target: `C:\Users\xy\f.yaml`, root: `C:\Users\x`, want: false, windowsOnly: true},
+		{name: "win drive root boundary", target: `C:\Users\x\f.yaml`, root: `C:\`, want: true, windowsOnly: true},
+		{name: "win different drive", target: `D:\Users\x\f.yaml`, root: `C:\Users\x`, want: false, windowsOnly: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.windowsOnly && runtime.GOOS != "windows" {
+				t.Skip("windows-only semantics (filepath.Clean is OS-specific)")
+			}
+			if got := WithinBoundary(tt.target, tt.root); got != tt.want {
+				t.Errorf("WithinBoundary(%q, %q) = %v, want %v", tt.target, tt.root, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEqual(t *testing.T) {
+	if !Equal("/home/u/proj", "/home/u/proj/") {
+		t.Error("trailing separator should not affect equality")
+	}
+	if Equal("/home/u/a", "/home/u/b") {
+		t.Error("distinct paths must not be equal")
+	}
+	if !Equal("", "") {
+		t.Error("two empty paths are equal")
+	}
+	if Equal("", "/home/u") {
+		t.Error("empty vs non-empty must not be equal")
+	}
+	if runtime.GOOS == "windows" {
+		if !Equal(`C:\Users\X\.kube\config`, "c:/users/x/.kube/config") {
+			t.Error("windows equality must ignore case and separator style")
+		}
+	}
+}
+
+func TestWindowsSystemRoots(t *testing.T) {
+	roots := WindowsSystemRoots()
+	if runtime.GOOS != "windows" {
+		if roots != nil {
+			t.Errorf("expected nil on %s, got %v", runtime.GOOS, roots)
+		}
+		return
+	}
+	if len(roots) == 0 {
+		t.Error("expected at least one system root on windows")
+	}
+}

--- a/utils/path.go
+++ b/utils/path.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 )
 
@@ -35,11 +34,11 @@ var sensitivePaths = []string{
 }
 
 // IsSensitivePath checks whether a file path points to a known sensitive location.
+// The comparison is case-insensitive on every OS: Windows filesystems are
+// case-insensitive (".SSH" is the same directory as ".ssh"), and on Unix
+// over-matching an odd-cased lookalike only errs on the safe side.
 func IsSensitivePath(absPath string) bool {
-	normalizedPath := filepath.ToSlash(absPath)
-	if runtime.GOOS != "windows" {
-		normalizedPath = strings.ToLower(normalizedPath)
-	}
+	normalizedPath := strings.ToLower(filepath.ToSlash(absPath))
 	for _, sensitive := range sensitivePaths {
 		sensitive = strings.ToLower(sensitive)
 		if strings.Contains(normalizedPath, "/"+sensitive+"/") ||

--- a/utils/unescape_jsonish.go
+++ b/utils/unescape_jsonish.go
@@ -44,3 +44,132 @@ func MaybeUnescapeJSONishArgs(input string) (string, bool) {
 
 	return input, false
 }
+
+// RepairJSONInvalidEscapes conserta texto JSON-ish em que barras invertidas
+// não foram escapadas — o caso clássico é o LLM embutir um path Windows
+// ("C:\Users\x") numa string JSON, produzindo escapes inválidos como \U.
+//
+// A decisão é POR LITERAL DE STRING, tudo-ou-nada: uma string que contém
+// qualquer escape inválido é "suja" — o emissor claramente não estava
+// escapando — e então TODAS as suas barras são tratadas como literais de
+// path e duplicadas, inclusive as que por coincidência formariam escapes
+// válidos (\b em "\builder", \t em "\temp\Users"). Preservam-se apenas \"
+// (aspas são ilegais em nomes de arquivo Windows, logo é um escape real) e
+// \\ (já escapada). Strings totalmente válidas ficam intactas, então um
+// "\n" legítimo numa chave irmã sobrevive ao reparo da chave suja.
+//
+// Retorna o input inalterado quando não há nada a reparar. Limitação
+// inerente: uma string SÓ com escapes coincidentemente válidos (ex.:
+// "C:\temp") é JSON válido e nunca chega a esta função — o erro segue para o
+// chamador, que devolve o problema ao modelo.
+func RepairJSONInvalidEscapes(s string) string {
+	var b strings.Builder
+	b.Grow(len(s) + 16)
+	changed := false
+
+	i := 0
+	for i < len(s) {
+		c := s[i]
+		b.WriteByte(c)
+		i++
+		if c != '"' {
+			continue
+		}
+
+		content, end := scanJSONStringLiteral(s, i)
+		if hasInvalidJSONEscape(content, end == len(s)) {
+			b.WriteString(doublePathBackslashes(content))
+			changed = true
+		} else {
+			b.WriteString(content)
+		}
+		i = end
+		if i < len(s) { // closing quote
+			b.WriteByte('"')
+			i++
+		}
+	}
+
+	if !changed {
+		return s
+	}
+	return b.String()
+}
+
+// scanJSONStringLiteral returns the content of the string literal starting at
+// s[start] (start points just past the opening quote) and the index of its
+// closing quote — or len(s) when the literal is unterminated.
+func scanJSONStringLiteral(s string, start int) (content string, end int) {
+	j := start
+	for j < len(s) {
+		switch s[j] {
+		case '\\':
+			j += 2 // skip the escaped character (whatever it is)
+			if j > len(s) {
+				j = len(s)
+			}
+		case '"':
+			return s[start:j], j
+		default:
+			j++
+		}
+	}
+	return s[start:], len(s)
+}
+
+// hasInvalidJSONEscape reports whether the string-literal content carries any
+// escape sequence the JSON grammar rejects. unterminated marks a literal that
+// ran off the end of the input (always in need of repair).
+func hasInvalidJSONEscape(content string, unterminated bool) bool {
+	if unterminated {
+		return true
+	}
+	isHex := func(c byte) bool {
+		return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
+	}
+	for k := 0; k < len(content); k++ {
+		if content[k] != '\\' {
+			continue
+		}
+		if k+1 >= len(content) {
+			return true
+		}
+		next := content[k+1]
+		switch {
+		case next == 'u':
+			if k+5 >= len(content) || !isHex(content[k+2]) || !isHex(content[k+3]) || !isHex(content[k+4]) || !isHex(content[k+5]) {
+				return true
+			}
+			k += 5
+		case strings.IndexByte(`"\/bfnrt`, next) >= 0:
+			k++
+		default:
+			return true
+		}
+	}
+	return false
+}
+
+// doublePathBackslashes rewrites a dirty string literal treating every
+// backslash as a literal path separator, preserving only \" (a real quote
+// escape — quotes cannot appear in Windows file names) and \\ (already
+// escaped).
+func doublePathBackslashes(content string) string {
+	var b strings.Builder
+	b.Grow(len(content) + 8)
+	for k := 0; k < len(content); k++ {
+		c := content[k]
+		if c != '\\' {
+			b.WriteByte(c)
+			continue
+		}
+		if k+1 < len(content) && (content[k+1] == '"' || content[k+1] == '\\') {
+			b.WriteByte('\\')
+			b.WriteByte(content[k+1])
+			k++
+			continue
+		}
+		b.WriteString(`\\`)
+	}
+	return b.String()
+}

--- a/utils/unescape_jsonish_test.go
+++ b/utils/unescape_jsonish_test.go
@@ -1,0 +1,98 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package utils
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRepairJSONInvalidEscapes(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "windows path with invalid escapes",
+			input: `{"file":"C:\Users\builder\deployment.yaml"}`,
+			want:  `{"file":"C:\\Users\\builder\\deployment.yaml"}`,
+		},
+		{
+			name:  "valid JSON untouched",
+			input: `{"file":"C:\\Users\\x\\f.yaml","n":"a\nb"}`,
+			want:  `{"file":"C:\\Users\\x\\f.yaml","n":"a\nb"}`,
+		},
+		{
+			name:  "valid unicode escape preserved",
+			input: "{\"s\":\"\\u0041\"}",
+			want:  "{\"s\":\"\\u0041\"}",
+		},
+		{
+			name:  "invalid unicode escape doubled",
+			input: `{"s":"C:\users"}`,
+			want:  `{"s":"C:\\users"}`,
+		},
+		{
+			name:  "trailing backslash at end of input",
+			input: `{"s":"x\`,
+			want:  `{"s":"x\\`,
+		},
+		{
+			name:  "backslash outside string untouched region",
+			input: `{"a":1}`,
+			want:  `{"a":1}`,
+		},
+		{
+			// \b and \t are valid JSON escapes, but in a string that also
+			// carries an invalid one (\U) the emitter clearly wasn't
+			// escaping — every backslash is a path separator.
+			name:  "coincidentally-valid escapes in a dirty string are path separators",
+			input: `{"file":"C:\Users\builder\temp\deployment.yaml"}`,
+			want:  `{"file":"C:\\Users\\builder\\temp\\deployment.yaml"}`,
+		},
+		{
+			// The dirty-string rewrite is per literal: a sibling string with
+			// a legitimate \n escape must survive untouched.
+			name:  "clean sibling string keeps its valid escapes",
+			input: `{"content":"line1\nline2","file":"C:\Users\x"}`,
+			want:  `{"content":"line1\nline2","file":"C:\\Users\\x"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RepairJSONInvalidEscapes(tt.input)
+			if got != tt.want {
+				t.Errorf("RepairJSONInvalidEscapes(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRepairJSONInvalidEscapes_ParsesAfterRepair proves the end-to-end
+// property: an LLM-emitted Windows path that json.Unmarshal rejects becomes
+// parseable after repair, with the path intact.
+func TestRepairJSONInvalidEscapes_ParsesAfterRepair(t *testing.T) {
+	raw := `{"cmd":"write","args":{"file":"C:\Users\builder\deployment.yaml","encoding":"base64"}}`
+
+	var v map[string]any
+	if err := json.Unmarshal([]byte(raw), &v); err == nil {
+		t.Fatal("fixture must be invalid JSON before repair (red half of the proof)")
+	}
+
+	repaired := RepairJSONInvalidEscapes(raw)
+	if err := json.Unmarshal([]byte(repaired), &v); err != nil {
+		t.Fatalf("repaired JSON must parse: %v", err)
+	}
+	args, ok := v["args"].(map[string]any)
+	if !ok {
+		t.Fatalf("args envelope lost: %#v", v)
+	}
+	if got := args["file"]; got != `C:\Users\builder\deployment.yaml` {
+		t.Errorf("file = %q, want the original Windows path", got)
+	}
+}

--- a/version/version.go
+++ b/version/version.go
@@ -35,12 +35,15 @@ type ReleaseInfo struct {
 	TargetHash  string `json:"target_commitish"`
 }
 
-// CheckLatestVersionImpl é a implementação injetável para checagem de versão (pode ser mocked)
-var CheckLatestVersionImpl = func(ctx context.Context) (string, bool, error) {
-	if strings.EqualFold(os.Getenv("CHATCLI_DISABLE_VERSION_CHECK"), "true") {
-		return "", false, nil
-	}
+// versionCheckDisabled centraliza o opt-out da checagem de release.
+func versionCheckDisabled() bool {
+	return strings.EqualFold(os.Getenv("CHATCLI_DISABLE_VERSION_CHECK"), "true")
+}
 
+// FetchLatestReleaseImpl é a implementação injetável da consulta à release
+// mais recente (o único seam de rede deste pacote; testes o substituem ou
+// apontam CHATCLI_LATEST_VERSION_URL para um servidor de teste).
+var FetchLatestReleaseImpl = func(ctx context.Context) (ReleaseInfo, error) {
 	client := &http.Client{
 		Timeout: 10 * time.Second,
 	}
@@ -52,14 +55,14 @@ var CheckLatestVersionImpl = func(ctx context.Context) (string, bool, error) {
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
-		return "", false, err
+		return ReleaseInfo{}, err
 	}
 
 	req.Header.Set("User-Agent", "ChatCLI-Version-Checker")
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", false, err
+		return ReleaseInfo{}, err
 	}
 	defer func() {
 		if closeErr := resp.Body.Close(); closeErr != nil {
@@ -68,55 +71,51 @@ var CheckLatestVersionImpl = func(ctx context.Context) (string, bool, error) {
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", false, fmt.Errorf("erro ao verificar versão: status %d", resp.StatusCode)
+		return ReleaseInfo{}, fmt.Errorf("erro ao verificar versão: status %d", resp.StatusCode)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", false, err
+		return ReleaseInfo{}, err
 	}
 
 	var releaseInfo ReleaseInfo
 	if err := json.Unmarshal(body, &releaseInfo); err != nil {
-		return "", false, err
+		return ReleaseInfo{}, err
 	}
-
-	latestVersion := strings.TrimPrefix(releaseInfo.TagName, "v")
-	currentVersionFull, _, _ := GetBuildInfo()
-	currentVersionBase := ExtractBaseVersion(currentVersionFull)
-	needsUpdate := NeedsUpdate(currentVersionBase, latestVersion)
-
-	// Enriquecer informações de build quando instalado via go install
-	// (sem ldflags — commit e data ficam "unknown")
-	enrichBuildInfoFromRelease(currentVersionBase, latestVersion, releaseInfo)
-
-	return latestVersion, needsUpdate, nil
+	return releaseInfo, nil
 }
 
-// enrichBuildInfoFromRelease preenche CommitHash e BuildDate a partir da
-// release do GitHub quando estes não foram injetados via ldflags (ex: go install).
-func enrichBuildInfoFromRelease(currentBase, latestBase string, release ReleaseInfo) {
-	if currentBase != latestBase {
-		return // Só enriquece se a versão instalada é a mesma da latest
+// enrichedFromRelease retorna uma cópia de v com CommitHash/BuildDate
+// preenchidos a partir dos metadados da release quando o próprio build não
+// os carimbou (go install baixa do module proxy, sem info de VCS em nenhum
+// SO) — e somente quando a versão instalada é exatamente a release que os
+// metadados descrevem. Função pura: nenhum estado do pacote é alterado.
+func (v VersionInfo) enrichedFromRelease(latestBase string, release ReleaseInfo) VersionInfo {
+	if ExtractBaseVersion(v.Version) != latestBase {
+		return v
 	}
 
-	if CommitHash == "unknown" || CommitHash == "" {
+	if v.CommitHash == "unknown" || v.CommitHash == "" {
 		if release.TargetHash != "" {
 			hash := release.TargetHash
 			if len(hash) > 12 {
 				hash = hash[:12]
 			}
-			CommitHash = hash
+			v.CommitHash = hash
 		}
 	}
 
-	if BuildDate == "unknown" || BuildDate == "" {
-		if release.PublishedAt != "" {
-			if t, err := time.Parse(time.RFC3339, release.PublishedAt); err == nil {
-				BuildDate = t.Format("2006-01-02 15:04:05")
-			}
+	// A data de publicação da release é mais fiel que a aproximação pela
+	// data do binário (que reflete a hora do go install, não a do release).
+	replaceableDate := v.BuildDate == "unknown" || v.BuildDate == "" ||
+		strings.HasSuffix(v.BuildDate, buildDateApproxSuffix)
+	if replaceableDate && release.PublishedAt != "" {
+		if t, err := time.Parse(time.RFC3339, release.PublishedAt); err == nil {
+			v.BuildDate = t.Format("2006-01-02 15:04:05")
 		}
 	}
+	return v
 }
 
 // GetBuildInfoImpl é a implementação injetável para GetBuildInfo (pode ser mocked)
@@ -171,12 +170,17 @@ var GetBuildInfoImpl = func() (string, string, string) {
 		if execPath, err := os.Executable(); err == nil {
 			if info, err := os.Stat(execPath); err == nil {
 				modTime := info.ModTime()
-				buildDate = fmt.Sprintf("%s (aproximado pela data do binário)", modTime.Format("2006-01-02 15:04:05"))
+				buildDate = modTime.Format("2006-01-02 15:04:05") + buildDateApproxSuffix
 			}
 		}
 	}
 	return version, commitHash, buildDate
 }
+
+// buildDateApproxSuffix marca uma BuildDate estimada pela data de modificação
+// do binário. enrichedFromRelease usa o marcador para saber que pode
+// substituí-la pela data real de publicação da release.
+const buildDateApproxSuffix = " (aproximado pela data do binário)"
 
 // Info retorna informações estruturadas sobre a versão atual
 type VersionInfo struct {
@@ -185,12 +189,18 @@ type VersionInfo struct {
 	BuildDate  string `json:"build_date"`
 }
 
-// GetCurrentVersion retorna as informações de versão atuais
+// GetCurrentVersion retorna as informações de versão atuais. Delega em
+// GetBuildInfo (em vez de ler as globais cruas) para que builds sem ldflags —
+// o caso `go install` — ainda apresentem a versão do módulo, o vcs.revision e
+// a data aproximada do binário. Para exibir também o enriquecimento via
+// GitHub release, use GetReport — que compõe tudo sem depender de ordem de
+// chamadas nem de estado mutável do pacote.
 func GetCurrentVersion() VersionInfo {
+	v, commit, date := GetBuildInfo()
 	return VersionInfo{
-		Version:    Version,
-		CommitHash: CommitHash,
-		BuildDate:  BuildDate,
+		Version:    v,
+		CommitHash: commit,
+		BuildDate:  date,
 	}
 }
 
@@ -340,7 +350,56 @@ func GetBuildInfo() (string, string, string) {
 	return GetBuildInfoImpl()
 }
 
-// CheckLatestVersionWithContext é o wrapper exportado (mantém a API inalterada)
+// Report reúne tudo que uma exibição de versão precisa: o build info
+// resolvido (enriquecido com metadados da release quando o build não tem
+// carimbo de VCS) e o resultado da checagem de atualização. Construí-lo não
+// tem efeitos colaterais no pacote nem exige ordem entre resolução e check.
+type Report struct {
+	Current     VersionInfo
+	Latest      string
+	NeedsUpdate bool
+	CheckErr    error
+}
+
+// GetReport resolve o build info atual e consulta a release mais recente em
+// uma única composição. Com a checagem desabilitada
+// (CHATCLI_DISABLE_VERSION_CHECK) o relatório carrega apenas o build info,
+// com Latest vazio e CheckErr nil — o mesmo contrato do check isolado.
+func GetReport(ctx context.Context) Report {
+	rep := Report{Current: GetCurrentVersion()}
+	if versionCheckDisabled() {
+		return rep
+	}
+
+	release, err := FetchLatestReleaseImpl(ctx)
+	if err != nil {
+		rep.CheckErr = err
+		return rep
+	}
+
+	rep.Latest = strings.TrimPrefix(release.TagName, "v")
+	rep.NeedsUpdate = NeedsUpdate(ExtractBaseVersion(rep.Current.Version), rep.Latest)
+	rep.Current = rep.Current.enrichedFromRelease(rep.Latest, release)
+	return rep
+}
+
+// Format renderiza o relatório no formato canônico de exibição.
+func (r Report) Format() string {
+	return FormatVersionInfo(r.Current, r.Latest, r.NeedsUpdate, r.CheckErr)
+}
+
+// CheckLatestVersionWithContext responde apenas "qual é a última versão e
+// preciso atualizar?", sem tocar em estado do pacote. Fluxos de exibição
+// devem preferir GetReport, que também enriquece o build info.
 func CheckLatestVersionWithContext(ctx context.Context) (string, bool, error) {
-	return CheckLatestVersionImpl(ctx)
+	if versionCheckDisabled() {
+		return "", false, nil
+	}
+	release, err := FetchLatestReleaseImpl(ctx)
+	if err != nil {
+		return "", false, err
+	}
+	latest := strings.TrimPrefix(release.TagName, "v")
+	currentVersionFull, _, _ := GetBuildInfo()
+	return latest, NeedsUpdate(ExtractBaseVersion(currentVersionFull), latest), nil
 }

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -2,9 +2,7 @@ package version
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -95,53 +93,15 @@ func TestCheckLatestVersionWithContext_Success(t *testing.T) {
 	}))
 	defer server.Close()
 
-	// Salva implementações originais
-	originalCheckImpl := CheckLatestVersionImpl
-	originalBuildImpl := GetBuildInfoImpl
+	// Aponta o fetch DEFAULT (código real) para o servidor de teste.
+	t.Setenv("CHATCLI_LATEST_VERSION_URL", server.URL)
 
 	// Mock GetBuildInfoImpl para retornar versão comparável (não "dev")
+	originalBuildImpl := GetBuildInfoImpl
 	GetBuildInfoImpl = func() (string, string, string) {
 		return "1.25.0", "abc1234", "2024-09-15"
 	}
-
-	// Mock CheckLatestVersionImpl para usar servidor de teste
-	CheckLatestVersionImpl = func(ctx context.Context) (string, bool, error) {
-		client := &http.Client{Timeout: 5 * time.Second}
-		req, err := http.NewRequestWithContext(ctx, "GET", server.URL, nil)
-		if err != nil {
-			return "", false, err
-		}
-		req.Header.Set("User-Agent", "ChatCLI-Version-Checker")
-
-		resp, err := client.Do(req)
-		if err != nil {
-			return "", false, err
-		}
-		defer resp.Body.Close()
-
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return "", false, err
-		}
-
-		var releaseInfo struct {
-			TagName string `json:"tag_name"`
-		}
-		if err := json.Unmarshal(body, &releaseInfo); err != nil {
-			return "", false, err
-		}
-
-		latestVersion := strings.TrimPrefix(releaseInfo.TagName, "v")
-		currentVersionFull, _, _ := GetBuildInfo()
-		currentVersionBase := ExtractBaseVersion(currentVersionFull)
-		needsUpdate := NeedsUpdate(currentVersionBase, latestVersion)
-
-		return latestVersion, needsUpdate, nil
-	}
-	defer func() {
-		CheckLatestVersionImpl = originalCheckImpl
-		GetBuildInfoImpl = originalBuildImpl
-	}()
+	defer func() { GetBuildInfoImpl = originalBuildImpl }()
 
 	ctx := context.Background()
 	latest, hasUpdate, err := CheckLatestVersionWithContext(ctx)
@@ -151,20 +111,98 @@ func TestCheckLatestVersionWithContext_Success(t *testing.T) {
 	assert.True(t, hasUpdate)
 }
 
+// TestGetReport_EnrichesFromRelease cobre o caso go install: sem ldflags o
+// commit é "unknown" e a data vem aproximada do binário; quando a versão
+// instalada é a própria release mais recente, o Report preenche ambos a
+// partir dos metadados da release — sem mutar estado do pacote e sem exigir
+// ordem de chamadas.
+func TestGetReport_EnrichesFromRelease(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"tag_name": "v1.25.0", "target_commitish": "0123456789abcdef", "published_at": "2026-07-01T12:00:00Z"}`))
+	}))
+	defer server.Close()
+	t.Setenv("CHATCLI_LATEST_VERSION_URL", server.URL)
+
+	originalBuildImpl := GetBuildInfoImpl
+	GetBuildInfoImpl = func() (string, string, string) {
+		return "1.25.0", "unknown", "2026-07-10 09:00:00" + buildDateApproxSuffix
+	}
+	defer func() { GetBuildInfoImpl = originalBuildImpl }()
+
+	rep := GetReport(context.Background())
+
+	assert.NoError(t, rep.CheckErr)
+	assert.Equal(t, "1.25.0", rep.Latest)
+	assert.False(t, rep.NeedsUpdate)
+	assert.Equal(t, "0123456789ab", rep.Current.CommitHash, "commit deve vir da release, truncado em 12")
+	assert.Equal(t, "2026-07-01 12:00:00", rep.Current.BuildDate, "data aproximada deve ceder à data da release")
+
+	// Pureza: as globais do pacote não podem ter sido tocadas.
+	assert.Equal(t, "unknown", CommitHash)
+	assert.Equal(t, "unknown", BuildDate)
+}
+
+// TestGetReport_NoEnrichmentOnVersionMismatch garante que metadados de uma
+// release DIFERENTE da versão instalada nunca contaminam o build info.
+func TestGetReport_NoEnrichmentOnVersionMismatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"tag_name": "v1.26.0", "target_commitish": "0123456789abcdef", "published_at": "2026-07-01T12:00:00Z"}`))
+	}))
+	defer server.Close()
+	t.Setenv("CHATCLI_LATEST_VERSION_URL", server.URL)
+
+	originalBuildImpl := GetBuildInfoImpl
+	GetBuildInfoImpl = func() (string, string, string) {
+		return "1.25.0", "unknown", "unknown"
+	}
+	defer func() { GetBuildInfoImpl = originalBuildImpl }()
+
+	rep := GetReport(context.Background())
+
+	assert.True(t, rep.NeedsUpdate)
+	assert.Equal(t, "unknown", rep.Current.CommitHash)
+	assert.Equal(t, "unknown", rep.Current.BuildDate)
+}
+
+// TestGetReport_LdflagsWinOverRelease: um build de release (ldflags) já tem
+// commit/data reais — os metadados do GitHub não devem sobrescrevê-los.
+func TestGetReport_LdflagsWinOverRelease(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"tag_name": "v1.25.0", "target_commitish": "ffffffffffff", "published_at": "2026-07-01T12:00:00Z"}`))
+	}))
+	defer server.Close()
+	t.Setenv("CHATCLI_LATEST_VERSION_URL", server.URL)
+
+	originalBuildImpl := GetBuildInfoImpl
+	GetBuildInfoImpl = func() (string, string, string) {
+		return "1.25.0", "abc1234", "2026-06-30 08:00:00"
+	}
+	defer func() { GetBuildInfoImpl = originalBuildImpl }()
+
+	rep := GetReport(context.Background())
+
+	assert.Equal(t, "abc1234", rep.Current.CommitHash)
+	assert.Equal(t, "2026-06-30 08:00:00", rep.Current.BuildDate)
+}
+
 func TestCheckLatestVersion_DisabledViaEnv(t *testing.T) {
 	t.Setenv("CHATCLI_DISABLE_VERSION_CHECK", "true")
 
-	originalImpl := CheckLatestVersionImpl
-	defer func() { CheckLatestVersionImpl = originalImpl }()
-
-	// Re-assign the default impl to pick up the env var check we just added
-	// (the closure captures os.Getenv at call time, not at init time)
 	ctx := context.Background()
 	latest, needsUpdate, err := CheckLatestVersionWithContext(ctx)
 
 	assert.NoError(t, err)
 	assert.Empty(t, latest)
 	assert.False(t, needsUpdate)
+
+	// GetReport respeita o mesmo opt-out: só build info, sem rede.
+	rep := GetReport(ctx)
+	assert.NoError(t, rep.CheckErr)
+	assert.Empty(t, rep.Latest)
+	assert.False(t, rep.NeedsUpdate)
 }
 
 func TestCheckLatestVersion_DisabledCaseInsensitive(t *testing.T) {
@@ -186,44 +224,9 @@ func TestCheckLatestVersionWithContext_Timeout(t *testing.T) {
 	}))
 	defer server.Close()
 
-	// Salva original
-	originalImpl := CheckLatestVersionImpl
-
-	// Override com implementação que usa o servidor de teste (com delay)
-	CheckLatestVersionImpl = func(ctx context.Context) (string, bool, error) {
-		client := &http.Client{Timeout: 5 * time.Second}
-		req, err := http.NewRequestWithContext(ctx, "GET", server.URL, nil)
-		if err != nil {
-			return "", false, err
-		}
-		req.Header.Set("User-Agent", "ChatCLI-Version-Checker")
-
-		resp, err := client.Do(req)
-		if err != nil {
-			return "", false, err
-		}
-		defer resp.Body.Close()
-
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return "", false, err
-		}
-
-		var releaseInfo struct {
-			TagName string `json:"tag_name"`
-		}
-		if err := json.Unmarshal(body, &releaseInfo); err != nil {
-			return "", false, err
-		}
-
-		latestVersion := strings.TrimPrefix(releaseInfo.TagName, "v")
-		currentVersionFull, _, _ := GetBuildInfo()
-		currentVersionBase := ExtractBaseVersion(currentVersionFull)
-		needsUpdate := NeedsUpdate(currentVersionBase, latestVersion)
-
-		return latestVersion, needsUpdate, nil
-	}
-	defer func() { CheckLatestVersionImpl = originalImpl }()
+	// Aponta o fetch DEFAULT (código real) para o servidor lento; o ctx do
+	// caller expira antes da resposta.
+	t.Setenv("CHATCLI_LATEST_VERSION_URL", server.URL)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()


### PR DESCRIPTION
## Summary

Windows users hit four independent defects that together made coder mode nearly unusable. This PR fixes all of them at root cause, plus the security gaps a full Windows path-handling sweep uncovered.

## 1. Coder mode froze after the first message

Typing showed nothing until Enter was pressed. Root cause: the centralized stdin reader polls with WaitForSingleObject, which signals for any console event — resize, focus, mouse — not just keystrokes. The goroutine then entered a blocking console read that stopStdinReader could not cancel, and the orphaned read stole keystrokes from the next go-prompt instance (which is what echoes them).

- The poll now classifies pending records with PeekConsoleInput: only a key-down carrying a character counts as ready, and non-text records are drained so they stop re-signaling.
- A still-blocked read is aborted with CancelSynchronousIo on the reader's locked OS thread — the documented API for cancelling synchronous console I/O. No synthetic input, no console-buffer mutation.
- RestoreCookedMode and resetTTYToSane now have a real SetConsoleMode implementation instead of being no-ops on Windows, so a raw mode left behind by a dirty overlay teardown no longer persists forever.

## 2. Coder write rejected every valid Windows path

Boundary checks concatenated a slash by hand, which never matches backslashed absolute paths — so anything short of exact equality was outside the workspace boundary. The new stdlib-only pkg/fspath package normalizes separators and compares case-insensitively on Windows, and now backs the engine and both agent validators.

The sweep across all tools also fixed real security gaps on Windows:
- The sensitive-file read blocklist was anchored to HOME, which is unset on Windows — SSH, AWS, GPG keys and kubeconfig were readable in agent mode. Now uses os.UserHomeDir.
- CHATCLI_AGENT_EXTRA_READ_PATHS split on colon, breaking drive letters. Now filepath.SplitList.
- Path traversal detection only matched forward-slash traversal; backslash traversal passed. 
- Sensitive-path matching was case-sensitive on a case-insensitive filesystem.
- Command allowlists did not strip backslashed directory prefixes nor Windows executable extensions.
- SystemRoot joined the sensitive-path blocklist as the Windows counterpart of the unix system dirs.

## 3. Tool args with Windows paths aborted the call

Models emit single-backslash Windows paths — invalid JSON escapes — and sometimes double-encode the args envelope as a JSON string. Both aborted the tool call with parsing errors. RepairJSONInvalidEscapes repairs dirty string literals with an all-or-nothing per-literal rule: a string containing any invalid escape is treated as unescaped, so coincidentally valid escapes inside it (backslash-b in builder, backslash-t in temp) become path separators, while clean sibling strings keep their legitimate escapes. The flattener and the policy normalizer both recover string envelopes, so the security prompt shows real flags instead of a JSON blob.

## 4. Prompt climbed and left ghost lines; version info empty on go install

- go-prompt skips the wrap-materializing newline on Windows, assuming legacy immediate wrap — but VT-enabled consoles (Windows Terminal, conhost with VT) use deferred wrap, desyncing its cursor model one row per exact column boundary. With the animated live prefix re-rendering four times a second, the prompt climbed continuously and the completion dropdown left ghost copies of the input line. A wrap-aware ConsoleWriter (OptionWriter, gated on VT being active) tracks the cursor column and injects the newline at the boundary, aligning the console with go-prompt's model. The palette overlay also erases the committed trigger line before opening.
- Version displays snapshotted ldflags globals before the update check enriched them, so go install builds always showed unknown commit and date — and one display path had already drifted out of the required call order. The version package is now side-effect free: a single injectable fetch seam, pure enrichment on VersionInfo, and GetReport composing everything order-independently for all three display paths.

## Testing

- Unit tests for every fix, including regression fixtures reproducing the exact field failures; red-green verified by reverting the flattener and watching the new tests fail.
- Full suite green; builds for darwin, linux and windows; golangci-lint clean natively and with GOOS=windows (which the native run does not cover for the _windows.go files).
- Known limitation stated in code: resizing the terminal mid-session still confuses go-prompt's frozen width on Windows; that requires the planned TUI migration.

## Impact

No API or dependency changes. go.mod untouched. All changes are Windows-gated or behavior-preserving on unix.