### PR TITLE
fix(docker): patch grpc-health-probe CVEs in image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,15 @@ COPY . .
 ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -ldflags="-s -w" -o chatcli .
 
-# Build grpc_health_probe with patched dependencies (CVE-2026-34986: go-jose/v4)
+# Build grpc_health_probe with patched dependencies:
+#   CVE-2026-34986 (go-jose/v4), GHSA-hrxh-6v49-42gf (grpc),
+#   CVE-2026-46600 (x/net), CVE-2026-56852 (x/text)
 RUN git clone --depth 1 https://github.com/grpc-ecosystem/grpc-health-probe /tmp/ghp && \
     cd /tmp/ghp && \
-    go get github.com/go-jose/go-jose/v4@v4.1.4 && \
+    go get github.com/go-jose/go-jose/v4@v4.1.4 \
+        google.golang.org/grpc@v1.82.1 \
+        golang.org/x/net@v0.57.0 \
+        golang.org/x/text@v0.40.0 && \
     go mod tidy && \
     CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -ldflags="-s -w" -o /usr/local/bin/grpc-health-probe . && \
     rm -rf /tmp/ghp


### PR DESCRIPTION
## Summary

ArtifactHub/Trivy flagged the `chatcliserver` image. Two targets:

### `usr/local/bin/grpc-health-probe` (rating D, 1 HIGH) — fixed here
The probe is built from upstream HEAD in the Dockerfile, which pins vulnerable versions. This PR bumps them at build time (same pattern already used for go-jose):

| Finding | Package | Was | Now |
|---|---|---|---|
| GHSA-hrxh-6v49-42gf (HIGH) | google.golang.org/grpc | v1.82.0 | v1.82.1 |
| CVE-2026-46600 | golang.org/x/net | v0.55.0 | v0.57.0 |
| CVE-2026-56852 | golang.org/x/text | v0.37.0 | v0.40.0 |

**Proof:** replicated the exact build stage locally; `go version -m` on the produced binary embeds v1.82.1 / v0.57.0 / v0.40.0 — which is exactly what Trivy reads.

### `usr/local/bin/chatcli` (rating B, 1 LOW + 1 UNKNOWN) — not fixable upstream yet
- **CVE-2023-36308** (`disintegration/imaging` v1.6.2, LOW): indirect dep of `goccy/go-graphviz` v0.2.10 (latest). Upstream imaging has no fixed release; Trivy itself reports "Fixed in: -".
- **GO-2026-5932** (`golang.org/x/crypto` v0.54.0): advisory that `x/crypto/openpgp` is unmaintained — "Fixed in: N/A". v0.54.0 is the latest published x/crypto. govulncheck confirms chatcli code does not call any affected symbol (0 reachable vulnerabilities).

Both are why the scan shows "Fixable: 0" for that target; they will clear when upstreams release fixes.