### PR TITLE
fix(bedrock): control plane uses the corporate HTTP client and bounded listing

### DIFF
--- a/llm/bedrock/awsclient.go
+++ b/llm/bedrock/awsclient.go
@@ -97,6 +97,32 @@ func RuntimeEndpointURL(region string) string {
 	return "https://bedrock-runtime." + region + ".amazonaws.com"
 }
 
+// awsLoadOptions is the single source of truth for the AWS LoadOptions
+// every Bedrock-side client uses: region/profile resolution, the
+// corporate-CA/proxy HTTP client and IMDS gating. Runtime AND control
+// plane MUST build from this — the two drifting apart is exactly how the
+// control plane once shipped without the corporate HTTP client, breaking
+// model listing behind TLS-intercepting proxies while chat worked fine.
+func awsLoadOptions(region, profile string, logger *zap.Logger) []func(*awsconfig.LoadOptions) error {
+	opts := []func(*awsconfig.LoadOptions) error{}
+	if region != "" {
+		opts = append(opts, awsconfig.WithRegion(region))
+	}
+	if profile != "" {
+		opts = append(opts, awsconfig.WithSharedConfigProfile(profile))
+	}
+	if httpClient, note := buildCorporateHTTPClient(logger); httpClient != nil {
+		opts = append(opts, awsconfig.WithHTTPClient(httpClient))
+		if note != "" {
+			logger.Warn(note)
+		}
+	}
+	if shouldDisableIMDS() {
+		opts = append(opts, awsconfig.WithEC2IMDSClientEnableState(imds.ClientDisabled))
+	}
+	return opts
+}
+
 // LoadBedrockRuntime builds a bedrockruntime.Client using the same
 // credential chain, region resolution, IMDS gating and corporate-CA
 // support that the chat client (BedrockClient) uses. Exported so other
@@ -114,23 +140,7 @@ func LoadBedrockRuntime(ctx context.Context, region, profile string, logger *zap
 	if logger == nil {
 		return nil, "", fmt.Errorf("bedrock: logger is required (pass zap.NewNop() if you don't need logs)")
 	}
-	opts := []func(*awsconfig.LoadOptions) error{}
-	if region != "" {
-		opts = append(opts, awsconfig.WithRegion(region))
-	}
-	if profile != "" {
-		opts = append(opts, awsconfig.WithSharedConfigProfile(profile))
-	}
-	if httpClient, note := buildCorporateHTTPClient(logger); httpClient != nil {
-		opts = append(opts, awsconfig.WithHTTPClient(httpClient))
-		if note != "" {
-			logger.Warn(note)
-		}
-	}
-	if shouldDisableIMDS() {
-		opts = append(opts, awsconfig.WithEC2IMDSClientEnableState(imds.ClientDisabled))
-	}
-	cfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsLoadOptions(region, profile, logger)...)
 	if err != nil {
 		return nil, "", fmt.Errorf("bedrock: failed to load AWS config: %w", err)
 	}

--- a/llm/bedrock/awsclient_test.go
+++ b/llm/bedrock/awsclient_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -174,6 +175,45 @@ func TestEnsureRuntimeControlPlaneHonorsSDKNativeVar(t *testing.T) {
 	controlOpts := c.control.Options()
 	require.NotNil(t, controlOpts.BaseEndpoint)
 	assert.Equal(t, "https://bedrock-control.vpc.internal", *controlOpts.BaseEndpoint)
+}
+
+func TestEnsureRuntimeControlPlaneGetsCorporateHTTPClient(t *testing.T) {
+	// Both planes must build from the same LoadOptions: a corporate
+	// TLS override configured for Bedrock has to reach the control-plane
+	// client too, or model listing breaks behind TLS-intercepting proxies
+	// while chat works.
+	clearEndpointEnv(t)
+	hermeticAWSEnv(t)
+	t.Setenv("CHATCLI_BEDROCK_INSECURE_SKIP_VERIFY", "true")
+
+	c := NewBedrockClient("anthropic.claude-sonnet-5", "", "", zap.NewNop(), 1, 0)
+	require.NoError(t, c.ensureRuntime(context.Background()))
+
+	assertCorporateTLS := func(name string, httpClient interface{}) {
+		bc, ok := httpClient.(*awshttp.BuildableClient)
+		require.True(t, ok, "%s: expected the corporate BuildableClient, got %T", name, httpClient)
+		tr := bc.GetTransport()
+		require.NotNil(t, tr.TLSClientConfig, "%s: corporate transport must carry a TLS config", name)
+		assert.True(t, tr.TLSClientConfig.InsecureSkipVerify,
+			"%s: the corporate TLS override did not reach this client", name)
+	}
+	assertCorporateTLS("runtime", c.runtime.Options().HTTPClient)
+	assertCorporateTLS("control", c.control.Options().HTTPClient)
+}
+
+func TestListModelsDegradesGracefullyWhenControlPlaneUnreachable(t *testing.T) {
+	// A corporate network that blocks the control-plane host must not
+	// break /switch: listing warns and returns empty so the manager falls
+	// back to the catalog. Port 9 (discard) refuses immediately, keeping
+	// the test fast while exercising the same failure path.
+	clearEndpointEnv(t)
+	hermeticAWSEnv(t)
+	t.Setenv("BEDROCK_CONTROL_BASE_URL", "http://127.0.0.1:9")
+
+	c := NewBedrockClient("anthropic.claude-sonnet-5", "", "", zap.NewNop(), 1, 0)
+	models, err := c.ListModels(context.Background())
+	require.NoError(t, err, "listing failures must degrade to the catalog, not error out")
+	assert.Empty(t, models)
 }
 
 func TestLoadBedrockRuntimeRejectsInvalidBaseURL(t *testing.T) {

--- a/llm/bedrock/bedrock_client.go
+++ b/llm/bedrock/bedrock_client.go
@@ -278,7 +278,6 @@ func (c *BedrockClient) ensureRuntime(ctx context.Context) error {
 	return nil
 }
 
-
 // SendPrompt dispatches to the correct body schema based on the resolved
 // model family (Anthropic Messages vs. OpenAI Chat Completions).
 // Retries are delegated to utils.Retry inside each family-specific path.

--- a/llm/bedrock/bedrock_client.go
+++ b/llm/bedrock/bedrock_client.go
@@ -20,7 +20,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	bedrocksvc "github.com/aws/aws-sdk-go-v2/service/bedrock"
 	bedrocktypes "github.com/aws/aws-sdk-go-v2/service/bedrock/types"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
@@ -235,7 +234,7 @@ func (c *BedrockClient) ensureRuntime(ctx context.Context) error {
 	// the embedding provider doesn't need it, which is why LoadBedrockRuntime
 	// returns just the runtime. We rebuild the AWS config locally here only
 	// to construct the bedrock control client with the same credential chain.
-	cfg, err := awsconfig.LoadDefaultConfig(ctx, controlPlaneConfigOptions(c.region, c.profile)...)
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsLoadOptions(c.region, c.profile, c.logger)...)
 	if err != nil {
 		return fmt.Errorf("bedrock: failed to load control-plane AWS config: %w", err)
 	}
@@ -279,22 +278,6 @@ func (c *BedrockClient) ensureRuntime(ctx context.Context) error {
 	return nil
 }
 
-// controlPlaneConfigOptions mirrors the LoadOptions used by the runtime
-// helper so the bedrock control-plane client (used for ListModels) sees
-// the same region/profile/IMDS settings as the runtime client.
-func controlPlaneConfigOptions(region, profile string) []func(*awsconfig.LoadOptions) error {
-	opts := []func(*awsconfig.LoadOptions) error{}
-	if region != "" {
-		opts = append(opts, awsconfig.WithRegion(region))
-	}
-	if profile != "" {
-		opts = append(opts, awsconfig.WithSharedConfigProfile(profile))
-	}
-	if shouldDisableIMDS() {
-		opts = append(opts, awsconfig.WithEC2IMDSClientEnableState(imds.ClientDisabled))
-	}
-	return opts
-}
 
 // SendPrompt dispatches to the correct body schema based on the resolved
 // model family (Anthropic Messages vs. OpenAI Chat Completions).
@@ -596,6 +579,18 @@ func buildCorporateHTTPClient(logger *zap.Logger) (aws.HTTPClient, string) {
 // See: https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages.html
 const anthropicBedrockVersion = "bedrock-2023-05-31"
 
+// bedrockListModelsTimeout bounds the whole control-plane listing when the
+// caller supplied no deadline; the /switch catalog fallback makes a slow
+// answer worthless anyway.
+const bedrockListModelsTimeout = 30 * time.Second
+
+// bedrockListEndpointHint travels in the structured warn when control-plane
+// listing fails — the most common corporate cause is the default AWS host
+// being unreachable or TLS-intercepted, both solved by endpoint/CA config.
+const bedrockListEndpointHint = "if your network requires a custom Bedrock endpoint or CA, " +
+	"set BEDROCK_BASE_URL or BEDROCK_CONTROL_BASE_URL, and CHATCLI_BEDROCK_CA_BUNDLE for a private CA; " +
+	"chat keeps working via the model catalog meanwhile"
+
 // ListModels queries Bedrock's control plane for Anthropic models the account
 // has access to. Returns both foundation models (direct on-demand, e.g. Claude
 // 3.x) AND inference profiles (global./us./eu./apac., required for Claude 3.7
@@ -604,6 +599,16 @@ const anthropicBedrockVersion = "bedrock-2023-05-31"
 func (c *BedrockClient) ListModels(ctx context.Context) ([]client.ModelInfo, error) {
 	if err := c.ensureRuntime(ctx); err != nil {
 		return nil, err
+	}
+
+	// Listing is best-effort UX — the catalog is the fallback — so it must
+	// never freeze the REPL. A corporate firewall that blackholes the
+	// control-plane host would otherwise hang through minutes of SDK
+	// connect retries; bound the whole listing when the caller didn't.
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, bedrockListModelsTimeout)
+		defer cancel()
 	}
 
 	seen := make(map[string]bool)
@@ -632,7 +637,8 @@ func (c *BedrockClient) ListModels(ctx context.Context) ([]client.ModelInfo, err
 		ByOutputModality: bedrocktypes.ModelModalityText,
 	})
 	if err != nil {
-		c.logger.Warn("bedrock: ListFoundationModels failed", zap.Error(err))
+		c.logger.Warn("bedrock: ListFoundationModels failed", zap.Error(err),
+			zap.String("hint", bedrockListEndpointHint))
 	} else {
 		for _, s := range fm.ModelSummaries {
 			id, displayName := derefModelSummary(s.ModelId, s.ModelName, s.ProviderName)
@@ -661,7 +667,8 @@ func (c *BedrockClient) ListModels(ctx context.Context) ([]client.ModelInfo, err
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
-			c.logger.Warn("bedrock: ListInferenceProfiles failed", zap.Error(err))
+			c.logger.Warn("bedrock: ListInferenceProfiles failed", zap.Error(err),
+				zap.String("hint", bedrockListEndpointHint))
 			break
 		}
 		for _, p := range page.InferenceProfileSummaries {


### PR DESCRIPTION
## Problem

Follow-up to #1225. In corporate environments, `/switch` model listing failed (or hung) against the default control-plane host `bedrock.<region>.amazonaws.com` while chat worked fine. Two defects:

1. **Config drift between planes**: the control-plane client (`ListFoundationModels`/`ListInferenceProfiles`) was built from its own copy of the AWS LoadOptions — region/profile/IMDS only — **without** the corporate-CA/proxy HTTP client (`CHATCLI_BEDROCK_CA_BUNDLE` etc.) that the runtime gets. Behind a TLS-intercepting proxy, listing died on TLS while chat worked. Pre-existing since the control-plane client was introduced; surfaced by corporate testing of #1225.
2. **No deadline on listing**: with a firewall that blackholes the host, the SDK's connect retries froze the REPL for minutes before erroring.

Note: the default host is correct when no override is set — `bedrock.<region>.amazonaws.com` **is** the control-plane endpoint. The bug was the missing corporate transport and the unbounded wait, not the destination.

## Fix

- Single shared `awsLoadOptions` helper is now the only source of AWS LoadOptions for both planes (region/profile + corporate HTTP client + IMDS gating) — the drift that caused this cannot recur.
- `ListModels` gets a 30s deadline when the caller supplied none; listing keeps degrading to the model catalog on failure (never breaks chat).
- The listing-failure warns now carry an actionable hint pointing at `BEDROCK_BASE_URL` / `BEDROCK_CONTROL_BASE_URL` / `CHATCLI_BEDROCK_CA_BUNDLE`.

## Tests

- `TestEnsureRuntimeControlPlaneGetsCorporateHTTPClient` — asserts the corporate TLS override actually reaches **both** clients' transports (fails on pre-fix code, where the control plane got the default client).
- `TestListModelsDegradesGracefullyWhenControlPlaneUnreachable` — control plane pointed at a refusing endpoint: listing returns empty with no error, `/switch` falls back to the catalog.

`go build ./...`, `llm/bedrock` + `llm/manager` green, golangci-lint clean.