### PR TITLE
fix: Bedrock compaction budget fallbacks and bracket-style tool call parsing

### DIFF
--- a/cli/agent/toolcall_parser.go
+++ b/cli/agent/toolcall_parser.go
@@ -52,6 +52,14 @@ func ParseToolCalls(text string) ([]ToolCall, error) {
 		calls = append(calls, mdCalls...)
 	}
 
+	// Last-resort fallback: "[tool: @name {args}]" shorthand. Some models
+	// (observed with Claude Opus 4.8 on Bedrock) emit this instead of the
+	// canonical tag. Gated on zero calls so prose that merely mentions the
+	// bracket syntax alongside a real <tool_call> never duplicates a batch.
+	if len(calls) == 0 {
+		calls = append(calls, parseBracketToolCalls(text)...)
+	}
+
 	// Apply JSON recovery/normalization to ALL parsed calls (XML, JSON, markdown).
 	// This fixes single quotes, unquoted keys, and other malformations.
 	// Must run AFTER all parsing stages so that every source benefits from recovery.
@@ -424,6 +432,122 @@ func parseJSONToolCalls(text string) []ToolCall {
 	}
 
 	return calls
+}
+
+// parseBracketToolCalls handles the "[tool: @name {args}]" shorthand:
+//
+//	[tool: @websearch {"query":"golang"}]
+//	[tool_call: @coder {'cmd':'read','args':{...}}]   (single quotes → recovery)
+//	[tool: websearch {"query":"x"}]                    (missing @ → prepended)
+//	[tool: @coder read --file main.go]                 (flat args string)
+//	[tool: @tools]                                     (no args)
+//
+// The "tool:"/"tool_call:" prefix inside the bracket is the intent signal —
+// a bare "[something]" in prose never matches. JSON args are extracted with
+// balanced-brace scanning, so a missing closing bracket (truncated response)
+// still recovers the call.
+func parseBracketToolCalls(text string) []ToolCall {
+	var calls []ToolCall
+	searchFrom := 0
+
+	for searchFrom < len(text) {
+		idx := indexCaseInsensitive(text[searchFrom:], "[tool")
+		if idx < 0 {
+			break
+		}
+		start := searchFrom + idx
+
+		name, pos, ok := parseBracketHeader(text, start+len("[tool"))
+		if !ok {
+			searchFrom = start + 1
+			continue
+		}
+
+		args, end := parseBracketArgs(text, pos)
+
+		// Optional trailing whitespace + closing ']' — tolerated if absent.
+		for end < len(text) && (text[end] == ' ' || text[end] == '\t') {
+			end++
+		}
+		if end < len(text) && text[end] == ']' {
+			end++
+		}
+
+		calls = append(calls, ToolCall{
+			Name: name,
+			Args: args,
+			Raw:  text[start:end],
+		})
+		searchFrom = end
+	}
+
+	return calls
+}
+
+// parseBracketHeader consumes the optional "_call" spelling, the mandatory
+// ":" separator and the tool name, starting right after "[tool". Returns the
+// @-normalized name and the position after it. ok=false means this bracket
+// is prose (no colon, empty name), not a call.
+func parseBracketHeader(text string, pos int) (string, int, bool) {
+	const callSuffix = "_call"
+	if pos+len(callSuffix) <= len(text) && strings.EqualFold(text[pos:pos+len(callSuffix)], callSuffix) {
+		pos += len(callSuffix)
+	}
+
+	// Require ":" (with optional surrounding spaces) — this is what
+	// separates the shorthand from prose like "[tool docs]".
+	pos = skipSpacesTabs(text, pos)
+	if pos >= len(text) || text[pos] != ':' {
+		return "", pos, false
+	}
+	pos = skipSpacesTabs(text, pos+1)
+
+	// Tool name: optional '@' + attribute-name chars.
+	nameStart := pos
+	if pos < len(text) && text[pos] == '@' {
+		pos++
+	}
+	for pos < len(text) && isAttrNameChar(text[pos]) {
+		pos++
+	}
+	name := text[nameStart:pos]
+	if strings.TrimPrefix(name, "@") == "" {
+		return "", pos, false
+	}
+	if !strings.HasPrefix(name, "@") {
+		name = "@" + name
+	}
+	for pos < len(text) && (text[pos] == ' ' || text[pos] == '\t' || text[pos] == '\n' || text[pos] == '\r') {
+		pos++
+	}
+	return name, pos, true
+}
+
+// parseBracketArgs extracts the args portion of a bracket call starting at
+// pos: a balanced JSON object, or a flat string up to the closing ']' (the
+// downstream lenient arg parser understands "exec ls -t file" shapes).
+// Returns the args and the position where they end.
+func parseBracketArgs(text string, pos int) (string, int) {
+	if pos < len(text) && text[pos] == '{' {
+		if obj := extractJSONObject(text, pos); obj != "" {
+			return obj, pos + len(obj)
+		}
+		// Unbalanced braces — fall through to flat-args handling.
+	}
+	if pos < len(text) && text[pos] == ']' {
+		return "", pos
+	}
+	if closeIdx := strings.IndexByte(text[pos:], ']'); closeIdx >= 0 {
+		return strings.TrimSpace(text[pos : pos+closeIdx]), pos + closeIdx
+	}
+	return strings.TrimSpace(text[pos:]), len(text)
+}
+
+func skipSpacesTabs(text string, pos int) int {
+	for pos < len(text) && (text[pos] == ' ' || text[pos] == '\t') {
+		pos++
+	}
+	return pos
 }
 
 // parseMarkdownCodeBlockToolCalls extracts tool calls from markdown code blocks.

--- a/cli/agent/toolcall_parser_bracket_test.go
+++ b/cli/agent/toolcall_parser_bracket_test.go
@@ -1,0 +1,116 @@
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Claude Opus 4.8 (observado via Bedrock) por vezes emite tool calls no
+// shorthand "[tool: @nome {args}]" em vez da tag <tool_call> canônica.
+// O parser precisa capturar o formato em vez de obrigar o usuário a
+// corrigir o modelo turno a turno (regra do projeto: parsing tolerante).
+
+func TestParseBracketToolCall_JSONArgs(t *testing.T) {
+	calls, err := ParseToolCalls(`Vou pesquisar isso.
+
+[tool: @websearch {"query":"golang 1.25 release notes"}]`)
+	require.NoError(t, err)
+	require.Len(t, calls, 1)
+	assert.Equal(t, "@websearch", calls[0].Name)
+	assert.JSONEq(t, `{"query":"golang 1.25 release notes"}`, calls[0].Args)
+}
+
+func TestParseBracketToolCall_MissingAtPrefix(t *testing.T) {
+	calls, err := ParseToolCalls(`[tool: websearch {"query":"chatcli"}]`)
+	require.NoError(t, err)
+	require.Len(t, calls, 1)
+	assert.Equal(t, "@websearch", calls[0].Name, "bare name must gain the @ prefix")
+}
+
+func TestParseBracketToolCall_ToolCallSpelling(t *testing.T) {
+	calls, err := ParseToolCalls(`[tool_call: @tools {"cmd":"list"}]`)
+	require.NoError(t, err)
+	require.Len(t, calls, 1)
+	assert.Equal(t, "@tools", calls[0].Name)
+}
+
+func TestParseBracketToolCall_SingleQuoteRecovery(t *testing.T) {
+	// Args maltratados (aspas simples) passam pela recovery normal de JSON.
+	calls, err := ParseToolCalls(`[tool: @websearch {'query':'golang'}]`)
+	require.NoError(t, err)
+	require.Len(t, calls, 1)
+	var obj map[string]any
+	require.NoError(t, json.Unmarshal([]byte(calls[0].Args), &obj),
+		"args must be valid JSON after recovery, got: %s", calls[0].Args)
+	assert.Equal(t, "golang", obj["query"])
+}
+
+func TestParseBracketToolCall_FlatStringArgs(t *testing.T) {
+	// Args sem chaves JSON: o flattener downstream entende "--flag value".
+	calls, err := ParseToolCalls(`[tool: @coder read --file main.go]`)
+	require.NoError(t, err)
+	require.Len(t, calls, 1)
+	assert.Equal(t, "@coder", calls[0].Name)
+	assert.Equal(t, "read --file main.go", calls[0].Args)
+}
+
+func TestParseBracketToolCall_CoderExecShape(t *testing.T) {
+	// Shape real observado com Opus 4.8 via Bedrock em modo coder.
+	calls, err := ParseToolCalls(`[tool: @coder exec ls -t meuarquivo.txt]`)
+	require.NoError(t, err)
+	require.Len(t, calls, 1)
+	assert.Equal(t, "@coder", calls[0].Name)
+	assert.Equal(t, "exec ls -t meuarquivo.txt", calls[0].Args)
+}
+
+func TestParseBracketToolCall_NoArgs(t *testing.T) {
+	calls, err := ParseToolCalls(`[tool: @tools]`)
+	require.NoError(t, err)
+	require.Len(t, calls, 1)
+	assert.Equal(t, "@tools", calls[0].Name)
+	assert.Empty(t, calls[0].Args)
+}
+
+func TestParseBracketToolCall_MultipleInBatch(t *testing.T) {
+	calls, err := ParseToolCalls(`Preciso de duas coisas:
+[tool: @websearch {"query":"a"}]
+[tool: @wikipedia {"cmd":"summary","args":{"title":"Go"}}]`)
+	require.NoError(t, err)
+	require.Len(t, calls, 2)
+	assert.Equal(t, "@websearch", calls[0].Name)
+	assert.Equal(t, "@wikipedia", calls[1].Name)
+}
+
+func TestParseBracketToolCall_UnclosedBracketLenient(t *testing.T) {
+	// Resposta truncada: o objeto JSON completo ainda é recuperável.
+	calls, err := ParseToolCalls(`[tool: @websearch {"query":"golang"}`)
+	require.NoError(t, err)
+	require.Len(t, calls, 1)
+	assert.JSONEq(t, `{"query":"golang"}`, calls[0].Args)
+}
+
+func TestParseBracketToolCall_XMLTakesPrecedence(t *testing.T) {
+	// Quando o formato canônico está presente, o shorthand em prose não
+	// gera chamadas duplicadas — o estágio bracket é só fallback.
+	calls, err := ParseToolCalls(`Como pedido em [tool: syntax], vou usar:
+<tool_call name="@websearch" args='{"query":"x"}' />`)
+	require.NoError(t, err)
+	require.Len(t, calls, 1)
+	assert.Equal(t, "@websearch", calls[0].Name)
+}
+
+func TestParseBracketToolCall_NegativeCases(t *testing.T) {
+	for _, text := range []string{
+		"a [toolbox: hammer] is not a tool call",
+		"see the [tool docs] for details",
+		"empty [tool: ] name",
+		"no brackets at all",
+	} {
+		calls, err := ParseToolCalls(text)
+		assert.NoError(t, err, text)
+		assert.Empty(t, calls, "must not parse a call from: %s", text)
+	}
+}

--- a/llm/bedrock/bedrock_client.go
+++ b/llm/bedrock/bedrock_client.go
@@ -194,7 +194,10 @@ func (c *BedrockClient) getMaxTokens() int {
 			return parsed
 		}
 	}
-	return catalog.GetMaxTokens(catalog.ProviderBedrock, c.model, 4096)
+	// Sem override: o terceiro argumento tem prioridade máxima em
+	// GetMaxTokens, então passar 4096 aqui ignorava o catálogo inteiro e
+	// estrangulava modelos com teto de 64K-128K (Fable/Sonnet/Opus).
+	return catalog.GetMaxTokens(catalog.ProviderBedrock, c.model, 0)
 }
 
 // shouldDisableIMDS returns true when the process is clearly NOT running on

--- a/llm/catalog/catalog.go
+++ b/llm/catalog/catalog.go
@@ -1545,6 +1545,56 @@ var registry = []ModelMeta{
 		Capabilities:    []string{"tools", "json_mode"},
 	},
 
+	// ── AWS Bedrock — Amazon Nova ────────────────────────────────────
+	// Família nativa da AWS, roteada pela Converse API (que normaliza no
+	// shape chat-completions). Os IDs primários usam o prefixo de
+	// inference profile "us." (exigido para invocação on-demand na
+	// maioria das regiões); os IDs base ficam como aliases. Sem estas
+	// entradas as janelas de 300K/1M caíam no fallback genérico do
+	// provider e a compactação disparava cedo demais. MaxOutputTokens
+	// segue o teto documentado de 5K da família; BEDROCK_MAX_TOKENS
+	// cobre deployments que exponham mais.
+	{
+		ID:              "us.amazon.nova-micro-v1:0",
+		Aliases:         []string{"bedrock-nova-micro", "amazon.nova-micro-v1:0", "nova-micro"},
+		DisplayName:     "Amazon Nova Micro (Bedrock)",
+		Provider:        ProviderBedrock,
+		ContextWindow:   128000,
+		MaxOutputTokens: 5120,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"tools", "json_mode"},
+	},
+	{
+		ID:              "us.amazon.nova-lite-v1:0",
+		Aliases:         []string{"bedrock-nova-lite", "amazon.nova-lite-v1:0", "nova-lite"},
+		DisplayName:     "Amazon Nova Lite (Bedrock)",
+		Provider:        ProviderBedrock,
+		ContextWindow:   300000,
+		MaxOutputTokens: 5120,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"tools", "vision", "json_mode"},
+	},
+	{
+		ID:              "us.amazon.nova-pro-v1:0",
+		Aliases:         []string{"bedrock-nova-pro", "amazon.nova-pro-v1:0", "nova-pro"},
+		DisplayName:     "Amazon Nova Pro (Bedrock)",
+		Provider:        ProviderBedrock,
+		ContextWindow:   300000,
+		MaxOutputTokens: 5120,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"tools", "vision", "json_mode"},
+	},
+	{
+		ID:              "us.amazon.nova-premier-v1:0",
+		Aliases:         []string{"bedrock-nova-premier", "amazon.nova-premier-v1:0", "nova-premier"},
+		DisplayName:     "Amazon Nova Premier (Bedrock, 1M ctx)",
+		Provider:        ProviderBedrock,
+		ContextWindow:   1000000,
+		MaxOutputTokens: 5120,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"tools", "vision", "json_mode"},
+	},
+
 	// ── StackSpot AI ─────────────────────────────────────────────────
 	{
 		// StackSpot's agent chat API does not accept max_tokens — the
@@ -1649,6 +1699,16 @@ func GetMaxTokens(provider, model string, override int) int {
 		// Claude 3+ família toda usa 200K input; output varia 4K-128K.
 		// 64K é o teto comum dos modelos atuais (sonnet 4.x, opus 4.5+).
 		return 64000
+	case ProviderBedrock:
+		// Espelha o racional do CLAUDEAI para modelos Claude fora do
+		// catálogo — modelos com cap menor (3.x) têm entrada própria, então
+		// um desconhecido é lançamento novo com teto ≥64K. Para o resto,
+		// 4096 é o piso seguro do catálogo AWS atual (Converse rejeita
+		// maxTokens acima do cap real do modelo).
+		if m := strings.ToLower(model); strings.Contains(m, "anthropic") || strings.Contains(m, "claude") {
+			return 64000
+		}
+		return 4096
 	case ProviderStackSpot:
 		// The StackSpot agent API ignores client-side max_tokens; this
 		// value only feeds local bookkeeping, so keep it aligned with
@@ -1704,7 +1764,20 @@ func GetContextWindow(provider, model string) int {
 		return 1000000
 	case ProviderClaudeAI:
 		return 200000
-	case ProviderOpenAI:
+	case ProviderOpenAI, ProviderOpenAIAssistant:
+		return 128000
+	case ProviderBedrock:
+		// Modelos fora do catálogo: application inference profiles com ID
+		// opaco, marketplace e lançamentos recentes. Sem este case eles
+		// caíam no default genérico de 50K e a compactação de histórico
+		// disparava em quase todo turno de agent — mesma classe de bug do
+		// StackSpot (PR #1044). Claude é a família dominante no Bedrock e
+		// tem piso real de 200K; o resto do catálogo atual da AWS (Nova,
+		// Llama, Mistral, DeepSeek) senta em 128K.
+		m := strings.ToLower(model)
+		if strings.Contains(m, "anthropic") || strings.Contains(m, "claude") {
+			return 200000
+		}
 		return 128000
 	case ProviderStackSpot:
 		// StackSpot agents sit on top of current frontier models (128K+

--- a/llm/catalog/catalog_test.go
+++ b/llm/catalog/catalog_test.go
@@ -435,3 +435,53 @@ func TestDevinCatalogEntries(t *testing.T) {
 	assert.Equal(t, 200000, GetContextWindow(ProviderDevin, "some-future-model"))
 	assert.Equal(t, 32000, GetMaxTokens(ProviderDevin, "some-future-model", 0))
 }
+
+// TestBedrockProviderFallbacks pins the Bedrock provider fallbacks for models
+// absent from the registry. Before these cases existed, any unresolvable
+// Bedrock model (application inference profiles with opaque IDs, marketplace
+// or freshly-launched models) fell through to the generic 50K default — the
+// same bug class as StackSpot (PR #1044) — which shrank the agent-mode
+// compaction budget to ~120K chars and made history compaction fire on
+// nearly every turn.
+func TestBedrockProviderFallbacks(t *testing.T) {
+	// Opaque application-inference-profile ARN: nothing in the registry can
+	// match it. Non-Claude current Bedrock models (Nova, Llama, Mistral,
+	// DeepSeek) all sit at 128K — that is the safe generic floor.
+	opaque := "arn:aws:bedrock:us-east-1:000000000000:application-inference-profile/synthetic0000"
+	assert.Equal(t, 128000, GetContextWindow(ProviderBedrock, opaque))
+	assert.Equal(t, 4096, GetMaxTokens(ProviderBedrock, opaque, 0))
+
+	// Future Claude model not yet in the registry: the Claude family floor
+	// is 200K input / 64K output, mirroring the CLAUDEAI provider fallback.
+	assert.Equal(t, 200000, GetContextWindow(ProviderBedrock, "anthropic.claude-future-model"))
+	assert.Equal(t, 64000, GetMaxTokens(ProviderBedrock, "anthropic.claude-future-model", 0))
+
+	// Explicit override still has the highest priority.
+	assert.Equal(t, 9000, GetMaxTokens(ProviderBedrock, opaque, 9000))
+}
+
+// TestOpenAIAssistantContextWindowFallback: assistant mode reports provider
+// OPENAI_ASSISTANT; without its own case it fell into the generic 50K default.
+func TestOpenAIAssistantContextWindowFallback(t *testing.T) {
+	assert.Equal(t, 128000, GetContextWindow(ProviderOpenAIAssistant, "unknown-assistant-model"))
+}
+
+// TestBedrockNovaEntries pins the Amazon Nova family. These are the flagship
+// non-Anthropic Bedrock models; without registry entries their 300K/1M
+// windows collapsed onto the provider fallback.
+func TestBedrockNovaEntries(t *testing.T) {
+	for model, wantCtx := range map[string]int{
+		"amazon.nova-micro-v1:0":      128000,
+		"amazon.nova-lite-v1:0":       300000,
+		"amazon.nova-pro-v1:0":        300000,
+		"amazon.nova-premier-v1:0":    1000000,
+		"us.amazon.nova-pro-v1:0":     300000, // cross-region inference profile spelling
+		"us.amazon.nova-premier-v1:0": 1000000,
+	} {
+		meta, ok := Resolve(ProviderBedrock, model)
+		assert.True(t, ok, "expected %s to resolve for BEDROCK", model)
+		assert.Equal(t, ProviderBedrock, meta.Provider, "%s provider", model)
+		assert.Equal(t, wantCtx, meta.ContextWindow, "%s context window", model)
+		assert.Equal(t, wantCtx, GetContextWindow(ProviderBedrock, model), "%s GetContextWindow", model)
+	}
+}


### PR DESCRIPTION
## Problem

Two related failure modes reported with Claude Opus 4.8 via Bedrock:

1. **History compaction firing on nearly every agent turn.** Bedrock had no case in the provider fallback switches of the model catalog, so any model the registry could not resolve (application inference profiles with opaque IDs, marketplace or freshly launched models) fell to the generic 50K context default. That shrank the agent-mode compaction budget to roughly 120K chars — the same bug class fixed for StackSpot in #1044.
2. **Tool calls silently dropped.** The model sometimes emits a bracket shorthand instead of the canonical tag, both with JSON args and flat coder-style args (observed: tool colon name followed by args inside square brackets). No parser stage captured it, forcing the user to correct the model turn after turn.

## Changes

### Catalog / Bedrock
- GetContextWindow: BEDROCK fallback — 200K for the Claude family, 128K otherwise; OPENAI_ASSISTANT now shares the OpenAI 128K case instead of falling to 50K
- GetMaxTokens: BEDROCK fallback — 64K for Claude, 4096 otherwise
- Amazon Nova family registry entries (micro 128K, lite/pro 300K, premier 1M) so their real windows stop collapsing onto the provider fallback; primary IDs use the cross-region inference profile spelling, bare IDs kept as aliases
- Bedrock client no longer passes 4096 as the override argument to GetMaxTokens — override has top priority, so the whole catalog was being bypassed and models with 64K-128K output caps were strangled to 4096

### Tool call parser
- New last-resort stage for the bracket shorthand, gated on zero calls from the existing XML, JSON and markdown stages so prose mentioning the syntax next to a real tool_call never duplicates a batch
- Accepted variants: tool or tool_call spelling, optional at-sign on the name (prepended when missing), balanced JSON args routed through the usual JSON recovery, flat string args passed through untouched for the lenient downstream arg parser, tolerant of a missing closing bracket on truncated responses

## Testing
- Red-first: new tests reproduced both bugs against main before the fixes
- go build plus full go test suite green
- Local quality-gate floors green: ai-smells, cyclo-new, i18n-parity, license-headers, api-breaking
- golangci-lint clean on touched packages