### PR TITLE
fix(devin): drop identity coercion and accept tool tag alias

### DIFF
--- a/cli/agent/toolcall_parser.go
+++ b/cli/agent/toolcall_parser.go
@@ -19,6 +19,8 @@ type ToolCall struct {
 // Supported formats:
 //   - XML self-closing: <tool_call name="@x" args="..." />
 //   - XML paired:       <tool_call name="@x" args="..."></tool_call>
+//   - <tool> alias:     <tool name="@x" args="..." /> — models backed by
+//     other agent CLIs (Devin CLI, Codex CLI, Claude Code) shorten the tag
 //   - Attributes in any order, single or double quotes
 //   - Args containing '>' characters (JSON, HTML entities, etc.)
 //   - JSON tool calls:  {"tool_call":"@coder","args":{...}}
@@ -112,20 +114,32 @@ func isDuplicateToolCall(existing []ToolCall, candidate ToolCall) bool {
 
 // parseXMLToolCalls uses a stateful scanner to properly handle quoted attributes
 // containing special characters like '>' that would break regex-based parsing.
+// It recognizes the canonical <tool_call ...> tag and the shorter <tool ...>
+// alias in a single left-to-right pass, so mixed batches keep document order.
 func parseXMLToolCalls(text string) ([]ToolCall, error) {
 	var calls []ToolCall
 	searchFrom := 0
 
 	for searchFrom < len(text) {
-		// Find the start of a <tool_call tag (case-insensitive)
-		idx := indexCaseInsensitive(text[searchFrom:], "<tool_call")
+		// Find the start of a <tool tag (case-insensitive). "<tool" is a
+		// prefix of "<tool_call", so one scan finds both spellings; the tag
+		// name is disambiguated right after.
+		idx := indexCaseInsensitive(text[searchFrom:], "<tool")
 		if idx < 0 {
 			break
 		}
 		tagStart := searchFrom + idx
 
-		// Ensure it's followed by whitespace or '>' (not part of another tag like <tool_caller>)
-		afterTag := tagStart + len("<tool_call")
+		tagName := "tool"
+		const canonical = "<tool_call"
+		if tagStart+len(canonical) <= len(text) &&
+			strings.EqualFold(text[tagStart:tagStart+len(canonical)], canonical) {
+			tagName = "tool_call"
+		}
+
+		// Ensure it's followed by whitespace or '>' (not part of another tag
+		// like <tool_caller> or <toolbox>)
+		afterTag := tagStart + 1 + len(tagName)
 		if afterTag < len(text) {
 			ch := text[afterTag]
 			if ch != ' ' && ch != '\t' && ch != '\n' && ch != '\r' && ch != '>' && ch != '/' {
@@ -146,16 +160,18 @@ func parseXMLToolCalls(text string) ([]ToolCall, error) {
 		var rawEnd int
 
 		if selfClosing {
-			// Self-closing: <tool_call ... />
+			// Self-closing: <tool_call ... /> or <tool ... />
 			rawEnd = tagEnd + 2 // skip "/>"
 		} else {
-			// Opening tag: <tool_call ... >
+			// Opening tag: <tool_call ... > or <tool ... >
 			rawEnd = tagEnd + 1 // skip ">"
 
-			// Look for optional closing </tool_call>
-			closeIdx := indexCaseInsensitive(text[rawEnd:], "</tool_call>")
+			// Look for the optional matching closing tag. The exact-match
+			// search means "</tool>" never swallows a "</tool_call>".
+			closing := "</" + tagName + ">"
+			closeIdx := indexCaseInsensitive(text[rawEnd:], closing)
 			if closeIdx >= 0 {
-				rawEnd = rawEnd + closeIdx + len("</tool_call>")
+				rawEnd = rawEnd + closeIdx + len(closing)
 			}
 		}
 

--- a/cli/agent/toolcall_parser_tool_alias_test.go
+++ b/cli/agent/toolcall_parser_tool_alias_test.go
@@ -1,0 +1,94 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Models backed by other agent CLIs (Devin CLI, Codex CLI, Claude Code)
+// frequently shorten the canonical <tool_call ...> tag to <tool ...>. The
+// parser must accept both spellings everywhere it accepts the canonical one.
+
+func TestParseToolCalls_ToolAliasSelfClosing(t *testing.T) {
+	text := `<reasoning>1. read the file</reasoning>
+<tool name="@coder" args='{"cmd":"read","args":{"file":"main.go"}}' />`
+
+	calls, err := ParseToolCalls(text)
+	require.NoError(t, err)
+	require.Len(t, calls, 1)
+	assert.Equal(t, "@coder", calls[0].Name)
+	assert.JSONEq(t, `{"cmd":"read","args":{"file":"main.go"}}`, calls[0].Args)
+	assert.Contains(t, calls[0].Raw, `<tool name=`)
+}
+
+func TestParseToolCalls_ToolAliasPaired(t *testing.T) {
+	text := `<tool name="@websearch" args='{"query":"golang generics"}'></tool>`
+
+	calls, err := ParseToolCalls(text)
+	require.NoError(t, err)
+	require.Len(t, calls, 1)
+	assert.Equal(t, "@websearch", calls[0].Name)
+	assert.JSONEq(t, `{"query":"golang generics"}`, calls[0].Args)
+	assert.Contains(t, calls[0].Raw, "</tool>")
+}
+
+func TestParseToolCalls_MixedTagsKeepDocumentOrder(t *testing.T) {
+	text := `<tool_call name="@coder" args='{"cmd":"read","args":{"file":"a.go"}}' />
+<tool name="@coder" args='{"cmd":"read","args":{"file":"b.go"}}' />
+<tool_call name="@coder" args='{"cmd":"read","args":{"file":"c.go"}}' />`
+
+	calls, err := ParseToolCalls(text)
+	require.NoError(t, err)
+	require.Len(t, calls, 3)
+	assert.Contains(t, calls[0].Args, "a.go")
+	assert.Contains(t, calls[1].Args, "b.go")
+	assert.Contains(t, calls[2].Args, "c.go")
+}
+
+func TestParseToolCalls_ToolAliasCaseInsensitive(t *testing.T) {
+	text := `<TOOL name="@coder" args='{"cmd":"tree","args":{}}' />`
+
+	calls, err := ParseToolCalls(text)
+	require.NoError(t, err)
+	require.Len(t, calls, 1)
+	assert.Equal(t, "@coder", calls[0].Name)
+}
+
+func TestParseToolCalls_ToolAliasArgsWithGreaterThan(t *testing.T) {
+	text := `<tool name="@coder" args='{"cmd":"exec","args":{"cmd":"grep -c x file > out.txt"}}' />`
+
+	calls, err := ParseToolCalls(text)
+	require.NoError(t, err)
+	require.Len(t, calls, 1)
+	assert.Contains(t, calls[0].Args, "> out.txt")
+}
+
+func TestParseToolCalls_ToolPrefixedTagsNotMatched(t *testing.T) {
+	// Neither <toolbox>, <tools> nor <tool_caller> are tool calls.
+	text := `<toolbox name="@coder" args='{}' /> <tools> </tools> <tool_caller name="@coder" args='{}' />`
+
+	calls, err := ParseToolCalls(text)
+	require.NoError(t, err)
+	assert.Empty(t, calls)
+}
+
+func TestParseToolCalls_PairedToolDoesNotSwallowToolCallClosing(t *testing.T) {
+	// A paired <tool> immediately followed by a canonical tool_call: the
+	// closing </tool> must terminate the first call without consuming the
+	// second tag's closing </tool_call>.
+	text := `<tool name="@coder" args='{"cmd":"tree","args":{}}'></tool>
+<tool_call name="@coder" args='{"cmd":"git-status","args":{}}'></tool_call>`
+
+	calls, err := ParseToolCalls(text)
+	require.NoError(t, err)
+	require.Len(t, calls, 2)
+	assert.Contains(t, calls[0].Args, "tree")
+	assert.Contains(t, calls[1].Args, "git-status")
+}

--- a/cli/agent_routing.go
+++ b/cli/agent_routing.go
@@ -130,6 +130,7 @@ func isTrivialAgentQuery(query string, explicitAgentInvocation bool) trivialQuer
 	// Mentions of tools or subcommands → agent territory.
 	lower := strings.ToLower(q)
 	if strings.Contains(lower, "<tool_call") ||
+		strings.Contains(lower, "<tool ") ||
 		strings.Contains(lower, "<agent_call") ||
 		strings.Contains(lower, "```") {
 		return trivialQueryClassification{trivial: false, reason: "has_tool_markup"}

--- a/cli/agent_tool_sanitizer.go
+++ b/cli/agent_tool_sanitizer.go
@@ -975,8 +975,11 @@ func stripAgentCallTags(s string) string {
 	return agentCallTagRe.ReplaceAllString(s, "")
 }
 
-// stripToolCallTags remove tags <tool_call .../> e <tool_call ...>...</tool_call> do texto.
-var toolCallTagRe = regexp.MustCompile(`(?is)<tool_call\b[^>]*/\s*>|<tool_call\b[^>]*>.*?</tool_call>`)
+// stripToolCallTags remove tags <tool_call .../> e <tool_call ...>...</tool_call>
+// do texto, incluindo o alias <tool .../> que modelos apoiados em outros agent
+// CLIs (Devin/Codex/Claude Code) costumam emitir. O `\b` impede que "<tool"
+// case com "<toolbox"; o grupo opcional cobre as duas grafias no fechamento.
+var toolCallTagRe = regexp.MustCompile(`(?is)<tool(?:_call)?\b[^>]*/\s*>|<tool(?:_call)?\b[^>]*>.*?</tool(?:_call)?\s*>`)
 
 func stripToolCallTags(s string) string {
 	return toolCallTagRe.ReplaceAllString(s, "")

--- a/cli/history_trimmer.go
+++ b/cli/history_trimmer.go
@@ -51,8 +51,10 @@ func (t *MessageTrimmer) compressOrEmpty(s string) string {
 var (
 	reasoningBlockRe   = regexp.MustCompile(`(?s)<reasoning>.*?</reasoning>`)
 	explanationBlockRe = regexp.MustCompile(`(?s)<explanation>.*?</explanation>`)
-	toolCallRe         = regexp.MustCompile(`(?s)<tool_call\s+name="([^"]*?)"\s+args='([^']*?)'\s*/>`)
-	toolCallAltRe      = regexp.MustCompile(`(?s)<tool_call\s+name="([^"]*?)"\s+args="([^"]*?)"\s*/>`)
+	// (?:_call)? also compacts the <tool ...> alias emitted by CLI-backed
+	// models (Devin/Codex/Claude Code); groups stay 1=name, 2=args.
+	toolCallRe         = regexp.MustCompile(`(?s)<tool(?:_call)?\s+name="([^"]*?)"\s+args='([^']*?)'\s*/>`)
+	toolCallAltRe      = regexp.MustCompile(`(?s)<tool(?:_call)?\s+name="([^"]*?)"\s+args="([^"]*?)"\s*/>`)
 	toolOutputBlockRe  = regexp.MustCompile(`(?s)<tool_output>\n?(.*?)\n?</tool_output>`)
 	// Pattern to detect tool feedback messages (from agent_mode.go format)
 	toolFeedbackPrefixRe = regexp.MustCompile(`^(?:The tool '|A ferramenta '|--- Resultado da Ação)`)

--- a/cli/history_trimmer.go
+++ b/cli/history_trimmer.go
@@ -53,9 +53,9 @@ var (
 	explanationBlockRe = regexp.MustCompile(`(?s)<explanation>.*?</explanation>`)
 	// (?:_call)? also compacts the <tool ...> alias emitted by CLI-backed
 	// models (Devin/Codex/Claude Code); groups stay 1=name, 2=args.
-	toolCallRe         = regexp.MustCompile(`(?s)<tool(?:_call)?\s+name="([^"]*?)"\s+args='([^']*?)'\s*/>`)
-	toolCallAltRe      = regexp.MustCompile(`(?s)<tool(?:_call)?\s+name="([^"]*?)"\s+args="([^"]*?)"\s*/>`)
-	toolOutputBlockRe  = regexp.MustCompile(`(?s)<tool_output>\n?(.*?)\n?</tool_output>`)
+	toolCallRe        = regexp.MustCompile(`(?s)<tool(?:_call)?\s+name="([^"]*?)"\s+args='([^']*?)'\s*/>`)
+	toolCallAltRe     = regexp.MustCompile(`(?s)<tool(?:_call)?\s+name="([^"]*?)"\s+args="([^"]*?)"\s*/>`)
+	toolOutputBlockRe = regexp.MustCompile(`(?s)<tool_output>\n?(.*?)\n?</tool_output>`)
 	// Pattern to detect tool feedback messages (from agent_mode.go format)
 	toolFeedbackPrefixRe = regexp.MustCompile(`^(?:The tool '|A ferramenta '|--- Resultado da Ação)`)
 	formatErrorPrefixRe  = regexp.MustCompile(`^FORMAT ERROR:`)

--- a/cli/outputpolicy/outputpolicy.go
+++ b/cli/outputpolicy/outputpolicy.go
@@ -157,7 +157,8 @@ func Classify(prompt string) Complexity {
 		}
 	}
 	// Code fences / tool markup / multiple sentences imply non-trivial work.
-	if strings.Contains(q, "```") || strings.Contains(q, "<tool_call") {
+	// "<tool " also catches the <tool ...> alias of <tool_call ...>.
+	if strings.Contains(q, "```") || strings.Contains(q, "<tool_call") || strings.Contains(q, "<tool ") {
 		return ComplexityComplex
 	}
 	if len(q) > trivialMaxLen {

--- a/cli/tool_alias_strip_trim_test.go
+++ b/cli/tool_alias_strip_trim_test.go
@@ -1,0 +1,56 @@
+/*
+ * ChatCLI - <tool> alias coverage for strip/trim surfaces.
+ * Copyright (c) 2024 Edilson Freitas. License: Apache-2.0.
+ */
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+// CLI-backed models (Devin/Codex/Claude Code) shorten <tool_call ...> to
+// <tool ...>. Every surface that strips or compacts the canonical markup must
+// treat the alias identically, or raw tags leak into the rendered chat.
+
+func TestStripToolCallTags_ToolAlias(t *testing.T) {
+	in := `before <tool name="@coder" args='{"cmd":"read","args":{"file":"a.go"}}' /> after`
+	out := stripToolCallTags(in)
+	assert.NotContains(t, out, "<tool")
+	assert.Contains(t, out, "before")
+	assert.Contains(t, out, "after")
+}
+
+func TestStripToolCallTags_ToolAliasPaired(t *testing.T) {
+	in := `x <tool name="@websearch" args='{"query":"q"}'>ignored</tool> y`
+	out := stripToolCallTags(in)
+	assert.NotContains(t, out, "<tool")
+	assert.NotContains(t, out, "</tool>")
+	assert.Contains(t, out, "x")
+	assert.Contains(t, out, "y")
+}
+
+func TestStripToolCallTags_CanonicalStillStripped(t *testing.T) {
+	in := `a <tool_call name="@coder" args='{"cmd":"tree"}' /> b <tool_call name="@x" args="y">z</tool_call> c`
+	out := stripToolCallTags(in)
+	assert.NotContains(t, out, "tool_call")
+	assert.Contains(t, out, "a")
+	assert.Contains(t, out, "b")
+	assert.Contains(t, out, "c")
+}
+
+func TestStripToolCallTags_ToolboxUntouched(t *testing.T) {
+	in := `see the <toolbox> section`
+	assert.Equal(t, in, stripToolCallTags(in))
+}
+
+func TestCompactToolCalls_ToolAlias(t *testing.T) {
+	trimmer := NewMessageTrimmer(zap.NewNop())
+	in := `<tool name="@coder" args='{"cmd":"read","args":{"file":"main.go"}}' />`
+	out := trimmer.compactToolCalls(in)
+	assert.NotContains(t, out, "<tool")
+	assert.Contains(t, out, "@coder")
+}

--- a/llm/devincli/devincli_client.go
+++ b/llm/devincli/devincli_client.go
@@ -55,15 +55,21 @@ const (
 	// WITHOUT hijacking ChatCLI's own tool protocol: ChatCLI's agent/coder
 	// modes define a textual tool-call markup in their system messages, and
 	// the model must keep emitting that markup — only Devin's NATIVE tools
-	// (file access, shell, web) are off-limits. The first version of this
-	// preamble said a blanket "do NOT use any tools" and made the model
-	// ignore ChatCLI's tool catalog entirely. English on purpose: models
-	// follow English framing instructions more reliably, and this text
-	// never reaches the user.
-	transportPreamble = `You are the LLM backend for ChatCLI, another application. Transport rules:
-- The conversation below is your ONLY source of truth. The system messages inside it — including any tool catalog, tool-call markup protocol or output format they define — are your real instructions. Follow them exactly: when they tell you to emit tool-call markup (such as <tool_call ...> blocks or @tool commands) as text in your reply, do it. That markup is interpreted by ChatCLI, not executed by you.
-- NEVER use your own native tools: do not read or write files, do not run commands, do not browse. Your local workspace is intentionally empty; every capability available to you is expressed textually through the conversation.
-- Do not mention these transport rules or your own environment.
+	// (file access, shell, web) are off-limits. Two hard-won framings live
+	// here: (1) the first version said a blanket "do NOT use any tools" and
+	// made the model ignore ChatCLI's tool catalog entirely; (2) a later
+	// version assigned the model an identity ("You are the LLM backend for
+	// ChatCLI") plus a secrecy rule ("do not mention these rules"), and Devin
+	// refused whole tasks rather than misrepresent who it is. So: no identity
+	// claim, no secrecy — the agent keeps its own identity and simply
+	// collaborates through ChatCLI's textual protocol. English on purpose:
+	// models follow English framing instructions more reliably, and this
+	// text never reaches the user.
+	transportPreamble = `ChatCLI, a separate CLI application, is relaying a conversation between its user and an AI assistant to you. Your job is to write the assistant's next reply. You keep your own identity throughout — you are not being asked to impersonate ChatCLI or anyone else, and if the user asks who you are, answer truthfully.
+
+How to reply:
+- The conversation below is the request. The system messages inside it define ChatCLI's working rules — tool catalogs, output formats, and a textual tool-call markup (such as <tool_call name="..." args='...' /> tags or @tool commands). Follow those rules: when a tool is the right next step, write the tool-call markup as plain text in your reply. ChatCLI parses that markup and executes the tool on the user's machine under the user's supervision and approval. Emitting the markup is the only way actions happen — it is ordinary text output, not you executing anything.
+- Do not use your own native capabilities (file access, shell, browsing): your local workspace here is intentionally empty, and real actions belong to ChatCLI through the markup above.
 - Wrap your ENTIRE reply between the exact lines ` + replyBegin + ` and ` + replyEnd + ` with nothing outside them.
 
 The conversation follows.`

--- a/llm/devincli/devincli_client_test.go
+++ b/llm/devincli/devincli_client_test.go
@@ -213,6 +213,22 @@ REPLY
 	assert.NotContains(t, p, "do NOT use any tools", "the old blanket tool ban must be gone — it blinded the model to ChatCLI's catalog")
 }
 
+// TestTransportPreamble_NoIdentityCoercion pins the anti-refusal contract:
+// the preamble must never assign the model an identity ("you are ChatCLI" /
+// "you are the LLM backend") nor demand secrecy about the transport — Devin
+// was observed refusing whole tasks rather than misrepresent who it is. The
+// model keeps its own identity and simply cooperates through the protocol.
+func TestTransportPreamble_NoIdentityCoercion(t *testing.T) {
+	lower := strings.ToLower(transportPreamble)
+	assert.NotContains(t, lower, "you are the llm backend", "must not assign an identity to the model")
+	assert.NotContains(t, lower, "you are chatcli", "must not tell the model it IS ChatCLI")
+	assert.NotContains(t, lower, "do not mention", "must not demand secrecy — it reads as deception and triggers refusals")
+	assert.Contains(t, lower, "keep your own identity", "must explicitly release the model from any impersonation")
+	assert.Contains(t, lower, "answer truthfully", "identity questions must be answerable honestly")
+	assert.Contains(t, transportPreamble, replyBegin)
+	assert.Contains(t, transportPreamble, replyEnd)
+}
+
 // TestSendPrompt_SerializesConcurrentInvocations pins the fix for the memory
 // worker racing an agent turn: two in-process calls must never have their
 // devin subprocesses alive at the same time (the CLI contends on per-user


### PR DESCRIPTION
## Problema

Usando o provider DEVIN, o Devin recusava tarefas inteiras: o preâmbulo de transporte dizia *you are the LLM backend for ChatCLI* e exigia sigilo sobre as regras (*do not mention these transport rules*). O agente lê isso como pedido de impersonação e se recusa — inclusive a emitir o markup textual de tool_call do ChatCLI. Além disso, modelos apoiados em outros agent CLIs (Devin, Codex, Claude Code) encurtam a tag `<tool_call ...>` para `<tool ...>`, que o parser não reconhecia.

## Mudanças

**Preâmbulo Devin sem coerção de identidade** (`llm/devincli/devincli_client.go`)
- Sem claim de identidade e sem regra de sigilo: o modelo mantém a própria identidade, responde honestamente quem é, e coopera via protocolo textual.
- Explica que emitir o markup como texto é o mecanismo legítimo de ação (ChatCLI executa sob aprovação do usuário) — não é uso disfarçado de tools.
- Sentinelas de framing e a proibição de tools nativas do Devin permanecem.
- `TestTransportPreamble_NoIdentityCoercion` pina o contrato anti-recusa.

**Alias `<tool>` no parser** (`cli/agent/toolcall_parser.go`)
- Scan único e stateful reconhece `<tool_call ...>` e `<tool ...>` (self-closing e pareado), preservando ordem do documento; `</tool>` exato nunca engole `</tool_call>`; `<toolbox>`/`<tool_caller>` continuam ignorados.
- Como agent, coder, chat exceptions (@ask/@knowledge/@graphview/@memory), MoA, workers ReAct e o toolshim convergem em `agent.ParseToolCalls`, todos os modos ganham o alias de uma vez — plugins nunca veem a tag, só `Name`+`Args` normalizados.

**Superfícies de limpeza e heurísticas**
- `stripToolCallTags` e as regexes de compaction do `history_trimmer` reconhecem o alias (senão tags cruas vazariam na renderização e inflariam o histórico).
- Smart routing (`agent_routing.go`) e política de esforço (`outputpolicy.go`) casam `<tool ` também — over-match só empurra para o lado conservador.

**Emissão continua canônica**: prompts, exemplos e trajetória seguem emitindo `<tool_call>`; só a tolerância de entrada aumentou.

## Testes

- 13 testes novos: alias self-closing/pareado/case-insensitive, ordem de documento em batch misto, args com `>`, tags prefixadas não casadas, strip/compaction do alias, contrato do preâmbulo.
- `go build ./...`, suíte completa `go test ./...` e `golangci-lint` verdes.