### PR TITLE
fix(scheduler): re-arm park polling in place to survive rescheduling

### DIFF
--- a/cli/agent_park.go
+++ b/cli/agent_park.go
@@ -184,10 +184,19 @@ func (a *AgentMode) enqueueParkJob(ctx context.Context, snap *park.Snapshot) (st
 		} else {
 			payload["command"] = req.Command
 		}
+		// Interval (recurring) on purpose: every poll cycle re-arms the
+		// SAME job in place (same JobID, same name-index entry), so the
+		// snapshot's SchedulerJobID stays valid for /parked and
+		// /cancel-park across cycles. A one-shot job that re-enqueues a
+		// sibling under the same name is rejected by the scheduler's
+		// duplicate-name admission while the current cycle is still
+		// Running — the poll chain died on the first non-matching probe.
+		// ParkPoll ends the recurrence via StopRecurrence when the probe
+		// matches or the deadline elapses.
 		job := scheduler.NewJob(
 			"park-poll:"+snap.Token,
 			owner,
-			scheduler.Schedule{Kind: scheduler.ScheduleRelative, Relative: req.Interval},
+			scheduler.Schedule{Kind: scheduler.ScheduleInterval, Interval: req.Interval},
 			scheduler.Action{Type: scheduler.ActionParkPoll, Payload: payload},
 		)
 		// Park is interactively user-approved before this code runs:

--- a/cli/scheduler/action/park_poll.go
+++ b/cli/scheduler/action/park_poll.go
@@ -5,14 +5,31 @@
  * (HTTP via the bridge or shell via RunShell), evaluates SuccessWhen,
  * and either:
  *
- *   - matches  → enqueue a one-shot AgentResume (outcome=matched)
- *   - timeouts → enqueue a one-shot AgentResume (outcome=timeout)
- *   - waits    → re-enqueue itself for `now + interval`
+ *   - matches  → enqueue a one-shot AgentResume (outcome=matched) and
+ *                finalize the recurring job via StopRecurrence
+ *   - timeouts → enqueue a one-shot AgentResume (outcome=timeout) and
+ *                finalize the recurring job via StopRecurrence
+ *   - waits    → return success so the dispatcher re-arms the SAME job
+ *                for the next interval cycle
  *
- * Self-rescheduling keeps each scheduler firing bounded and idempotent;
- * a single fire never blocks beyond the per-iteration HTTP/shell
- * timeout. Crash-resilience falls out of the scheduler WAL: an
- * incomplete poll iteration is replayed on restart.
+ * The poll job is a recurring interval schedule re-armed in place: one
+ * JobID and one name-index entry across every cycle. Re-enqueueing a
+ * sibling job under the same name (the original design) is rejected by
+ * the scheduler's duplicate-name admission while the current cycle is
+ * still Running — the chain died on the first non-matching probe.
+ * Sibling re-scheduling survives only as a fallback for legacy one-shot
+ * relative jobs replayed from a pre-upgrade WAL, with a per-iteration
+ * unique name.
+ *
+ * Each firing stays bounded and idempotent; a single fire never blocks
+ * beyond the per-iteration HTTP/shell timeout. Crash-resilience falls
+ * out of the scheduler WAL: an incomplete poll iteration is replayed on
+ * restart.
+ *
+ * Failure is never silent: if the poll chain cannot continue (legacy
+ * re-enqueue rejected) or the resume job cannot be admitted, the
+ * executor falls back to waking the agent directly through
+ * NotifyParkComplete so the user always hears back from a park.
  *
  * Payload (all strings are durations parseable by time.ParseDuration
  * unless noted):
@@ -36,6 +53,7 @@ package action
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -117,19 +135,28 @@ func (p ParkPoll) Execute(ctx context.Context, action scheduler.Action, env *sch
 	// Run the probe, classify, and decide.
 	matched, summary, runErr := p.probe(ctx, env, action, mode, probeTimeout)
 	if runErr != nil {
-		// Transient probe failure: log it and re-schedule.
-		// Permanent shape errors (e.g. invalid URL) bubble up to the
-		// scheduler's failure path, which still triggers the retry
-		// policy but caps at MaxRetries — eventually firing AgentResume
-		// with timeout if the probes never recover.
-		return p.rescheduleSelf(ctx, action, env, "probe error: "+runErr.Error(), false)
+		// Probe failure: keep the cycle alive and try again on the
+		// next interval — the absolute deadline above caps how long a
+		// broken probe can spin before AgentResume fires with timeout.
+		return p.continuePolling(ctx, action, env, "probe error: "+runErr.Error())
 	}
 
 	if matchSuccessWhen(successWhen, summary, matched) {
 		return p.fireResume(ctx, env, token, "matched", summary.detail())
 	}
 
-	return p.rescheduleSelf(ctx, action, env, "probe did not match yet: "+summary.short(), true)
+	return p.continuePolling(ctx, action, env, "probe did not match yet: "+summary.short())
+}
+
+// continuePolling keeps the poll chain alive for one more interval. On
+// the recurring (interval) schedule this is simply a successful result —
+// the dispatcher re-arms the same job. Legacy one-shot relative jobs
+// replayed from a pre-upgrade WAL fall back to sibling re-scheduling.
+func (p ParkPoll) continuePolling(ctx context.Context, action scheduler.Action, env *scheduler.ExecEnv, reason string) scheduler.ActionResult {
+	if strings.HasPrefix(env.Job.Type, string(scheduler.ScheduleInterval)) {
+		return scheduler.ActionResult{Output: "park_poll: waiting — " + reason}
+	}
+	return p.rescheduleSelf(ctx, action, env, reason)
 }
 
 // probeSummary captures the fields evaluated by SuccessWhen.
@@ -265,13 +292,27 @@ func matchNumberOrRange(actual int, spec string) bool {
 }
 
 // fireResume queues a one-shot AgentResume job that the scheduler will
-// fire immediately. Returns a successful ActionResult so the polling
-// chain itself records as completed.
+// fire immediately. Returns a successful ActionResult with
+// StopRecurrence set so the recurring poll job finalizes instead of
+// re-arming another cycle.
 //
 // Schedule must be positive — Schedule.Validate rejects Relative=0 — so
 // we use 1ms which the dispatcher rounds to "due now" on the next tick
 // of the queue (typically <100ms). Effectively immediate.
+//
+// A duplicate-name rejection means an identically-named resume job is
+// already live (a retried closing cycle) — the wake-up is on its way,
+// so it counts as success. Any other admission failure falls back to
+// waking the agent directly through the bridge: a park must never end
+// without the user hearing back.
 func (ParkPoll) fireResume(ctx context.Context, env *scheduler.ExecEnv, token, outcome, detail string) scheduler.ActionResult {
+	done := scheduler.ActionResult{
+		Output:         fmt.Sprintf("resume fired: outcome=%s", outcome),
+		StopRecurrence: true,
+	}
+	if env.Enqueue == nil {
+		return scheduler.ActionResult{Err: fmt.Errorf("park_poll: scheduler enqueue not wired")}
+	}
 	job := scheduler.NewJob(
 		"park-resume:"+token,
 		env.Job.Owner,
@@ -286,33 +327,53 @@ func (ParkPoll) fireResume(ctx context.Context, env *scheduler.ExecEnv, token, o
 		},
 	)
 	job.DangerousConfirmed = env.Job.DangerousConfirmed
-	if env.Enqueue == nil {
-		return scheduler.ActionResult{Err: fmt.Errorf("park_poll: scheduler enqueue not wired")}
+	_, err := env.Enqueue(ctx, job)
+	if err == nil || errors.Is(err, scheduler.ErrDuplicateName) {
+		return done
 	}
-	if _, err := env.Enqueue(ctx, job); err != nil {
-		return scheduler.ActionResult{Err: fmt.Errorf("park_poll: enqueue resume: %w", err)}
+	if env.Bridge != nil {
+		if nerr := env.Bridge.NotifyParkComplete(ctx, token, outcome, detail); nerr == nil {
+			done.Output += " (direct notify; resume job rejected: " + err.Error() + ")"
+			return done
+		}
 	}
-	return scheduler.ActionResult{Output: fmt.Sprintf("resume fired: outcome=%s", outcome)}
+	return scheduler.ActionResult{Err: fmt.Errorf("park_poll: enqueue resume: %w", err)}
 }
 
-// rescheduleSelf enqueues another ParkPoll iteration.
-func (p ParkPoll) rescheduleSelf(ctx context.Context, action scheduler.Action, env *scheduler.ExecEnv, reason string, transient bool) scheduler.ActionResult {
-	interval := payloadDuration(action, "interval", 30*time.Second)
-	job := scheduler.NewJob(
-		"park-poll:"+action.PayloadString("resume_token", ""),
-		env.Job.Owner,
-		scheduler.Schedule{Kind: scheduler.ScheduleRelative, Relative: interval},
-		action,
-	)
-	job.DangerousConfirmed = env.Job.DangerousConfirmed
+// rescheduleSelf enqueues a sibling ParkPoll iteration. Legacy path for
+// one-shot relative jobs replayed from a pre-upgrade WAL — recurring
+// jobs re-arm in place and never come through here. The sibling gets a
+// per-iteration unique name because the scheduler's duplicate-name
+// admission rejects the base name while the current cycle is still
+// Running. If the sibling cannot be admitted, the chain wakes the agent
+// with an error outcome instead of dying silently.
+func (p ParkPoll) rescheduleSelf(ctx context.Context, action scheduler.Action, env *scheduler.ExecEnv, reason string) scheduler.ActionResult {
+	token := action.PayloadString("resume_token", "")
 	if env.Enqueue == nil {
 		return scheduler.ActionResult{Err: fmt.Errorf("park_poll: scheduler enqueue not wired")}
 	}
+
+	// Copy the payload before bumping the iteration counter — the map
+	// is shared with the running job, which the scheduler may be
+	// serializing to the WAL concurrently.
+	iteration := payloadInt64(action, "iteration") + 1
+	payload := make(map[string]any, len(action.Payload)+1)
+	for k, v := range action.Payload {
+		payload[k] = v
+	}
+	payload["iteration"] = iteration
+
+	interval := payloadDuration(action, "interval", 30*time.Second)
+	job := scheduler.NewJob(
+		fmt.Sprintf("park-poll:%s.i%d", token, iteration),
+		env.Job.Owner,
+		scheduler.Schedule{Kind: scheduler.ScheduleRelative, Relative: interval},
+		scheduler.Action{Type: action.Type, Payload: payload},
+	)
+	job.DangerousConfirmed = env.Job.DangerousConfirmed
 	if _, err := env.Enqueue(ctx, job); err != nil {
-		return scheduler.ActionResult{Err: fmt.Errorf("park_poll: re-enqueue: %w", err)}
+		return p.fireResume(ctx, env, token, "error",
+			fmt.Sprintf("park polling aborted: could not schedule the next probe (%s); last state: %s", err, reason))
 	}
-	return scheduler.ActionResult{
-		Output:    "park_poll: rescheduled — " + reason,
-		Transient: transient,
-	}
+	return scheduler.ActionResult{Output: "park_poll: rescheduled — " + reason}
 }

--- a/cli/scheduler/action/park_poll_integration_test.go
+++ b/cli/scheduler/action/park_poll_integration_test.go
@@ -1,0 +1,160 @@
+/*
+ * Integration tests for the @park polling loop against a REAL
+ * scheduler. The unit tests in park_poll_test.go stub env.Enqueue, so
+ * they never exercise Scheduler.Enqueue's duplicate-name admission —
+ * which is exactly where the poll chain used to die: the re-scheduled
+ * iteration reused the live job's name and was rejected with
+ * ErrDuplicateName on the very first non-matching probe.
+ */
+package action
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/diillson/chatcli/cli/scheduler"
+)
+
+// newParkScheduler boots a real scheduler wired to the fake bridge with
+// only the park executors registered.
+func newParkScheduler(t *testing.T, b *fakeBridge) *scheduler.Scheduler {
+	t.Helper()
+	cfg := scheduler.DefaultConfig()
+	cfg.DataDir = t.TempDir()
+	cfg.AuditEnabled = false
+	cfg.SnapshotInterval = 0
+	cfg.WALGCInterval = 0
+	cfg.DaemonAutoConnect = false
+
+	s, err := scheduler.New(cfg, b, scheduler.SchedulerDeps{}, nil)
+	if err != nil {
+		t.Fatalf("scheduler.New: %v", err)
+	}
+	if err := s.Actions().Register(NewParkPoll()); err != nil {
+		t.Fatalf("register park_poll: %v", err)
+	}
+	if err := s.Actions().Register(NewAgentResume()); err != nil {
+		t.Fatalf("register agent_resume: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	if err := s.Start(ctx); err != nil {
+		t.Fatalf("scheduler start: %v", err)
+	}
+	t.Cleanup(func() { s.DrainAndShutdown(2 * time.Second) })
+	return s
+}
+
+func waitFor(t *testing.T, timeout time.Duration, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("timed out after %s waiting for %s", timeout, what)
+}
+
+func parkPollAction(token, interval string, deadline time.Time) scheduler.Action {
+	return scheduler.Action{
+		Type: scheduler.ActionParkPoll,
+		Payload: map[string]any{
+			"resume_token":  token,
+			"mode":          "for_cmd",
+			"command":       "check-status",
+			"interval":      interval,
+			"deadline_unix": deadline.Unix(),
+			"success_when":  "exit=0",
+		},
+	}
+}
+
+// TestParkPoll_RealScheduler_RearmsAcrossCyclesAndStopsOnMatch is the
+// user-reported scenario: a for_cmd park whose probe does NOT match on
+// the first firing must keep polling (it used to fail with "scheduler:
+// duplicate name" on the first re-schedule), then fire AgentResume once
+// the probe matches — and the recurring job must finalize instead of
+// polling forever.
+func TestParkPoll_RealScheduler_RearmsAcrossCyclesAndStopsOnMatch(t *testing.T) {
+	b := &fakeBridge{cmdExit: 1}
+	b.cmdMatchAfter.Store(3) // probes 1-2 miss, probe 3 matches
+	s := newParkScheduler(t, b)
+
+	const token = "tok-int-rearm"
+	job := scheduler.NewJob(
+		"park-poll:"+token,
+		scheduler.Owner{Kind: "park", ID: "agent", Tag: token},
+		scheduler.Schedule{Kind: scheduler.ScheduleInterval, Interval: 80 * time.Millisecond},
+		parkPollAction(token, "80ms", time.Now().Add(time.Minute)),
+	)
+	job.DangerousConfirmed = true
+
+	created, err := s.Enqueue(context.Background(), job)
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	waitFor(t, 10*time.Second, "AgentResume to notify the bridge", func() bool {
+		return b.notifyCalls.Load() >= 1
+	})
+	if b.notifyOut != "matched" {
+		t.Fatalf("resume outcome: want matched, got %q", b.notifyOut)
+	}
+	if b.notifyTok != token {
+		t.Fatalf("resume token: want %q, got %q", token, b.notifyTok)
+	}
+	if got := b.cmdCalls.Load(); got < 3 {
+		t.Fatalf("poll must survive re-scheduling across cycles: want >=3 probes, got %d", got)
+	}
+
+	// The whole poll must have run on the SAME job record (in-place
+	// re-arm), and the match must stop the recurrence.
+	waitFor(t, 5*time.Second, "poll job to reach a terminal status", func() bool {
+		j, qerr := s.Query(created.ID)
+		return qerr == nil && j.Status.IsTerminal()
+	})
+	j, err := s.Query(created.ID)
+	if err != nil {
+		t.Fatalf("query poll job: %v", err)
+	}
+	if j.Status != scheduler.StatusCompleted {
+		t.Fatalf("poll job status: want %s, got %s (last error: %+v)", scheduler.StatusCompleted, j.Status, j.LastResult)
+	}
+}
+
+// TestParkPoll_RealScheduler_LegacyRelativeJob_KeepsPolling covers
+// pre-upgrade jobs replayed from the WAL: they still carry the old
+// one-shot relative schedule, so the executor must fall back to sibling
+// re-scheduling — with a name the admission check accepts.
+func TestParkPoll_RealScheduler_LegacyRelativeJob_KeepsPolling(t *testing.T) {
+	b := &fakeBridge{cmdExit: 1}
+	b.cmdMatchAfter.Store(2) // probe 1 misses, probe 2 matches
+	s := newParkScheduler(t, b)
+
+	const token = "tok-legacy-poll"
+	job := scheduler.NewJob(
+		"park-poll:"+token,
+		scheduler.Owner{Kind: "park", ID: "agent", Tag: token},
+		scheduler.Schedule{Kind: scheduler.ScheduleRelative, Relative: 60 * time.Millisecond},
+		parkPollAction(token, "60ms", time.Now().Add(time.Minute)),
+	)
+	job.DangerousConfirmed = true
+
+	if _, err := s.Enqueue(context.Background(), job); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	waitFor(t, 10*time.Second, "AgentResume to notify the bridge", func() bool {
+		return b.notifyCalls.Load() >= 1
+	})
+	if b.notifyOut != "matched" {
+		t.Fatalf("resume outcome: want matched, got %q", b.notifyOut)
+	}
+	if got := b.cmdCalls.Load(); got < 2 {
+		t.Fatalf("legacy poll must keep polling: want >=2 probes, got %d", got)
+	}
+}

--- a/cli/scheduler/action/park_poll_test.go
+++ b/cli/scheduler/action/park_poll_test.go
@@ -27,6 +27,10 @@ type fakeBridge struct {
 	cmdExit   int
 	cmdErr    error
 	cmdCalls  atomic.Int32
+	// cmdMatchAfter, when > 0, forces exit 0 from that probe count on.
+	// Lets integration tests flip a failing probe to success without a
+	// data race on cmdExit mid-run.
+	cmdMatchAfter atomic.Int32
 
 	notifyCalls atomic.Int32
 	notifyTok   string
@@ -48,8 +52,12 @@ func (f *fakeBridge) SendLLMPrompt(_ context.Context, _, _ string, _ int) (strin
 }
 func (f *fakeBridge) FireHook(_ hooks.HookEvent) *hooks.HookResult { return nil }
 func (f *fakeBridge) RunShell(_ context.Context, _ string, _ map[string]string, _, _ bool) (string, string, int, error) {
-	f.cmdCalls.Add(1)
-	return f.cmdStdout, f.cmdStderr, f.cmdExit, f.cmdErr
+	calls := f.cmdCalls.Add(1)
+	exit := f.cmdExit
+	if after := f.cmdMatchAfter.Load(); after > 0 && calls >= after {
+		exit = 0
+	}
+	return f.cmdStdout, f.cmdStderr, exit, f.cmdErr
 }
 func (f *fakeBridge) ClassifyShellCommand(_ string) scheduler.ShellPolicy {
 	return scheduler.ShellPolicyAllow
@@ -61,8 +69,10 @@ func (f *fakeBridge) LLMClient() client.LLMClient    { return nil }
 func (f *fakeBridge) AppendHistory(_ models.Message) {}
 func (f *fakeBridge) PublishEvent(_ scheduler.Event) {}
 func (f *fakeBridge) NotifyParkComplete(_ context.Context, tok, outcome, detail string) error {
-	f.notifyCalls.Add(1)
+	// Fields first, counter last: the atomic Add is the release edge a
+	// concurrent test observes before reading the fields.
 	f.notifyTok, f.notifyOut, f.notifyDet = tok, outcome, detail
+	f.notifyCalls.Add(1)
 	return nil
 }
 func (f *fakeBridge) RunHTTPProbe(_ context.Context, _, _ string, _ map[string]string, _ time.Duration) (int, string, error) {
@@ -176,8 +186,105 @@ func TestParkPoll_HTTP_RescheduleSelf(t *testing.T) {
 	if len(enq.jobs) != 1 || enq.jobs[0].Action.Type != scheduler.ActionParkPoll {
 		t.Fatalf("expected self-reschedule, got %+v", enq.jobs)
 	}
-	if !res.Transient {
-		t.Fatalf("non-match probe should mark Transient so retry policy applies")
+	// The sibling must NOT reuse the live job's name — the scheduler's
+	// duplicate-name admission would reject it while the current cycle
+	// is still Running.
+	if enq.jobs[0].Name != "park-poll:tok-abcdefgh.i1" {
+		t.Fatalf("sibling must carry a per-iteration unique name, got %q", enq.jobs[0].Name)
+	}
+	if res.StopRecurrence {
+		t.Fatalf("waiting must not stop recurrence")
+	}
+}
+
+func TestParkPoll_RecurringJob_WaitsInPlace(t *testing.T) {
+	b := &fakeBridge{httpStatus: 503}
+	enq := &trackingEnqueue{}
+	env := newEnv(t, b, enq)
+	env.Job.Type = string(scheduler.ScheduleInterval)
+
+	action := scheduler.Action{
+		Type: scheduler.ActionParkPoll,
+		Payload: map[string]any{
+			"resume_token":  "tok-abcdefgh",
+			"mode":          "for_url",
+			"url":           "https://x",
+			"interval":      "30s",
+			"deadline_unix": time.Now().Add(5 * time.Minute).Unix(),
+			"success_when":  "status=200",
+		},
+	}
+	res := ParkPoll{}.Execute(context.Background(), action, env)
+	if res.Err != nil {
+		t.Fatalf("execute err: %v", res.Err)
+	}
+	// Recurring jobs re-arm in the dispatcher: no sibling enqueue, no
+	// StopRecurrence — a plain success carries the cycle forward.
+	if len(enq.jobs) != 0 {
+		t.Fatalf("recurring job must not enqueue a sibling, got %+v", enq.jobs)
+	}
+	if res.StopRecurrence {
+		t.Fatalf("waiting must not stop recurrence")
+	}
+}
+
+func TestParkPoll_Match_StopsRecurrence(t *testing.T) {
+	b := &fakeBridge{httpStatus: 200}
+	enq := &trackingEnqueue{}
+	env := newEnv(t, b, enq)
+	env.Job.Type = string(scheduler.ScheduleInterval)
+
+	action := scheduler.Action{
+		Type: scheduler.ActionParkPoll,
+		Payload: map[string]any{
+			"resume_token":  "tok-abcdefgh",
+			"mode":          "for_url",
+			"url":           "https://x",
+			"interval":      "30s",
+			"deadline_unix": time.Now().Add(5 * time.Minute).Unix(),
+			"success_when":  "status=200",
+		},
+	}
+	res := ParkPoll{}.Execute(context.Background(), action, env)
+	if res.Err != nil {
+		t.Fatalf("execute err: %v", res.Err)
+	}
+	if !res.StopRecurrence {
+		t.Fatalf("matched probe must finalize the recurring poll job")
+	}
+	if len(enq.jobs) != 1 || enq.jobs[0].Action.Type != scheduler.ActionAgentResume {
+		t.Fatalf("expected AgentResume fanout, got %+v", enq.jobs)
+	}
+}
+
+func TestParkPoll_ResumeEnqueueRejected_NotifiesBridgeDirectly(t *testing.T) {
+	b := &fakeBridge{httpStatus: 200}
+	env := newEnv(t, b, &trackingEnqueue{})
+	env.Job.Type = string(scheduler.ScheduleInterval)
+	env.Enqueue = func(_ context.Context, _ *scheduler.Job) (*scheduler.Job, error) {
+		return nil, errors.New("admission rejected")
+	}
+
+	action := scheduler.Action{
+		Type: scheduler.ActionParkPoll,
+		Payload: map[string]any{
+			"resume_token":  "tok-abcdefgh",
+			"mode":          "for_url",
+			"url":           "https://x",
+			"interval":      "30s",
+			"deadline_unix": time.Now().Add(5 * time.Minute).Unix(),
+			"success_when":  "status=200",
+		},
+	}
+	res := ParkPoll{}.Execute(context.Background(), action, env)
+	if res.Err != nil {
+		t.Fatalf("direct-notify fallback must succeed, got err: %v", res.Err)
+	}
+	if !res.StopRecurrence {
+		t.Fatalf("fallback wake-up must still finalize the poll job")
+	}
+	if b.notifyCalls.Load() != 1 || b.notifyOut != "matched" {
+		t.Fatalf("bridge must be notified directly: calls=%d outcome=%q", b.notifyCalls.Load(), b.notifyOut)
 	}
 }
 

--- a/cli/scheduler/dispatcher.go
+++ b/cli/scheduler/dispatcher.go
@@ -411,8 +411,10 @@ func (s *Scheduler) runAction(ctx context.Context, j *Job) {
 	if res.Err == nil {
 		// Recurring schedules re-arm here, BEFORE the (terminal)
 		// Completed transition. Non-recurring jobs go straight to
-		// Completed and run unblockDependents / fireTriggers.
-		if j.Schedule.IsRecurring() {
+		// Completed and run unblockDependents / fireTriggers. An
+		// executor that reached its own termination condition opts
+		// out of the re-arm via StopRecurrence.
+		if j.Schedule.IsRecurring() && !res.StopRecurrence {
 			s.rearmRecurring(j, exec)
 			return
 		}

--- a/cli/scheduler/registry.go
+++ b/cli/scheduler/registry.go
@@ -136,6 +136,13 @@ type ActionResult struct {
 	// Transient mirrors EvalOutcome.Transient — retryable vs permanent.
 	Transient bool
 	Err       error
+	// StopRecurrence asks the dispatcher to finalize a recurring job
+	// after this successful execution instead of re-arming the next
+	// cycle. Executors that own their own termination condition (e.g.
+	// park_poll, which polls until its probe matches or its deadline
+	// elapses) set this on the closing cycle. Ignored when Err != nil
+	// or the schedule is not recurring.
+	StopRecurrence bool
 }
 
 // ActionExecutor is a plug-in that can run one action type.

--- a/cli/scheduler/scheduler.go
+++ b/cli/scheduler/scheduler.go
@@ -471,20 +471,26 @@ func (s *Scheduler) Enqueue(ctx context.Context, job *Job) (*Job, error) {
 	s.byName[job.Name] = job.ID
 	s.mu.Unlock()
 
-	if job.Status == StatusPending && !job.NextFireAt.IsZero() {
-		s.queue.Enqueue(job.ID, job.NextFireAt)
+	// Snapshot creation-time state BEFORE handing the job to the queue:
+	// a job that is already due (e.g. the 1ms relative park resume) can
+	// be picked up by a worker and transitioned while this function is
+	// still running, so lock-free reads of job fields past the
+	// queue.Enqueue below would race with that transition.
+	clone := job.Clone()
+
+	if clone.Status == StatusPending && !clone.NextFireAt.IsZero() {
+		s.queue.Enqueue(job.ID, clone.NextFireAt)
 	}
 
-	s.metrics.JobsCreated.WithLabelValues(string(job.Owner.Kind), string(job.Action.Type)).Inc()
+	s.metrics.JobsCreated.WithLabelValues(string(clone.Owner.Kind), string(clone.Action.Type)).Inc()
 	s.metrics.ActiveJobs.Set(float64(s.activeCount()))
 	s.metrics.QueueDepth.Set(float64(s.queue.Len()))
 	s.version.Add(1)
 
 	s.emit(NewEvent(EventJobCreated).WithJob(job).
-		WithMessage(fmt.Sprintf("job %q created (status=%s)", job.Name, job.Status)).
-		WithData("action", string(job.Action.Type)))
+		WithMessage(fmt.Sprintf("job %q created (status=%s)", clone.Name, clone.Status)).
+		WithData("action", string(clone.Action.Type)))
 
-	clone := job.Clone()
 	return clone, nil
 }
 

--- a/cli/scheduler_bridge.go
+++ b/cli/scheduler_bridge.go
@@ -654,8 +654,41 @@ func (b *schedulerBridge) PublishEvent(evt scheduler.Event) {
 	// force-refreshing the go-prompt prefix. Cheap no-op if not in an
 	// interactive loop.
 	b.cli.markSchedulerDirty()
-	_ = evt
+
+	// Safety net: a park job that dies OUTSIDE its executor (action
+	// timeout, breaker open, retries exhausted, WAL write error) never
+	// reaches the executor's own wake-up fallbacks — without this hook
+	// the parked agent stays suspended forever and the user is told
+	// nothing unless they run /parked. Wake the agent with an error
+	// outcome; the resume path is idempotent per token.
+	if token, outcome, detail, ok := parkWakeupFromEvent(evt); ok {
+		if err := b.wakeParkedAgent(token, outcome, detail); err != nil && b.cli.logger != nil {
+			b.cli.logger.Warn("park: failed to wake agent after scheduler job failure",
+				zap.String("token", token),
+				zap.String("job_id", string(evt.JobID)),
+				zap.Error(err))
+		}
+	}
 	_ = time.Now
+}
+
+// parkWakeupFromEvent decides whether a scheduler event represents a
+// park job dying without having resumed its agent, and if so, how to
+// wake it. Park jobs carry the resume token in Owner.Tag. Cancellation
+// is deliberately excluded — /cancel-park owns that conversation.
+func parkWakeupFromEvent(evt scheduler.Event) (token, outcome, detail string, ok bool) {
+	if evt.Type != scheduler.EventJobFailed && evt.Type != scheduler.EventJobTimedOut {
+		return "", "", "", false
+	}
+	if evt.Owner.Kind != "park" || evt.Owner.Tag == "" {
+		return "", "", "", false
+	}
+	outcome = "error"
+	if evt.Type == scheduler.EventJobTimedOut {
+		outcome = "timeout"
+	}
+	detail = fmt.Sprintf("scheduler job %q (%s) ended without resuming: %s", evt.Name, evt.JobID, evt.Message)
+	return evt.Owner.Tag, outcome, detail, true
 }
 
 // truncateBridge mirrors scheduler.truncate but lives here so we
@@ -677,6 +710,14 @@ func truncateBridge(s string, n int) string {
 // agent invocation — the scheduler dispatcher must not block waiting
 // on the user's interactive loop.
 func (b *schedulerBridge) NotifyParkComplete(_ context.Context, token, outcome, detail string) error {
+	return b.wakeParkedAgent(token, outcome, detail)
+}
+
+// wakeParkedAgent is the context-free body of NotifyParkComplete — the
+// operation is fire-and-forget by design (queue + banner + TTY inject)
+// and must never block on a caller's lifetime, so no context
+// participates. PublishEvent's park wake-up net calls this directly.
+func (b *schedulerBridge) wakeParkedAgent(token, outcome, detail string) error {
 	if b.cli == nil {
 		return fmt.Errorf("park: bridge not bound to CLI")
 	}

--- a/cli/scheduler_bridge_test.go
+++ b/cli/scheduler_bridge_test.go
@@ -17,6 +17,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/diillson/chatcli/cli/scheduler"
 )
 
 func TestClassifyAgentSlash(t *testing.T) {
@@ -220,5 +222,52 @@ func TestAgentModeRunInflight_CASGuard(t *testing.T) {
 	flag.Store(false)
 	if !flag.CompareAndSwap(false, true) {
 		t.Fatal("after Store(false), CAS should succeed again")
+	}
+}
+
+// TestParkWakeupFromEvent covers the PublishEvent safety net that wakes
+// a parked agent when its scheduler job dies outside the executor
+// (retries exhausted, action timeout, breaker) — previously the park
+// failed silently and nothing came back to the user.
+func TestParkWakeupFromEvent(t *testing.T) {
+	parkOwner := scheduler.Owner{Kind: "park", ID: "agent", Tag: "tok-abcdefgh"}
+
+	failed := scheduler.NewEvent(scheduler.EventJobFailed)
+	failed.Owner = parkOwner
+	failed.Name = "park-poll:tok-abcdefgh"
+	failed.Message = "retries exhausted"
+	token, outcome, detail, ok := parkWakeupFromEvent(failed)
+	if !ok || token != "tok-abcdefgh" || outcome != "error" {
+		t.Fatalf("failed park job must wake with error outcome: ok=%v token=%q outcome=%q", ok, token, outcome)
+	}
+	if !strings.Contains(detail, "retries exhausted") {
+		t.Fatalf("detail must carry the failure message, got %q", detail)
+	}
+
+	timedOut := scheduler.NewEvent(scheduler.EventJobTimedOut)
+	timedOut.Owner = parkOwner
+	if _, outcome, _, ok := parkWakeupFromEvent(timedOut); !ok || outcome != "timeout" {
+		t.Fatalf("timed-out park job must wake with timeout outcome: ok=%v outcome=%q", ok, outcome)
+	}
+
+	// Cancellation is /cancel-park's conversation, not the net's.
+	cancelled := scheduler.NewEvent(scheduler.EventJobCancelled)
+	cancelled.Owner = parkOwner
+	if _, _, _, ok := parkWakeupFromEvent(cancelled); ok {
+		t.Fatal("cancelled park job must not trigger the wake-up net")
+	}
+
+	// Non-park owners never trigger it.
+	other := scheduler.NewEvent(scheduler.EventJobFailed)
+	other.Owner = scheduler.Owner{Kind: scheduler.OwnerUser, ID: "tester"}
+	if _, _, _, ok := parkWakeupFromEvent(other); ok {
+		t.Fatal("non-park job failure must not trigger the wake-up net")
+	}
+
+	// A park owner without a token has nothing to resume.
+	noTag := scheduler.NewEvent(scheduler.EventJobFailed)
+	noTag.Owner = scheduler.Owner{Kind: "park", ID: "agent"}
+	if _, _, _, ok := parkWakeupFromEvent(noTag); ok {
+		t.Fatal("park job without a token must not trigger the wake-up net")
 	}
 }


### PR DESCRIPTION
## Problem

A polling park (`@park for_cmd` / `for_url`) died on its **first non-matching probe** with `scheduler: duplicate name`. The poll job was a one-shot `park-poll:<token>` that re-enqueued a **sibling** job (new ID, same name) while the current cycle was still `Running` — the scheduler's duplicate-name admission correctly rejected it, killing the poll chain. Worse: the park died **silently** — the agent never resumed and nothing was reported to the user unless they inspected `/parked`.

Latent since #879: the unit tests stub `env.Enqueue`, so the real admission path was never exercised.

## Fix

- **In-place re-arm**: the poll job is now a recurring `ScheduleInterval` job re-armed by the existing `rearmRecurring` machinery — one JobID and one name-index entry across every cycle. "Not matched yet" is a successful result that re-arms; "matched / deadline elapsed" finalizes the recurrence through the new additive `ActionResult.StopRecurrence` field. Bonus: the snapshot's `SchedulerJobID` stays valid across cycles, so `/parked` and `/cancel-park` keep pointing at the live job.
- **Never silent**: any failure to continue the chain wakes the agent —
  - `fireResume` treats a duplicate resume job as idempotent success and falls back to notifying the bridge directly if resume admission fails;
  - a legacy sibling that cannot be admitted fires a resume with an `error` outcome;
  - a safety net in `schedulerBridge.PublishEvent` wakes the agent when a park job dies **outside** its executor (retries exhausted, action timeout, breaker) via `EventJobFailed` / `EventJobTimedOut`.
- **Backward compatible**: pre-upgrade one-shot relative jobs replayed from the WAL fall back to sibling rescheduling with a per-iteration unique name (`park-poll:<token>.i<N>`).
- **Pre-existing race fixed**: `Scheduler.Enqueue` read job fields after handing the job to the queue; a 1ms-due job was already being transitioned by a worker. The creation-time snapshot (`Clone`) now happens before `queue.Enqueue`.

## Proof

New integration tests run the poll loop against a **real** scheduler (red before, green after):
- `TestParkPoll_RealScheduler_RearmsAcrossCyclesAndStopsOnMatch` — probe misses twice, matches on the 3rd cycle; same job record end-to-end, resume fires with `matched`, job completes.
- `TestParkPoll_RealScheduler_LegacyRelativeJob_KeepsPolling` — legacy WAL shape keeps polling.

Plus unit coverage for the new transitions (`StopRecurrence`, in-place wait, direct-notify fallback, `parkWakeupFromEvent`). Full gates: `go build ./...`, `go vet ./...`, `golangci-lint run ./...`, `go test ./... -count=1` and `-race` stress on the touched packages — all green.
