### PR TITLE
feat(memory): proactive auto-recall in index mode

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -1123,6 +1123,19 @@ func (a *AgentMode) buildWorkspaceBlocks(ctx context.Context, query string) (str
 	}
 
 	dynamicText := a.cli.contextBuilder.BuildDynamicContext()
+	// Proactive recall (index mode only): the top hint-matching facts ride in
+	// the UNCACHED trailing block with the wall-clock context — hint-driven
+	// text changes every turn, and placing it in the stable workspace block
+	// would poison the prompt cache for everything after it.
+	if mode == memModeIndex {
+		if ar := a.cli.memoryAutoRecallBlock(hints); ar != "" {
+			if dynamicText == "" {
+				dynamicText = ar
+			} else {
+				dynamicText = ar + "\n\n" + dynamicText
+			}
+		}
+	}
 	return workspaceText, dynamicText
 }
 

--- a/cli/config_memory.go
+++ b/cli/config_memory.go
@@ -33,6 +33,14 @@ func (cli *ChatCLI) showConfigMemory() {
 	}
 	kv(p, "CHATCLI_MEMORY_MODE", desc)
 	kv(p, "CHATCLI_MEMORY_ENABLED", envBool("CHATCLI_MEMORY_ENABLED"))
+	autoRecallVal := i18n.T("cfg.val.enabled")
+	if !memoryAutoRecallEnabled() {
+		autoRecallVal = i18n.T("cfg.val.disabled")
+	}
+	if os.Getenv("CHATCLI_MEMORY_AUTORECALL") == "" {
+		autoRecallVal = defaultMarker + autoRecallVal
+	}
+	kv(p, "CHATCLI_MEMORY_AUTORECALL", autoRecallVal)
 
 	if cli.memoryStore != nil {
 		if idx := cli.memoryStore.GetMemoryIndex(0); idx != "" {

--- a/cli/memory_autorecall.go
+++ b/cli/memory_autorecall.go
@@ -1,0 +1,93 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+/*
+ * ChatCLI - memory_autorecall.go
+ *
+ * Proactive recall for the "index" memory mode. The pull model keeps per-turn
+ * cost bounded, but it relies on the model CHOOSING to call @memory recall —
+ * and models routinely skip the call, answering with a 600-char digest while
+ * the relevant gotcha sits unread in the fact index. Auto-recall closes that
+ * gap: each agent/coder turn, the hints already extracted from recent
+ * messages rank the fact index, and the top few matches (tiny, budget-capped)
+ * ride into the prompt alongside the digest.
+ *
+ * Cache discipline: the block is hint-driven, so it changes turn to turn. It
+ * is therefore injected into the UNCACHED trailing block (with the wall-clock
+ * dynamic context), never into the stable workspace block — a volatile line
+ * placed early would poison every cached block after it (see the chat
+ * pipeline's stable-prefix/volatile-suffix contract).
+ *
+ * Gated by CHATCLI_MEMORY_AUTORECALL (default on; only meaningful in "index"
+ * mode — "full" already injects the whole retrieval, "off" injects nothing).
+ */
+package cli
+
+import (
+	"os"
+	"strings"
+)
+
+const (
+	// autoRecallMaxFacts caps how many facts ride per turn — this is a nudge,
+	// not a retrieval; the model pulls detail via @memory recall.
+	autoRecallMaxFacts = 3
+
+	// autoRecallBudget caps the block size in bytes.
+	autoRecallBudget = 700
+)
+
+// autoRecallHeader is an English model-facing constant, like memoryRecallHint.
+const autoRecallHeader = "[MEMORY AUTO-RECALL]\n" +
+	"Long-term facts matching the current task (pull full detail or more with @memory recall):\n"
+
+// memoryAutoRecallEnabled reads CHATCLI_MEMORY_AUTORECALL; unset means enabled.
+func memoryAutoRecallEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("CHATCLI_MEMORY_AUTORECALL"))) {
+	case "false", "0", "off", "no", "disabled":
+		return false
+	}
+	return true
+}
+
+// memoryAutoRecallBlock ranks the fact index against the turn's hints and
+// renders the top matches as a compact block, or "" when there is nothing
+// relevant to say. Injected facts are marked accessed so reinforcement works
+// exactly as it does for full-mode retrieval.
+func (cli *ChatCLI) memoryAutoRecallBlock(hints []string) string {
+	if !memoryAutoRecallEnabled() || cli.memoryStore == nil || len(hints) == 0 {
+		return ""
+	}
+	mgr := cli.memoryStore.Manager()
+	if mgr == nil || mgr.Facts == nil {
+		return ""
+	}
+
+	facts := mgr.Facts.Search(hints)
+	if len(facts) == 0 {
+		return ""
+	}
+	if len(facts) > autoRecallMaxFacts {
+		facts = facts[:autoRecallMaxFacts]
+	}
+
+	var b strings.Builder
+	b.WriteString(autoRecallHeader)
+	accessed := make([]string, 0, len(facts))
+	for _, f := range facts {
+		line := "- [" + f.Category + "] " + f.Content
+		if b.Len()+len(line)+1 > autoRecallBudget {
+			break
+		}
+		b.WriteString(line)
+		b.WriteByte('\n')
+		accessed = append(accessed, f.ID)
+	}
+	if len(accessed) == 0 {
+		return ""
+	}
+	mgr.Facts.MarkAccessed(accessed)
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/cli/memory_autorecall_agent_test.go
+++ b/cli/memory_autorecall_agent_test.go
@@ -1,0 +1,74 @@
+/*
+ * ChatCLI - Auto-recall wiring tests (agent workspace blocks).
+ * Copyright (c) 2024 Edilson Freitas. License: Apache-2.0.
+ */
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/cli/workspace"
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+// newAgentAutoRecallCLI wires the minimal agent stack: memory store with a
+// seeded fact, a context builder over it, and recent history whose keywords
+// hit the fact.
+func newAgentAutoRecallCLI(t *testing.T) (*ChatCLI, *AgentMode) {
+	t.Helper()
+	dir := t.TempDir()
+	ms := workspace.NewMemoryStore(dir, zap.NewNop())
+	if !ms.Manager().Facts.AddFact("embed.FS requires forward slashes, never filepath.Join", "gotcha", []string{"embed", "windows"}) {
+		t.Fatal("seed fact")
+	}
+	cli := &ChatCLI{
+		memoryStore:    ms,
+		contextBuilder: workspace.NewContextBuilder(workspace.NewBootstrapLoader(dir, dir, zap.NewNop()), ms, dir),
+		logger:         zap.NewNop(),
+	}
+	cli.history = []models.Message{
+		{Role: "user", Content: "why does embed break on windows paths?"},
+	}
+	return cli, NewAgentMode(cli, zap.NewNop())
+}
+
+func TestBuildWorkspaceBlocks_InjectsAutoRecallInIndexMode(t *testing.T) {
+	t.Setenv("CHATCLI_MEMORY_MODE", "index")
+	cli, a := newAgentAutoRecallCLI(t)
+
+	workspaceText, dynamicText := a.buildWorkspaceBlocks(context.Background(), "embed windows")
+	if !strings.Contains(dynamicText, "[MEMORY AUTO-RECALL]") || !strings.Contains(dynamicText, "forward slashes") {
+		t.Errorf("index mode must inject auto-recall into the UNCACHED dynamic block, got: %s", dynamicText)
+	}
+	if strings.Contains(workspaceText, "[MEMORY AUTO-RECALL]") {
+		t.Errorf("auto-recall must NEVER land in the cacheable workspace block: %s", workspaceText)
+	}
+	if !strings.Contains(dynamicText, "Current date and time") {
+		t.Errorf("wall-clock context must survive alongside auto-recall: %s", dynamicText)
+	}
+	_ = cli
+}
+
+func TestBuildWorkspaceBlocks_NoAutoRecallInFullMode(t *testing.T) {
+	t.Setenv("CHATCLI_MEMORY_MODE", "full")
+	_, a := newAgentAutoRecallCLI(t)
+
+	_, dynamicText := a.buildWorkspaceBlocks(context.Background(), "embed windows")
+	if strings.Contains(dynamicText, "[MEMORY AUTO-RECALL]") {
+		t.Errorf("full mode already pushes retrieval; auto-recall must not double-inject: %s", dynamicText)
+	}
+}
+
+func TestShowConfigMemory_ExposesAutoRecall(t *testing.T) {
+	c := minimalCLI(t)
+	out := captureStdout(t, func() { c.showConfigMemory() })
+	if !strings.Contains(out, "CHATCLI_MEMORY_AUTORECALL") {
+		t.Errorf("config memory must expose the auto-recall gate, got: %s", out)
+	}
+	if !strings.Contains(out, "CHATCLI_MEMORY_MODE") {
+		t.Errorf("config memory must keep the mode line, got: %s", out)
+	}
+}

--- a/cli/memory_autorecall_test.go
+++ b/cli/memory_autorecall_test.go
@@ -1,0 +1,81 @@
+/*
+ * ChatCLI - Proactive auto-recall tests.
+ * Copyright (c) 2024 Edilson Freitas. License: Apache-2.0.
+ */
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func newAutoRecallCLI(t *testing.T) *ChatCLI {
+	t.Helper()
+	cli := newTestCLIWithMemory(t)
+	mgr := cli.memoryStore.Manager()
+	if !mgr.Facts.AddFact("embed.FS requires forward slashes, never filepath.Join", "gotcha", []string{"embed", "windows"}) {
+		t.Fatal("seed fact 1")
+	}
+	if !mgr.Facts.AddFact("The scheduler daemon re-arms intervals in place", "architecture", []string{"scheduler"}) {
+		t.Fatal("seed fact 2")
+	}
+	return cli
+}
+
+func TestMemoryAutoRecallBlock_MatchesHints(t *testing.T) {
+	cli := newAutoRecallCLI(t)
+
+	block := cli.memoryAutoRecallBlock([]string{"embed", "windows", "paths"})
+	if !strings.Contains(block, "[MEMORY AUTO-RECALL]") {
+		t.Fatalf("expected auto-recall header, got %q", block)
+	}
+	if !strings.Contains(block, "forward slashes") {
+		t.Errorf("expected the matching gotcha, got %q", block)
+	}
+	if strings.Contains(block, "scheduler daemon") {
+		t.Errorf("unrelated fact must not ride along, got %q", block)
+	}
+}
+
+func TestMemoryAutoRecallBlock_EmptyCases(t *testing.T) {
+	cli := newAutoRecallCLI(t)
+
+	if got := cli.memoryAutoRecallBlock(nil); got != "" {
+		t.Errorf("no hints must inject nothing (empty hints would dump ALL facts), got %q", got)
+	}
+	if got := cli.memoryAutoRecallBlock([]string{"kubernetes", "istio"}); got != "" {
+		t.Errorf("no matching fact must inject nothing, got %q", got)
+	}
+
+	t.Setenv("CHATCLI_MEMORY_AUTORECALL", "off")
+	if got := cli.memoryAutoRecallBlock([]string{"embed"}); got != "" {
+		t.Errorf("disabled auto-recall must inject nothing, got %q", got)
+	}
+
+	bare := &ChatCLI{}
+	if got := bare.memoryAutoRecallBlock([]string{"embed"}); got != "" {
+		t.Errorf("no memory store must inject nothing, got %q", got)
+	}
+}
+
+func TestMemoryAutoRecallBlock_CapsFactCount(t *testing.T) {
+	cli := newAutoRecallCLI(t)
+	mgr := cli.memoryStore.Manager()
+	for _, c := range []string{"alpha", "beta", "gamma", "delta", "epsilon"} {
+		mgr.Facts.AddFact("gateway detail "+c+" for routing", "pattern", []string{"gateway"})
+	}
+
+	block := cli.memoryAutoRecallBlock([]string{"gateway", "routing"})
+	if block == "" {
+		t.Fatal("expected a block")
+	}
+	lines := 0
+	for _, l := range strings.Split(block, "\n") {
+		if strings.HasPrefix(l, "- ") {
+			lines++
+		}
+	}
+	if lines > autoRecallMaxFacts {
+		t.Errorf("block must cap at %d facts, got %d:\n%s", autoRecallMaxFacts, lines, block)
+	}
+}


### PR DESCRIPTION
## Motivação

PR 3 (final) do plano de memória de longo prazo (PR 1: #1202 episódios; PR 2: #1203 sessões). O modo `index` (default) mantém o custo por turno limitado, mas depende do modelo **escolher** chamar `@memory recall` — e modelos rotineiramente pulam a chamada, respondendo só com o digest de 600 chars enquanto o gotcha relevante fica sem ser lido no fact index.

## O que entra

**Bloco de auto-recall** (`cli/memory_autorecall.go`)
- A cada turno de agent/coder no modo `index`, os hints já extraídos das últimas mensagens ranqueiam o fact index (`Facts.Search` — léxico × temporal, mesmo scorer do full mode) e os **top 3 matches** entram no prompt como bloco compacto (`[MEMORY AUTO-RECALL]`), com budget de 700 bytes.
- Facts injetados são marcados como acessados — o reforço de score funciona igual ao retrieval do full mode.
- Sem hints ou sem match → bloco vazio (nunca despeja o index inteiro).

**Disciplina de cache** — o ponto delicado do PR:
- O bloco é hint-driven, muda a cada turno. Por isso entra no **bloco final não-cacheado** (junto do wall-clock/cwd), nunca no workspace block estável — uma linha volátil cedo no prompt envenenaria todos os blocos cacheados depois dela (contrato stable-prefix/volatile-suffix do pipeline).
- O digest estável do modo index permanece byte-idêntico entre turnos; zero impacto no prompt cache.

**Gate e superfície**: `CHATCLI_MEMORY_AUTORECALL` (default on), exposto em `/config memory` com marcador de default. `full` e `off` intocados; chat não é afetado (`index` já degrada para `full` lá). Gateway e MCP server herdam automaticamente (mesmo `Run`).

## Testes

Match por hint (fato relevante entra, irrelevante não), casos vazios (sem hints / sem match / env off / sem store), cap de 3 fatos. Suíte completa `go test ./...` verde, `golangci-lint` zero, gofmt limpo, script do Floor 4 verde local.

## Plano de memória — fechado com este PR

1. ✅ #1202 — memória episódica (o QUANDO)
2. ✅ #1203 — sessões pesquisáveis + autosave (o registro bruto)
3. ✅ este — auto-recall proativo (facts certos sem depender do pull)

Pendente futuro (fora do plano de 3): rollups derivados de episódios.