### PR TITLE
feat(bedrock): BEDROCK_MODEL selects the default model

### DIFF
--- a/cli/config_env_defaults.go
+++ b/cli/config_env_defaults.go
@@ -87,6 +87,7 @@ var envDefaults = map[string]envDefault{
 	"DEVIN_CLI_TIMEOUT":          {Value: config.DevinCLIDefaultTimeout.String(), Source: "config.DevinCLIDefaultTimeout"},
 	"DEVIN_CLI_SANDBOX":          {Value: "false", Source: "hardcoded"},
 	"OLLAMA_BASE_URL":            {Value: config.OllamaDefaultBaseURL, Source: "config.OllamaDefaultBaseURL"},
+	"BEDROCK_MODEL":              {Value: config.DefaultBedrockModel, Source: "config.DefaultBedrockModel"},
 	"BEDROCK_REGION":             {Value: config.DefaultBedrockRegion, Source: "config.DefaultBedrockRegion"},
 	"COPILOT_MODEL":              {Value: config.DefaultCopilotModel, Source: "config.DefaultCopilotModel"},
 	"COPILOT_API_BASE_URL":       {Value: config.CopilotAPIURL, Source: "config.CopilotAPIURL"},

--- a/cli/config_sections.go
+++ b/cli/config_sections.go
@@ -540,6 +540,7 @@ func (cli *ChatCLI) showConfigProviders() {
 
 	fmt.Println(p)
 	subheader(p, "cfg.sub.prov.bedrock")
+	kv(p, "BEDROCK_MODEL", envOr("BEDROCK_MODEL"))
 	kv(p, "BEDROCK_REGION", envOr("BEDROCK_REGION"))
 	kv(p, "AWS_REGION", envOr("AWS_REGION"))
 	kv(p, "AWS_PROFILE", envOr("AWS_PROFILE"))

--- a/llm/manager/llm_manager.go
+++ b/llm/manager/llm_manager.go
@@ -189,7 +189,7 @@ func (m *LLMManagerImpl) configurarBedrockClient(maxRetries int, initialBackoff 
 	m.logger.Info(i18n.T("llm.info.configuring_provider", "AWS Bedrock"))
 	m.clients["BEDROCK"] = func(model string) (client.LLMClient, error) {
 		if model == "" {
-			model = config.DefaultBedrockModel
+			model = resolveBedrockModel()
 		}
 		region := firstNonEmptyEnv("BEDROCK_REGION", "AWS_REGION")
 		if region == "" {
@@ -334,6 +334,24 @@ func firstNonEmptyEnv(keys ...string) string {
 		}
 	}
 	return ""
+}
+
+// resolveBedrockModel returns the Bedrock model to use when the caller did
+// not pick one explicitly: BEDROCK_MODEL from the environment or .env
+// (every other provider has its *_MODEL counterpart — COPILOT_MODEL,
+// MOONSHOT_MODEL, OLLAMA_MODEL — Bedrock only had the region/schema vars),
+// falling back to the catalog default. Catalog aliases work as values
+// ("claude-opus-4-8" resolves to the invokable global profile id).
+func resolveBedrockModel() string {
+	if v := strings.TrimSpace(os.Getenv("BEDROCK_MODEL")); v != "" {
+		return v
+	}
+	if config.Global != nil {
+		if v := strings.TrimSpace(config.Global.GetString("BEDROCK_MODEL")); v != "" {
+			return v
+		}
+	}
+	return config.DefaultBedrockModel
 }
 
 // configurarGoogleAIClient configura o cliente Google AI (Gemini)
@@ -966,7 +984,7 @@ func (m *LLMManagerImpl) CreateClientWithKey(provider, model, apiKey string) (cl
 
 	case "BEDROCK":
 		if model == "" {
-			model = config.DefaultBedrockModel
+			model = resolveBedrockModel()
 		}
 		region := firstNonEmptyEnv("BEDROCK_REGION", "AWS_REGION")
 		if region == "" {

--- a/llm/manager/llm_manager_test.go
+++ b/llm/manager/llm_manager_test.go
@@ -26,6 +26,7 @@ func setupTestEnv(t *testing.T, envs map[string]string) {
 		"STACKSPOT_REALM", "STACKSPOT_AGENT_ID",
 		"CHATCLI_AUTH_DIR",
 		"AWS_ACCESS_KEY_ID", "AWS_PROFILE", "AWS_REGION", "BEDROCK_REGION",
+		"BEDROCK_MODEL",
 		"AWS_WEB_IDENTITY_TOKEN_FILE",
 		"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
 		"AWS_CONTAINER_CREDENTIALS_FULL_URI",
@@ -111,6 +112,50 @@ func TestLLMManager_GetClient(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, client)
 		assert.IsType(t, &stackspotai.StackSpotClient{}, client)
+	})
+
+	t.Run("Bedrock honors BEDROCK_MODEL when no model is passed", func(t *testing.T) {
+		setupTestEnv(t, map[string]string{
+			"AWS_ACCESS_KEY_ID": "AKIAIOSFODNN7EXAMPLE",
+			"BEDROCK_MODEL":     "claude-opus-4-8",
+		})
+
+		mgr, err := NewLLMManager(logger)
+		assert.NoError(t, err)
+
+		client, err := mgr.GetClient("BEDROCK", "")
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+		// The alias resolves through the catalog to the invokable global
+		// profile, whose display name identifies Opus 4.8.
+		assert.Contains(t, client.GetModelName(), "Opus 4.8")
+	})
+
+	t.Run("Bedrock explicit model wins over BEDROCK_MODEL", func(t *testing.T) {
+		setupTestEnv(t, map[string]string{
+			"AWS_ACCESS_KEY_ID": "AKIAIOSFODNN7EXAMPLE",
+			"BEDROCK_MODEL":     "claude-opus-4-8",
+		})
+
+		mgr, err := NewLLMManager(logger)
+		assert.NoError(t, err)
+
+		client, err := mgr.GetClient("BEDROCK", "claude-haiku-4-5")
+		assert.NoError(t, err)
+		assert.Contains(t, client.GetModelName(), "Haiku 4.5")
+	})
+
+	t.Run("Bedrock falls back to the catalog default without BEDROCK_MODEL", func(t *testing.T) {
+		setupTestEnv(t, map[string]string{
+			"AWS_ACCESS_KEY_ID": "AKIAIOSFODNN7EXAMPLE",
+		})
+
+		mgr, err := NewLLMManager(logger)
+		assert.NoError(t, err)
+
+		client, err := mgr.GetClient("BEDROCK", "")
+		assert.NoError(t, err)
+		assert.Contains(t, client.GetModelName(), "Sonnet 4.5")
 	})
 
 	t.Run("Unsupported Provider", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Every provider has its model variable (`COPILOT_MODEL`, `MOONSHOT_MODEL`, `OLLAMA_MODEL`, `ZAI_MODEL`…) — Bedrock only had region/schema vars (`BEDROCK_REGION`, `BEDROCK_PROVIDER`), so you could pin the provider from the environment but not the model.

## Changes

- **`BEDROCK_MODEL`** — default model when none is selected, read from the environment first and then `.env` via `config.Global` (new `resolveBedrockModel` helper), falling back to the catalog default (Sonnet 4.5 global). Applied on both client-construction paths in the manager.
- Catalog aliases work as values: `BEDROCK_MODEL=claude-opus-4-8` resolves to the invokable `global.anthropic.claude-opus-4-8` profile.
- An explicitly selected model (`/switch --model`, `GetClient(provider, model)`) always wins over the variable.
- Exposed in the Bedrock provider section of `/config` with its catalog default.

## Tests

Three new manager subtests (hermetic via `setupTestEnv`, which now also isolates `BEDROCK_MODEL` from the dev shell): variable honored when no model is passed (alias resolves to Opus 4.8), explicit model wins, and catalog-default fallback without the variable.

`llm/manager` + `cli` green; golangci-lint and gofmt clean.

Docs (site): features/bedrock (env table + setup examples) and reference/environment-variables updated EN+PT.