### PR TITLE
fix(bedrock): invoke Opus 4.8/4.7 and Sonnet 4 through global inference profiles

### DIFF
--- a/llm/bedrock/mantle.go
+++ b/llm/bedrock/mantle.go
@@ -80,6 +80,20 @@ func usesMantleEndpoint(model string) bool {
 // canonical "anthropic."-prefixed dateless IDs only.
 var mantleProfilePrefixes = []string{"us.", "eu.", "apac.", "jp.", "au.", "global."}
 
+// stripInferenceProfilePrefix removes a cross-region profile prefix from a
+// Claude Bedrock id ("global.anthropic.claude-x" → "anthropic.claude-x").
+// Non-Claude and unprefixed ids come back unchanged.
+func stripInferenceProfilePrefix(id string) string {
+	trimmed := strings.TrimSpace(id)
+	m := strings.ToLower(trimmed)
+	for _, p := range mantleProfilePrefixes {
+		if strings.HasPrefix(m, p) && strings.HasPrefix(m[len(p):], "anthropic.") {
+			return trimmed[len(p):]
+		}
+	}
+	return trimmed
+}
+
 // mantleModelID canonicalizes whatever Bedrock-side spelling the user
 // selected — an inference-profile ID discovered via ListInferenceProfiles
 // ("us.anthropic.claude-sonnet-5", "global.anthropic.claude-sonnet-5-v1:0"),
@@ -88,19 +102,18 @@ var mantleProfilePrefixes = []string{"us.", "eu.", "apac.", "jp.", "au.", "globa
 // returns 404 not_found_error ("model does not exist").
 //
 // Resolution order: the Bedrock catalog first (it owns the invokable
-// Mantle id, and Resolve matches the embedded claude segment inside
-// profile-prefixed IDs); a mechanical profile-prefix strip as fallback
-// for real-but-uncataloged Claude IDs; non-Claude ids pass through.
+// Mantle id; the catalog canonical may itself be a global. profile — for
+// InvokeModel-era models like Opus 4.8 — so its prefix is stripped too);
+// a mechanical profile-prefix strip as fallback for real-but-uncataloged
+// Claude IDs; non-Claude ids pass through.
 func mantleModelID(model string) string {
-	if meta, ok := catalog.Resolve(catalog.ProviderBedrock, model); ok &&
-		strings.HasPrefix(strings.ToLower(meta.ID), "anthropic.") {
-		return meta.ID
-	}
-	m := strings.ToLower(strings.TrimSpace(model))
-	for _, p := range mantleProfilePrefixes {
-		if strings.HasPrefix(m, p) && strings.HasPrefix(m[len(p):], "anthropic.") {
-			return strings.TrimSpace(model)[len(p):]
+	if meta, ok := catalog.Resolve(catalog.ProviderBedrock, model); ok {
+		if id := stripInferenceProfilePrefix(meta.ID); strings.HasPrefix(strings.ToLower(id), "anthropic.") {
+			return id
 		}
+	}
+	if id := stripInferenceProfilePrefix(model); strings.HasPrefix(strings.ToLower(id), "anthropic.") {
+		return id
 	}
 	return model
 }

--- a/llm/bedrock/mantle_test.go
+++ b/llm/bedrock/mantle_test.go
@@ -103,6 +103,11 @@ func TestMantleModelID(t *testing.T) {
 		"global.anthropic.claude-fable-5":   "anthropic.claude-fable-5",
 		// Bare first-party id (users type it out of habit).
 		"claude-sonnet-5": "anthropic.claude-sonnet-5",
+		// Catalog canonical is a global. profile for InvokeModel-era models
+		// (Opus 4.8/4.7): forced-mantle routing must still strip it down to
+		// the dateless id the Messages endpoint serves.
+		"claude-opus-4-8":                  "anthropic.claude-opus-4-8",
+		"global.anthropic.claude-opus-4-8": "anthropic.claude-opus-4-8",
 		// Unknown-but-real Claude profile id the catalog can't resolve:
 		// the mechanical prefix strip is the fallback.
 		"us.anthropic.claude-zeta-9-v1:0": "anthropic.claude-zeta-9-v1:0",

--- a/llm/catalog/catalog.go
+++ b/llm/catalog/catalog.go
@@ -1253,16 +1253,20 @@ var registry = []ModelMeta{
 		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking", "bedrock_mantle_only"},
 	},
 	// Claude 4.8 (May 28 2026). Opus 4.8 = 1M / 128K per Anthropic.
-	// The previously-shipped dated profile IDs (…-20260528-v1:0) never
-	// existed on AWS; they stay as aliases so pinned configs keep resolving.
+	// Canonical id is the global. inference profile: the bare dateless id
+	// has no on-demand surface — InvokeModel answers ValidationException
+	// "retry with the ID or ARN of an inference profile", same pattern as
+	// Opus 4.6. The previously-shipped dated profile IDs (…-20260528-v1:0)
+	// never existed on AWS; they stay as aliases so pinned configs keep
+	// resolving.
 	{
-		ID: "anthropic.claude-opus-4-8",
+		ID: "global.anthropic.claude-opus-4-8",
 		Aliases: []string{
-			"bedrock-opus-4-8", "global.anthropic.claude-opus-4-8",
+			"bedrock-opus-4-8", "anthropic.claude-opus-4-8",
 			"global.anthropic.claude-opus-4-8-20260528-v1:0",
 			"anthropic.claude-opus-4-8-20260528-v1:0", "claude-opus-4-8",
 		},
-		DisplayName:     "Claude Opus 4.8 (Bedrock, 1M ctx)",
+		DisplayName:     "Claude Opus 4.8 (Bedrock, global, 1M ctx)",
 		Provider:        ProviderBedrock,
 		ContextWindow:   1000000,
 		MaxOutputTokens: 128000,
@@ -1286,13 +1290,13 @@ var registry = []ModelMeta{
 		Capabilities:    []string{"tools", "vision", "json_mode"},
 	},
 	{
-		ID: "anthropic.claude-opus-4-7",
+		ID: "global.anthropic.claude-opus-4-7",
 		Aliases: []string{
-			"bedrock-opus-4-7", "global.anthropic.claude-opus-4-7",
+			"bedrock-opus-4-7", "anthropic.claude-opus-4-7",
 			"global.anthropic.claude-opus-4-7-20260401-v1:0",
 			"anthropic.claude-opus-4-7-20260401-v1:0", "claude-opus-4-7",
 		},
-		DisplayName:     "Claude Opus 4.7 (Bedrock, 1M ctx)",
+		DisplayName:     "Claude Opus 4.7 (Bedrock, global, 1M ctx)",
 		Provider:        ProviderBedrock,
 		ContextWindow:   1000000,
 		MaxOutputTokens: 128000,
@@ -1377,10 +1381,25 @@ var registry = []ModelMeta{
 		Capabilities:    []string{"tools", "vision", "json_mode"},
 	},
 
-	// Claude 4 / 4.1
+	// Claude 4 / 4.1. Sonnet 4 has a real global. inference profile (AWS
+	// launched global cross-region inference with it, Sep 2025) — canonical
+	// goes global so /switch works from any region; the us./eu. regional
+	// profiles stay as their own entries for operators pinning geography.
+	// Opus 4 and 4.1 have NO global profile on AWS — us. remains the
+	// broadest invokable spelling for them.
+	{
+		ID:              "global.anthropic.claude-sonnet-4-20250514-v1:0",
+		Aliases:         []string{"bedrock-sonnet-4", "anthropic.claude-sonnet-4-20250514-v1:0", "claude-sonnet-4"},
+		DisplayName:     "Claude Sonnet 4 (Bedrock, global)",
+		Provider:        ProviderBedrock,
+		ContextWindow:   200000,
+		MaxOutputTokens: 64000,
+		PreferredAPI:    APIAnthropicMessages,
+		Capabilities:    []string{"tools", "vision", "json_mode"},
+	},
 	{
 		ID:              "us.anthropic.claude-sonnet-4-20250514-v1:0",
-		Aliases:         []string{"bedrock-sonnet-4", "anthropic.claude-sonnet-4-20250514-v1:0", "claude-sonnet-4"},
+		Aliases:         []string{"bedrock-sonnet-4-us"},
 		DisplayName:     "Claude Sonnet 4 (Bedrock, us)",
 		Provider:        ProviderBedrock,
 		ContextWindow:   200000,

--- a/llm/catalog/catalog_test.go
+++ b/llm/catalog/catalog_test.go
@@ -218,11 +218,12 @@ func TestClaudeOpus48Specs(t *testing.T) {
 			"claude-opus-4-8 should advertise %q capability", capability)
 	}
 
-	// Bedrock mirror — dateless id per Anthropic's Bedrock docs (Opus 4.8
-	// has no ARN-versioned model ID on Bedrock).
+	// Bedrock mirror — canonical is the global. inference profile over the
+	// dateless id (Opus 4.8 has no ARN-versioned model ID on Bedrock and
+	// the bare id is not on-demand invokable).
 	bedMeta, ok := Resolve(ProviderBedrock, "claude-opus-4-8")
 	assert.True(t, ok, "claude-opus-4-8 must resolve via Bedrock alias")
-	assert.Equal(t, "anthropic.claude-opus-4-8", bedMeta.ID)
+	assert.Equal(t, "global.anthropic.claude-opus-4-8", bedMeta.ID)
 	assert.Equal(t, 1000000, bedMeta.ContextWindow)
 	assert.Equal(t, 128000, bedMeta.MaxOutputTokens)
 	assert.True(t,
@@ -232,7 +233,7 @@ func TestClaudeOpus48Specs(t *testing.T) {
 	// resolving for anyone who pinned it in scripts or env.
 	legacy, ok := Resolve(ProviderBedrock, "global.anthropic.claude-opus-4-8-20260528-v1:0")
 	assert.True(t, ok, "legacy dated Bedrock id must still resolve as alias")
-	assert.Equal(t, "anthropic.claude-opus-4-8", legacy.ID)
+	assert.Equal(t, "global.anthropic.claude-opus-4-8", legacy.ID)
 	// fast_mode is a first-party research preview and
 	// mid_conversation_system is not served by Bedrock — neither may be
 	// advertised on the Bedrock mirror or the client would emit


### PR DESCRIPTION
## Problem

`/switch` to Claude Opus 4.8 (or 4.7) on Bedrock failed out of the box: the catalog canonical was the bare dateless id (`anthropic.claude-opus-4-8`), which has **no on-demand surface** on `InvokeModel` — AWS rejects it with `ValidationException: … retry your request with the ID or ARN of an inference profile` (region or global). Same class of error hit Sonnet 4 users outside `us-*` regions, since its canonical was the `us.` profile.

## Fix

- **Opus 4.8 / Opus 4.7**: canonical → `global.anthropic.claude-opus-4-8` / `global.anthropic.claude-opus-4-7` (the pattern Opus 4.6 already used). Bare dateless ids and the legacy dated spellings stay as aliases so pinned configs keep resolving.
- **Sonnet 4**: canonical → `global.anthropic.claude-sonnet-4-20250514-v1:0` (real global profile since Sep 2025), works from any region. The `us.` profile becomes its own entry (`bedrock-sonnet-4-us`) alongside the existing `eu.` one for operators pinning geography.
- **Opus 4 / 4.1**: unchanged — AWS offers no global profile for them; `us.` remains the broadest invokable spelling.
- **`mantleModelID`** now strips the profile prefix from catalog canonicals too, so `BEDROCK_ANTHROPIC_ENDPOINT=mantle` forced onto a profile-canonical model still sends the dateless id the Messages endpoint serves (it 404s on profile ids). New `stripInferenceProfilePrefix` helper, covered in `TestMantleModelID`.

Sonnet 5 / Fable 5 are untouched: mantle-only, bare dateless ids remain correct there.

## Tests

- `catalog_test` canonical pins updated (`claude-opus-4-8` → global id; legacy dated alias still resolves).
- `TestMantleModelID` gains the profile-canonical cases (`claude-opus-4-8` and `global.anthropic.claude-opus-4-8` → `anthropic.claude-opus-4-8`).
- `llm/catalog`, `llm/bedrock`, `llm/manager`, `cli` green; golangci-lint and gofmt clean.

Docs (site): features/bedrock + reference/supported-models corrected EN+PT — the previous claim that dateless ids "don't require an inference profile" was wrong for the InvokeModel pair.