### PR TITLE
fix(model): preserve delegate prompt and show routed model in turn spinner

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -1717,6 +1717,15 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 		turnAgents := 0
 		turnToolCalls := 0
 
+		// Resolve per-turn client + effort hint from any active "@model use"
+		// route override or skill hints. Model swap is transparent; effort
+		// flows via ctx so the provider's SendPrompt can enable extended
+		// thinking / reasoning. Resolved BEFORE the turn timer starts so the
+		// spinner names the model that actually serves this turn — labeling
+		// it with the session model while an override routes the call
+		// elsewhere makes the UI contradict the logs.
+		turnClient, turnCtx := a.clientAndCtxForTurn(ctx)
+
 		// Inicia o timer do turno (substitui a animação de "Pensando...").
 		// Item 8: indicator reflete TANTO as linhas já drenadas para a
 		// messageQueue QUANTO as linhas em trânsito no channel
@@ -1724,7 +1733,7 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 		// fechou para drenar). Sem essa soma, o usuário pressiona Enter
 		// e nada muda visualmente no spinner — só vê (1 na fila) na
 		// próxima iteração do turn.
-		modelName := a.cli.Client.GetModelName()
+		modelName := turnClient.GetModelName()
 		a.turnTimer.Start(ctx, func(d time.Duration) {
 			msg := "Processando..."
 			a.cli.messageQueueMu.Lock()
@@ -1756,11 +1765,6 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 		// Build the outgoing turn history and enforce budget before sending to API
 		turnHistory := buildTurnHistoryWithAnchor()
 		turnHistory, _ = agent.EnforceToolResultBudget(turnHistory, a.logger)
-
-		// Resolve per-turn client + effort hint from any active skill
-		// hints. Model swap is transparent; effort flows via ctx so the
-		// provider's SendPrompt can enable extended thinking / reasoning.
-		turnClient, turnCtx := a.clientAndCtxForTurn(ctx)
 
 		// Detect native function calling support
 		var nativeToolCalls []models.ToolCall

--- a/cli/plugins/builtin_model.go
+++ b/cli/plugins/builtin_model.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
+	"unicode"
 )
 
 // ModelRoutingAdapter is the surface the @model tool needs from the live
@@ -273,8 +274,26 @@ func parseModelInvocation(args []string) (modelInvocation, error) {
 
 	// argv / flag form. Scan tokens, honoring --model / --prompt / --cmd /
 	// --max_tokens (and =forms), and collect the rest as positionals.
+	//
+	// Token boundaries matter here: the agent's tool flattener rewrites the
+	// {cmd,args} envelope into "--flag value" argv elements where a value —
+	// notably a delegate prompt — is ONE element that may contain spaces and
+	// newlines. Re-splitting the joined payload on whitespace would shatter
+	// that prompt into words and the delegated model would receive only the
+	// first one. So multi-element argv is consumed element-wise; only a
+	// single free-text argument is tokenized, and even then quoted runs are
+	// kept together so `--prompt "long text"` survives.
 	var positionals []string
-	fields := strings.Fields(payload)
+	var fields []string
+	if len(args) > 1 {
+		for _, a := range args {
+			if t := strings.TrimSpace(a); t != "" {
+				fields = append(fields, t)
+			}
+		}
+	} else {
+		fields = splitArgsRespectingQuotes(payload)
+	}
 	for i := 0; i < len(fields); i++ {
 		f := fields[i]
 		key, val, hasEq := strings.Cut(f, "=")
@@ -330,6 +349,43 @@ func parseModelInvocation(args []string) (modelInvocation, error) {
 		}
 	}
 	return inv, nil
+}
+
+// splitArgsRespectingQuotes tokenizes a single free-text invocation on
+// whitespace while keeping "double" and 'single' quoted runs together, so a
+// one-string `delegate x --prompt "long text"` keeps the prompt whole. A
+// quote only opens a run at a token boundary — apostrophes inside prose
+// (user's, don't) stay literal.
+func splitArgsRespectingQuotes(s string) []string {
+	var (
+		tokens []string
+		cur    strings.Builder
+		quote  rune
+	)
+	flush := func() {
+		if cur.Len() > 0 {
+			tokens = append(tokens, cur.String())
+			cur.Reset()
+		}
+	}
+	for _, r := range s {
+		switch {
+		case quote != 0:
+			if r == quote {
+				quote = 0
+			} else {
+				cur.WriteRune(r)
+			}
+		case (r == '"' || r == '\'') && cur.Len() == 0:
+			quote = r
+		case unicode.IsSpace(r):
+			flush()
+		default:
+			cur.WriteRune(r)
+		}
+	}
+	flush()
+	return tokens
 }
 
 func canonicalModelCmd(cmd string) string {

--- a/cli/plugins/builtin_model_test.go
+++ b/cli/plugins/builtin_model_test.go
@@ -73,6 +73,14 @@ func TestParseModelInvocation(t *testing.T) {
 		{"flag eq form", []string{"use", "--model=haiku"}, "use", "haiku", "", 0},
 		{"positional delegate joins prompt", []string{"delegate", "GOOGLEAI:gemini-2.5-flash", "summarize", "the", "log"}, "delegate", "GOOGLEAI:gemini-2.5-flash", "summarize the log", 0},
 		{"synonyms", []string{"switch", "haiku"}, "use", "haiku", "", 0},
+		// The agent's tool flattener rewrites {cmd,args} into "--flag value"
+		// argv elements; a multi-word prompt arrives as ONE element and must
+		// reach the delegated model whole, not shattered on whitespace.
+		{"flattener delegate keeps prompt whole", []string{"--cmd", "delegate", "--model", "DEVINCLI:devin", "--prompt", "Summarize the build log into the 3 root errors"}, "delegate", "DEVINCLI:devin", "Summarize the build log into the 3 root errors", 0},
+		{"flattener delegate with max_tokens", []string{"delegate", "--model", "GOOGLEAI:gemini-2.5-flash", "--prompt", "translate this text to English", "--max_tokens", "256"}, "delegate", "GOOGLEAI:gemini-2.5-flash", "translate this text to English", 256},
+		{"flattener prompt with apostrophe", []string{"delegate", "--model", "haiku", "--prompt", "explain the user's stack trace, don't guess"}, "delegate", "haiku", "explain the user's stack trace, don't guess", 0},
+		{"single-string delegate honors quotes", []string{`delegate GOOGLEAI:gemini-2.5-flash --prompt "summarize the whole log"`}, "delegate", "GOOGLEAI:gemini-2.5-flash", "summarize the whole log", 0},
+		{"flattener prompt with newlines", []string{"delegate", "--model", "haiku", "--prompt", "line one\nline two"}, "delegate", "haiku", "line one\nline two", 0},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Problem

Two defects in the `@model` routing tool surfaced in real use:

1. **`delegate` dropped the prompt.** The agent's tool flattener rewrites the `{cmd,args}` envelope into `--flag value` argv pairs, where the delegate prompt arrives as a single element containing spaces/newlines. `parseModelInvocation` joined the argv into one string and re-split it on whitespace — the delegated model received only the **first word** of the prompt and answered without a real question (observed with the Devin provider, but it affected every delegate call routed through the flattener).

2. **The turn spinner named the wrong model under an active override.** The spinner's model label was captured from the session client *before* the per-turn resolver applied the `@model use` route override. Calls were correctly served by the routed model (logs told the truth), but the spinner kept displaying the previous one for the whole task — the UI contradicted the logs.

## Fix

- `cli/plugins/builtin_model.go`: multi-element argv is now consumed element-wise, preserving each value (prompt included) exactly as the flattener emitted it. A single free-text argument is still tokenized, now quote-aware (`--prompt "long text"` survives; apostrophes inside prose stay literal).
- `cli/agent_mode.go`: `clientAndCtxForTurn` is resolved **before** the turn timer starts, and the spinner labels the effective turn client's model — session model, skill hint or `@model use` override, whichever actually serves the call.

## Verification

- New parser tests reproduce the exact failure red→green: against the old parser they fail with `prompt:"Summarize"` instead of the full sentence.
- `go test -race -coverpkg=./... ./...` green.
- Floor 3 (patch coverage) and Floor 4 (AI smells) pass locally; gofmt/vet/golangci-lint clean.