### PR TITLE
feat(memory): derive rollups from the episodic record

### DIFF
--- a/cli/workspace/memory/rollup.go
+++ b/cli/workspace/memory/rollup.go
@@ -17,10 +17,18 @@ import (
 	"go.uber.org/zap"
 )
 
-// RollupStore consolidates daily notes into weekly digests and weekly digests
-// into monthly ones — the long-range narrative daily notes cannot provide
-// (they expire after ~30 days). Weeklies keep the recent trajectory sharp;
-// monthlies preserve it indefinitely at low cost.
+// RollupStore consolidates the period's work record into weekly digests and
+// weekly digests into monthly ones — the long-range narrative daily notes
+// cannot provide (they expire after ~30 days). Weeklies keep the recent
+// trajectory sharp; monthlies preserve it indefinitely at low cost.
+//
+// Sources, when the episodic store is attached (SetEpisodes): the period's
+// EPISODES lead each digest's source — they are the durable, dated, factual
+// record of what was actually done — and the daily notes follow as color.
+// Before episodes existed, digests were summaries of summaries (dailies →
+// weekly → monthly), each hop lossy; anchoring on episodes stops the decay,
+// and weeks/months whose daily notes already expired still get a digest from
+// their episodes alone.
 //
 // Layout under the memory dir:
 //
@@ -29,11 +37,19 @@ import (
 type RollupStore struct {
 	memoryDir string
 	logger    *zap.Logger
+	episodes  *EpisodeStore // optional; nil → daily-notes-only sources
 }
 
 // NewRollupStore creates a rollup store rooted at the memory directory.
 func NewRollupStore(memoryDir string, logger *zap.Logger) *RollupStore {
 	return &RollupStore{memoryDir: memoryDir, logger: logger}
+}
+
+// SetEpisodes attaches the episodic timeline as the leading rollup source.
+// Additive wiring (mirrors the retriever's SetEpisodes) so the constructor
+// signature stays stable; nil keeps the legacy daily-notes-only behavior.
+func (rs *RollupStore) SetEpisodes(es *EpisodeStore) {
+	rs.episodes = es
 }
 
 const (
@@ -65,7 +81,7 @@ func (rs *RollupStore) Run(ctx context.Context, summarize SummarizeFunc) (int, e
 
 	now := time.Now()
 	today := now.Format("2006-01-02")
-	for _, wk := range groupByISOWeek(dailies) {
+	for _, wk := range rs.allWeeks(dailies) {
 		// Calendar-date comparison: a week is elapsed only when its Sunday is
 		// strictly before today, regardless of time zone of the parsed dates.
 		if wk.end.Format("2006-01-02") >= today {
@@ -75,7 +91,14 @@ func (rs *RollupStore) Run(ctx context.Context, summarize SummarizeFunc) (int, e
 		if fileExists(path) {
 			continue
 		}
-		digest := rs.digest(ctx, summarize, weeklyPromptHeader(wk), wk.content())
+		// Episodes lead the source: the durable dated record grounds the
+		// digest, the notes add color. A week whose daily notes already
+		// expired still rolls from its episodes alone.
+		source := rs.episodesSection(wk.start, wk.end.AddDate(0, 0, 1)) + wk.content()
+		if strings.TrimSpace(source) == "" {
+			continue
+		}
+		digest := rs.digest(ctx, summarize, weeklyPromptHeader(wk), source)
 		header := fmt.Sprintf("# Week %s (%s – %s)\n\n", wk.label, wk.start.Format("2006-01-02"), wk.end.Format("2006-01-02"))
 		if err := rs.writeDigest(path, header+digest); err != nil {
 			rs.logger.Warn("weekly rollup write failed", zap.String("week", wk.label), zap.Error(err))
@@ -111,11 +134,11 @@ func (rs *RollupStore) rollMonths(ctx context.Context, summarize SummarizeFunc, 
 		if fileExists(path) {
 			continue
 		}
-		source := rs.monthSource(month)
+		source := rs.monthEpisodesSection(month) + rs.monthSource(month)
 		if strings.TrimSpace(source) == "" {
 			continue
 		}
-		prompt := "Condense these work notes from " + month + " into a monthly digest: at most 10 bullets covering achievements, decisions, blockers and themes. Write in the same language as the notes. Output only the bullets.\n\n"
+		prompt := "Condense this work record from " + month + " into a monthly digest: at most 10 bullets covering achievements, decisions, blockers and themes. Lines under the Episodes heading are the durable dated record of completed work — ground the digest in them; the notes and weekly digests add context. Write in the same language as the source. Output only the bullets.\n\n"
 		digest := rs.digest(ctx, summarize, prompt, source)
 		if err := rs.writeDigest(path, "# Month "+month+"\n\n"+digest); err != nil {
 			rs.logger.Warn("monthly rollup write failed", zap.String("month", month), zap.Error(err))
@@ -152,6 +175,48 @@ func (rs *RollupStore) FormatTrajectory(maxChars int) string {
 	return strings.TrimSpace(out)
 }
 
+// episodesSection renders the [from, to) window's episodes as the leading
+// source block for a digest, or "" when the store is absent or the window is
+// empty. FormatEpisodes emits "- " bullets, so the deterministic fallback
+// (condenseBullets) naturally keeps episodes first when no LLM is available.
+func (rs *RollupStore) episodesSection(from, to time.Time) string {
+	if rs.episodes == nil {
+		return ""
+	}
+	eps := rs.episodes.Range(from, to, "", "", 0)
+	if len(eps) == 0 {
+		return ""
+	}
+	return "## Episodes (durable dated work record)\n" + FormatEpisodes(eps) + "\n\n"
+}
+
+// allWeeks merges the weeks that have daily notes with the weeks that have
+// episodes, so a period whose notes already expired still gets its digest.
+// Weeks coming only from episodes carry no files; their source is the
+// episodes section alone.
+func (rs *RollupStore) allWeeks(dailies []dailyFile) []isoWeek {
+	weeks := groupByISOWeek(dailies)
+	if rs.episodes == nil {
+		return weeks
+	}
+	have := make(map[string]bool, len(weeks))
+	for _, wk := range weeks {
+		have[wk.label] = true
+	}
+	for _, e := range rs.episodes.Range(time.Time{}, time.Time{}, "", "", 0) {
+		year, week := e.Date.ISOWeek()
+		label := fmt.Sprintf("%04d-W%02d", year, week)
+		if have[label] {
+			continue
+		}
+		have[label] = true
+		start := startOfISOWeek(e.Date)
+		weeks = append(weeks, isoWeek{label: label, start: start, end: start.AddDate(0, 0, 6)})
+	}
+	sort.Slice(weeks, func(i, j int) bool { return weeks[i].label < weeks[j].label })
+	return weeks
+}
+
 // --- digest production -------------------------------------------------------
 
 // digest asks the LLM for a condensation and falls back to deterministic
@@ -175,9 +240,10 @@ func (rs *RollupStore) digest(ctx context.Context, summarize SummarizeFunc, prom
 }
 
 func weeklyPromptHeader(wk isoWeek) string {
-	return "Condense these daily work notes from week " + wk.label +
+	return "Condense this work record from week " + wk.label +
 		" into a weekly digest: at most 8 bullets covering achievements, decisions, blockers and recurring themes. " +
-		"Write in the same language as the notes. Output only the bullets.\n\n"
+		"Lines under the Episodes heading are the durable dated record of completed work — ground the digest in them; the daily notes add context. " +
+		"Write in the same language as the source. Output only the bullets.\n\n"
 }
 
 // condenseBullets keeps the first maxBullets bullet lines — a lossy but
@@ -300,7 +366,8 @@ func startOfDay(d time.Time) time.Time {
 	return time.Date(d.Year(), d.Month(), d.Day(), 0, 0, 0, 0, d.Location())
 }
 
-// listSourceMonths returns every YYYY-MM that has dailies or weeklies.
+// listSourceMonths returns every YYYY-MM that has dailies, weeklies or
+// episodes.
 func (rs *RollupStore) listSourceMonths() ([]string, error) {
 	months := make(map[string]struct{})
 	dailies, err := rs.listDailyNotes()
@@ -314,6 +381,11 @@ func (rs *RollupStore) listSourceMonths() ([]string, error) {
 		base := strings.TrimSuffix(filepath.Base(w), ".md") // 2026-W27
 		if wk, ok := parseWeekLabel(base); ok {
 			months[wk.Format("2006-01")] = struct{}{}
+		}
+	}
+	if rs.episodes != nil {
+		for _, e := range rs.episodes.Range(time.Time{}, time.Time{}, "", "", 0) {
+			months[e.Date.Format("2006-01")] = struct{}{}
 		}
 	}
 	out := make([]string, 0, len(months))
@@ -356,6 +428,16 @@ func (rs *RollupStore) monthSource(month string) string {
 		}
 	}
 	return sb.String()
+}
+
+// monthEpisodesSection renders the month's episodes as the leading monthly
+// source block, or "" (absent store, unparseable month, empty window).
+func (rs *RollupStore) monthEpisodesSection(month string) string {
+	first, err := time.ParseInLocation("2006-01", month, time.Local)
+	if err != nil {
+		return ""
+	}
+	return rs.episodesSection(first, first.AddDate(0, 1, 0))
 }
 
 // parseWeekLabel converts "2026-W27" to the Monday that starts that week.

--- a/cli/workspace/memory/rollup_episodes_test.go
+++ b/cli/workspace/memory/rollup_episodes_test.go
@@ -1,0 +1,122 @@
+/*
+ * ChatCLI - Episode-derived rollup tests.
+ * Copyright (c) 2024 Edilson Freitas. License: Apache-2.0.
+ */
+package memory
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// pastMonday returns the Monday of a week ~n weeks back, safely elapsed.
+func pastMonday(n int) time.Time {
+	return startOfISOWeek(time.Now().AddDate(0, 0, -7*n))
+}
+
+func TestRollup_WeeklyFromEpisodesOnly(t *testing.T) {
+	dir := t.TempDir()
+	rs := NewRollupStore(dir, testLogger())
+	es := NewEpisodeStore(dir, 100, zap.NewNop())
+	rs.SetEpisodes(es)
+
+	// A week with NO daily notes (they expired) but with episodes — the old
+	// pipeline produced nothing for it.
+	monday := pastMonday(10)
+	es.Add(Episode{Date: monday.AddDate(0, 0, 1), Project: "chatcli",
+		Summary: "Shipped the OAuth refresh fix", Outcome: "merged as PR 1047"})
+	es.Add(Episode{Date: monday.AddDate(0, 0, 3),
+		Summary: "Decided on the in-memory queue design"})
+
+	written, err := rs.Run(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if written < 1 {
+		t.Fatalf("expected digests from episodes alone, wrote %d", written)
+	}
+
+	year, week := monday.ISOWeek()
+	data, err := os.ReadFile(filepath.Join(dir, "weekly", fmt.Sprintf("%04d-W%02d.md", year, week)))
+	if err != nil {
+		t.Fatalf("weekly digest missing for episodes-only week: %v", err)
+	}
+	for _, want := range []string{"OAuth refresh fix", "in-memory queue"} {
+		if !strings.Contains(string(data), want) {
+			t.Errorf("weekly digest missing %q:\n%s", want, data)
+		}
+	}
+
+	// The elapsed month must roll from episodes too.
+	if monday.Format("2006-01") != time.Now().Format("2006-01") {
+		monthly := filepath.Join(dir, "monthly", monday.Format("2006-01")+".md")
+		mdata, err := os.ReadFile(monthly)
+		if err != nil {
+			t.Fatalf("monthly digest missing for episodes-only month: %v", err)
+		}
+		if !strings.Contains(string(mdata), "OAuth refresh fix") {
+			t.Errorf("monthly digest must carry the episode: %s", mdata)
+		}
+	}
+}
+
+func TestRollup_EpisodesLeadDailyNotesFollow(t *testing.T) {
+	dir := t.TempDir()
+	rs := NewRollupStore(dir, testLogger())
+	es := NewEpisodeStore(dir, 100, zap.NewNop())
+	rs.SetEpisodes(es)
+
+	monday := pastMonday(8)
+	es.Add(Episode{Date: monday, Summary: "Hardened the episode store", Outcome: "quarantine covered"})
+	writeDailyNoteAt(t, dir, monday, "leu arquivos de configuração")
+
+	if _, err := rs.Run(context.Background(), nil); err != nil {
+		t.Fatal(err)
+	}
+
+	year, week := monday.ISOWeek()
+	data, err := os.ReadFile(filepath.Join(dir, "weekly", fmt.Sprintf("%04d-W%02d.md", year, week)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(data)
+	epIdx := strings.Index(body, "Hardened the episode store")
+	noteIdx := strings.Index(body, "leu arquivos")
+	if epIdx < 0 || noteIdx < 0 {
+		t.Fatalf("digest must carry episode AND note content:\n%s", body)
+	}
+	if epIdx > noteIdx {
+		t.Errorf("episodes must lead the digest (deterministic fallback keeps source order):\n%s", body)
+	}
+}
+
+func TestRollup_NilEpisodesKeepsLegacyBehavior(t *testing.T) {
+	dir := t.TempDir()
+	rs := NewRollupStore(dir, testLogger()) // SetEpisodes never called
+
+	monday := pastMonday(6)
+	writeDailyNoteAt(t, dir, monday, "nota antiga")
+
+	written, err := rs.Run(context.Background(), nil)
+	if err != nil || written < 1 {
+		t.Fatalf("legacy daily-note rollup must keep working: %d / %v", written, err)
+	}
+}
+
+func TestManager_RollupsWiredToEpisodes(t *testing.T) {
+	m := NewManager(t.TempDir(), DefaultConfig(), zap.NewNop())
+	monday := pastMonday(5)
+	m.Episodes.Add(Episode{Date: monday, Summary: "Wired the rollup pipeline"})
+
+	written, err := m.RunRollups(context.Background(), nil)
+	if err != nil || written < 1 {
+		t.Fatalf("manager-wired rollups must digest episodes: %d / %v", written, err)
+	}
+}

--- a/cli/workspace/memory/store.go
+++ b/cli/workspace/memory/store.go
@@ -78,6 +78,7 @@ func NewManager(memoryDir string, config Config, logger *zap.Logger) *Manager {
 	m.retriever = NewRelevanceRetriever(m.Facts, m.Profile, m.Topics, m.Projects, m.Patterns, m.Daily, config)
 	m.retriever.SetRollups(m.Rollups)
 	m.retriever.SetEpisodes(m.Episodes)
+	m.Rollups.SetEpisodes(m.Episodes)
 	m.migration = NewMigration(memoryDir, m.Facts, logger)
 
 	// Auto-migrate if needed


### PR DESCRIPTION
## Motivação

Follow-up do plano de memória (#1202/#1203/#1204). Os digests semanais/mensais eram **resumos de resumos**: dailies → weekly → monthly, cada salto lossy. Pior: um período cujas daily notes já expiraram (TTL 30d) **não produzia digest nenhum** — a trajetória de longo prazo ia afinando silenciosamente.

## O que muda

- **Episódios lideram a fonte de cada digest** (`RollupStore.SetEpisodes`, mesmo wiring aditivo do retriever): o registro permanente/datado/factual do trabalho ancora o rollup; as daily notes viram contexto complementar.
- **Semanas e meses só-com-episódios agora rolam**: `allWeeks` une semanas com notes e semanas com episódios; `listSourceMonths` idem — fecha o buraco onde a história sumia junto com a retenção das notes.
- **Fallback determinístico preserva episódios primeiro** por construção (`FormatEpisodes` emite bullets `- ` e a seção vem antes na fonte — `condenseBullets` mantém a ordem). Prompts de sumarização instruem que o heading Episodes é a fonte autoritativa.
- **Zero breaking**: store sem `SetEpisodes` mantém o comportamento legado byte a byte (teste pina); assinaturas de construtor intactas.

## Testes

Semana só-de-episódios gera weekly+monthly com o conteúdo; episódios precedem notes no fallback determinístico; nil episodes = legado intacto; wiring do Manager ponta a ponta. Testes legados de rollup passam sem alteração. Suíte completa verde, lint zero, Floor 3 e Floor 4 verificados localmente (exit 0).

Com este PR, as 4 camadas de memória se fecham: fatos (o que é verdade), episódios (o que aconteceu e quando), sessões (o registro bruto pesquisável) e rollups (a narrativa de longo prazo — agora sem decair).