### PR TITLE
fix: session /max-tokens override reflects in agent, coder and config

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -1268,10 +1268,12 @@ func (a *AgentMode) RunOnce(ctx context.Context, query string, autoExecute bool)
 
 	a.cli.animation.ShowThinkingAnimation(a.cli.Client.GetModelName())
 
-	aiResponse, err := a.cli.Client.SendPrompt(ctx, enrichedQuery, a.cli.history, 0)
+	// Session /max-tokens override (0 = provider default), same as the loop.
+	legacyMaxTokens := a.cli.UserMaxTokens
+	aiResponse, err := a.cli.Client.SendPrompt(ctx, enrichedQuery, a.cli.history, legacyMaxTokens)
 	// Auto-retry on OAuth token expiration (401)
 	if a.cli.refreshClientOnAuthError(err) {
-		aiResponse, err = a.cli.Client.SendPrompt(ctx, enrichedQuery, a.cli.history, 0)
+		aiResponse, err = a.cli.Client.SendPrompt(ctx, enrichedQuery, a.cli.history, legacyMaxTokens)
 	}
 	a.cli.animation.StopThinkingAnimation()
 	if err != nil {
@@ -1449,6 +1451,19 @@ func (a *AgentMode) getToolContextString() string {
 	return toolContext
 }
 
+// adoptSessionMaxTokens reconciles the agent loop's per-turn max-tokens with
+// the session /max-tokens override (cli.UserMaxTokens). The override is
+// adopted whenever the user changes it — raising or lowering — but an
+// unchanged override never clobbers a value the truncation-recovery
+// escalation raised in the meantime. Returns the new (current, lastAdopted)
+// pair.
+func adoptSessionMaxTokens(current, lastAdopted, sessionOverride int) (int, int) {
+	if sessionOverride > 0 && sessionOverride != lastAdopted {
+		return sessionOverride, sessionOverride
+	}
+	return current, lastAdopted
+}
+
 // processAIResponseAndAct is the ReAct main loop. It is deliberately
 // large — it interleaves stdin draining, LLM streaming, tool parsing,
 // policy enforcement, compaction, and UI rendering — and a targeted
@@ -1551,6 +1566,7 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 	contextRecovery := agent.NewContextRecovery(agent.DefaultContextRecoveryConfig(), a.logger)
 	currentMaxTokens := 0           // 0 = use provider default
 	providerMaxTokensCap := 128_000 // conservative default; providers may support more
+	lastSessionMaxTokens := 0       // last /max-tokens override adopted into currentMaxTokens
 
 	// Stagnation detector — breaks out of the ReAct loop when the model
 	// re-emits the SAME batch of tool_calls for N consecutive turns, which
@@ -1579,6 +1595,12 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 			return ctx.Err()
 		default:
 		}
+
+		// Honor the session /max-tokens override exactly like chat mode does.
+		// Re-read every turn (raising OR lowering reflects here), while
+		// preserving any truncation-driven escalation applied meanwhile.
+		currentMaxTokens, lastSessionMaxTokens = adoptSessionMaxTokens(
+			currentMaxTokens, lastSessionMaxTokens, a.cli.UserMaxTokens)
 
 		// Surface background memory/skill writes (auto-extraction ticker,
 		// queued notices) the moment they land instead of holding them until

--- a/cli/agent_mode_maxtokens_test.go
+++ b/cli/agent_mode_maxtokens_test.go
@@ -1,9 +1,14 @@
 package cli
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"testing"
 
+	"github.com/diillson/chatcli/models"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 )
 
 // O loop do agent/coder ignorava o override de sessão do /max-tokens
@@ -76,4 +81,56 @@ func TestAdoptSessionMaxTokens(t *testing.T) {
 			assert.Equal(t, tc.wantAdopted, gotAdopted, "lastAdopted")
 		})
 	}
+}
+
+// maxTokensCaptureFake registra o maxTokens recebido pelo SendPrompt para
+// provar que o override de sessão chega ao provider.
+type maxTokensCaptureFake struct {
+	gotMaxTokens int
+	err          error
+}
+
+func (f *maxTokensCaptureFake) GetModelName() string { return "fake" }
+func (f *maxTokensCaptureFake) SendPrompt(_ context.Context, _ string, _ []models.Message, maxTokens int) (string, error) {
+	f.gotMaxTokens = maxTokens
+	return "ok", f.err
+}
+
+// sendOutputToAI é caminho de chat: o override de sessão do /max-tokens
+// precisa chegar ao SendPrompt em vez do 0 fixo que ignorava o ajuste.
+func TestSendOutputToAI_HonorsSessionMaxTokens(t *testing.T) {
+	fake := &maxTokensCaptureFake{err: errors.New("synthetic: stop before rendering")}
+	c := &ChatCLI{
+		animation:     NewAnimationManager(),
+		logger:        zap.NewNop(),
+		Client:        fake,
+		UserMaxTokens: 32000,
+	}
+	c.animation.SetSuppressed(true)
+
+	c.sendOutputToAI("stdout sample", "extra context")
+
+	assert.Equal(t, 32000, fake.gotMaxTokens,
+		"session /max-tokens override must reach SendPrompt")
+	// O prompt localizado entra no histórico como mensagem de usuário.
+	assert.Len(t, c.history, 1)
+	assert.Equal(t, "user", c.history[0].Role)
+	assert.Contains(t, c.history[0].Content, "stdout sample")
+}
+
+// effectiveMaxTokensDisplay marca quando o número exibido vem do override de
+// sessão, para o /config nunca ler como default estático.
+func TestEffectiveMaxTokensDisplay(t *testing.T) {
+	plain := &ChatCLI{Provider: "OPENAI", Model: "unknown-model"}
+	assert.Equal(t, fmt.Sprintf("%d", plain.getMaxTokensForCurrentLLM()),
+		plain.effectiveMaxTokensDisplay(),
+		"without an override the display is the bare effective number")
+
+	withOverride := &ChatCLI{Provider: "OPENAI", Model: "unknown-model", UserMaxTokens: 64000}
+	got := withOverride.effectiveMaxTokensDisplay()
+	// A camada i18n aplica separador de milhar ao %d ("64,000"), então a
+	// asserção usa o prefixo do número e a annotation, estáveis nos locales.
+	assert.Contains(t, got, "64", "override value must be displayed")
+	assert.Contains(t, got, "/max-tokens",
+		"override display must carry the session-override annotation")
 }

--- a/cli/agent_mode_maxtokens_test.go
+++ b/cli/agent_mode_maxtokens_test.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// O loop do agent/coder ignorava o override de sessão do /max-tokens
+// (currentMaxTokens fixo em 0 = provider default). adoptSessionMaxTokens é a
+// reconciliação por turno: adota o override sempre que o usuário o altera,
+// sem clobberar a escalation de truncação quando o override não mudou.
+func TestAdoptSessionMaxTokens(t *testing.T) {
+	cases := []struct {
+		name        string
+		current     int
+		lastAdopted int
+		override    int
+		wantCurrent int
+		wantAdopted int
+	}{
+		{
+			name:        "no override keeps provider default",
+			current:     0,
+			lastAdopted: 0,
+			override:    0,
+			wantCurrent: 0,
+			wantAdopted: 0,
+		},
+		{
+			name:        "first override is adopted",
+			current:     0,
+			lastAdopted: 0,
+			override:    32000,
+			wantCurrent: 32000,
+			wantAdopted: 32000,
+		},
+		{
+			name:        "raised override is adopted",
+			current:     32000,
+			lastAdopted: 32000,
+			override:    64000,
+			wantCurrent: 64000,
+			wantAdopted: 64000,
+		},
+		{
+			name:        "lowered override is adopted",
+			current:     64000,
+			lastAdopted: 64000,
+			override:    16000,
+			wantCurrent: 16000,
+			wantAdopted: 16000,
+		},
+		{
+			name:        "unchanged override preserves truncation escalation",
+			current:     96000, // escalation raised beyond the 64000 override
+			lastAdopted: 64000,
+			override:    64000,
+			wantCurrent: 96000,
+			wantAdopted: 64000,
+		},
+		{
+			name:        "override change wins over prior escalation",
+			current:     96000,
+			lastAdopted: 64000,
+			override:    128000,
+			wantCurrent: 128000,
+			wantAdopted: 128000,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotCurrent, gotAdopted := adoptSessionMaxTokens(tc.current, tc.lastAdopted, tc.override)
+			assert.Equal(t, tc.wantCurrent, gotCurrent, "current")
+			assert.Equal(t, tc.wantAdopted, gotAdopted, "lastAdopted")
+		})
+	}
+}

--- a/cli/chat_pipeline_test.go
+++ b/cli/chat_pipeline_test.go
@@ -266,6 +266,21 @@ func TestProviderMaxTokensOverride(t *testing.T) {
 			env:      map[string]string{"OPENAI_MAX_TOKENS": "4096"},
 			want:     4096,
 		},
+		{
+			// The Bedrock client honors BEDROCK_MAX_TOKENS; the table must
+			// agree or /config's effective max tokens diverges from what
+			// the provider actually sends.
+			name:     "bedrock env propagates",
+			provider: "BEDROCK",
+			env:      map[string]string{"BEDROCK_MAX_TOKENS": "16384"},
+			want:     16384,
+		},
+		{
+			name:     "openrouter env propagates",
+			provider: "OPENROUTER",
+			env:      map[string]string{"OPENROUTER_MAX_TOKENS": "12000"},
+			want:     12000,
+		},
 	}
 	// Collect every env var used across the table so each subtest can
 	// reset to a clean slate before applying its own overrides.

--- a/cli/cli_commands.go
+++ b/cli/cli_commands.go
@@ -218,11 +218,12 @@ func (cli *ChatCLI) sendOutputToAI(output string, aiContext string) {
 
 	safeOutput := utils.SanitizeSensitiveText(output)
 	safeContext := utils.SanitizeSensitiveText(aiContext)
+	outputPrompt := i18n.T("command.output.to_ai_prompt", safeOutput, safeContext)
 
 	// Adicionar o output do comando ao histórico como mensagem do usuário
 	cli.history = append(cli.history, models.Message{
 		Role:    "user",
-		Content: fmt.Sprintf("Saída do comando:\n%s\n\nContexto: %s", safeOutput, safeContext),
+		Content: outputPrompt,
 	})
 	// Exibir mensagem "Pensando..." com animação
 	cli.animation.ShowThinkingAnimation(cli.Client.GetModelName())
@@ -232,7 +233,7 @@ func (cli *ChatCLI) sendOutputToAI(output string, aiContext string) {
 	defer cancel()
 
 	//Enviar o output e o contexto para a IA
-	aiResponse, err := cli.Client.SendPrompt(ctx, fmt.Sprintf("Saída do comando:\n%s\n\nContexto: %s", safeOutput, safeContext), cli.history, cli.UserMaxTokens)
+	aiResponse, err := cli.Client.SendPrompt(ctx, outputPrompt, cli.history, cli.UserMaxTokens)
 
 	//parar a animação
 	cli.animation.StopThinkingAnimation()

--- a/cli/cli_commands.go
+++ b/cli/cli_commands.go
@@ -232,7 +232,7 @@ func (cli *ChatCLI) sendOutputToAI(output string, aiContext string) {
 	defer cancel()
 
 	//Enviar o output e o contexto para a IA
-	aiResponse, err := cli.Client.SendPrompt(ctx, fmt.Sprintf("Saída do comando:\n%s\n\nContexto: %s", safeOutput, safeContext), cli.history, 0)
+	aiResponse, err := cli.Client.SendPrompt(ctx, fmt.Sprintf("Saída do comando:\n%s\n\nContexto: %s", safeOutput, safeContext), cli.history, cli.UserMaxTokens)
 
 	//parar a animação
 	cli.animation.StopThinkingAnimation()

--- a/cli/cli_file_processing.go
+++ b/cli/cli_file_processing.go
@@ -634,7 +634,7 @@ func (cli *ChatCLI) handleNextChunk(ctx context.Context) bool {
 	cli.animation.ShowThinkingAnimation(cli.Client.GetModelName())
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
-	aiResponse, err := cli.Client.SendPrompt(ctx, prompt+"\n\n"+nextChunk.Content, cli.history, 0)
+	aiResponse, err := cli.Client.SendPrompt(ctx, prompt+"\n\n"+nextChunk.Content, cli.history, cli.UserMaxTokens)
 	cli.animation.StopThinkingAnimation()
 
 	if err != nil {
@@ -689,7 +689,7 @@ func (cli *ChatCLI) handleRetryLastChunk(ctx context.Context) bool {
 	cli.animation.ShowThinkingAnimation(cli.Client.GetModelName())
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
-	aiResponse, err := cli.Client.SendPrompt(ctx, prompt+"\n\n"+chunk.Content, cli.history, 0)
+	aiResponse, err := cli.Client.SendPrompt(ctx, prompt+"\n\n"+chunk.Content, cli.history, cli.UserMaxTokens)
 	cli.animation.StopThinkingAnimation()
 
 	if err != nil {

--- a/cli/cli_llm.go
+++ b/cli/cli_llm.go
@@ -603,6 +603,10 @@ var providerMaxTokensEnv = map[string]string{
 	"STACKSPOT":     "STACKSPOT_MAX_TOKENS",
 	"COPILOT":       "COPILOT_MAX_TOKENS",
 	"GITHUB_MODELS": "GITHUB_MODELS_MAX_TOKENS",
+	// BEDROCK_MAX_TOKENS is the primary env the Bedrock client reads (it
+	// also accepts ANTHROPIC_MAX_TOKENS as a secondary, handled client-side).
+	"BEDROCK":    "BEDROCK_MAX_TOKENS",
+	"OPENROUTER": "OPENROUTER_MAX_TOKENS",
 }
 
 // getMaxTokensForCurrentLLM picks the per-turn `max_tokens` for the active
@@ -621,6 +625,17 @@ func (cli *ChatCLI) getMaxTokensForCurrentLLM() int {
 	}
 	override := providerMaxTokensOverride(cli.Provider)
 	return catalog.GetMaxTokens(cli.Provider, cli.Model, override)
+}
+
+// effectiveMaxTokensDisplay renders the effective max-tokens for /config,
+// flagging when the number comes from the session /max-tokens override so
+// the display never reads as a static default while an override is live.
+func (cli *ChatCLI) effectiveMaxTokensDisplay() string {
+	effective := cli.getMaxTokensForCurrentLLM()
+	if cli.UserMaxTokens > 0 {
+		return i18n.T("cfg.val.max_tokens_session_override", effective)
+	}
+	return fmt.Sprintf("%d", effective)
 }
 
 // providerMaxTokensOverride reads the configured env var for the provider

--- a/cli/config_sections.go
+++ b/cli/config_sections.go
@@ -329,7 +329,7 @@ func (cli *ChatCLI) showConfigPanorama() {
 		kv(p, i18n.T("cfg.kv.model_client"), cli.Client.GetModelName())
 	}
 	kv(p, i18n.T("cfg.kv.preferred_api"), string(catalog.GetPreferredAPI(cli.Provider, cli.Model)))
-	kv(p, i18n.T("cfg.kv.effective_max_tokens"), fmt.Sprintf("%d", cli.getMaxTokensForCurrentLLM()))
+	kv(p, i18n.T("cfg.kv.effective_max_tokens"), cli.effectiveMaxTokensDisplay())
 
 	// Session summary
 	fmt.Println(p)
@@ -482,7 +482,7 @@ func (cli *ChatCLI) showConfigProviders() {
 	// Current
 	kv(p, i18n.T("cfg.kv.active_provider"), cli.Provider)
 	kv(p, i18n.T("cfg.kv.active_model"), cli.Model)
-	kv(p, i18n.T("cfg.kv.effective_max_tokens"), fmt.Sprintf("%d", cli.getMaxTokensForCurrentLLM()))
+	kv(p, i18n.T("cfg.kv.effective_max_tokens"), cli.effectiveMaxTokensDisplay())
 
 	// Available (nil-safe — manager may not be wired during early boot/tests)
 	if cli.manager != nil {

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -2161,6 +2161,7 @@
   "cfg.kv.model_client": "Model (client)",
   "cfg.kv.preferred_api": "Preferred API",
   "cfg.kv.effective_max_tokens": "Effective max tokens",
+  "cfg.val.max_tokens_session_override": "%d (session override via /max-tokens)",
   "cfg.kv.session": "Session",
   "cfg.kv.messages": "Messages",
   "cfg.kv.tokens_used": "Tokens used",

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -1387,6 +1387,7 @@
   "command.error.execution": "Error executing command:",
   "command.output.not_captured": "Command output could not be captured for history.",
   "command.output.header": "Command output",
+  "command.output.to_ai_prompt": "Command output:\n%s\n\nContext: %s",
   "command.sending_to_ai": "Sending command output to the AI...",
   "command.error.processing_request": "An error occurred while processing the request.",
   "cli.error.no_provider_configured": "No LLM provider configured. Use /auth login anthropic | openai-codex | github-copilot to authenticate, then /switch to select a provider.",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -2161,6 +2161,7 @@
   "cfg.kv.model_client": "Model (client)",
   "cfg.kv.preferred_api": "Preferred API",
   "cfg.kv.effective_max_tokens": "Effective max tokens",
+  "cfg.val.max_tokens_session_override": "%d (session override via /max-tokens)",
   "cfg.kv.session": "Session",
   "cfg.kv.messages": "Messages",
   "cfg.kv.tokens_used": "Tokens used",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1387,6 +1387,7 @@
   "command.error.execution": "Error executing command:",
   "command.output.not_captured": "Command output could not be captured for history.",
   "command.output.header": "Command output",
+  "command.output.to_ai_prompt": "Command output:\n%s\n\nContext: %s",
   "command.sending_to_ai": "Sending command output to the AI...",
   "command.error.processing_request": "An error occurred while processing the request.",
   "cli.error.no_provider_configured": "No LLM provider configured. Use /auth login anthropic | openai-codex | github-copilot to authenticate, then /switch to select a provider.",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -1387,6 +1387,7 @@
   "command.error.execution": "Erro ao executar comando:",
   "command.output.not_captured": "A saída do comando não pôde ser capturada para o histórico.",
   "command.output.header": "Saída do comando",
+  "command.output.to_ai_prompt": "Saída do comando:\n%s\n\nContexto: %s",
   "command.sending_to_ai": "Enviando saída do comando para a IA...",
   "command.error.processing_request": "Ocorreu um erro ao processar a requisição.",
   "cli.error.no_provider_configured": "Nenhum provedor LLM configurado. Use /auth login anthropic | openai-codex | github-copilot para autenticar, depois /switch para selecionar um provedor.",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -2161,6 +2161,7 @@
   "cfg.kv.model_client": "Modelo (client)",
   "cfg.kv.preferred_api": "API preferida",
   "cfg.kv.effective_max_tokens": "Max tokens efetivo",
+  "cfg.val.max_tokens_session_override": "%d (override de sessão via /max-tokens)",
   "cfg.kv.session": "Sessão",
   "cfg.kv.messages": "Mensagens",
   "cfg.kv.tokens_used": "Tokens usados",

--- a/llm/catalog/catalog.go
+++ b/llm/catalog/catalog.go
@@ -1775,7 +1775,7 @@ func GetContextWindow(provider, model string) int {
 		// novo — a família atual (Fable 5, Sonnet 5, Opus 4.6+) é toda 1M e
 		// os modelos antigos de 200K têm entrada própria no catálogo; um
 		// overshoot é recuperável (compact + retry no context-too-long),
-		// um undershoot compacta cedo demais em TODO turno. O resto do
+		// um undershoot compacta cedo demais a cada turno. O resto do
 		// catálogo AWS (Nova, Llama, Mistral, DeepSeek) senta em 128K.
 		m := strings.ToLower(model)
 		if strings.Contains(m, "anthropic") || strings.Contains(m, "claude") {

--- a/llm/catalog/catalog.go
+++ b/llm/catalog/catalog.go
@@ -1771,12 +1771,15 @@ func GetContextWindow(provider, model string) int {
 		// opaco, marketplace e lançamentos recentes. Sem este case eles
 		// caíam no default genérico de 50K e a compactação de histórico
 		// disparava em quase todo turno de agent — mesma classe de bug do
-		// StackSpot (PR #1044). Claude é a família dominante no Bedrock e
-		// tem piso real de 200K; o resto do catálogo atual da AWS (Nova,
-		// Llama, Mistral, DeepSeek) senta em 128K.
+		// StackSpot (PR #1044). Claude desconhecido no Bedrock é lançamento
+		// novo — a família atual (Fable 5, Sonnet 5, Opus 4.6+) é toda 1M e
+		// os modelos antigos de 200K têm entrada própria no catálogo; um
+		// overshoot é recuperável (compact + retry no context-too-long),
+		// um undershoot compacta cedo demais em TODO turno. O resto do
+		// catálogo AWS (Nova, Llama, Mistral, DeepSeek) senta em 128K.
 		m := strings.ToLower(model)
 		if strings.Contains(m, "anthropic") || strings.Contains(m, "claude") {
-			return 200000
+			return 1000000
 		}
 		return 128000
 	case ProviderStackSpot:

--- a/llm/catalog/catalog_test.go
+++ b/llm/catalog/catalog_test.go
@@ -451,9 +451,12 @@ func TestBedrockProviderFallbacks(t *testing.T) {
 	assert.Equal(t, 128000, GetContextWindow(ProviderBedrock, opaque))
 	assert.Equal(t, 4096, GetMaxTokens(ProviderBedrock, opaque, 0))
 
-	// Future Claude model not yet in the registry: the Claude family floor
-	// is 200K input / 64K output, mirroring the CLAUDEAI provider fallback.
-	assert.Equal(t, 200000, GetContextWindow(ProviderBedrock, "anthropic.claude-future-model"))
+	// Future Claude model not yet in the registry: the current family
+	// (Fable 5, Sonnet 5, Opus 4.6+) is all 1M input; the older 200K
+	// models have their own registry entries, so an unknown Claude is a
+	// fresh launch. Output floor stays 64K (some current models cap there
+	// and an over-cap max_tokens is a hard API error).
+	assert.Equal(t, 1000000, GetContextWindow(ProviderBedrock, "anthropic.claude-future-model"))
 	assert.Equal(t, 64000, GetMaxTokens(ProviderBedrock, "anthropic.claude-future-model", 0))
 
 	// Explicit override still has the highest priority.


### PR DESCRIPTION
## Problem

The /max-tokens session override only applied to chat mode. The agent and coder ReAct loop hardcoded max tokens to zero (provider default), so raising the limit mid-session had no effect exactly where the heavy computation happens — and the /config effective max tokens readout could diverge from what providers actually send.

## Changes

- **Agent/coder loop**: re-reads the session override every turn via a small reconciliation helper — raises and lowers are adopted, while an unchanged override never clobbers the truncation-driven escalation. The legacy one-shot agent path, command-output analysis and file-chunk processing now pass the override through as well.
- **providerMaxTokensEnv**: added the missing BEDROCK and OPENROUTER entries. Before, /config showed a catalog number while the Bedrock client honored BEDROCK_MAX_TOKENS, and chat mode silently overrode that env with the catalog ceiling.
- **/config panorama and providers sections**: the effective max tokens line now flags when the value comes from the session override (localized en, en-US, pt-BR).
- **Bedrock context-window fallback for unknown Claude models raised 200K to 1M**: the current family (Fable 5, Sonnet 5, Opus 4.6+) is all 1M and the older 200K models have their own registry entries; undershooting compacts on every turn while overshooting is recoverable by the existing compact-and-retry path. Output fallback stays 64K since an over-cap max_tokens is a hard API error.

Out of scope, noted for a follow-up: the gateway daemon mirrors only provider/model via runtime_model.json; carrying the max-tokens override across processes would be a schema change to that contract.

## Testing

- Red-first: BEDROCK/OPENROUTER env-map cases failed against main before the fix
- New unit table for the per-turn adoption helper covering adopt/raise/lower/escalation-preserve
- Full go test suite and golangci-lint green