### PR TITLE
fix(agent): close native tool_call batches on park and pair results positionally

### DIFF
--- a/cli/agent/tool_result_pairing.go
+++ b/cli/agent/tool_result_pairing.go
@@ -6,8 +6,15 @@
  * Ensures every tool_use block in the conversation history has a matching
  * tool_result, and every tool_result references a valid tool_use.
  *
- * Inspired by openclaude's ensureToolResultPairing() which cross-message
- * tracks all tool_use IDs and generates synthetic error results for orphans.
+ * Pairing is POSITIONAL (block-scoped), not global: each assistant message
+ * that carries tool_calls owns the stretch of history up to the next
+ * assistant message, and its results are matched only inside that stretch.
+ * This is required for providers whose tool_call IDs are NOT globally
+ * unique — Moonshot/Kimi K3 emits deterministic per-turn IDs such as
+ * "web_fetch:0"/"web_fetch:1" that repeat on every turn, so a global
+ * id→result map silently pairs an old dangling call with a newer turn's
+ * result and ships an invalid history (API 400: "tool_call_ids did not
+ * have response messages").
  */
 package agent
 
@@ -31,7 +38,8 @@ const (
 type PairingRepairReport struct {
 	SyntheticResultsInjected int      // tool_use blocks without matching tool_result
 	OrphanResultsRemoved     int      // tool_result blocks without matching tool_use
-	DuplicateToolUsePruned   int      // duplicate tool_use IDs across messages
+	DuplicateToolUsePruned   int      // duplicate tool_use IDs within a single assistant message
+	ResultsRelocated         int      // results moved next to their tool_call past interposed messages
 	MissingToolUseIDs        []string // IDs of tool calls that had no result
 	OrphanToolResultIDs      []string // IDs of tool results that had no call
 }
@@ -40,21 +48,25 @@ type PairingRepairReport struct {
 func (r *PairingRepairReport) HasRepairs() bool {
 	return r.SyntheticResultsInjected > 0 ||
 		r.OrphanResultsRemoved > 0 ||
-		r.DuplicateToolUsePruned > 0
+		r.DuplicateToolUsePruned > 0 ||
+		r.ResultsRelocated > 0
 }
 
-// EnsureToolResultPairing validates and repairs the conversation history to ensure:
+// EnsureToolResultPairing validates and repairs the conversation history so that
+// every assistant message carrying ToolCalls is immediately followed by exactly
+// one tool result message per call — the shape every native tool API requires.
 //
-//  1. Every assistant message with ToolCalls has corresponding tool result messages
-//     with matching ToolCallIDs following it (before the next assistant message).
-//  2. Every tool result message references a tool_use ID that exists in a preceding
-//     assistant message.
-//  3. No duplicate tool_use IDs exist across the conversation.
+// Scope rules (per assistant block, in order):
 //
-// Repairs:
-//   - Missing tool results: injects synthetic error tool_result messages
-//   - Orphan tool results: removes them from history
-//   - Duplicate tool_use IDs: prunes all but the first occurrence
+//  1. Results are claimed from the stretch between the assistant message and
+//     the NEXT assistant message. A matching result that sits past interposed
+//     user/system messages is relocated to be adjacent to its call.
+//  2. Calls with no claimable result get a synthetic error result injected
+//     directly after the assistant message.
+//  3. Duplicate IDs WITHIN one assistant message are pruned (all but the first).
+//     The same ID reappearing in a LATER assistant message is legal — providers
+//     like Moonshot/Kimi reuse deterministic per-turn IDs.
+//  4. Tool result messages not claimed by any block are orphans and removed.
 //
 // Returns the repaired history and a report of what was changed.
 // If no repairs are needed, returns the original slice unchanged.
@@ -65,74 +77,19 @@ func EnsureToolResultPairing(history []models.Message, logger *zap.Logger) ([]mo
 		return history, report
 	}
 
-	// Phase 1: Collect all tool_use IDs and their positions
-	type toolUseInfo struct {
-		id       string
-		msgIndex int
-		name     string
-	}
+	claimed := make([]bool, len(history)) // tool results claimed by an assistant block
+	repaired := make([]models.Message, 0, len(history))
 
-	allToolUses := make(map[string]toolUseInfo) // id → info (first occurrence)
-	allToolResults := make(map[string]int)      // toolCallID → message index
-	seenToolUseIDs := make(map[string]bool)     // for dedup detection
+	for i := 0; i < len(history); i++ {
+		msg := history[i]
 
-	for i, msg := range history {
-		if msg.Role == "assistant" && len(msg.ToolCalls) > 0 {
-			for _, tc := range msg.ToolCalls {
-				if tc.ID == "" {
-					continue
-				}
-				if seenToolUseIDs[tc.ID] {
-					report.DuplicateToolUsePruned++
-					continue
-				}
-				seenToolUseIDs[tc.ID] = true
-				allToolUses[tc.ID] = toolUseInfo{id: tc.ID, msgIndex: i, name: tc.Name}
+		if msg.Role == "tool" {
+			if claimed[i] {
+				continue // already emitted next to its assistant block
 			}
-		}
-		if msg.Role == "tool" && msg.ToolCallID != "" {
-			allToolResults[msg.ToolCallID] = i
-		}
-	}
-
-	// Phase 2: Find mismatches
-	// tool_use without tool_result
-	missingResults := make(map[string]toolUseInfo)
-	for id, info := range allToolUses {
-		if _, hasResult := allToolResults[id]; !hasResult {
-			missingResults[id] = info
-			report.MissingToolUseIDs = append(report.MissingToolUseIDs, id)
-		}
-	}
-
-	// tool_result without tool_use
-	orphanResults := make(map[string]int)
-	for resultID, idx := range allToolResults {
-		if _, hasUse := allToolUses[resultID]; !hasUse {
-			orphanResults[resultID] = idx
-			report.OrphanToolResultIDs = append(report.OrphanToolResultIDs, resultID)
-		}
-	}
-
-	report.SyntheticResultsInjected = len(missingResults)
-	report.OrphanResultsRemoved = len(orphanResults)
-
-	if !report.HasRepairs() {
-		return history, report
-	}
-
-	// Phase 3: Build repaired history
-	repaired := make([]models.Message, 0, len(history)+len(missingResults))
-
-	// Track which orphan indices to skip
-	orphanIndices := make(map[int]bool)
-	for _, idx := range orphanResults {
-		orphanIndices[idx] = true
-	}
-
-	for i, msg := range history {
-		// Skip orphaned tool results
-		if orphanIndices[i] {
+			// Unclaimed tool result: no preceding block owns this ID → orphan.
+			report.OrphanResultsRemoved++
+			report.OrphanToolResultIDs = append(report.OrphanToolResultIDs, msg.ToolCallID)
 			if logger != nil {
 				logger.Warn("Removed orphaned tool result",
 					zap.String("tool_call_id", msg.ToolCallID),
@@ -141,45 +98,92 @@ func EnsureToolResultPairing(history []models.Message, logger *zap.Logger) ([]mo
 			continue
 		}
 
-		// Handle duplicate tool_use IDs in assistant messages
-		if msg.Role == "assistant" && len(msg.ToolCalls) > 0 && report.DuplicateToolUsePruned > 0 {
-			seen := make(map[string]bool)
-			dedupCalls := make([]models.ToolCall, 0, len(msg.ToolCalls))
-			for _, tc := range msg.ToolCalls {
-				if tc.ID != "" && seen[tc.ID] {
-					continue
-				}
-				seen[tc.ID] = true
-				dedupCalls = append(dedupCalls, tc)
-			}
-			msg.ToolCalls = dedupCalls
+		if msg.Role != "assistant" || len(msg.ToolCalls) == 0 {
+			repaired = append(repaired, msg)
+			continue
 		}
 
+		// Assistant block: prune intra-message duplicate IDs, then claim
+		// results from the stretch up to the next assistant message.
+		seen := make(map[string]bool, len(msg.ToolCalls))
+		calls := make([]models.ToolCall, 0, len(msg.ToolCalls))
+		for _, tc := range msg.ToolCalls {
+			if tc.ID != "" && seen[tc.ID] {
+				report.DuplicateToolUsePruned++
+				continue
+			}
+			seen[tc.ID] = true
+			calls = append(calls, tc)
+		}
+		if len(calls) < len(msg.ToolCalls) {
+			msg.ToolCalls = calls
+		}
 		repaired = append(repaired, msg)
 
-		// After an assistant message with tool calls, inject synthetic results
-		// for any tool_use IDs that have no corresponding tool_result
-		if msg.Role == "assistant" && len(msg.ToolCalls) > 0 {
-			for _, tc := range msg.ToolCalls {
-				if _, missing := missingResults[tc.ID]; missing {
-					synthetic := models.Message{
-						Role:       "tool",
-						Content:    SyntheticToolResultContent,
-						ToolCallID: tc.ID,
-					}
-					repaired = append(repaired, synthetic)
+		// Claim pass: first matching unclaimed result per call ID, scanning
+		// only until the next assistant message (that one owns what follows).
+		found := make(map[string]int, len(calls)) // call ID → history index
+		adjacentEnd := i + 1                      // end of the run of tool messages directly after the block
+		for adjacentEnd < len(history) && history[adjacentEnd].Role == "tool" {
+			adjacentEnd++
+		}
+		for j := i + 1; j < len(history); j++ {
+			if history[j].Role == "assistant" {
+				break
+			}
+			if history[j].Role != "tool" || claimed[j] {
+				continue
+			}
+			id := history[j].ToolCallID
+			if _, want := seen[id]; !want || id == "" {
+				continue
+			}
+			if _, dup := found[id]; dup {
+				continue
+			}
+			found[id] = j
+			claimed[j] = true
+		}
 
+		// Emission pass: one result per call, in call order — real when
+		// claimed, synthetic otherwise.
+		for _, tc := range calls {
+			if tc.ID == "" {
+				continue
+			}
+			if j, ok := found[tc.ID]; ok {
+				repaired = append(repaired, history[j])
+				if j >= adjacentEnd {
+					// It sat past an interposed non-tool message; emitting it
+					// here relocates it next to its call.
+					report.ResultsRelocated++
 					if logger != nil {
-						logger.Warn("Injected synthetic tool result for orphaned tool_use",
+						logger.Warn("Relocated displaced tool result next to its tool_call",
 							zap.String("tool_call_id", tc.ID),
-							zap.String("tool_name", tc.Name),
-							zap.Int("assistant_message_index", i))
+							zap.Int("from_index", j))
 					}
 				}
+				continue
+			}
+			repaired = append(repaired, models.Message{
+				Role:       "tool",
+				Content:    SyntheticToolResultContent,
+				ToolCallID: tc.ID,
+			})
+			report.SyntheticResultsInjected++
+			report.MissingToolUseIDs = append(report.MissingToolUseIDs, tc.ID)
+			if logger != nil {
+				logger.Warn("Injected synthetic tool result for orphaned tool_use",
+					zap.String("tool_call_id", tc.ID),
+					zap.String("tool_name", tc.Name),
+					zap.Int("assistant_message_index", i))
 			}
 		}
 	}
 
+	if !report.HasRepairs() {
+		return history, report
+	}
 	return repaired, report
 }
 

--- a/cli/agent/tool_result_pairing.go
+++ b/cli/agent/tool_result_pairing.go
@@ -30,7 +30,16 @@ const (
 	SyntheticToolResultContent = "[Tool result missing — the tool execution was interrupted or failed silently. " +
 		"Do NOT retry this tool call. Analyze what went wrong and try a different approach.]"
 
-	// OrphanToolResultContent replaces orphaned tool results that reference non-existent tool_use IDs.
+	// SyntheticToolResultErrorCode marks injected synthetic results so
+	// providers surface them as errors (OpenAI-family [ERROR:...] marker,
+	// Anthropic is_error) instead of apparent successes, and so downstream
+	// consumers can distinguish repair synthetics from real outputs.
+	SyntheticToolResultErrorCode = "missing_result"
+
+	// OrphanToolResultContent is kept for API compatibility.
+	//
+	// Deprecated: orphaned tool results are REMOVED from history, never
+	// replaced with this placeholder. No code references it.
 	OrphanToolResultContent = "[Orphaned tool result — no matching tool call found. This result has been discarded.]"
 )
 
@@ -38,7 +47,7 @@ const (
 type PairingRepairReport struct {
 	SyntheticResultsInjected int      // tool_use blocks without matching tool_result
 	OrphanResultsRemoved     int      // tool_result blocks without matching tool_use
-	DuplicateToolUsePruned   int      // duplicate tool_use IDs within a single assistant message
+	DuplicateToolUsePruned   int      // duplicate or empty tool_use IDs within a single assistant message
 	ResultsRelocated         int      // results moved next to their tool_call past interposed messages
 	MissingToolUseIDs        []string // IDs of tool calls that had no result
 	OrphanToolResultIDs      []string // IDs of tool results that had no call
@@ -63,22 +72,26 @@ func (r *PairingRepairReport) HasRepairs() bool {
 //     user/system messages is relocated to be adjacent to its call.
 //  2. Calls with no claimable result get a synthetic error result injected
 //     directly after the assistant message.
-//  3. Duplicate IDs WITHIN one assistant message are pruned (all but the first).
-//     The same ID reappearing in a LATER assistant message is legal — providers
-//     like Moonshot/Kimi reuse deterministic per-turn IDs.
+//  3. Duplicate IDs WITHIN one assistant message are pruned (all but the
+//     first), and calls with an empty ID are pruned outright — they can never
+//     be paired, and serializing them ships an invalid empty id. The same ID
+//     reappearing in a LATER assistant message is legal — providers like
+//     Moonshot/Kimi reuse deterministic per-turn IDs.
 //  4. Tool result messages not claimed by any block are orphans and removed.
 //
 // Returns the repaired history and a report of what was changed.
-// If no repairs are needed, returns the original slice unchanged.
+// If no repairs are needed, returns the original slice unchanged — the common
+// case is allocation-free via a validation prepass, since this runs on the
+// persistent history every agent turn.
 func EnsureToolResultPairing(history []models.Message, logger *zap.Logger) ([]models.Message, *PairingRepairReport) {
 	report := &PairingRepairReport{}
 
-	if len(history) == 0 {
+	if len(history) == 0 || !pairingNeedsRepair(history) {
 		return history, report
 	}
 
 	claimed := make([]bool, len(history)) // tool results claimed by an assistant block
-	repaired := make([]models.Message, 0, len(history))
+	repaired := make([]models.Message, 0, len(history)+4)
 
 	for i := 0; i < len(history); i++ {
 		msg := history[i]
@@ -103,18 +116,9 @@ func EnsureToolResultPairing(history []models.Message, logger *zap.Logger) ([]mo
 			continue
 		}
 
-		// Assistant block: prune intra-message duplicate IDs, then claim
-		// results from the stretch up to the next assistant message.
-		seen := make(map[string]bool, len(msg.ToolCalls))
-		calls := make([]models.ToolCall, 0, len(msg.ToolCalls))
-		for _, tc := range msg.ToolCalls {
-			if tc.ID != "" && seen[tc.ID] {
-				report.DuplicateToolUsePruned++
-				continue
-			}
-			seen[tc.ID] = true
-			calls = append(calls, tc)
-		}
+		// Assistant block: prune empty-ID and intra-message duplicate IDs,
+		// then claim results from the stretch up to the next assistant message.
+		calls := pruneInvalidCalls(msg.ToolCalls, report)
 		if len(calls) < len(msg.ToolCalls) {
 			msg.ToolCalls = calls
 		}
@@ -122,54 +126,53 @@ func EnsureToolResultPairing(history []models.Message, logger *zap.Logger) ([]mo
 
 		// Claim pass: first matching unclaimed result per call ID, scanning
 		// only until the next assistant message (that one owns what follows).
-		found := make(map[string]int, len(calls)) // call ID → history index
-		adjacentEnd := i + 1                      // end of the run of tool messages directly after the block
-		for adjacentEnd < len(history) && history[adjacentEnd].Role == "tool" {
-			adjacentEnd++
+		// A claim made after a non-tool message was passed is a relocation.
+		wanted := make(map[string]bool, len(calls))
+		for _, tc := range calls {
+			wanted[tc.ID] = true
 		}
+		type claim struct {
+			idx       int
+			relocated bool
+		}
+		found := make(map[string]claim, len(calls))
+		interposed := false
 		for j := i + 1; j < len(history); j++ {
 			if history[j].Role == "assistant" {
 				break
 			}
-			if history[j].Role != "tool" || claimed[j] {
+			if history[j].Role != "tool" {
+				interposed = true
 				continue
 			}
 			id := history[j].ToolCallID
-			if _, want := seen[id]; !want || id == "" {
+			if id == "" || !wanted[id] {
 				continue
 			}
 			if _, dup := found[id]; dup {
 				continue
 			}
-			found[id] = j
+			found[id] = claim{idx: j, relocated: interposed}
 			claimed[j] = true
 		}
 
 		// Emission pass: one result per call, in call order — real when
 		// claimed, synthetic otherwise.
 		for _, tc := range calls {
-			if tc.ID == "" {
-				continue
-			}
-			if j, ok := found[tc.ID]; ok {
-				repaired = append(repaired, history[j])
-				if j >= adjacentEnd {
-					// It sat past an interposed non-tool message; emitting it
-					// here relocates it next to its call.
+			if c, ok := found[tc.ID]; ok {
+				repaired = append(repaired, history[c.idx])
+				if c.relocated {
 					report.ResultsRelocated++
 					if logger != nil {
 						logger.Warn("Relocated displaced tool result next to its tool_call",
 							zap.String("tool_call_id", tc.ID),
-							zap.Int("from_index", j))
+							zap.Int("from_index", c.idx))
 					}
 				}
 				continue
 			}
-			repaired = append(repaired, models.Message{
-				Role:       "tool",
-				Content:    SyntheticToolResultContent,
-				ToolCallID: tc.ID,
-			})
+			repaired = append(repaired, models.NewToolResultMessage(
+				tc.ID, SyntheticToolResultContent, true, SyntheticToolResultErrorCode))
 			report.SyntheticResultsInjected++
 			report.MissingToolUseIDs = append(report.MissingToolUseIDs, tc.ID)
 			if logger != nil {
@@ -187,11 +190,107 @@ func EnsureToolResultPairing(history []models.Message, logger *zap.Logger) ([]mo
 	return repaired, report
 }
 
+// pruneInvalidCalls drops empty-ID calls and intra-message duplicates (all
+// but the first occurrence), counting both in DuplicateToolUsePruned. It
+// returns the original slice untouched when nothing needs pruning — the
+// overwhelmingly common case.
+func pruneInvalidCalls(toolCalls []models.ToolCall, report *PairingRepairReport) []models.ToolCall {
+	dirty := false
+	for i, tc := range toolCalls {
+		if tc.ID == "" {
+			dirty = true
+			break
+		}
+		for j := 0; j < i; j++ {
+			if toolCalls[j].ID == tc.ID {
+				dirty = true
+				break
+			}
+		}
+		if dirty {
+			break
+		}
+	}
+	if !dirty {
+		return toolCalls
+	}
+
+	seen := make(map[string]bool, len(toolCalls))
+	calls := make([]models.ToolCall, 0, len(toolCalls))
+	for _, tc := range toolCalls {
+		if tc.ID == "" || seen[tc.ID] {
+			report.DuplicateToolUsePruned++
+			continue
+		}
+		seen[tc.ID] = true
+		calls = append(calls, tc)
+	}
+	return calls
+}
+
+// pairingNeedsRepair is the allocation-light validation prepass: it returns
+// false exactly when the repair pass would report no repairs, so the caller
+// can keep the original slice. Mirrors the repair semantics: every assistant
+// block's calls must have non-empty unique IDs and be answered by STRICTLY
+// adjacent tool messages (relocation counts as a repair), and every tool
+// message must be part of such an adjacent run with a matching ID.
+func pairingNeedsRepair(history []models.Message) bool {
+	i := 0
+	for i < len(history) {
+		msg := history[i]
+		if msg.Role == "tool" {
+			return true // not consumed by a block below → orphan or displaced
+		}
+		if msg.Role != "assistant" || len(msg.ToolCalls) == 0 {
+			i++
+			continue
+		}
+		calls := msg.ToolCalls
+		for k, tc := range calls {
+			if tc.ID == "" {
+				return true
+			}
+			for j := 0; j < k; j++ {
+				if calls[j].ID == tc.ID {
+					return true
+				}
+			}
+		}
+		// Consume the adjacent tool run; every result must match a distinct call.
+		matched := 0
+		j := i + 1
+		for ; j < len(history) && history[j].Role == "tool"; j++ {
+			id := history[j].ToolCallID
+			ok := false
+			for _, tc := range calls {
+				if tc.ID == id {
+					ok = true
+					break
+				}
+			}
+			if !ok || matched >= len(calls) {
+				return true // extra/foreign result in the adjacent run
+			}
+			// Duplicate result for the same ID inside the run?
+			for k := i + 1; k < j; k++ {
+				if history[k].ToolCallID == id {
+					return true
+				}
+			}
+			matched++
+		}
+		if matched != len(calls) {
+			return true // missing results (or displaced past interposed prose)
+		}
+		i = j
+	}
+	return false
+}
+
 // ValidateToolResultPairing checks if the history has pairing issues without repairing.
 // Returns true if the history is valid (no repairs needed).
 func ValidateToolResultPairing(history []models.Message) bool {
-	_, report := EnsureToolResultPairing(history, nil)
-	return !report.HasRepairs()
+	return !pairingNeedsRepair(history)
 }
 
 // CountPendingToolCalls returns how many tool calls in the last assistant message

--- a/cli/agent/tool_result_pairing_test.go
+++ b/cli/agent/tool_result_pairing_test.go
@@ -190,6 +190,61 @@ func TestEnsureToolResultPairing_ResultBeyondNextAssistantNotClaimed(t *testing.
 	assert.Equal(t, "interleaved", repaired[2].Content)
 }
 
+func TestEnsureToolResultPairing_SyntheticsAreErrorMarked(t *testing.T) {
+	history := []models.Message{
+		assistantWithCalls("web_fetch:0"),
+	}
+
+	repaired, report := EnsureToolResultPairing(history, nil)
+
+	require.Equal(t, 1, report.SyntheticResultsInjected)
+	require.Len(t, repaired, 2)
+	// The synthetic must surface as an ERROR on the wire (OpenAI [ERROR:...]
+	// marker / Anthropic is_error) so the model never reads an interrupted
+	// call as a success.
+	assert.True(t, repaired[1].IsError)
+	assert.Equal(t, SyntheticToolResultErrorCode, repaired[1].ErrorCode)
+}
+
+func TestEnsureToolResultPairing_EmptyIDCallPruned(t *testing.T) {
+	history := []models.Message{
+		{Role: "assistant", ToolCalls: []models.ToolCall{
+			{ID: "", Name: "web_fetch", Type: "function"},
+			{ID: "web_fetch:1", Name: "web_fetch", Type: "function"},
+		}},
+		toolResult("web_fetch:1", "ok"),
+	}
+
+	repaired, report := EnsureToolResultPairing(history, nil)
+
+	// The empty-ID call can never be paired and would serialize an invalid
+	// empty id — it is pruned, and the history stabilizes (a second pass
+	// reports nothing).
+	assert.Equal(t, 1, report.DuplicateToolUsePruned)
+	require.Len(t, repaired, 2)
+	require.Len(t, repaired[0].ToolCalls, 1)
+	assert.Equal(t, "web_fetch:1", repaired[0].ToolCalls[0].ID)
+
+	again, report2 := EnsureToolResultPairing(repaired, nil)
+	assert.False(t, report2.HasRepairs())
+	assert.Equal(t, repaired, again)
+}
+
+func TestEnsureToolResultPairing_OutOfOrderAdjacentIsValid(t *testing.T) {
+	// Results adjacent but in reverse call order: the API only requires the
+	// set to follow the block, so this must NOT trigger a rewrite.
+	history := []models.Message{
+		assistantWithCalls("web_fetch:0", "web_fetch:1"),
+		toolResult("web_fetch:1", "b"),
+		toolResult("web_fetch:0", "a"),
+	}
+
+	repaired, report := EnsureToolResultPairing(history, nil)
+
+	assert.False(t, report.HasRepairs())
+	assert.Equal(t, history, repaired)
+}
+
 func TestCountPendingToolCalls_LastBlockScoped(t *testing.T) {
 	history := []models.Message{
 		assistantWithCalls("web_fetch:0", "web_fetch:1"),

--- a/cli/agent/tool_result_pairing_test.go
+++ b/cli/agent/tool_result_pairing_test.go
@@ -1,0 +1,202 @@
+/*
+ * ChatCLI - Tool Result Pairing Validator tests
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * The duplicate-ID scenarios mirror Moonshot/Kimi K3, whose tool_call IDs
+ * are deterministic per turn ("web_fetch:0", "web_fetch:1") and repeat
+ * across turns — the exact shape that made the previous global-map pairing
+ * ship dangling tool_calls and got rejected by the API with a 400.
+ */
+package agent
+
+import (
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func assistantWithCalls(ids ...string) models.Message {
+	calls := make([]models.ToolCall, 0, len(ids))
+	for _, id := range ids {
+		calls = append(calls, models.ToolCall{ID: id, Name: "web_fetch", Type: "function"})
+	}
+	return models.Message{Role: "assistant", ToolCalls: calls}
+}
+
+func toolResult(id, content string) models.Message {
+	return models.NewToolResultMessage(id, content, false, "")
+}
+
+func TestEnsureToolResultPairing_ValidHistoryUnchanged(t *testing.T) {
+	history := []models.Message{
+		{Role: "system", Content: "sys"},
+		{Role: "user", Content: "go"},
+		assistantWithCalls("web_fetch:0", "web_fetch:1"),
+		toolResult("web_fetch:0", "a"),
+		toolResult("web_fetch:1", "b"),
+		{Role: "assistant", Content: "done"},
+	}
+
+	repaired, report := EnsureToolResultPairing(history, nil)
+
+	assert.False(t, report.HasRepairs())
+	assert.Equal(t, history, repaired)
+}
+
+func TestEnsureToolResultPairing_DuplicateIDsAcrossTurns_SecondBlockDangling(t *testing.T) {
+	// Turn A answered; turn B reuses the SAME IDs (Kimi K3) but its results
+	// were lost. The old global-map pairing saw turn A's results and injected
+	// nothing → API 400. Block-scoped pairing must fix turn B.
+	history := []models.Message{
+		{Role: "user", Content: "go"},
+		assistantWithCalls("web_fetch:0", "web_fetch:1"),
+		toolResult("web_fetch:0", "a"),
+		toolResult("web_fetch:1", "b"),
+		assistantWithCalls("web_fetch:0", "web_fetch:1"),
+		{Role: "user", Content: "[batch feedback]"},
+	}
+
+	repaired, report := EnsureToolResultPairing(history, nil)
+
+	assert.Equal(t, 2, report.SyntheticResultsInjected)
+	assert.Zero(t, report.OrphanResultsRemoved)
+	require.Len(t, repaired, 8)
+	// Turn B must be immediately followed by its two synthetic results.
+	assert.Equal(t, "tool", repaired[5].Role)
+	assert.Equal(t, "web_fetch:0", repaired[5].ToolCallID)
+	assert.Equal(t, SyntheticToolResultContent, repaired[5].Content)
+	assert.Equal(t, "tool", repaired[6].Role)
+	assert.Equal(t, "web_fetch:1", repaired[6].ToolCallID)
+	assert.Equal(t, "user", repaired[7].Role)
+	// Turn A keeps its real results.
+	assert.Equal(t, "a", repaired[2].Content)
+	assert.Equal(t, "b", repaired[3].Content)
+}
+
+func TestEnsureToolResultPairing_DanglingFirstBlock_LaterBlockAnswered(t *testing.T) {
+	// The park-session shape: an OLD dangling block, then a later turn with
+	// the same IDs properly answered. The old code paired the old block with
+	// the new results (global map) and repaired nothing.
+	history := []models.Message{
+		assistantWithCalls("web_fetch:0", "web_fetch:1"),
+		{Role: "user", Content: "[legacy batch feedback]"},
+		assistantWithCalls("web_fetch:0", "web_fetch:1"),
+		toolResult("web_fetch:0", "fresh-a"),
+		toolResult("web_fetch:1", "fresh-b"),
+	}
+
+	repaired, report := EnsureToolResultPairing(history, nil)
+
+	assert.Equal(t, 2, report.SyntheticResultsInjected)
+	require.Len(t, repaired, 7)
+	// Old block gets synthetics, adjacent.
+	assert.Equal(t, SyntheticToolResultContent, repaired[1].Content)
+	assert.Equal(t, SyntheticToolResultContent, repaired[2].Content)
+	assert.Equal(t, "user", repaired[3].Role)
+	// New block keeps its own results.
+	assert.Equal(t, "fresh-a", repaired[5].Content)
+	assert.Equal(t, "fresh-b", repaired[6].Content)
+}
+
+func TestEnsureToolResultPairing_InterposedMessageRelocatesResults(t *testing.T) {
+	// Mid-batch feedback appended between the assistant tool_calls and the
+	// results breaks provider adjacency; the results must be pulled back
+	// next to their calls and the feedback pushed after them.
+	history := []models.Message{
+		assistantWithCalls("web_fetch:0", "web_fetch:1"),
+		{Role: "user", Content: "SECURITY BLOCK: something"},
+		toolResult("web_fetch:0", "a"),
+		toolResult("web_fetch:1", "b"),
+	}
+
+	repaired, report := EnsureToolResultPairing(history, nil)
+
+	assert.Equal(t, 2, report.ResultsRelocated)
+	assert.Zero(t, report.SyntheticResultsInjected)
+	require.Len(t, repaired, 4)
+	assert.Equal(t, "tool", repaired[1].Role)
+	assert.Equal(t, "a", repaired[1].Content)
+	assert.Equal(t, "tool", repaired[2].Role)
+	assert.Equal(t, "b", repaired[2].Content)
+	assert.Equal(t, "user", repaired[3].Role)
+}
+
+func TestEnsureToolResultPairing_OrphanResultRemoved(t *testing.T) {
+	history := []models.Message{
+		{Role: "user", Content: "go"},
+		toolResult("ghost:0", "nobody asked"),
+		{Role: "assistant", Content: "done"},
+	}
+
+	repaired, report := EnsureToolResultPairing(history, nil)
+
+	assert.Equal(t, 1, report.OrphanResultsRemoved)
+	assert.Equal(t, []string{"ghost:0"}, report.OrphanToolResultIDs)
+	require.Len(t, repaired, 2)
+	assert.Equal(t, "user", repaired[0].Role)
+	assert.Equal(t, "assistant", repaired[1].Role)
+}
+
+func TestEnsureToolResultPairing_PartialResultsGetSynthetics(t *testing.T) {
+	history := []models.Message{
+		assistantWithCalls("web_fetch:0", "web_fetch:1", "park:2"),
+		toolResult("web_fetch:0", "only this ran"),
+	}
+
+	repaired, report := EnsureToolResultPairing(history, nil)
+
+	assert.Equal(t, 2, report.SyntheticResultsInjected)
+	assert.ElementsMatch(t, []string{"web_fetch:1", "park:2"}, report.MissingToolUseIDs)
+	require.Len(t, repaired, 4)
+	// Emitted in call order: real, synthetic, synthetic.
+	assert.Equal(t, "web_fetch:0", repaired[1].ToolCallID)
+	assert.Equal(t, "only this ran", repaired[1].Content)
+	assert.Equal(t, "web_fetch:1", repaired[2].ToolCallID)
+	assert.Equal(t, "park:2", repaired[3].ToolCallID)
+}
+
+func TestEnsureToolResultPairing_IntraMessageDuplicatePruned(t *testing.T) {
+	history := []models.Message{
+		assistantWithCalls("dup:0", "dup:0"),
+		toolResult("dup:0", "once"),
+	}
+
+	repaired, report := EnsureToolResultPairing(history, nil)
+
+	assert.Equal(t, 1, report.DuplicateToolUsePruned)
+	require.Len(t, repaired, 2)
+	require.Len(t, repaired[0].ToolCalls, 1)
+	assert.Equal(t, "once", repaired[1].Content)
+}
+
+func TestEnsureToolResultPairing_ResultBeyondNextAssistantNotClaimed(t *testing.T) {
+	// A result sitting past the NEXT assistant message belongs to that later
+	// block's stretch, never to the earlier one.
+	history := []models.Message{
+		assistantWithCalls("web_fetch:0"),
+		{Role: "assistant", Content: "interleaved"},
+		toolResult("web_fetch:0", "late"),
+	}
+
+	repaired, report := EnsureToolResultPairing(history, nil)
+
+	assert.Equal(t, 1, report.SyntheticResultsInjected)
+	assert.Equal(t, 1, report.OrphanResultsRemoved)
+	require.Len(t, repaired, 3)
+	assert.Equal(t, SyntheticToolResultContent, repaired[1].Content)
+	assert.Equal(t, "interleaved", repaired[2].Content)
+}
+
+func TestCountPendingToolCalls_LastBlockScoped(t *testing.T) {
+	history := []models.Message{
+		assistantWithCalls("web_fetch:0", "web_fetch:1"),
+		toolResult("web_fetch:0", "a"),
+	}
+	assert.Equal(t, 1, CountPendingToolCalls(history))
+
+	history = append(history, toolResult("web_fetch:1", "b"))
+	assert.Equal(t, 0, CountPendingToolCalls(history))
+}

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -2093,6 +2093,11 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 					renderer.Colorize(
 						i18n.T("agent.early_exit.stagnation", repeats),
 						agent.ColorYellow))
+				// Close the just-persisted native batch first: stagnation
+				// fires BEFORE execution, so without this the run ends with
+				// assistant(tool_calls) + user — the dangling shape strict
+				// providers reject on the next request.
+				a.closeNativeBatch(nativeToolCalls, nil, toolResultNotExecutedStagnation)
 				// Acknowledge the partial assistant text so a later
 				// manual continuation starts from a consistent state.
 				a.cli.history = append(a.cli.history, models.Message{
@@ -2439,9 +2444,13 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 				a.cli.history = append(a.cli.history, models.Message{Role: "user", Content: feedback})
 
 				// If there are also tool_calls in the same response, skip them —
-				// the orchestrator should use agent_calls OR tool_calls, not both in the same turn.
+				// the orchestrator should use agent_calls OR tool_calls, not both
+				// in the same turn. Native calls must still be CLOSED: leaving
+				// them unanswered ships the dangling shape strict providers 400
+				// on whenever the loop terminates right after this turn.
 				if len(toolCalls) > 0 {
 					a.logger.Info("Skipping tool_calls because agent_calls were dispatched in this turn")
+					a.closeNativeBatch(nativeToolCalls, nil, toolResultNotExecutedAgentCalls)
 				}
 				showTurnStats()
 				continue
@@ -2692,6 +2701,12 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 						}
 
 						if ctx.Err() != nil {
+							// Close the batch before bailing: the assistant
+							// tool_calls message is already persisted, and an
+							// unanswered batch left behind is exactly the
+							// dangling shape strict providers 400 on — in
+							// chat mode too, which has no repair pass.
+							a.closeNativeBatch(nativeToolCalls, turnToolResults, toolResultNotExecutedCanceled)
 							return ctx.Err()
 						}
 					} else {
@@ -2874,8 +2889,13 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 								renderer.RenderStreamBoxEnd(agent.ColorPurple)
 							}
 
-							// Se o contexto foi cancelado (Ctrl+C), propaga imediatamente
+							// Se o contexto foi cancelado (Ctrl+C), propaga
+							// imediatamente — fechando o batch antes, para o
+							// histórico durável nunca ficar com tool_calls
+							// sem resposta (o formato que providers estritos
+							// rejeitam com 400, inclusive via chat).
 							if ctx.Err() != nil {
+								a.closeNativeBatch(nativeToolCalls, turnToolResults, toolResultNotExecutedCanceled)
 								return ctx.Err()
 							}
 
@@ -2893,6 +2913,7 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 							// as two `╰────╮` rows.
 							if req, parked := park.AsParkError(execErr); parked {
 								var pendingID string
+								var beforeClosure []models.Message
 								if i < len(nativeToolCalls) {
 									pendingID = nativeToolCalls[i].ID
 									// Close every OTHER native call of this
@@ -2907,10 +2928,20 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 									// park call itself stays pending —
 									// RunResumed pairs it with the real park
 									// outcome.
+									beforeClosure = a.cli.history
 									a.cli.history = insertStructuredToolResults(a.cli.history,
 										buildParkBatchClosure(nativeToolCalls, turnToolResults, i))
 								}
-								return a.handleAgentPark(ctx, req, pendingID, toolName)
+								parkErr := a.handleAgentPark(ctx, req, pendingID, toolName)
+								if parkErr != nil && !errors.Is(parkErr, errAgentParkedRequested) && beforeClosure != nil {
+									// Park never armed (snapshot save / enqueue
+									// failed): the closures claiming "the agent
+									// parked" would be false history. Restore
+									// the pre-closure slice — the next turn's
+									// pairing repair closes the batch honestly.
+									a.cli.history = beforeClosure
+								}
+								return parkErr
 							}
 						}
 					}
@@ -2987,6 +3018,21 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 					toolOutput, _ = a.cli.compressionLayer.CompressToolOutput(tc.Name, toolOutput)
 				}
 
+				// Per-tool truncation (Item 6) BEFORE the structured capture:
+				// turnToolResults feeds the persistent history and park
+				// snapshots via the structured emission paths, so an
+				// untruncated multi-hundred-KB fetch must never be captured.
+				// Plugins that implement plugins.TruncationAware get their
+				// own per-call cap; the rest use the global default. Errors
+				// are left verbatim so the model can debug them in full.
+				if execErr == nil {
+					maxChars := plugins.DefaultMaxResultChars
+					if p, ok := a.cli.pluginManager.GetPlugin(tc.Name); ok && p != nil {
+						maxChars = plugins.EffectiveMaxResultChars(p)
+					}
+					toolOutput = plugins.TruncateForLLM(toolOutput, maxChars)
+				}
+
 				// Capture the structured outcome for downstream phases.
 				// Duration is wall-clock for this single tool — Fase 3 will
 				// also use it to size the per-batch concurrency budget.
@@ -3018,18 +3064,9 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 					break // Fail-Fast: Para a execução do lote
 				}
 
-				// Per-tool truncation (Item 6). Plugins that
-				// implement plugins.TruncationAware get their own
-				// per-call cap; the rest use the global default.
-				// We look the plugin up again here because the
-				// inner-scope `plugin` variable from the dispatch
-				// block is no longer in scope at this site.
-				maxChars := plugins.DefaultMaxResultChars
-				if p, ok := a.cli.pluginManager.GetPlugin(tc.Name); ok && p != nil {
-					maxChars = plugins.EffectiveMaxResultChars(p)
-				}
-				toolOutput = plugins.TruncateForLLM(toolOutput, maxChars)
-
+				// Per-tool truncation already applied above, before the
+				// structured capture — both the legacy concatenation and
+				// turnToolResults see the same bounded output.
 				batchOutputBuilder.WriteString(toolOutput)
 				batchOutputBuilder.WriteString("\n\n")
 				successCount++

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -1729,15 +1729,22 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 			fmt.Print(metrics.FormatTimerStatus(d, modelName, msg))
 		})
 
-		turnHistory := buildTurnHistoryWithAnchor()
-
-		// Validate tool result pairing and enforce budget before sending to API
-		turnHistory, pairingReport := agent.EnsureToolResultPairing(turnHistory, a.logger)
+		// Validate/repair tool result pairing on the PERSISTENT history —
+		// not just the outgoing copy — so the repaired shape survives into
+		// later turns and into park snapshots. Repairing only the per-turn
+		// copy let dangling tool_calls live forever in a.cli.history and
+		// resurface on every park/resume cycle.
+		repairedHistory, pairingReport := agent.EnsureToolResultPairing(a.cli.history, a.logger)
 		if pairingReport.HasRepairs() {
+			a.cli.history = repairedHistory
 			a.logger.Info("Tool result pairing repaired before API call",
 				zap.Int("synthetic_results", pairingReport.SyntheticResultsInjected),
-				zap.Int("orphans_removed", pairingReport.OrphanResultsRemoved))
+				zap.Int("orphans_removed", pairingReport.OrphanResultsRemoved),
+				zap.Int("results_relocated", pairingReport.ResultsRelocated))
 		}
+
+		// Build the outgoing turn history and enforce budget before sending to API
+		turnHistory := buildTurnHistoryWithAnchor()
 		turnHistory, _ = agent.EnforceToolResultBudget(turnHistory, a.logger)
 
 		// Resolve per-turn client + effort hint from any active skill
@@ -2888,6 +2895,20 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 								var pendingID string
 								if i < len(nativeToolCalls) {
 									pendingID = nativeToolCalls[i].ID
+									// Close every OTHER native call of this
+									// batch before snapshotting: the loop
+									// suspends here, so the structured
+									// emission tail below never runs. Without
+									// this, calls batched alongside @park
+									// (e.g. web_fetch × 2 + park) stay
+									// dangling in the snapshot forever and
+									// every resume ships an invalid history
+									// (Moonshot/OpenAI-compat 400). Only the
+									// park call itself stays pending —
+									// RunResumed pairs it with the real park
+									// outcome.
+									a.cli.history = insertStructuredToolResults(a.cli.history,
+										buildParkBatchClosure(nativeToolCalls, turnToolResults, i))
 								}
 								return a.handleAgentPark(ctx, req, pendingID, toolName)
 							}
@@ -3047,43 +3068,30 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 				}
 			}
 
-			// Lógica de Continuação:
-			// Se houve erro de validação (onde já inserimos msg específica no histórico) E nenhuma ação rodou,
-			// apenas damos continue para a IA tentar corrigir.
-			if batchHasError && !strings.Contains(batchOutputBuilder.String(), "Resultado da Ação") {
-				continue
-			}
-
 			// Provider-agnostic tool_result emission: when the assistant
-			// produced native tool_calls in this turn AND every call has
-			// a matching structured result, emit one models.Message with
-			// Role="tool" per call (ToolCallID + IsError + ErrorCode
-			// flowing through). Each provider adapter
-			// (claudeai, openai, moonshot, minimax, zai, openrouter)
-			// already knows how to translate role="tool" into its
-			// native shape — Anthropic tool_result with is_error,
-			// OpenAI-family tool message with [ERROR:<code>] marker.
+			// produced native tool_calls in this turn, EVERY call gets a
+			// Role="tool" message — real outcomes for the executed prefix
+			// (the batch is fail-fast, so turnToolResults aligns
+			// index-for-index with the first calls) and "not executed"
+			// closures for the rest. This must hold even on mid-batch
+			// errors: skipping the emission leaves dangling tool_calls
+			// that strict OpenAI-compat providers reject with 400, and
+			// providers with deterministic per-turn IDs (Kimi K3:
+			// "web_fetch:0") defeat any later ID-based repair — so the
+			// shape is closed at the source. Results are INSERTED right
+			// after the assistant message, before any feedback appended
+			// mid-batch (security blocks, format-fix prompts), preserving
+			// the adjacency every native tool API validates. Each provider
+			// adapter (claudeai, openai, moonshot, minimax, zai,
+			// openrouter) already translates role="tool" into its native
+			// shape — Anthropic tool_result with is_error, OpenAI-family
+			// tool message with [ERROR:<code>] marker.
 			//
-			// We keep the legacy concatenated user message ONLY when
-			// the assistant did not produce native tool_calls (text-
-			// mode XML dispatch path), so providers that don't carry
-			// tool_use IDs still see the batch output for context.
-			useStructured := len(nativeToolCalls) > 0 &&
-				len(turnToolResults) == len(nativeToolCalls) &&
-				!batchHasError // mid-batch infra error doesn't produce a full result slice
-
-			if useStructured {
-				for i, res := range turnToolResults {
-					content := res.Output
-					// Per-tool truncation already applied in the loop.
-					a.cli.history = append(a.cli.history,
-						models.NewToolResultMessage(
-							nativeToolCalls[i].ID,
-							content,
-							res.IsError,
-							res.ErrorCode,
-						))
-				}
+			// The legacy concatenated user message remains ONLY for the
+			// text-mode XML dispatch path, where no tool_use IDs exist.
+			if len(nativeToolCalls) > 0 {
+				a.cli.history = insertStructuredToolResults(a.cli.history,
+					buildNativeBatchResults(nativeToolCalls, turnToolResults, toolResultNotExecutedBatchError))
 				// Optional replanning hint as a side note, kept as a
 				// system-style nudge rather than a malformed user message.
 				if a.taskTracker != nil && a.taskTracker.NeedsReplanning() {
@@ -3092,6 +3100,11 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 						Content: "ATENÇÃO: Múltiplas falhas detectadas. Crie um NOVO <reasoning> com uma lista replanejada de tarefas, considerando os erros anteriores.",
 					})
 				}
+			} else if batchHasError && !strings.Contains(batchOutputBuilder.String(), "Resultado da Ação") {
+				// Erro de validação sem nenhuma ação executada (via XML):
+				// a msg de correção específica já está no histórico —
+				// apenas damos continue para a IA tentar corrigir.
+				continue
 			} else {
 				// Legacy path: text-mode dispatch or partially-failed batch.
 				// One user message carries everything; provider adapters

--- a/cli/agent_native_results.go
+++ b/cli/agent_native_results.go
@@ -1,0 +1,112 @@
+/*
+ * ChatCLI - Native tool_call result emission helpers
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * When the assistant message carries NATIVE tool_calls, every provider's
+ * tool API (Anthropic, OpenAI-compatible: Moonshot, MiniMax, ZAI, ...)
+ * requires one tool result per call, adjacent to the assistant message.
+ * These helpers guarantee that shape at the two spots where the batch loop
+ * can end without a complete result set: a mid-batch error (fail-fast) and
+ * an @park suspension.
+ */
+package cli
+
+import (
+	"github.com/diillson/chatcli/cli/agent"
+	"github.com/diillson/chatcli/models"
+)
+
+// LLM-facing closure texts for calls that never ran. English on purpose
+// (model-facing, not user-facing) and explicit about the recovery move so
+// the model re-issues instead of hallucinating an outcome.
+const (
+	toolResultNotExecutedBatchError = "[Tool call not executed — an earlier action in this batch failed and the " +
+		"batch was aborted (fail-fast). Re-issue this call if it is still needed.]"
+	toolResultNotExecutedPark = "[Tool call not executed — the agent parked (suspended) before this call ran. " +
+		"Re-issue this call after resume if it is still needed.]"
+	// toolResultErrorCodeNotExecuted marks closure results for calls that
+	// were never dispatched, distinguishing them from real execution errors.
+	toolResultErrorCodeNotExecuted = "not_executed"
+)
+
+// insertStructuredToolResults inserts role:"tool" messages immediately after
+// the last assistant message carrying tool_calls — after any tool results
+// already sitting there, but BEFORE any feedback message appended mid-batch
+// (security blocks, format-fix prompts). Plain append would strand the
+// results behind those user messages and break the adjacency every native
+// tool API validates.
+func insertStructuredToolResults(history []models.Message, results []models.Message) []models.Message {
+	if len(results) == 0 {
+		return history
+	}
+	anchor := -1
+	for i := len(history) - 1; i >= 0; i-- {
+		if history[i].Role == "assistant" && len(history[i].ToolCalls) > 0 {
+			anchor = i
+			break
+		}
+	}
+	if anchor == -1 {
+		return append(history, results...)
+	}
+	insertAt := anchor + 1
+	for insertAt < len(history) && history[insertAt].Role == "tool" {
+		insertAt++
+	}
+	out := make([]models.Message, 0, len(history)+len(results))
+	out = append(out, history[:insertAt]...)
+	out = append(out, results...)
+	out = append(out, history[insertAt:]...)
+	return out
+}
+
+// buildNativeBatchResults produces one tool result message per native call.
+// executed holds the structured outcomes for the batch's executed prefix
+// (the loop is fail-fast, so outcomes always align index-for-index with the
+// first len(executed) calls); every call beyond it gets a "not executed"
+// closure carrying notExecutedContent.
+func buildNativeBatchResults(
+	nativeToolCalls []models.ToolCall,
+	executed []agent.ToolResult,
+	notExecutedContent string,
+) []models.Message {
+	results := make([]models.Message, 0, len(nativeToolCalls))
+	for idx, ntc := range nativeToolCalls {
+		if idx < len(executed) {
+			res := executed[idx]
+			results = append(results, models.NewToolResultMessage(ntc.ID, res.Output, res.IsError, res.ErrorCode))
+			continue
+		}
+		results = append(results, models.NewToolResultMessage(
+			ntc.ID, notExecutedContent, true, toolResultErrorCodeNotExecuted))
+	}
+	return results
+}
+
+// buildParkBatchClosure closes every native call of the in-flight batch
+// EXCEPT the park call itself (parkIdx), which stays pending — RunResumed
+// synthesizes its result with the real park outcome at resume time. Without
+// this closure the park snapshot inherits dangling tool_calls (the batch
+// loop suspends before its structured-emission tail runs) and every resume
+// ships an invalid history.
+func buildParkBatchClosure(
+	nativeToolCalls []models.ToolCall,
+	executed []agent.ToolResult,
+	parkIdx int,
+) []models.Message {
+	results := make([]models.Message, 0, len(nativeToolCalls))
+	for idx, ntc := range nativeToolCalls {
+		if idx == parkIdx {
+			continue
+		}
+		if idx < len(executed) {
+			res := executed[idx]
+			results = append(results, models.NewToolResultMessage(ntc.ID, res.Output, res.IsError, res.ErrorCode))
+			continue
+		}
+		results = append(results, models.NewToolResultMessage(
+			ntc.ID, toolResultNotExecutedPark, true, toolResultErrorCodeNotExecuted))
+	}
+	return results
+}

--- a/cli/agent_native_results.go
+++ b/cli/agent_native_results.go
@@ -6,9 +6,10 @@
  * When the assistant message carries NATIVE tool_calls, every provider's
  * tool API (Anthropic, OpenAI-compatible: Moonshot, MiniMax, ZAI, ...)
  * requires one tool result per call, adjacent to the assistant message.
- * These helpers guarantee that shape at the two spots where the batch loop
- * can end without a complete result set: a mid-batch error (fail-fast) and
- * an @park suspension.
+ * These helpers guarantee that shape at every spot where the ReAct loop
+ * can end a turn without a complete result set: mid-batch errors
+ * (fail-fast), @park suspension, context cancellation, stagnation stop,
+ * and the agent_call dispatch path that supersedes the batch.
  */
 package cli
 
@@ -21,10 +22,17 @@ import (
 // (model-facing, not user-facing) and explicit about the recovery move so
 // the model re-issues instead of hallucinating an outcome.
 const (
-	toolResultNotExecutedBatchError = "[Tool call not executed — an earlier action in this batch failed and the " +
-		"batch was aborted (fail-fast). Re-issue this call if it is still needed.]"
+	toolResultNotExecutedBatchError = "[Tool call not executed — the batch stopped before this call completed " +
+		"(an action failed or was blocked; see the accompanying feedback message for the reason). " +
+		"Re-issue this call if it is still needed.]"
 	toolResultNotExecutedPark = "[Tool call not executed — the agent parked (suspended) before this call ran. " +
 		"Re-issue this call after resume if it is still needed.]"
+	toolResultNotExecutedCanceled = "[Tool call interrupted — the run was canceled before this call completed. " +
+		"Re-issue this call if it is still needed.]"
+	toolResultNotExecutedStagnation = "[Tool call not executed — the same tool batch was repeated without new " +
+		"information and the loop was stopped (stagnation). Do NOT re-issue the identical call; change approach.]"
+	toolResultNotExecutedAgentCalls = "[Tool call not executed — agent_calls were dispatched this turn instead; " +
+		"their results are in the following message. Re-issue this call only if the delegated work did not cover it.]"
 	// toolResultErrorCodeNotExecuted marks closure results for calls that
 	// were never dispatched, distinguishing them from real execution errors.
 	toolResultErrorCodeNotExecuted = "not_executed"
@@ -54,6 +62,11 @@ func insertStructuredToolResults(history []models.Message, results []models.Mess
 	for insertAt < len(history) && history[insertAt].Role == "tool" {
 		insertAt++
 	}
+	if insertAt == len(history) {
+		// Common case: the block is the tail — a plain append preserves
+		// slice capacity instead of copying the whole history.
+		return append(history, results...)
+	}
 	out := make([]models.Message, 0, len(history)+len(results))
 	out = append(out, history[:insertAt]...)
 	out = append(out, results...)
@@ -61,18 +74,24 @@ func insertStructuredToolResults(history []models.Message, results []models.Mess
 	return out
 }
 
-// buildNativeBatchResults produces one tool result message per native call.
-// executed holds the structured outcomes for the batch's executed prefix
-// (the loop is fail-fast, so outcomes always align index-for-index with the
-// first len(executed) calls); every call beyond it gets a "not executed"
-// closure carrying notExecutedContent.
-func buildNativeBatchResults(
+// buildBatchResults is the single emission core: one tool result message per
+// native call, in call order. Calls at an index below len(executed) carry the
+// structured outcome (the batch loop is fail-fast, so outcomes always align
+// index-for-index with the executed prefix); every other call gets a
+// "not executed" closure carrying notExecutedContent. skipIdx (or -1) leaves
+// exactly one call unanswered — the @park call, whose result RunResumed
+// synthesizes with the real park outcome at resume time.
+func buildBatchResults(
 	nativeToolCalls []models.ToolCall,
 	executed []agent.ToolResult,
 	notExecutedContent string,
+	skipIdx int,
 ) []models.Message {
 	results := make([]models.Message, 0, len(nativeToolCalls))
 	for idx, ntc := range nativeToolCalls {
+		if idx == skipIdx {
+			continue
+		}
 		if idx < len(executed) {
 			res := executed[idx]
 			results = append(results, models.NewToolResultMessage(ntc.ID, res.Output, res.IsError, res.ErrorCode))
@@ -84,29 +103,41 @@ func buildNativeBatchResults(
 	return results
 }
 
+// buildNativeBatchResults produces one tool result message per native call —
+// see buildBatchResults for the alignment contract.
+func buildNativeBatchResults(
+	nativeToolCalls []models.ToolCall,
+	executed []agent.ToolResult,
+	notExecutedContent string,
+) []models.Message {
+	return buildBatchResults(nativeToolCalls, executed, notExecutedContent, -1)
+}
+
 // buildParkBatchClosure closes every native call of the in-flight batch
-// EXCEPT the park call itself (parkIdx), which stays pending — RunResumed
-// synthesizes its result with the real park outcome at resume time. Without
-// this closure the park snapshot inherits dangling tool_calls (the batch
-// loop suspends before its structured-emission tail runs) and every resume
-// ships an invalid history.
+// EXCEPT the park call itself (parkIdx). Without this closure the park
+// snapshot inherits dangling tool_calls (the batch loop suspends before its
+// structured-emission tail runs) and every resume ships an invalid history.
 func buildParkBatchClosure(
 	nativeToolCalls []models.ToolCall,
 	executed []agent.ToolResult,
 	parkIdx int,
 ) []models.Message {
-	results := make([]models.Message, 0, len(nativeToolCalls))
-	for idx, ntc := range nativeToolCalls {
-		if idx == parkIdx {
-			continue
-		}
-		if idx < len(executed) {
-			res := executed[idx]
-			results = append(results, models.NewToolResultMessage(ntc.ID, res.Output, res.IsError, res.ErrorCode))
-			continue
-		}
-		results = append(results, models.NewToolResultMessage(
-			ntc.ID, toolResultNotExecutedPark, true, toolResultErrorCodeNotExecuted))
+	return buildBatchResults(nativeToolCalls, executed, toolResultNotExecutedPark, parkIdx)
+}
+
+// closeNativeBatch closes every native call of the current turn in one shot —
+// the executed prefix with real outcomes, the rest with notExecutedContent —
+// inserted adjacent to the assistant message. Used by the loop's non-standard
+// exit paths (cancellation, stagnation, agent_call dispatch) so no exit can
+// leave dangling tool_calls in the persistent history.
+func (a *AgentMode) closeNativeBatch(
+	nativeToolCalls []models.ToolCall,
+	executed []agent.ToolResult,
+	notExecutedContent string,
+) {
+	if len(nativeToolCalls) == 0 {
+		return
 	}
-	return results
+	a.cli.history = insertStructuredToolResults(a.cli.history,
+		buildNativeBatchResults(nativeToolCalls, executed, notExecutedContent))
 }

--- a/cli/agent_native_results_test.go
+++ b/cli/agent_native_results_test.go
@@ -1,0 +1,130 @@
+/*
+ * ChatCLI - Native tool_call result emission helpers tests
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"testing"
+
+	"github.com/diillson/chatcli/cli/agent"
+	"github.com/diillson/chatcli/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func nativeCalls(ids ...string) []models.ToolCall {
+	calls := make([]models.ToolCall, 0, len(ids))
+	for _, id := range ids {
+		calls = append(calls, models.ToolCall{ID: id, Name: "web_fetch", Type: "function"})
+	}
+	return calls
+}
+
+func TestInsertStructuredToolResults_BeforeMidBatchFeedback(t *testing.T) {
+	history := []models.Message{
+		{Role: "user", Content: "go"},
+		{Role: "assistant", ToolCalls: nativeCalls("web_fetch:0", "web_fetch:1")},
+		{Role: "user", Content: "SECURITY BLOCK: denied"},
+	}
+	results := []models.Message{
+		models.NewToolResultMessage("web_fetch:0", "ok", false, ""),
+		models.NewToolResultMessage("web_fetch:1", "[not executed]", true, "not_executed"),
+	}
+
+	out := insertStructuredToolResults(history, results)
+
+	require.Len(t, out, 5)
+	assert.Equal(t, "assistant", out[1].Role)
+	assert.Equal(t, "web_fetch:0", out[2].ToolCallID)
+	assert.Equal(t, "web_fetch:1", out[3].ToolCallID)
+	assert.Equal(t, "SECURITY BLOCK: denied", out[4].Content)
+}
+
+func TestInsertStructuredToolResults_AfterExistingToolRun(t *testing.T) {
+	history := []models.Message{
+		{Role: "assistant", ToolCalls: nativeCalls("a:0", "a:1")},
+		models.NewToolResultMessage("a:0", "already there", false, ""),
+	}
+	results := []models.Message{
+		models.NewToolResultMessage("a:1", "late", false, ""),
+	}
+
+	out := insertStructuredToolResults(history, results)
+
+	require.Len(t, out, 3)
+	assert.Equal(t, "a:0", out[1].ToolCallID)
+	assert.Equal(t, "a:1", out[2].ToolCallID)
+}
+
+func TestInsertStructuredToolResults_NoAnchorAppends(t *testing.T) {
+	history := []models.Message{{Role: "user", Content: "hi"}}
+	results := []models.Message{models.NewToolResultMessage("x:0", "y", false, "")}
+
+	out := insertStructuredToolResults(history, results)
+
+	require.Len(t, out, 2)
+	assert.Equal(t, "x:0", out[1].ToolCallID)
+}
+
+func TestInsertStructuredToolResults_EmptyResultsNoop(t *testing.T) {
+	history := []models.Message{{Role: "user", Content: "hi"}}
+	assert.Equal(t, history, insertStructuredToolResults(history, nil))
+}
+
+func TestBuildNativeBatchResults_FailFastTail(t *testing.T) {
+	calls := nativeCalls("web_fetch:0", "web_fetch:1", "web_fetch:2")
+	executed := []agent.ToolResult{
+		{Output: "ok"},
+		{Output: "boom", IsError: true, ErrorCode: "network"},
+	}
+
+	results := buildNativeBatchResults(calls, executed, toolResultNotExecutedBatchError)
+
+	require.Len(t, results, 3)
+	assert.Equal(t, "ok", results[0].Content)
+	assert.False(t, results[0].IsError)
+	assert.Equal(t, "boom", results[1].Content)
+	assert.True(t, results[1].IsError)
+	assert.Equal(t, "network", results[1].ErrorCode)
+	assert.Equal(t, toolResultNotExecutedBatchError, results[2].Content)
+	assert.True(t, results[2].IsError)
+	assert.Equal(t, toolResultErrorCodeNotExecuted, results[2].ErrorCode)
+}
+
+func TestBuildParkBatchClosure_ClosesEverythingExceptPark(t *testing.T) {
+	// The park session shape: [web_fetch:0, web_fetch:1, park:2] — the two
+	// fetches executed, park suspends the loop. The closure must answer the
+	// fetches and leave ONLY the park call pending for resume.
+	calls := nativeCalls("web_fetch:0", "web_fetch:1")
+	calls = append(calls, models.ToolCall{ID: "park:2", Name: "park", Type: "function"})
+	executed := []agent.ToolResult{
+		{Output: "placar 1"},
+		{Output: "placar 2"},
+	}
+
+	results := buildParkBatchClosure(calls, executed, 2)
+
+	require.Len(t, results, 2)
+	assert.Equal(t, "web_fetch:0", results[0].ToolCallID)
+	assert.Equal(t, "placar 1", results[0].Content)
+	assert.Equal(t, "web_fetch:1", results[1].ToolCallID)
+	assert.Equal(t, "placar 2", results[1].Content)
+}
+
+func TestBuildParkBatchClosure_ParkFirstRestNotExecuted(t *testing.T) {
+	calls := nativeCalls("park:0", "web_fetch:1")
+
+	results := buildParkBatchClosure(calls, nil, 0)
+
+	require.Len(t, results, 1)
+	assert.Equal(t, "web_fetch:1", results[0].ToolCallID)
+	assert.Equal(t, toolResultNotExecutedPark, results[0].Content)
+	assert.True(t, results[0].IsError)
+}
+
+func TestBuildParkBatchClosure_SingleParkCallEmpty(t *testing.T) {
+	calls := []models.ToolCall{{ID: "park:0", Name: "park"}}
+	assert.Empty(t, buildParkBatchClosure(calls, nil, 0))
+}

--- a/cli/agent_park.go
+++ b/cli/agent_park.go
@@ -379,9 +379,17 @@ func (a *AgentMode) RunResumed(ctx context.Context, snap *park.Snapshot, outcome
 		return nil
 	}
 	if err != nil {
-		// Real failure (API error, cancel): KEEP the snapshot so the user
-		// can retry with /resume <token> instead of the park dying silently
-		// on a transient error. parkPrune / Sweep collects it if abandoned.
+		// Deliberate abort (Ctrl+C): retire the snapshot. The scheduler job
+		// that fired this resume is already consumed, so a kept snapshot
+		// would show up in /parked looking armed while nothing will ever
+		// auto-fire it — a zombie park lying to the user.
+		if errors.Is(err, context.Canceled) {
+			_ = park.Delete(snap.Token)
+			return err
+		}
+		// Transient failure (API error): KEEP the snapshot so the user can
+		// retry with /resume <token> instead of the park dying silently.
+		// parkPrune / Sweep collects it if abandoned.
 		a.logger.Warn("park: resumed run failed; snapshot kept for manual /resume",
 			zap.String("token", snap.Token), zap.Error(err))
 		return err

--- a/cli/agent_park.go
+++ b/cli/agent_park.go
@@ -370,11 +370,26 @@ func (a *AgentMode) RunResumed(ctx context.Context, snap *park.Snapshot, outcome
 	maxTurns := AgentMaxTurns()
 	err := a.processAIResponseAndAct(ctx, maxTurns)
 
-	// Successful completion (or any non-park error): retire the snapshot.
-	if !errors.Is(err, errAgentParkedRequested) {
-		_ = park.Delete(snap.Token)
+	// Parking again mid-resume is a SUCCESSFUL suspension, exactly like the
+	// sentinel handling in Run(): a new snapshot + scheduler job were just
+	// created for the next cycle. Returning the sentinel here made
+	// runWithCancellation print it as "❌ Erro na execução" on every
+	// monitoring cycle (park → resume → park again).
+	if errors.Is(err, errAgentParkedRequested) {
+		return nil
 	}
-	return err
+	if err != nil {
+		// Real failure (API error, cancel): KEEP the snapshot so the user
+		// can retry with /resume <token> instead of the park dying silently
+		// on a transient error. parkPrune / Sweep collects it if abandoned.
+		a.logger.Warn("park: resumed run failed; snapshot kept for manual /resume",
+			zap.String("token", snap.Token), zap.Error(err))
+		return err
+	}
+
+	// Successful completion: retire the snapshot.
+	_ = park.Delete(snap.Token)
+	return nil
 }
 
 // buildParkResumeMessage builds the synthetic tool result the LLM sees

--- a/cli/agent_park_commands.go
+++ b/cli/agent_park_commands.go
@@ -252,21 +252,34 @@ func (cli *ChatCLI) resolveParkToken(input string) (string, error) {
 //
 // outcome and detail come from either the AgentResume payload (auto)
 // or are fixed strings ("manual", "") for explicit /resume.
-func (cli *ChatCLI) runResumeForToken(ctx context.Context, token, outcome, detail string) {
+func (cli *ChatCLI) runResumeForToken(ctx context.Context, token, outcome, detail string) bool {
 	snap, err := park.Load(token)
 	if err != nil {
 		fmt.Println(colorize("  ⚠ "+i18n.T("park.resume.load_failed", err), ColorYellow))
-		return
+		return false
 	}
 	if cli.agentMode == nil {
 		cli.agentMode = NewAgentMode(cli, cli.logger)
 	}
+	var runErr error
 	cli.runWithCancellation(ctx, "Park Resume", func(ctx context.Context) error {
-		return cli.agentMode.RunResumed(ctx, snap, outcome, detail)
+		runErr = cli.agentMode.RunResumed(ctx, snap, outcome, detail)
+		return runErr
 	})
 	if cli.memWorker != nil {
 		cli.memWorker.nudge(ctx)
 	}
+	if runErr != nil && !errors.Is(runErr, context.Canceled) {
+		// RunResumed kept the snapshot for retry — surface the recovery
+		// path, otherwise the user only sees the failure print and has no
+		// idea an immediate /resume works.
+		short := token
+		if len(short) > 8 {
+			short = short[:8]
+		}
+		fmt.Println(colorize("  ⚠ "+i18n.T("park.resume.retry_hint", short), ColorYellow))
+	}
+	return runErr == nil
 }
 
 // drainPendingResumes consumes the bridge-populated queue once. Called
@@ -304,8 +317,12 @@ func (cli *ChatCLI) drainPendingResumes(ctx context.Context) bool {
 			outcome = out.Outcome
 			detail = out.Detail
 		}
-		cli.runResumeForToken(ctx, token, outcome, detail)
-		cli.markRecentlyResumed(token)
+		// Stamp the idempotency guard ONLY on success: a failed resume keeps
+		// its snapshot precisely so the user can retry with /resume, and the
+		// 30s recently-resumed window would silently swallow that retry.
+		if cli.runResumeForToken(ctx, token, outcome, detail) {
+			cli.markRecentlyResumed(token)
+		}
 		processed = true
 	}
 	return processed

--- a/cli/agent_park_resume_retry_test.go
+++ b/cli/agent_park_resume_retry_test.go
@@ -1,0 +1,39 @@
+/*
+ * ChatCLI - Park resume retry-path tests.
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestRunResumeForToken_MissingSnapshotReturnsFalse(t *testing.T) {
+	t.Setenv("CHATCLI_PARK_DIR", t.TempDir())
+	cli := &ChatCLI{logger: zap.NewNop()}
+
+	ok := cli.runResumeForToken(context.Background(), "zz-token-that-does-not-exist", "manual", "")
+
+	// A failed resume must report failure so drainPendingResumes does NOT
+	// stamp the recently-resumed guard — stamping it silently swallowed the
+	// manual /resume retry for 30s.
+	assert.False(t, ok)
+}
+
+func TestDrainPendingResumes_FailedResumeDoesNotStampGuard(t *testing.T) {
+	t.Setenv("CHATCLI_PARK_DIR", t.TempDir())
+	cli := &ChatCLI{logger: zap.NewNop()}
+	cli.pendingResumeQueue = []string{"zz-token-that-does-not-exist"}
+
+	processed := cli.drainPendingResumes(context.Background())
+
+	assert.True(t, processed)
+	// The failed token must remain retryable: the 30s idempotency guard is
+	// only for resumes that actually ran.
+	assert.False(t, cli.wasRecentlyResumed("zz-token-that-does-not-exist"))
+}

--- a/cli/chat_ask.go
+++ b/cli/chat_ask.go
@@ -110,7 +110,12 @@ func (cli *ChatCLI) executeChatAskNative(
 ) (string, error) {
 	tools := buildChatExceptionTools(askOn, kbOn, gvOn, memOn)
 	prompt := userInput + additionalContext
-	history := tempHistory
+	// The chat temp history copies agent-mode messages verbatim, ToolCalls
+	// included. An agent run that ended on a non-standard exit (cancel,
+	// stagnation) can have left dangling tool_calls that only the AGENT
+	// pipeline repairs — repair the outgoing copy here or strict
+	// OpenAI-compat providers reject the request with a 400.
+	history, _ := agent.EnsureToolResultPairing(tempHistory, cli.logger)
 	gvDone := false
 
 	for round := 0; ; round++ {

--- a/cli/history_compactor.go
+++ b/cli/history_compactor.go
@@ -312,6 +312,7 @@ func (hc *HistoryCompactor) structuredSummarize(
 	}
 
 	recentStart := len(history) - cfg.MinKeepRecent
+	recentStart = snapToToolBlockBoundary(history, recentStart, systemEnd)
 	if recentStart <= systemEnd {
 		// Not enough messages to split — nothing to summarize
 		return history, nil
@@ -366,6 +367,33 @@ func (hc *HistoryCompactor) structuredSummarize(
 	return result, nil
 }
 
+// snapToToolBlockBoundary moves a keep-recent cut point so it never splits an
+// assistant tool_calls message from its tool results. A cut landing on a
+// role:"tool" message would summarize/drop the owning assistant message and
+// leave orphan results at the head of the kept tail — which the agent-mode
+// pairing repair then deletes (losing the freshest real outputs) and which
+// chat-mode WithTools serialization has no repair for at all. The cut is
+// moved LEFT to the owning assistant-with-calls message so the whole block
+// stays in the verbatim tail; anything interposed between them belongs to
+// the block and moves with it.
+func snapToToolBlockBoundary(history []models.Message, recentStart, systemEnd int) int {
+	if recentStart <= systemEnd || recentStart >= len(history) {
+		return recentStart
+	}
+	if history[recentStart].Role != "tool" {
+		return recentStart
+	}
+	for i := recentStart - 1; i >= systemEnd; i-- {
+		if history[i].Role == "assistant" {
+			if len(history[i].ToolCalls) > 0 {
+				return i
+			}
+			break // plain assistant: the tool tail is already orphaned upstream
+		}
+	}
+	return recentStart
+}
+
 // emergencyTruncate is the last resort: drops middle messages without summarization.
 func (hc *HistoryCompactor) emergencyTruncate(history []models.Message, cfg CompactConfig) []models.Message {
 	systemEnd := 0
@@ -383,6 +411,7 @@ func (hc *HistoryCompactor) emergencyTruncate(history []models.Message, cfg Comp
 	}
 
 	recentStart := len(history) - keepRecent
+	recentStart = snapToToolBlockBoundary(history, recentStart, systemEnd)
 	if recentStart <= systemEnd {
 		return history
 	}

--- a/cli/history_compactor_blocksnap_test.go
+++ b/cli/history_compactor_blocksnap_test.go
@@ -1,0 +1,64 @@
+/*
+ * ChatCLI - Compaction tool-block boundary snapping tests
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/diillson/chatcli/cli/agent"
+	"github.com/diillson/chatcli/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func toolBlock(id, out string) []models.Message {
+	return []models.Message{
+		{Role: "assistant", ToolCalls: []models.ToolCall{{ID: id, Name: "web_fetch", Type: "function"}}},
+		models.NewToolResultMessage(id, out, false, ""),
+	}
+}
+
+func TestSnapToToolBlockBoundary_MovesCutToOwningAssistant(t *testing.T) {
+	history := []models.Message{
+		{Role: "system", Content: "sys"},
+		{Role: "user", Content: "go"},
+		{Role: "assistant", ToolCalls: []models.ToolCall{
+			{ID: "web_fetch:0", Name: "web_fetch"}, {ID: "web_fetch:1", Name: "web_fetch"},
+		}},
+		models.NewToolResultMessage("web_fetch:0", "a", false, ""),
+		models.NewToolResultMessage("web_fetch:1", "b", false, ""),
+		{Role: "assistant", Content: "done"},
+	}
+
+	// A cut landing on either tool result must snap back to the assistant.
+	assert.Equal(t, 2, snapToToolBlockBoundary(history, 3, 1))
+	assert.Equal(t, 2, snapToToolBlockBoundary(history, 4, 1))
+	// Cuts on non-tool messages are untouched.
+	assert.Equal(t, 5, snapToToolBlockBoundary(history, 5, 1))
+	assert.Equal(t, 2, snapToToolBlockBoundary(history, 2, 1))
+}
+
+func TestEmergencyTruncate_NeverOrphansToolResults(t *testing.T) {
+	hc := NewHistoryCompactor(zap.NewNop())
+	cfg := DefaultCompactConfig("MOONSHOT", "kimi-k3")
+	cfg.MinKeepRecent = 3
+
+	history := []models.Message{{Role: "system", Content: "sys"}}
+	for i := 0; i < 6; i++ {
+		history = append(history, models.Message{Role: "user", Content: fmt.Sprintf("u%d", i)})
+		history = append(history, toolBlock(fmt.Sprintf("web_fetch:%d", i), "out")...)
+	}
+	// MinKeepRecent=3 lands the cut mid-block for this shape.
+	out := hc.emergencyTruncate(history, cfg)
+
+	// The kept tail must never START with an orphan tool result, and the
+	// whole result must be a provider-valid pairing shape.
+	require.NotEmpty(t, out)
+	assert.True(t, agent.ValidateToolResultPairing(out),
+		"emergencyTruncate produced a history the pairing validator rejects")
+}

--- a/cli/history_compactor_blocksnap_test.go
+++ b/cli/history_compactor_blocksnap_test.go
@@ -6,6 +6,7 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -41,6 +42,56 @@ func TestSnapToToolBlockBoundary_MovesCutToOwningAssistant(t *testing.T) {
 	// Cuts on non-tool messages are untouched.
 	assert.Equal(t, 5, snapToToolBlockBoundary(history, 5, 1))
 	assert.Equal(t, 2, snapToToolBlockBoundary(history, 2, 1))
+}
+
+func TestEmergencyTruncate_ShortHistoryUnchanged(t *testing.T) {
+	hc := NewHistoryCompactor(zap.NewNop())
+	cfg := DefaultCompactConfig("MOONSHOT", "kimi-k3")
+	cfg.MinKeepRecent = 10
+
+	history := []models.Message{
+		{Role: "system", Content: "sys"},
+		{Role: "user", Content: "u"},
+		{Role: "assistant", Content: "a"},
+	}
+	out := hc.emergencyTruncate(history, cfg)
+	assert.Equal(t, history, out)
+}
+
+func TestStructuredSummarize_TooSmallReturnsUnchanged(t *testing.T) {
+	hc := NewHistoryCompactor(zap.NewNop())
+	cfg := DefaultCompactConfig("MOONSHOT", "kimi-k3")
+	cfg.MinKeepRecent = 2
+
+	history := []models.Message{
+		{Role: "system", Content: "sys"},
+		{Role: "user", Content: "u"},
+		{Role: "assistant", Content: "a"},
+		{Role: "user", Content: "u2"},
+	}
+	out, err := hc.structuredSummarize(context.Background(), history, nil, cfg)
+	require.NoError(t, err)
+	assert.Equal(t, history, out)
+}
+
+func TestStructuredSummarize_SnapKeepsToolBlockIntact(t *testing.T) {
+	hc := NewHistoryCompactor(zap.NewNop())
+	cfg := DefaultCompactConfig("MOONSHOT", "kimi-k3")
+	cfg.MinKeepRecent = 1
+
+	// Cut would land on the tool result (len-1); the snap must pull the
+	// whole block into the verbatim tail, leaving < 4 middle messages so
+	// summarization is skipped without any LLM call (nil client is safe).
+	history := []models.Message{
+		{Role: "system", Content: "sys"},
+		{Role: "user", Content: "u1"},
+		{Role: "user", Content: "u2"},
+		{Role: "assistant", ToolCalls: []models.ToolCall{{ID: "web_fetch:0", Name: "web_fetch"}}},
+		models.NewToolResultMessage("web_fetch:0", "out", false, ""),
+	}
+	out, err := hc.structuredSummarize(context.Background(), history, nil, cfg)
+	require.NoError(t, err)
+	assert.True(t, agent.ValidateToolResultPairing(out))
 }
 
 func TestEmergencyTruncate_NeverOrphansToolResults(t *testing.T) {

--- a/cli/memory_worker.go
+++ b/cli/memory_worker.go
@@ -44,8 +44,14 @@ const (
 	memoryMinNewMessages = 4
 	// Minimum time between memory extraction runs.
 	memoryCooldown = 2 * time.Minute
-	// Timeout for the LLM call that extracts memory.
-	memoryExtractTimeout = 60 * time.Second
+	// Timeout for the LLM call that extracts memory. Sized for reasoning
+	// ("thinking") models: Kimi K3 / GLM / o-series routinely take 1-3 min
+	// on the extraction prompt (instructions + existing context + segment),
+	// and 60s produced steady "context deadline exceeded" failure streaks
+	// that surfaced as the user-visible "extração falhando" notice. Each
+	// provider attempt gets its own budget, so the chain still bails out of
+	// a truly hung provider.
+	memoryExtractTimeout = 180 * time.Second
 	// How often to check for compaction (6 hours).
 	compactionCheckInterval = 6 * time.Hour
 	// How often to check for daily note cleanup (24 hours).

--- a/cli/memory_worker.go
+++ b/cli/memory_worker.go
@@ -237,11 +237,25 @@ func (mw *memoryWorker) runRollups(ctx context.Context) {
 }
 
 func (mw *memoryWorker) maybeExtract(ctx context.Context) {
+	// Single read of the slice header: the agent loop swaps cli.history for
+	// repaired/compacted (possibly SHORTER) slices mid-run, so re-reading it
+	// between the len check and the slice expression can panic on bounds.
+	// Every access below goes through this snapshot.
+	hist := mw.cli.history
+	historyLen := len(hist)
+
 	mw.mu.Lock()
 	lastIdx := mw.lastProcessedIdx
+	if lastIdx > historyLen {
+		// History shrank behind the watermark (pairing repair removed
+		// orphans, compaction summarized, park resume restored a snapshot).
+		// Clamp both the local and the stored watermark so the next delta
+		// is computed against reality.
+		lastIdx = historyLen
+		mw.lastProcessedIdx = historyLen
+	}
 	mw.mu.Unlock()
 
-	historyLen := len(mw.cli.history)
 	newMessages := historyLen - lastIdx
 
 	// One gate for back-pressure, cadence (cooldown + min new messages) and the
@@ -253,7 +267,7 @@ func (mw *memoryWorker) maybeExtract(ctx context.Context) {
 
 	// Extract the new messages (copy to avoid races)
 	messagesToProcess := make([]models.Message, newMessages)
-	copy(messagesToProcess, mw.cli.history[lastIdx:])
+	copy(messagesToProcess, hist[lastIdx:])
 
 	mw.logger.Debug("Memory worker: extracting annotations",
 		zap.Int("new_messages", newMessages),

--- a/cli/memory_worker_extract_test.go
+++ b/cli/memory_worker_extract_test.go
@@ -1,0 +1,65 @@
+/*
+ * ChatCLI - Memory worker extraction gate tests.
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Covers the maybeExtract entry: the single-read history snapshot, the
+ * watermark clamp when the history shrank behind the worker (pairing
+ * repair / compaction / park-resume restore), and the happy extraction
+ * path over the snapshot.
+ */
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+)
+
+func TestMaybeExtract_ClampsWatermarkWhenHistoryShrank(t *testing.T) {
+	active := &scriptedClient{name: "claude", response: "NOTHING_NEW"}
+	mw := newResilienceWorker(t, active)
+
+	mw.cli.history = []models.Message{{Role: "user", Content: "only one"}}
+	mw.mu.Lock()
+	mw.lastProcessedIdx = 40 // stale watermark from a longer, pre-repair history
+	mw.mu.Unlock()
+
+	mw.maybeExtract(context.Background())
+
+	mw.mu.Lock()
+	got := mw.lastProcessedIdx
+	mw.mu.Unlock()
+	if got != 1 {
+		t.Fatalf("watermark = %d, want clamped to len(history) = 1", got)
+	}
+	if active.calls.Load() != 0 {
+		t.Fatal("no extraction may run for a zero delta — the clamp must gate it out")
+	}
+}
+
+func TestMaybeExtract_ExtractsSnapshotAndAdvancesWatermark(t *testing.T) {
+	active := &scriptedClient{name: "claude", response: "NOTHING_NEW"}
+	mw := newResilienceWorker(t, active)
+
+	mw.cli.history = []models.Message{
+		{Role: "user", Content: "u1"},
+		{Role: "assistant", Content: "a1"},
+		{Role: "user", Content: "u2"},
+		{Role: "assistant", Content: "a2"},
+		{Role: "user", Content: "u3"},
+	}
+
+	mw.maybeExtract(context.Background())
+
+	if active.calls.Load() == 0 {
+		t.Fatal("extraction LLM call must have run for a 5-message delta")
+	}
+	mw.mu.Lock()
+	got := mw.lastProcessedIdx
+	mw.mu.Unlock()
+	if got != 5 {
+		t.Fatalf("watermark = %d, want advanced to 5 after successful extraction", got)
+	}
+}

--- a/cli/moa_turn.go
+++ b/cli/moa_turn.go
@@ -141,6 +141,11 @@ func (cli *ChatCLI) runMoaTurnNative(
 		tools = append(tools, memoryRecallToolDefinition())
 	}
 
+	// Repair tool_call/tool_result pairing on the outgoing copy: the shared
+	// history can carry dangling tool_calls from an agent run that ended on
+	// a non-standard exit, and this WithTools path has no other repair layer.
+	history, _ = agent.EnsureToolResultPairing(history, cli.logger)
+
 	for round := 0; ; round++ {
 		resp, err := tac.SendPromptWithTools(ctx, prompt, history, tools, 0)
 		if err != nil {

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -3123,6 +3123,7 @@
   "park.list.header": "Parked agents (token / mode / description / scheduler status):",
   "park.resume.usage": "Usage: /resume <token>   (token may be a unique prefix; use /parked to list)",
   "park.resume.load_failed": "failed to load park snapshot: %v",
+  "park.resume.retry_hint": "resume failed and the snapshot was kept — run /resume %s to retry",
   "park.cancel.usage": "Usage: /cancel-park <token>   (use /parked to list)",
   "park.cancel.job_failed": "failed to cancel scheduler job: %v",
   "park.cancel.delete_failed": "failed to delete snapshot: %v",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -3123,6 +3123,7 @@
   "park.list.header": "Parked agents (token / mode / description / scheduler status):",
   "park.resume.usage": "Usage: /resume <token>   (token may be a unique prefix; use /parked to list)",
   "park.resume.load_failed": "failed to load park snapshot: %v",
+  "park.resume.retry_hint": "resume failed and the snapshot was kept — run /resume %s to retry",
   "park.cancel.usage": "Usage: /cancel-park <token>   (use /parked to list)",
   "park.cancel.job_failed": "failed to cancel scheduler job: %v",
   "park.cancel.delete_failed": "failed to delete snapshot: %v",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -3123,6 +3123,7 @@
   "park.list.header": "Agents estacionados (token / modo / descrição / status do scheduler):",
   "park.resume.usage": "Uso: /resume <token>   (token pode ser prefixo único; use /parked para listar)",
   "park.resume.load_failed": "falha ao carregar snapshot do park: %v",
+  "park.resume.retry_hint": "resume falhou e o snapshot foi mantido — use /resume %s para tentar novamente",
   "park.cancel.usage": "Uso: /cancel-park <token>   (use /parked para listar)",
   "park.cancel.job_failed": "falha ao cancelar job do scheduler: %v",
   "park.cancel.delete_failed": "falha ao remover snapshot: %v",

--- a/llm/moonshot/tool_pairing_wire_test.go
+++ b/llm/moonshot/tool_pairing_wire_test.go
@@ -1,0 +1,102 @@
+/*
+ * ChatCLI - Moonshot wire-shape regression test
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Reproduces the live-monitoring session that Moonshot rejected with
+ * "an assistant message with 'tool_calls' must be followed by tool messages
+ * responding to each 'tool_call_id'... web_fetch:0, web_fetch:1": Kimi K3
+ * reuses deterministic per-turn IDs, an @park suspension left a batch
+ * unanswered, and the repaired history must serialize into a message array
+ * that satisfies Moonshot's adjacency validation.
+ */
+package moonshot
+
+import (
+	"testing"
+
+	"github.com/diillson/chatcli/cli/agent"
+	"github.com/diillson/chatcli/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// validateMoonshotAdjacency mimics the server-side check: every assistant
+// message with tool_calls must be immediately followed by tool messages
+// answering each of its tool_call_ids, before any other role appears.
+func validateMoonshotAdjacency(t *testing.T, messages []interface{}) {
+	t.Helper()
+	for i := 0; i < len(messages); i++ {
+		m, ok := messages[i].(map[string]interface{})
+		require.True(t, ok)
+		calls, has := m["tool_calls"].([]map[string]interface{})
+		if !has || len(calls) == 0 {
+			continue
+		}
+		pending := make(map[string]bool, len(calls))
+		for _, c := range calls {
+			pending[c["id"].(string)] = true
+		}
+		j := i + 1
+		for ; j < len(messages); j++ {
+			next := messages[j].(map[string]interface{})
+			if next["role"] != "tool" {
+				break
+			}
+			delete(pending, next["tool_call_id"].(string))
+		}
+		assert.Empty(t, pending,
+			"assistant message %d has tool_call_ids without adjacent tool responses", i)
+	}
+}
+
+func TestBuildToolMessages_RepairedParkHistorySatisfiesAdjacency(t *testing.T) {
+	kimiCalls := func(ids ...string) []models.ToolCall {
+		out := make([]models.ToolCall, 0, len(ids))
+		for _, id := range ids {
+			out = append(out, models.ToolCall{ID: id, Name: "web_fetch", Type: "function"})
+		}
+		return out
+	}
+
+	history := []models.Message{
+		{Role: "system", Content: "sys"},
+		{Role: "user", Content: "monitore o jogo"},
+		// Cycle 1: fetches answered normally (Kimi per-turn IDs).
+		{Role: "assistant", ToolCalls: kimiCalls("web_fetch:0", "web_fetch:1")},
+		models.NewToolResultMessage("web_fetch:0", "placar A", false, ""),
+		models.NewToolResultMessage("web_fetch:1", "placar B", false, ""),
+		// Cycle 2: SAME IDs, batch suspended by @park before emission — the
+		// dangling shape the park snapshot used to inherit.
+		{Role: "assistant", Content: "report", ToolCalls: kimiCalls("web_fetch:0", "web_fetch:1")},
+		// Park resume feedback arrives as a user message.
+		{Role: "user", Content: "[@park completed] outcome=elapsed"},
+	}
+
+	repaired, report := agent.EnsureToolResultPairing(history, nil)
+	require.True(t, report.HasRepairs())
+
+	messages := buildToolMessages("", repaired)
+	validateMoonshotAdjacency(t, messages)
+}
+
+func TestBuildToolMessages_UnrepairedParkHistoryFailsAdjacency(t *testing.T) {
+	// Sanity check on the validator itself: the pre-repair history is the
+	// exact shape Moonshot 400s on.
+	history := []models.Message{
+		{Role: "assistant", ToolCalls: []models.ToolCall{
+			{ID: "web_fetch:0", Name: "web_fetch", Type: "function"},
+			{ID: "web_fetch:1", Name: "web_fetch", Type: "function"},
+		}},
+		{Role: "user", Content: "[@park completed] outcome=elapsed"},
+	}
+
+	messages := buildToolMessages("", history)
+
+	m := messages[0].(map[string]interface{})
+	calls := m["tool_calls"].([]map[string]interface{})
+	require.Len(t, calls, 2)
+	next := messages[1].(map[string]interface{})
+	assert.NotEqual(t, "tool", next["role"],
+		"pre-repair history must exhibit the dangling shape the API rejects")
+}


### PR DESCRIPTION
## Problem

Live-monitoring sessions on Moonshot / Kimi K3 (`@park` every N minutes + `web_fetch`) died after a park/resume cycle with:

```
400 — an assistant message with 'tool_calls' must be followed by tool messages responding
to each 'tool_call_id'. The following tool_call_ids did not have response messages:
web_fetch:0, web_fetch:1
```

The error repeated on every prompt Enter (each one re-drains the pending resume with the same broken snapshot), and the park eventually died silently because a failed resume deleted its snapshot.

## Root cause (4 compounding defects)

Kimi K3 emits **deterministic per-turn tool_call IDs** (`web_fetch:0`, `web_fetch:1` — they restart every turn), unlike the globally-unique `toolu_…`/`call_…` schemes:

1. **Park mid-batch lost results** — `handleAgentPark` returned before the batch loop's structured emission tail, so calls batched alongside `@park` stayed dangling in the snapshot; resume only synthesized the park call's own result.
2. **Any mid-batch error dropped ALL native results** — the fail-fast path fell back to the legacy concatenated user message, leaving the assistant `tool_calls` unanswered.
3. **The pairing safety net was blind to repeated IDs** — `EnsureToolResultPairing` used global ID maps, so an earlier turn's result masked the dangling turn and no synthetic repair was injected.
4. **Repairs were never persisted** — applied only to the outgoing per-turn copy; `a.cli.history` and every park snapshot inherited the broken shape forever.

## Fix

- `cli/agent_native_results.go` (new): `buildParkBatchClosure` closes every native call except the park itself before snapshotting; `buildNativeBatchResults` emits one `role:tool` message per call on ANY batch outcome (real prefix + `not_executed` closures); `insertStructuredToolResults` inserts them adjacent to the assistant message, before any mid-batch feedback.
- `cli/agent/tool_result_pairing.go`: rewritten as **positional/block-scoped** pairing — each assistant block claims results only from its stretch up to the next assistant message; displaced results are relocated, missing ones get synthetics per block, true orphans are removed. Correct for providers with non-unique IDs.
- `cli/agent_mode.go`: pairing repair now runs on the persistent history (survives into later turns and park snapshots).
- `cli/agent_park.go`: `RunResumed` treats a re-park as success (kills the false `❌ Erro na execução: agent parked…` on every monitoring cycle) and keeps the snapshot on real errors so `/resume <token>` can retry.
- `cli/memory_worker.go`: extraction timeout 60s → 180s — log-confirmed `context deadline exceeded` streaks with thinking models (Kimi K3 takes 1–3 min on the extraction prompt), which surfaced as the user-visible "extração falhando" notice.

## Tests

- `cli/agent/tool_result_pairing_test.go`: 9 cases incl. the Kimi duplicate-ID scenarios — **proven red on the old algorithm** (0 synthetics injected → 400-invalid history ships) and green on the new one.
- `cli/agent_native_results_test.go`: batch closure/insertion semantics incl. the exact `[web_fetch, web_fetch, park]` session shape.
- `llm/moonshot/tool_pairing_wire_test.go`: wire-level regression — the repaired park history serialized by `buildToolMessages` satisfies the same adjacency validation Moonshot enforces server-side; the pre-repair history provably exhibits the rejected shape.
- `go build ./...`, `go test ./...` and full-module `golangci-lint` clean.