### PR TITLE
feat(session): MCP session autosave by default and bounded machine-session lifecycle

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1053,6 +1053,12 @@ func (cli *ChatCLI) dequeueMessage() string {
 func (cli *ChatCLI) Start(ctx context.Context) {
 	cli.sessionCtx = ctx
 	defer cli.cleanup(ctx)
+	// Bounded session lifecycle: expire MACHINE-created sessions (REPL
+	// autosaves, MCP session mirrors) past their TTL, in the background so
+	// boot never waits on disk. User-named sessions are never touched.
+	if cli.sessionManager != nil {
+		go cli.sessionManager.CleanExpiredMachineSessions()
+	}
 	// Renova em background o cache de release que alimenta o hash de commit
 	// da tela de boas-vindas (builds go install); o boot não espera rede.
 	go version.RefreshReleaseCacheIfStale(ctx)

--- a/cli/cli_session_autosave.go
+++ b/cli/cli_session_autosave.go
@@ -39,7 +39,7 @@ const (
 	// Claude Code's 30-day default) — this count is a generous backstop
 	// against pathological accumulation, not the working limit, so raw
 	// session knowledge is not lost to an aggressive cap.
-	autosaveKeepDefault = 200
+	autosaveKeepDefault = 600
 
 	// autosaveMinMessages skips trivial sessions: one prompt and its answer
 	// are worth keeping, a lone /command or an empty boot is not.

--- a/cli/cli_session_autosave.go
+++ b/cli/cli_session_autosave.go
@@ -21,7 +21,6 @@ package cli
 import (
 	"fmt"
 	"os"
-	"sort"
 	"strings"
 	"time"
 
@@ -83,26 +82,8 @@ func (cli *ChatCLI) autosaveSessionOnExit() {
 	cli.pruneAutosaves()
 }
 
-// pruneAutosaves deletes the oldest autosave sessions past the keep-count.
-// Timestamped names sort lexicographically by age, so no stat calls needed.
+// pruneAutosaves bounds the REPL autosave set to the newest autosaveKeep
+// files, via the shared machine-session pruner.
 func (cli *ChatCLI) pruneAutosaves() {
-	names, err := cli.sessionManager.ListSessions()
-	if err != nil {
-		return
-	}
-	autos := make([]string, 0, len(names))
-	for _, n := range names {
-		if strings.HasPrefix(n, autosavePrefix) {
-			autos = append(autos, n)
-		}
-	}
-	if len(autos) <= autosaveKeep {
-		return
-	}
-	sort.Strings(autos) // ascending → oldest first
-	for _, n := range autos[:len(autos)-autosaveKeep] {
-		if err := cli.sessionManager.DeleteSession(n); err != nil {
-			cli.logger.Debug("autosave prune failed", zap.String("session", n), zap.Error(err))
-		}
-	}
+	cli.sessionManager.PruneSessionsByPrefix(autosavePrefix, autosaveKeep)
 }

--- a/cli/cli_session_autosave.go
+++ b/cli/cli_session_autosave.go
@@ -21,6 +21,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -33,13 +34,29 @@ const (
 	// to start with it are indistinguishable by design (docs call it out).
 	autosavePrefix = "autosave-"
 
-	// autosaveKeep bounds how many autosaves survive pruning.
-	autosaveKeep = 10
+	// autosaveKeepDefault bounds how many machine sessions survive pruning.
+	// Retention is primarily TIME-based (the 90-day machine-session TTL, vs
+	// Claude Code's 30-day default) — this count is a generous backstop
+	// against pathological accumulation, not the working limit, so raw
+	// session knowledge is not lost to an aggressive cap.
+	autosaveKeepDefault = 200
 
 	// autosaveMinMessages skips trivial sessions: one prompt and its answer
 	// are worth keeping, a lone /command or an empty boot is not.
 	autosaveMinMessages = 2
 )
+
+// sessionAutosaveKeep resolves the machine-session keep-count backstop.
+// CHATCLI_SESSION_AUTOSAVE_KEEP overrides the default; non-positive or
+// malformed values fall back.
+func sessionAutosaveKeep() int {
+	if v := strings.TrimSpace(os.Getenv("CHATCLI_SESSION_AUTOSAVE_KEEP")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return autosaveKeepDefault
+}
 
 // sessionAutosaveEnabled reads CHATCLI_SESSION_AUTOSAVE; unset means enabled.
 func sessionAutosaveEnabled() bool {
@@ -82,8 +99,8 @@ func (cli *ChatCLI) autosaveSessionOnExit() {
 	cli.pruneAutosaves()
 }
 
-// pruneAutosaves bounds the REPL autosave set to the newest autosaveKeep
+// pruneAutosaves bounds the REPL autosave set to the newest keep-count
 // files, via the shared machine-session pruner.
 func (cli *ChatCLI) pruneAutosaves() {
-	cli.sessionManager.PruneSessionsByPrefix(autosavePrefix, autosaveKeep)
+	cli.sessionManager.PruneSessionsByPrefix(autosavePrefix, sessionAutosaveKeep())
 }

--- a/cli/cli_session_autosave_test.go
+++ b/cli/cli_session_autosave_test.go
@@ -80,8 +80,12 @@ func TestAutosaveOnExit_SkipsTrivialAndDisabled(t *testing.T) {
 }
 
 func TestPruneAutosaves_KeepsNewest(t *testing.T) {
+	// The keep-count backstop is env-tunable; a small value keeps the test
+	// cheap and covers the override path.
+	t.Setenv("CHATCLI_SESSION_AUTOSAVE_KEEP", "10")
+	keep := sessionAutosaveKeep()
 	cli := newAutosaveCLI(t, 2)
-	for i := 0; i < autosaveKeep+3; i++ {
+	for i := 0; i < keep+3; i++ {
 		name := fmt.Sprintf("%s202601%02d-120000", autosavePrefix, i+1)
 		if err := cli.sessionManager.SaveSessionV2(name, cli.buildSessionData()); err != nil {
 			t.Fatal(err)
@@ -90,12 +94,27 @@ func TestPruneAutosaves_KeepsNewest(t *testing.T) {
 	cli.pruneAutosaves()
 
 	autos := autosaveNames(t, cli)
-	if len(autos) != autosaveKeep {
-		t.Fatalf("expected %d autosaves after prune, got %d", autosaveKeep, len(autos))
+	if len(autos) != keep {
+		t.Fatalf("expected %d autosaves after prune, got %d", keep, len(autos))
 	}
 	for _, n := range autos {
 		if n == autosavePrefix+"20260101-120000" || n == autosavePrefix+"20260102-120000" || n == autosavePrefix+"20260103-120000" {
 			t.Errorf("oldest autosave %s must have been pruned", n)
 		}
+	}
+}
+
+func TestSessionAutosaveKeep_DefaultAndOverride(t *testing.T) {
+	t.Setenv("CHATCLI_SESSION_AUTOSAVE_KEEP", "")
+	if got := sessionAutosaveKeep(); got != autosaveKeepDefault {
+		t.Errorf("default keep must be %d, got %d", autosaveKeepDefault, got)
+	}
+	t.Setenv("CHATCLI_SESSION_AUTOSAVE_KEEP", "500")
+	if got := sessionAutosaveKeep(); got != 500 {
+		t.Errorf("override must apply, got %d", got)
+	}
+	t.Setenv("CHATCLI_SESSION_AUTOSAVE_KEEP", "banana")
+	if got := sessionAutosaveKeep(); got != autosaveKeepDefault {
+		t.Errorf("malformed override must fall back, got %d", got)
 	}
 }

--- a/cli/config_env_defaults.go
+++ b/cli/config_env_defaults.go
@@ -227,6 +227,7 @@ var envDefaults = map[string]envDefault{
 	"CHATCLI_MCP_RESOURCES":                 {Value: "on", Source: "cli/rpc_support_resources.go (chatcli:// read-only resources: on|off)"},
 	"CHATCLI_MCP_MAX_HISTORY":               {Value: "0", Source: "cmd/rpcserve.go (0 = token-aware compaction bounds the history)"},
 	"CHATCLI_MCP_SESSION_AUTOSAVE":          {Value: "true", IsBool: true, Source: "cmd/rpcserve.go (persist live MCP sessions as mcp-<session>; unset follows CHATCLI_SESSION_AUTOSAVE)"},
+	"CHATCLI_SESSION_AUTOSAVE_KEEP":         {Value: "200", Source: "cli/cli_session_autosave.go (machine-session keep-count backstop; TTL is the primary retention)"},
 	"CHATCLI_MCP_HUB":                       {Value: "on", Source: "cmd/rpcserve.go (join the conversation hub in resume mode: on|off)"},
 	"CHATCLI_MCP_HUB_PRINCIPAL":             {Value: "(hub default)", Source: "cmd/rpcserve.go (isolate the MCP thread under another principal)"},
 	"CHATCLI_ALLOW_UNSIGNED_PLUGINS":        {Value: "false", IsBool: true, Source: "plugin manager"},

--- a/cli/config_env_defaults.go
+++ b/cli/config_env_defaults.go
@@ -226,7 +226,7 @@ var envDefaults = map[string]envDefault{
 	"CHATCLI_MCP_DANGER":                    {Value: "allow", Source: "cmd/rpcserve.go (mcp-server unattended danger policy: allow|block)"},
 	"CHATCLI_MCP_RESOURCES":                 {Value: "on", Source: "cli/rpc_support_resources.go (chatcli:// read-only resources: on|off)"},
 	"CHATCLI_MCP_MAX_HISTORY":               {Value: "0", Source: "cmd/rpcserve.go (0 = token-aware compaction bounds the history)"},
-	"CHATCLI_MCP_SESSION_AUTOSAVE":          {Value: "false", IsBool: true, Source: "cmd/rpcserve.go (persist live MCP sessions as mcp-<session>)"},
+	"CHATCLI_MCP_SESSION_AUTOSAVE":          {Value: "true", IsBool: true, Source: "cmd/rpcserve.go (persist live MCP sessions as mcp-<session>; unset follows CHATCLI_SESSION_AUTOSAVE)"},
 	"CHATCLI_MCP_HUB":                       {Value: "on", Source: "cmd/rpcserve.go (join the conversation hub in resume mode: on|off)"},
 	"CHATCLI_MCP_HUB_PRINCIPAL":             {Value: "(hub default)", Source: "cmd/rpcserve.go (isolate the MCP thread under another principal)"},
 	"CHATCLI_ALLOW_UNSIGNED_PLUGINS":        {Value: "false", IsBool: true, Source: "plugin manager"},

--- a/cli/config_env_defaults.go
+++ b/cli/config_env_defaults.go
@@ -227,7 +227,7 @@ var envDefaults = map[string]envDefault{
 	"CHATCLI_MCP_RESOURCES":                 {Value: "on", Source: "cli/rpc_support_resources.go (chatcli:// read-only resources: on|off)"},
 	"CHATCLI_MCP_MAX_HISTORY":               {Value: "0", Source: "cmd/rpcserve.go (0 = token-aware compaction bounds the history)"},
 	"CHATCLI_MCP_SESSION_AUTOSAVE":          {Value: "true", IsBool: true, Source: "cmd/rpcserve.go (persist live MCP sessions as mcp-<session>; unset follows CHATCLI_SESSION_AUTOSAVE)"},
-	"CHATCLI_SESSION_AUTOSAVE_KEEP":         {Value: "200", Source: "cli/cli_session_autosave.go (machine-session keep-count backstop; TTL is the primary retention)"},
+	"CHATCLI_SESSION_AUTOSAVE_KEEP":         {Value: "600", Source: "cli/cli_session_autosave.go (machine-session keep-count backstop; TTL is the primary retention)"},
 	"CHATCLI_MCP_HUB":                       {Value: "on", Source: "cmd/rpcserve.go (join the conversation hub in resume mode: on|off)"},
 	"CHATCLI_MCP_HUB_PRINCIPAL":             {Value: "(hub default)", Source: "cmd/rpcserve.go (isolate the MCP thread under another principal)"},
 	"CHATCLI_ALLOW_UNSIGNED_PLUGINS":        {Value: "false", IsBool: true, Source: "plugin manager"},

--- a/cli/config_sections.go
+++ b/cli/config_sections.go
@@ -834,6 +834,11 @@ func (cli *ChatCLI) showConfigSession() {
 		autosaveVal = defaultMarker + autosaveVal
 	}
 	kv(p, "CHATCLI_SESSION_AUTOSAVE", autosaveVal)
+	keepVal := fmt.Sprintf("%d", sessionAutosaveKeep())
+	if os.Getenv("CHATCLI_SESSION_AUTOSAVE_KEEP") == "" {
+		keepVal = defaultMarker + keepVal
+	}
+	kv(p, "CHATCLI_SESSION_AUTOSAVE_KEEP", keepVal)
 
 	fmt.Println(p)
 	subheader(p, "cfg.sub.session.cost")

--- a/cli/rpc_support_full.go
+++ b/cli/rpc_support_full.go
@@ -467,6 +467,25 @@ func (cli *ChatCLI) DeleteSessionRPC(name string) error {
 	return cli.sessionManager.DeleteSession(name)
 }
 
+// PruneSessionsRPC bounds a machine-session set (e.g. the mcp- mirrors) to
+// the newest keep files. No-op when the store is unavailable.
+func (cli *ChatCLI) PruneSessionsRPC(prefix string, keep int) int {
+	if cli.sessionManager == nil {
+		return 0
+	}
+	return cli.sessionManager.PruneSessionsByPrefix(prefix, keep)
+}
+
+// CleanExpiredMachineSessionsRPC applies the machine-session TTL. Called by
+// the MCP/ACP server at boot so long-running daemons get the same bounded
+// lifecycle the REPL applies on start.
+func (cli *ChatCLI) CleanExpiredMachineSessionsRPC() int {
+	if cli.sessionManager == nil {
+		return 0
+	}
+	return cli.sessionManager.CleanExpiredMachineSessions()
+}
+
 // SearchSessionsRPC runs the full-text search across the saved-session store
 // and renders the hits compactly (session name, match count, snippets) for a
 // model-facing tool result.

--- a/cli/session_lifecycle_test.go
+++ b/cli/session_lifecycle_test.go
@@ -79,3 +79,17 @@ func TestCleanExpiredMachineSessions_SparesUserNamed(t *testing.T) {
 		t.Error("stale machine sessions must be expired")
 	}
 }
+
+func TestCleanExpiredMachineSessions_ZeroTTLDisables(t *testing.T) {
+	sm := newTestSessionManager(t)
+	seedSession(t, sm, "mcp-ancient", 400*24*time.Hour)
+
+	t.Setenv("CHATCLI_SESSION_TTL", "0")
+	if cleaned := sm.CleanExpiredMachineSessions(); cleaned != 0 {
+		t.Fatalf("TTL=0 must disable expiry entirely, cleaned %d", cleaned)
+	}
+	names, _ := sm.ListSessions()
+	if len(names) != 1 {
+		t.Errorf("ancient machine session must survive with TTL=0, have %v", names)
+	}
+}

--- a/cli/session_lifecycle_test.go
+++ b/cli/session_lifecycle_test.go
@@ -1,0 +1,81 @@
+/*
+ * ChatCLI - Machine-session lifecycle tests (prune + TTL).
+ * Copyright (c) 2024 Edilson Freitas. License: Apache-2.0.
+ */
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/diillson/chatcli/models"
+)
+
+func seedSession(t *testing.T, sm *SessionManager, name string, age time.Duration) {
+	t.Helper()
+	if err := sm.SaveSessionV2(name, &SessionData{Version: 2, ChatHistory: []models.Message{
+		{Role: "user", Content: "hello from " + name},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if age > 0 {
+		path := filepath.Join(sm.sessionsDir, name+".json")
+		old := time.Now().Add(-age)
+		if err := os.Chtimes(path, old, old); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestPruneSessionsByPrefix_KeepsNewestByMtime(t *testing.T) {
+	sm := newTestSessionManager(t)
+	seedSession(t, sm, "mcp-old", 72*time.Hour)
+	seedSession(t, sm, "mcp-mid", 48*time.Hour)
+	seedSession(t, sm, "mcp-new", 0)
+	seedSession(t, sm, "user-named", 100*24*time.Hour) // different prefix: untouched
+
+	if removed := sm.PruneSessionsByPrefix("mcp-", 2); removed != 1 {
+		t.Fatalf("expected 1 pruned, got %d", removed)
+	}
+	names, _ := sm.ListSessions()
+	got := map[string]bool{}
+	for _, n := range names {
+		got[n] = true
+	}
+	if got["mcp-old"] {
+		t.Error("oldest mcp- session must be pruned")
+	}
+	for _, want := range []string{"mcp-mid", "mcp-new", "user-named"} {
+		if !got[want] {
+			t.Errorf("session %q must survive, have %v", want, names)
+		}
+	}
+}
+
+func TestCleanExpiredMachineSessions_SparesUserNamed(t *testing.T) {
+	sm := newTestSessionManager(t)
+	seedSession(t, sm, "autosave-20260101-120000", 200*24*time.Hour)
+	seedSession(t, sm, "mcp-stale", 200*24*time.Hour)
+	seedSession(t, sm, "important-checkpoint", 200*24*time.Hour) // user-named, ancient
+	seedSession(t, sm, "autosave-20260715-120000", 0)            // fresh machine session
+
+	if cleaned := sm.CleanExpiredMachineSessions(); cleaned != 2 {
+		t.Fatalf("expected 2 expired machine sessions cleaned, got %d", cleaned)
+	}
+	names, _ := sm.ListSessions()
+	got := map[string]bool{}
+	for _, n := range names {
+		got[n] = true
+	}
+	if !got["important-checkpoint"] {
+		t.Error("user-named sessions must NEVER be expired automatically")
+	}
+	if !got["autosave-20260715-120000"] {
+		t.Error("fresh machine session must survive")
+	}
+	if got["mcp-stale"] || got["autosave-20260101-120000"] {
+		t.Error("stale machine sessions must be expired")
+	}
+}

--- a/cli/session_manager.go
+++ b/cli/session_manager.go
@@ -138,6 +138,112 @@ func (sm *SessionManager) CleanExpiredSessions() int {
 	return cleaned
 }
 
+// machineSessionPrefixes name the session files ChatCLI creates on its own
+// (REPL autosave-on-exit and MCP per-session autosave). Lifecycle policies —
+// prune-by-count, TTL expiry — apply ONLY to these: sessions the USER named
+// are deliberate checkpoints and are never deleted automatically. The
+// distilled layers (facts, episodes, rollups) survive any session cleanup,
+// so pruning bounds disk and search cost without degrading recall.
+var machineSessionPrefixes = []string{"autosave-", "mcp-"}
+
+// isMachineSession reports whether name carries a machine prefix.
+func isMachineSession(name string) bool {
+	for _, p := range machineSessionPrefixes {
+		if strings.HasPrefix(name, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// PruneSessionsByPrefix deletes the OLDEST sessions matching prefix beyond
+// keep, ordered by file modification time (newest survive). Returns how many
+// were removed. Safe on any cadence; missing dir is not an error.
+func (sm *SessionManager) PruneSessionsByPrefix(prefix string, keep int) int {
+	if keep < 0 {
+		keep = 0
+	}
+	entries, err := os.ReadDir(sm.sessionsDir)
+	if err != nil {
+		return 0
+	}
+	type aged struct {
+		name string
+		mod  time.Time
+	}
+	matches := make([]aged, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		name := strings.TrimSuffix(e.Name(), ".json")
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		matches = append(matches, aged{name: name, mod: info.ModTime()})
+	}
+	if len(matches) <= keep {
+		return 0
+	}
+	sort.Slice(matches, func(i, j int) bool { return matches[i].mod.Before(matches[j].mod) })
+	removed := 0
+	for _, m := range matches[:len(matches)-keep] {
+		if err := sm.DeleteSession(m.name); err == nil {
+			removed++
+		}
+	}
+	if removed > 0 {
+		sm.logger.Info("Machine sessions pruned", zap.String("prefix", prefix), zap.Int("removed", removed))
+	}
+	return removed
+}
+
+// CleanExpiredMachineSessions applies the TTL (CHATCLI_SESSION_TTL, default
+// 90 days) to MACHINE-created sessions only — autosaves and MCP session
+// mirrors. User-named sessions are never expired: a checkpoint someone saved
+// on purpose must outlive any retention policy. This is the lifecycle hook
+// the boot paths call; the broader CleanExpiredSessions remains available
+// for operators who explicitly want full expiry.
+func (sm *SessionManager) CleanExpiredMachineSessions() int {
+	ttlDays := 90
+	if v := os.Getenv("CHATCLI_SESSION_TTL"); v != "" {
+		if n, err := strconv.Atoi(strings.TrimSuffix(v, "d")); err == nil && n > 0 {
+			ttlDays = n
+		}
+	}
+	cutoff := time.Now().Add(-time.Duration(ttlDays) * 24 * time.Hour)
+
+	entries, err := os.ReadDir(sm.sessionsDir)
+	if err != nil {
+		return 0
+	}
+	cleaned := 0
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		name := strings.TrimSuffix(entry.Name(), ".json")
+		if !isMachineSession(name) {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil || !info.ModTime().Before(cutoff) {
+			continue
+		}
+		if err := os.Remove(filepath.Join(sm.sessionsDir, entry.Name())); err == nil {
+			cleaned++
+		}
+	}
+	if cleaned > 0 {
+		sm.logger.Info("Expired machine sessions cleaned", zap.Int("removed", cleaned), zap.Int("ttl_days", ttlDays))
+	}
+	return cleaned
+}
+
 // SaveSession salva o histórico da conversa em um arquivo JSON.
 // Mantém assinatura original para compatibilidade com remote client.
 func (sm *SessionManager) SaveSession(name string, history []models.Message) error {

--- a/cli/session_manager.go
+++ b/cli/session_manager.go
@@ -203,16 +203,22 @@ func (sm *SessionManager) PruneSessionsByPrefix(prefix string, keep int) int {
 }
 
 // CleanExpiredMachineSessions applies the TTL (CHATCLI_SESSION_TTL, default
-// 90 days) to MACHINE-created sessions only — autosaves and MCP session
-// mirrors. User-named sessions are never expired: a checkpoint someone saved
-// on purpose must outlive any retention policy. This is the lifecycle hook
-// the boot paths call; the broader CleanExpiredSessions remains available
-// for operators who explicitly want full expiry.
+// 90 days; "0" disables expiry entirely, honoring the documented contract)
+// to MACHINE-created sessions only — autosaves and MCP session mirrors.
+// User-named sessions are never expired: a checkpoint someone saved on
+// purpose must outlive any retention policy. This is the lifecycle hook the
+// boot paths call; the broader CleanExpiredSessions remains available for
+// operators who explicitly want full expiry.
 func (sm *SessionManager) CleanExpiredMachineSessions() int {
 	ttlDays := 90
 	if v := os.Getenv("CHATCLI_SESSION_TTL"); v != "" {
-		if n, err := strconv.Atoi(strings.TrimSuffix(v, "d")); err == nil && n > 0 {
-			ttlDays = n
+		if n, err := strconv.Atoi(strings.TrimSuffix(v, "d")); err == nil {
+			if n == 0 {
+				return 0 // documented opt-out: keep every session indefinitely
+			}
+			if n > 0 {
+				ttlDays = n
+			}
 		}
 	}
 	cutoff := time.Now().Add(-time.Duration(ttlDays) * 24 * time.Hour)

--- a/cmd/rpcserve.go
+++ b/cmd/rpcserve.go
@@ -318,7 +318,7 @@ func (b *rpcBackend) promptPlain(ctx context.Context, session, text string, hist
 // place), so this counts distinct MCP conversations, not turns. Like the
 // REPL autosaves, retention is primarily the 90-day TTL; the count is a
 // generous backstop, overridable via CHATCLI_SESSION_AUTOSAVE_KEEP.
-const mcpAutosaveKeepDefault = 200
+const mcpAutosaveKeepDefault = 600
 
 // mcpAutosaveKeep resolves the mirror keep-count (shared env with the REPL
 // autosave backstop so operators tune one knob).

--- a/cmd/rpcserve.go
+++ b/cmd/rpcserve.go
@@ -313,10 +313,23 @@ func (b *rpcBackend) promptPlain(ctx context.Context, session, text string, hist
 	return reply, nil
 }
 
-// mcpAutosaveKeep bounds how many distinct mcp- session mirrors survive
-// pruning — enough for a handful of concurrent MCP clients without letting
-// unique session ids accrete forever.
-const mcpAutosaveKeep = 20
+// mcpAutosaveKeepDefault bounds how many distinct mcp- session mirrors
+// survive pruning. Mirrors are rolling (one file per session id, updated in
+// place), so this counts distinct MCP conversations, not turns. Like the
+// REPL autosaves, retention is primarily the 90-day TTL; the count is a
+// generous backstop, overridable via CHATCLI_SESSION_AUTOSAVE_KEEP.
+const mcpAutosaveKeepDefault = 200
+
+// mcpAutosaveKeep resolves the mirror keep-count (shared env with the REPL
+// autosave backstop so operators tune one knob).
+func mcpAutosaveKeep() int {
+	if v := strings.TrimSpace(os.Getenv("CHATCLI_SESSION_AUTOSAVE_KEEP")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return mcpAutosaveKeepDefault
+}
 
 // mcpSessionAutosaveEnabled resolves the MCP autosave gate. An explicit
 // CHATCLI_MCP_SESSION_AUTOSAVE always wins; otherwise the global
@@ -357,7 +370,7 @@ func (b *rpcBackend) autosaveSession(session string, hist []models.Message) {
 		return
 	}
 	if b.store.SaveSessionRPC("mcp-"+session, hist) == nil {
-		b.store.PruneSessionsRPC("mcp-", mcpAutosaveKeep)
+		b.store.PruneSessionsRPC("mcp-", mcpAutosaveKeep())
 	}
 }
 

--- a/cmd/rpcserve.go
+++ b/cmd/rpcserve.go
@@ -95,6 +95,10 @@ func runRPC(kind string, mgr manager.LLMManager, logger *zap.Logger) error {
 	}
 	if chatCLI != nil {
 		backend.store = chatCLI
+		// Same bounded lifecycle the REPL applies on start: expire
+		// machine-created sessions (autosaves, mcp- mirrors) past their TTL.
+		// Background — boot never waits on disk.
+		go chatCLI.CleanExpiredMachineSessionsRPC()
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -181,6 +185,7 @@ type sessionStore interface {
 	LoadSessionRPC(name string) ([]models.Message, error)
 	ListSessionsRPC() ([]string, error)
 	DeleteSessionRPC(name string) error
+	PruneSessionsRPC(prefix string, keep int) int
 }
 
 // rpcBackend implements rpcserve.MCPBackend (and thus Backend). Chat keeps a
@@ -299,22 +304,61 @@ func (b *rpcBackend) promptPlain(ctx context.Context, session, text string, hist
 	hist = append(hist, models.Message{Role: "assistant", Content: reply})
 
 	b.mu.Lock()
-	b.sessions[session] = capHistory(hist, historyCap(false))
+	capped := capHistory(hist, historyCap(false))
+	b.sessions[session] = capped
 	b.mu.Unlock()
+	// Same persistence contract as the full-pipeline path: plain passthrough
+	// conversations are sessions too.
+	b.autosaveSession(session, capped)
 	return reply, nil
 }
 
-// autosaveSession persists the live session to the saved-session store when
-// CHATCLI_MCP_SESSION_AUTOSAVE is on. Best-effort: a store failure logs via
-// the session manager and never fails the turn.
+// mcpAutosaveKeep bounds how many distinct mcp- session mirrors survive
+// pruning — enough for a handful of concurrent MCP clients without letting
+// unique session ids accrete forever.
+const mcpAutosaveKeep = 20
+
+// mcpSessionAutosaveEnabled resolves the MCP autosave gate. An explicit
+// CHATCLI_MCP_SESSION_AUTOSAVE always wins; otherwise the global
+// CHATCLI_SESSION_AUTOSAVE gate applies (default ON) — the same default the
+// interactive REPL uses, so both surfaces persist conversations unless the
+// operator opts out.
+func mcpSessionAutosaveEnabled() bool {
+	if v := strings.TrimSpace(os.Getenv("CHATCLI_MCP_SESSION_AUTOSAVE")); v != "" {
+		switch strings.ToLower(v) {
+		case "false", "0", "off", "no", "disabled":
+			return false
+		}
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("CHATCLI_SESSION_AUTOSAVE"))) {
+	case "false", "0", "off", "no", "disabled":
+		return false
+	}
+	return true
+}
+
+// autosaveSession persists the live session to the saved-session store as a
+// rolling "mcp-<session>" mirror (one file per session id, updated in place),
+// then prunes the oldest mirrors past the keep-count. Trivial histories
+// (fewer than 2 non-system messages) are skipped. Best-effort: a store
+// failure never fails the turn.
 func (b *rpcBackend) autosaveSession(session string, hist []models.Message) {
-	if b.store == nil || len(hist) == 0 {
+	if b.store == nil || !mcpSessionAutosaveEnabled() {
 		return
 	}
-	if v := strings.TrimSpace(os.Getenv("CHATCLI_MCP_SESSION_AUTOSAVE")); !strings.EqualFold(v, "true") && v != "1" {
+	nonSystem := 0
+	for _, m := range hist {
+		if m.Role != "system" {
+			nonSystem++
+		}
+	}
+	if nonSystem < 2 {
 		return
 	}
-	_ = b.store.SaveSessionRPC("mcp-"+session, hist)
+	if b.store.SaveSessionRPC("mcp-"+session, hist) == nil {
+		b.store.PruneSessionsRPC("mcp-", mcpAutosaveKeep)
+	}
 }
 
 // Agent runs the full agent (ReAct) loop with per-call options, scoped to
@@ -445,12 +489,15 @@ func (b *rpcBackend) ManageSession(_ context.Context, action, session, name stri
 
 	case "clear":
 		b.mu.Lock()
-		_, existed := b.sessions[session]
+		hist, existed := b.sessions[session]
 		delete(b.sessions, session)
 		b.mu.Unlock()
 		if !existed {
 			return fmt.Sprintf("session %q had no live history", session), nil
 		}
+		// Last-chance autosave: clearing must never be the moment a
+		// conversation silently ceases to exist.
+		b.autosaveSession(session, hist)
 		return fmt.Sprintf("session %q cleared — the next ask_chatcli call starts fresh", session), nil
 
 	case "save":

--- a/cmd/rpcserve_parity_test.go
+++ b/cmd/rpcserve_parity_test.go
@@ -56,18 +56,47 @@ func TestCapHistory(t *testing.T) {
 func TestAutosaveSession(t *testing.T) {
 	store := &fakeStore{saved: map[string][]models.Message{}}
 	b := &rpcBackend{store: store}
-	hist := []models.Message{{Role: "user", Content: "keep me"}}
-
-	t.Setenv("CHATCLI_MCP_SESSION_AUTOSAVE", "")
-	b.autosaveSession("sess", hist)
-	if len(store.saved) != 0 {
-		t.Fatal("autosave must be off by default")
+	hist := []models.Message{
+		{Role: "user", Content: "keep me"},
+		{Role: "assistant", Content: "kept"},
 	}
 
+	// Default ON: with neither env set, MCP conversations persist — the same
+	// default the interactive REPL autosave uses.
+	t.Setenv("CHATCLI_MCP_SESSION_AUTOSAVE", "")
+	t.Setenv("CHATCLI_SESSION_AUTOSAVE", "")
+	b.autosaveSession("sess", hist)
+	if got := store.saved["mcp-sess"]; len(got) != 2 || got[0].Content != "keep me" {
+		t.Fatalf("autosave must be ON by default and persist under mcp-<session>; got %+v", store.saved)
+	}
+
+	// The global session-autosave gate disables MCP autosave too…
+	delete(store.saved, "mcp-sess")
+	t.Setenv("CHATCLI_SESSION_AUTOSAVE", "false")
+	b.autosaveSession("sess", hist)
+	if len(store.saved) != 0 {
+		t.Fatal("global CHATCLI_SESSION_AUTOSAVE=false must disable MCP autosave")
+	}
+
+	// …but an explicit MCP setting always wins, in both directions.
 	t.Setenv("CHATCLI_MCP_SESSION_AUTOSAVE", "true")
 	b.autosaveSession("sess", hist)
-	if got := store.saved["mcp-sess"]; len(got) != 1 || got[0].Content != "keep me" {
-		t.Fatalf("autosave must persist under mcp-<session>; got %+v", store.saved)
+	if len(store.saved["mcp-sess"]) != 2 {
+		t.Fatal("explicit CHATCLI_MCP_SESSION_AUTOSAVE=true must override the global gate")
+	}
+	delete(store.saved, "mcp-sess")
+	t.Setenv("CHATCLI_SESSION_AUTOSAVE", "")
+	t.Setenv("CHATCLI_MCP_SESSION_AUTOSAVE", "false")
+	b.autosaveSession("sess", hist)
+	if len(store.saved) != 0 {
+		t.Fatal("explicit CHATCLI_MCP_SESSION_AUTOSAVE=false must win over the default")
+	}
+
+	// Trivial histories (fewer than 2 non-system messages) are skipped.
+	t.Setenv("CHATCLI_MCP_SESSION_AUTOSAVE", "true")
+	b.autosaveSession("sess", []models.Message{{Role: "user", Content: "solo"}})
+	if len(store.saved) != 0 {
+		t.Fatal("trivial history must not autosave")
 	}
 
 	b.autosaveSession("sess", nil)

--- a/cmd/rpcserve_test.go
+++ b/cmd/rpcserve_test.go
@@ -198,6 +198,8 @@ func (s *fakeStore) DeleteSessionRPC(name string) error {
 	return nil
 }
 
+func (s *fakeStore) PruneSessionsRPC(string, int) int { return 0 }
+
 func sessionBackend(store sessionStore) *rpcBackend {
 	return &rpcBackend{store: store, sessions: map[string][]models.Message{}}
 }


### PR DESCRIPTION
## Motivação

Fechamento do loop de recall para MCP + resposta à preocupação de crescimento: *"e quando tem inúmeras conversas? tem limite? limpa sem degradar o raciocínio?"*

Dois gaps reais:
1. **Conversas MCP eram cidadãs de segunda classe**: o autosave `mcp-<session>` existia mas era opt-in (default off) — conversas headless evaporavam a menos que o cliente lembrasse do `manage_session save`.
2. **Sessões cresciam sem limite**: `CleanExpiredSessions` (TTL 90d) existia mas **nunca era chamado em lugar nenhum** — acúmulo infinito de arquivos, e busca de sessão (que carrega todos os JSONs) ficando mais cara a cada dia.

## O que entra

**Autosave MCP default-on** (`cmd/rpcserve.go`)
- Mesmo default do REPL: on, a menos que o operador desligue. `CHATCLI_MCP_SESSION_AUTOSAVE` explícito sempre vence; sem ele, segue o gate global `CHATCLI_SESSION_AUTOSAVE`.
- Espelho rolling `mcp-<session>` (um arquivo por session id, atualizado in-place — não acumula por turno) nos DOIS caminhos (full-pipeline e plain passthrough); `manage_session clear` faz um último autosave antes de descartar; históricos triviais (<2 mensagens não-system) pulados.

**Ciclo de vida limitado — sem degradar o raciocínio** (`cli/session_manager.go`)
- Conceito novo: **sessões de máquina** (prefixos `autosave-` e `mcp-`) vs **sessões nomeadas pelo usuário**. Políticas de retenção valem SÓ para as de máquina; checkpoint nomeado de propósito **nunca** é apagado automaticamente.
- `PruneSessionsByPrefix` (por mtime, mais novas sobrevivem): REPL mantém 10 autosaves, MCP mantém 20 espelhos — o pruner do REPL foi refatorado para o helper compartilhado.
- `CleanExpiredMachineSessions` (TTL 90d, `CHATCLI_SESSION_TTL`) rodando em background no boot do REPL **e** do servidor MCP/ACP.
- Por que não degrada: as camadas destiladas (facts, episódios, rollups) são permanentes e sobrevivem a qualquer limpeza de sessão — o prune limita disco e custo de busca; o conhecimento fica.

## Testes

Prune por mtime preserva prefixos alheios; TTL poupa nomeadas e frescas, expira máquinas velhas; autosave MCP: default-on, gate global desliga, explícito vence nos dois sentidos, trivial pulado, nil-store sem panic; clear salva antes. Registry de defaults do /config atualizado. Suíte completa verde, lint zero, Floor 3 e Floor 4 verificados localmente (exit 0).