### PR TITLE
fix(cli): resolve provider model at boot for every provider and refresh Gemini and xAI catalogs

### DIFF
--- a/cli/cli_config.go
+++ b/cli/cli_config.go
@@ -126,77 +126,76 @@ func (cli *ChatCLI) reloadConfiguration(ctx context.Context) {
 	}
 }
 
+// bootModelSource declara de onde vem o modelo de cada provider no boot:
+// env primária, env de fallback opcional e o default do config. Cada
+// provider suportado pelo manager PRECISA de uma entrada aqui — um provider
+// ausente deixava cli.Model vazio, o catálogo resolvia (provider, "") para
+// os fallbacks conservadores e a sessão inteira rodava com max-tokens e
+// janela de contexto degradados, mesmo com o client interno falando com o
+// modelo certo (foi o caso do BEDROCK: 128K virando default).
+// STACKSPOT fica de fora por desenho: o "modelo" é o agent (realm/agent-id),
+// e o fallback de provider do catálogo já cobre a sizing.
+type bootModelSource struct {
+	envVar      string
+	fallbackEnv string
+	defaultName string
+}
+
+var bootModelSources = map[string]bootModelSource{
+	"OPENAI":           {envVar: "OPENAI_MODEL", defaultName: config.DefaultOpenAIModel},
+	"OPENAI_ASSISTANT": {envVar: "OPENAI_ASSISTANT_MODEL", fallbackEnv: "OPENAI_MODEL", defaultName: config.DefaultOpenAiAssistModel},
+	"CLAUDEAI":         {envVar: "ANTHROPIC_MODEL", defaultName: config.DefaultClaudeAIModel},
+	"GOOGLEAI":         {envVar: "GOOGLEAI_MODEL", defaultName: config.DefaultGoogleAIModel},
+	"XAI":              {envVar: "XAI_MODEL", defaultName: config.DefaultXAIModel},
+	"ZAI":              {envVar: "ZAI_MODEL", defaultName: config.DefaultZAIModel},
+	"MINIMAX":          {envVar: "MINIMAX_MODEL", defaultName: config.DefaultMiniMaxModel},
+	"MOONSHOT":         {envVar: "MOONSHOT_MODEL", defaultName: config.DefaultMoonshotModel},
+	"OLLAMA":           {envVar: "OLLAMA_MODEL", defaultName: config.DefaultOllamaModel},
+	"COPILOT":          {envVar: "COPILOT_MODEL", defaultName: config.DefaultCopilotModel},
+	"GITHUB_MODELS":    {envVar: "GITHUB_MODELS_MODEL", defaultName: config.DefaultGitHubModelsModel},
+	"BEDROCK":          {envVar: "BEDROCK_MODEL", defaultName: config.DefaultBedrockModel},
+	"OPENROUTER":       {envVar: "OPENROUTER_MODEL", defaultName: config.DefaultOpenRouterModel},
+	"DEVIN":            {envVar: "DEVIN_MODEL", defaultName: config.DefaultDevinModel},
+}
+
+// resolveBootModelEnv resolve uma env de modelo no boot com a mesma
+// precedência que as factories do manager usam: ambiente do processo
+// primeiro, depois o config.Global (.env/config persistido).
+func resolveBootModelEnv(name string) string {
+	if name == "" {
+		return ""
+	}
+	if v := strings.TrimSpace(os.Getenv(name)); v != "" {
+		return v
+	}
+	if config.Global != nil {
+		if v := strings.TrimSpace(config.Global.GetString(name)); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
 func (cli *ChatCLI) configureProviderAndModel() {
-	cli.Provider = os.Getenv("LLM_PROVIDER")
+	// Normalização de case: LLM_PROVIDER=bedrock (minúsculo) furava todas
+	// as comparações exatas e deixava provider E modelo desalinhados.
+	cli.Provider = strings.ToUpper(strings.TrimSpace(os.Getenv("LLM_PROVIDER")))
 	if cli.Provider == "" {
 		cli.Provider = config.DefaultLLMProvider
 	}
-	if cli.Provider == "OPENAI" {
-		cli.Model = os.Getenv("OPENAI_MODEL")
-		if cli.Model == "" {
-			cli.Model = config.DefaultOpenAIModel
-		}
+	src, ok := bootModelSources[cli.Provider]
+	if !ok {
+		return
 	}
-	if cli.Provider == "OPENAI_ASSISTANT" {
-		cli.Model = os.Getenv("OPENAI_ASSISTANT_MODEL")
-		if cli.Model == "" {
-			cli.Model = utils.GetEnvOrDefault("OPENAI_MODEL", config.DefaultOpenAiAssistModel)
-		}
+	if m := resolveBootModelEnv(src.envVar); m != "" {
+		cli.Model = m
+		return
 	}
-	if cli.Provider == "CLAUDEAI" {
-		cli.Model = os.Getenv("ANTHROPIC_MODEL")
-		if cli.Model == "" {
-			cli.Model = config.DefaultClaudeAIModel
-		}
+	if m := resolveBootModelEnv(src.fallbackEnv); m != "" {
+		cli.Model = m
+		return
 	}
-	if cli.Provider == "GOOGLEAI" {
-		cli.Model = os.Getenv("GOOGLEAI_MODEL")
-		if cli.Model == "" {
-			cli.Model = config.DefaultGoogleAIModel
-		}
-	}
-	if cli.Provider == "XAI" {
-		cli.Model = os.Getenv("XAI_MODEL")
-		if cli.Model == "" {
-			cli.Model = config.DefaultXAIModel
-		}
-	}
-	if cli.Provider == "ZAI" {
-		cli.Model = os.Getenv("ZAI_MODEL")
-		if cli.Model == "" {
-			cli.Model = config.DefaultZAIModel
-		}
-	}
-	if cli.Provider == "MINIMAX" {
-		cli.Model = os.Getenv("MINIMAX_MODEL")
-		if cli.Model == "" {
-			cli.Model = config.DefaultMiniMaxModel
-		}
-	}
-	if cli.Provider == "MOONSHOT" {
-		cli.Model = os.Getenv("MOONSHOT_MODEL")
-		if cli.Model == "" {
-			cli.Model = config.DefaultMoonshotModel
-		}
-	}
-	if cli.Provider == "OLLAMA" {
-		cli.Model = os.Getenv("OLLAMA_MODEL")
-		if cli.Model == "" {
-			cli.Model = config.DefaultOllamaModel
-		}
-	}
-	if cli.Provider == "COPILOT" {
-		cli.Model = os.Getenv("COPILOT_MODEL")
-		if cli.Model == "" {
-			cli.Model = config.DefaultCopilotModel
-		}
-	}
-	if cli.Provider == "GITHUB_MODELS" {
-		cli.Model = os.Getenv("GITHUB_MODELS_MODEL")
-		if cli.Model == "" {
-			cli.Model = config.DefaultGitHubModelsModel
-		}
-	}
+	cli.Model = src.defaultName
 }
 
 func (cli *ChatCLI) setExecutionProfile(p ExecutionProfile) {

--- a/cli/cli_config_boot_test.go
+++ b/cli/cli_config_boot_test.go
@@ -1,0 +1,77 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"testing"
+
+	"github.com/diillson/chatcli/config"
+	"github.com/diillson/chatcli/llm/catalog"
+)
+
+// Boot regression for the class of bug where a provider missing from the
+// boot model table left cli.Model empty: the internal client talked to the
+// right model while catalog sizing resolved (provider, "") to conservative
+// fallbacks, so the whole session ran with a degraded max-tokens and
+// context window. /model worked; starting preconfigured did not.
+func TestConfigureProviderAndModelCoversEveryProvider(t *testing.T) {
+	for provider, src := range bootModelSources {
+		t.Run(provider, func(t *testing.T) {
+			t.Setenv("LLM_PROVIDER", provider)
+			t.Setenv(src.envVar, "custom-model-under-test")
+			cli := &ChatCLI{}
+			cli.configureProviderAndModel()
+			if cli.Provider != provider {
+				t.Fatalf("Provider = %q, want %q", cli.Provider, provider)
+			}
+			if cli.Model != "custom-model-under-test" {
+				t.Fatalf("Model = %q — the %s env must reach cli.Model at boot", cli.Model, src.envVar)
+			}
+		})
+	}
+}
+
+// The exact scenario reported in production: LLM_PROVIDER=bedrock
+// (lowercase!) plus BEDROCK_MODEL set. Before the fix the lowercase value
+// failed every exact comparison AND Bedrock had no entry in the boot
+// chain, so a 128K model sized as the tiny provider fallback.
+func TestConfigureProviderAndModelBedrockFromEnv(t *testing.T) {
+	t.Setenv("LLM_PROVIDER", "bedrock")
+	t.Setenv("BEDROCK_MODEL", "global.anthropic.claude-opus-4-8")
+	cli := &ChatCLI{}
+	cli.configureProviderAndModel()
+
+	if cli.Provider != "BEDROCK" {
+		t.Fatalf("Provider = %q, lowercase env must normalize to BEDROCK", cli.Provider)
+	}
+	if got := catalog.GetMaxTokens(cli.Provider, cli.Model, 0); got != 128000 {
+		t.Fatalf("boot-configured Opus 4.8 must size at 128000 max tokens, got %d", got)
+	}
+	if got := catalog.GetContextWindow(cli.Provider, cli.Model); got != 1000000 {
+		t.Fatalf("boot-configured Opus 4.8 must size at the 1M window, got %d", got)
+	}
+}
+
+func TestConfigureProviderAndModelDefaultsWhenEnvUnset(t *testing.T) {
+	t.Setenv("LLM_PROVIDER", "BEDROCK")
+	t.Setenv("BEDROCK_MODEL", "")
+	cli := &ChatCLI{}
+	cli.configureProviderAndModel()
+	if cli.Model != config.DefaultBedrockModel {
+		t.Fatalf("Model = %q, want the catalog default %q", cli.Model, config.DefaultBedrockModel)
+	}
+}
+
+func TestConfigureProviderAndModelAssistantFallbackChain(t *testing.T) {
+	t.Setenv("LLM_PROVIDER", "OPENAI_ASSISTANT")
+	t.Setenv("OPENAI_ASSISTANT_MODEL", "")
+	t.Setenv("OPENAI_MODEL", "gpt-5.2")
+	cli := &ChatCLI{}
+	cli.configureProviderAndModel()
+	if cli.Model != "gpt-5.2" {
+		t.Fatalf("Model = %q, assistant must fall back to OPENAI_MODEL", cli.Model)
+	}
+}

--- a/cli/config_env_defaults.go
+++ b/cli/config_env_defaults.go
@@ -97,6 +97,7 @@ var envDefaults = map[string]envDefault{
 	"MOONSHOT_MODEL":             {Value: config.DefaultMoonshotModel, Source: "config.DefaultMoonshotModel"},
 	"MOONSHOT_API_URL":           {Value: config.MoonshotAPIURL, Source: "config.MoonshotAPIURL"},
 	"MOONSHOT_THINKING":          {Value: "auto", Source: "moonshot client default"},
+	"OPENROUTER_MODEL":           {Value: config.DefaultOpenRouterModel, Source: "config.DefaultOpenRouterModel"},
 	"OPENROUTER_FALLBACK_MODELS": {Value: "(none)", Source: "openrouter client"},
 	"OPENROUTER_PROVIDER_ORDER":  {Value: "(none)", Source: "openrouter client"},
 

--- a/cli/config_sections.go
+++ b/cli/config_sections.go
@@ -574,6 +574,7 @@ func (cli *ChatCLI) showConfigProviders() {
 	fmt.Println(p)
 	subheader(p, "cfg.sub.prov.openrouter")
 	kv(p, "OPENROUTER_API_KEY", presence(os.Getenv("OPENROUTER_API_KEY")))
+	kv(p, "OPENROUTER_MODEL", envOr("OPENROUTER_MODEL"))
 	kv(p, "OPENROUTER_MAX_TOKENS", envOr("OPENROUTER_MAX_TOKENS"))
 	kv(p, "OPENROUTER_FALLBACK_MODELS", envOr("OPENROUTER_FALLBACK_MODELS"))
 	kv(p, "OPENROUTER_PROVIDER_ORDER", envOr("OPENROUTER_PROVIDER_ORDER"))

--- a/llm/catalog/catalog.go
+++ b/llm/catalog/catalog.go
@@ -576,11 +576,78 @@ var registry = []ModelMeta{
 		Capabilities:    []string{"vision", "json_mode", "tools"},
 	},
 	// Google Gemini Models. Specs from ai.google.dev model docs:
-	// every Gemini 2.x exposes a 1,048,576-token input window with a
+	// every Gemini 2.x/3.x exposes a 1,048,576-token input window with a
 	// 65,536-token max output (8,192 on the older 2.0 generation). The
 	// previous catalog set MaxOutputTokens equal to ContextWindow, which
 	// is physically impossible — the API rejects requests with output
 	// over the per-model cap.
+	//
+	// Gemini 3.x generation (verified per-model on ai.google.dev, Jul
+	// 2026): 3.6-flash (stable, current default workhorse, Jul 21 2026),
+	// 3.5-flash, 3.5-flash-lite and 3.1-flash-lite stable; 3.1-pro-preview
+	// and 3-flash-preview in preview. The whole generation shares the
+	// uniform 1,048,576 / 65,536 profile. Newest first so generic alias
+	// prefixes ("gemini-3") don't shadow the more specific ids.
+	{
+		ID:              "gemini-3.6-flash",
+		Aliases:         []string{"gemini-3.6-flash", "gemini-3.6-flash-latest"},
+		DisplayName:     "Gemini 3.6 Flash",
+		Provider:        ProviderGoogleAI,
+		ContextWindow:   1048576,
+		MaxOutputTokens: 65536,
+		PreferredAPI:    "gemini_api",
+		Capabilities:    []string{"vision", "tools", "json_mode", "code_execution"},
+	},
+	{
+		ID:              "gemini-3.5-flash",
+		Aliases:         []string{"gemini-3.5-flash", "gemini-3.5-flash-latest"},
+		DisplayName:     "Gemini 3.5 Flash",
+		Provider:        ProviderGoogleAI,
+		ContextWindow:   1048576,
+		MaxOutputTokens: 65536,
+		PreferredAPI:    "gemini_api",
+		Capabilities:    []string{"vision", "tools", "json_mode", "code_execution"},
+	},
+	{
+		ID:              "gemini-3.5-flash-lite",
+		Aliases:         []string{"gemini-3.5-flash-lite"},
+		DisplayName:     "Gemini 3.5 Flash Lite",
+		Provider:        ProviderGoogleAI,
+		ContextWindow:   1048576,
+		MaxOutputTokens: 65536,
+		PreferredAPI:    "gemini_api",
+		Capabilities:    []string{"vision", "tools", "json_mode"},
+	},
+	{
+		ID:              "gemini-3.1-pro-preview",
+		Aliases:         []string{"gemini-3.1-pro-preview", "gemini-3.1-pro", "gemini-3.1-pro-preview-customtools"},
+		DisplayName:     "Gemini 3.1 Pro (preview)",
+		Provider:        ProviderGoogleAI,
+		ContextWindow:   1048576,
+		MaxOutputTokens: 65536,
+		PreferredAPI:    "gemini_api",
+		Capabilities:    []string{"vision", "tools", "json_mode", "code_execution"},
+	},
+	{
+		ID:              "gemini-3.1-flash-lite",
+		Aliases:         []string{"gemini-3.1-flash-lite"},
+		DisplayName:     "Gemini 3.1 Flash Lite",
+		Provider:        ProviderGoogleAI,
+		ContextWindow:   1048576,
+		MaxOutputTokens: 65536,
+		PreferredAPI:    "gemini_api",
+		Capabilities:    []string{"vision", "tools", "json_mode"},
+	},
+	{
+		ID:              "gemini-3-flash-preview",
+		Aliases:         []string{"gemini-3-flash-preview"},
+		DisplayName:     "Gemini 3 Flash (preview)",
+		Provider:        ProviderGoogleAI,
+		ContextWindow:   1048576,
+		MaxOutputTokens: 65536,
+		PreferredAPI:    "gemini_api",
+		Capabilities:    []string{"vision", "tools", "json_mode"},
+	},
 	{
 		ID:              "gemini-2.5-pro",
 		Aliases:         []string{"gemini-2.5-pro", "gemini-2.5-pro-latest"},
@@ -778,6 +845,74 @@ var registry = []ModelMeta{
 	// OpenRouter mirror (which xAI also publishes against). Aliases were
 	// previously written as a single comma-joined string instead of
 	// separate entries — Resolve() never matched them. Fixed here.
+	//
+	// 2026 generation (context windows per docs.x.ai/docs/models, Jul
+	// 2026): grok-4.5 500K, grok-4.3 1M (flagship, Apr 30 2026), the
+	// grok-4.20 family 1M, grok-build 256K. xAI still documents no
+	// separate output cap — the 16K ceiling below follows the same
+	// convention as the older entries. Newest first; the entry carrying
+	// the generic "grok-4.20" alias sits after the more specific 4.20
+	// variants so it cannot shadow them.
+	{
+		ID:              "grok-4.5",
+		Aliases:         []string{"grok-4.5", "grok-4.5-latest"},
+		DisplayName:     "Grok-4.5",
+		Provider:        ProviderXAI,
+		ContextWindow:   500000,
+		MaxOutputTokens: 16384,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"vision", "tools", "json_mode"},
+	},
+	{
+		ID:              "grok-4.3",
+		Aliases:         []string{"grok-4.3", "grok-4.3-latest"},
+		DisplayName:     "Grok-4.3",
+		Provider:        ProviderXAI,
+		ContextWindow:   1000000,
+		MaxOutputTokens: 16384,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"vision", "tools", "json_mode"},
+	},
+	{
+		ID:              "grok-4.20-multi-agent-0309",
+		Aliases:         []string{"grok-4.20-multi-agent-0309", "grok-4.20-multi-agent"},
+		DisplayName:     "Grok-4.20 Multi-Agent",
+		Provider:        ProviderXAI,
+		ContextWindow:   1000000,
+		MaxOutputTokens: 16384,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"vision", "tools", "json_mode"},
+	},
+	{
+		ID:              "grok-4.20-0309-non-reasoning",
+		Aliases:         []string{"grok-4.20-0309-non-reasoning", "grok-4.20-non-reasoning"},
+		DisplayName:     "Grok-4.20 (non-reasoning)",
+		Provider:        ProviderXAI,
+		ContextWindow:   1000000,
+		MaxOutputTokens: 16384,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"vision", "tools", "json_mode"},
+	},
+	{
+		ID:              "grok-4.20-0309-reasoning",
+		Aliases:         []string{"grok-4.20-0309-reasoning", "grok-4.20-reasoning", "grok-4.20"},
+		DisplayName:     "Grok-4.20 (reasoning)",
+		Provider:        ProviderXAI,
+		ContextWindow:   1000000,
+		MaxOutputTokens: 16384,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"vision", "tools", "json_mode"},
+	},
+	{
+		ID:              "grok-build-0.1",
+		Aliases:         []string{"grok-build-0.1", "grok-build"},
+		DisplayName:     "Grok Build 0.1",
+		Provider:        ProviderXAI,
+		ContextWindow:   256000,
+		MaxOutputTokens: 16384,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"vision", "tools", "json_mode"},
+	},
 	{
 		// grok-4-fast: 2M context. xAI does not document a separate output
 		// cap; we ceil at 16K to keep the value comparable to other models

--- a/llm/catalog/catalog_test.go
+++ b/llm/catalog/catalog_test.go
@@ -463,6 +463,62 @@ func TestBedrockProviderFallbacks(t *testing.T) {
 	assert.Equal(t, 9000, GetMaxTokens(ProviderBedrock, opaque, 9000))
 }
 
+// TestGemini3FamilyEntries pins the Gemini 3.x generation added Jul 2026.
+// Every model page on ai.google.dev documents the uniform 1,048,576 input /
+// 65,536 output profile; a missing entry would drop these ids onto the
+// GoogleAI provider fallback and undersize the context window.
+func TestGemini3FamilyEntries(t *testing.T) {
+	for _, id := range []string{
+		"gemini-3.6-flash",
+		"gemini-3.5-flash",
+		"gemini-3.5-flash-lite",
+		"gemini-3.1-pro-preview",
+		"gemini-3.1-flash-lite",
+		"gemini-3-flash-preview",
+	} {
+		meta, ok := Resolve(ProviderGoogleAI, id)
+		if !assert.True(t, ok, "missing catalog entry for %s", id) {
+			continue
+		}
+		assert.Equal(t, id, meta.ID, "id %s must resolve to its own entry, not an older generation", id)
+		assert.Equal(t, 1048576, meta.ContextWindow, "%s", id)
+		assert.Equal(t, 65536, meta.MaxOutputTokens, "%s", id)
+	}
+	// The customtools variant and the bare 3.1-pro spelling ride the
+	// preview entry via aliases.
+	meta, ok := Resolve(ProviderGoogleAI, "gemini-3.1-pro-preview-customtools")
+	assert.True(t, ok)
+	assert.Equal(t, "gemini-3.1-pro-preview", meta.ID)
+}
+
+// TestGrok2026Entries pins the 2026 xAI lineup (context windows per
+// docs.x.ai; xAI documents no output cap, so entries keep the repo's 16K
+// ceiling convention).
+func TestGrok2026Entries(t *testing.T) {
+	cases := map[string]int{
+		"grok-4.5":                     500000,
+		"grok-4.3":                     1000000,
+		"grok-4.20-0309-reasoning":     1000000,
+		"grok-4.20-0309-non-reasoning": 1000000,
+		"grok-4.20-multi-agent-0309":   1000000,
+		"grok-build-0.1":               256000,
+	}
+	for id, wantCtx := range cases {
+		meta, ok := Resolve(ProviderXAI, id)
+		if !assert.True(t, ok, "missing catalog entry for %s", id) {
+			continue
+		}
+		assert.Equal(t, id, meta.ID, "id %s must resolve to its own entry", id)
+		assert.Equal(t, wantCtx, meta.ContextWindow, "%s", id)
+		assert.Equal(t, 16384, meta.MaxOutputTokens, "%s", id)
+	}
+	// The generic alias rides the reasoning variant and must not shadow
+	// the more specific 4.20 ids (they sit earlier in the registry).
+	meta, ok := Resolve(ProviderXAI, "grok-4.20")
+	assert.True(t, ok)
+	assert.Equal(t, "grok-4.20-0309-reasoning", meta.ID)
+}
+
 // TestBedrockFallbackMaxTokensFamilies pins the per-family output ceilings
 // for Bedrock models outside the registry. Overshoot is a hard
 // ValidationException, so each sniff sits on the SMALLEST ceiling among the

--- a/llm/manager/llm_manager.go
+++ b/llm/manager/llm_manager.go
@@ -336,22 +336,26 @@ func firstNonEmptyEnv(keys ...string) string {
 	return ""
 }
 
-// resolveBedrockModel returns the Bedrock model to use when the caller did
-// not pick one explicitly: BEDROCK_MODEL from the environment or .env
-// (every other provider has its *_MODEL counterpart — COPILOT_MODEL,
-// MOONSHOT_MODEL, OLLAMA_MODEL — Bedrock only had the region/schema vars),
-// falling back to the catalog default. Catalog aliases work as values
-// ("claude-opus-4-8" resolves to the invokable global profile id).
-func resolveBedrockModel() string {
-	if v := strings.TrimSpace(os.Getenv("BEDROCK_MODEL")); v != "" {
+// resolveModelEnv returns the model to use when the caller did not pick
+// one explicitly: the given env var from the process environment first,
+// then the persisted config (.env / config file), then the provider's
+// default. Catalog aliases work as values ("claude-opus-4-8" resolves to
+// the invokable global profile id).
+func resolveModelEnv(key, def string) string {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
 		return v
 	}
 	if config.Global != nil {
-		if v := strings.TrimSpace(config.Global.GetString("BEDROCK_MODEL")); v != "" {
+		if v := strings.TrimSpace(config.Global.GetString(key)); v != "" {
 			return v
 		}
 	}
-	return config.DefaultBedrockModel
+	return def
+}
+
+// resolveBedrockModel keeps the historical name for the Bedrock call sites.
+func resolveBedrockModel() string {
+	return resolveModelEnv("BEDROCK_MODEL", config.DefaultBedrockModel)
 }
 
 // configurarGoogleAIClient configura o cliente Google AI (Gemini)
@@ -977,7 +981,10 @@ func (m *LLMManagerImpl) CreateClientWithKey(provider, model, apiKey string) (cl
 
 	case "OPENROUTER":
 		if model == "" {
-			model = config.DefaultOpenRouterModel
+			// OPENROUTER_MODEL is documented on the site's configure-provider
+			// guide but was never read anywhere — users following the docs
+			// silently got the default model.
+			model = resolveModelEnv("OPENROUTER_MODEL", config.DefaultOpenRouterModel)
 		}
 		tp := auth.NewStaticTokenProvider(apiKey, auth.AuthModeAPIKey, "")
 		return openrouter.NewOpenRouterClient(tp, model, m.logger, maxRetries, initialBackoff), nil

--- a/llm/manager/llm_manager_create_test.go
+++ b/llm/manager/llm_manager_create_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/diillson/chatcli/i18n"
@@ -51,6 +52,39 @@ func TestCreateClientWithKey_SupportedProviders(t *testing.T) {
 				t.Fatalf("CreateClientWithKey(%s) returned nil client", c.provider)
 			}
 		})
+	}
+}
+
+// OPENROUTER_MODEL is documented on the site's configure-provider guide;
+// an empty model must resolve through it (then the default) instead of
+// silently pinning the default model.
+func TestCreateClientWithKey_OpenRouterModelEnv(t *testing.T) {
+	i18n.Init()
+	setupTestEnv(t, map[string]string{})
+	t.Setenv("OPENROUTER_MODEL", "moonshotai/kimi-k3")
+	logger, _ := zap.NewDevelopment()
+	mgr, err := NewLLMManager(logger)
+	if err != nil {
+		t.Fatalf("NewLLMManager: %v", err)
+	}
+	impl := mgr.(*LLMManagerImpl)
+	defer impl.Close()
+
+	cli, err := impl.CreateClientWithKey("OPENROUTER", "", "or-key")
+	if err != nil {
+		t.Fatalf("CreateClientWithKey: %v", err)
+	}
+	if name := cli.GetModelName(); !strings.Contains(name, "kimi-k3") {
+		t.Fatalf("model name %q must reflect OPENROUTER_MODEL", name)
+	}
+
+	t.Setenv("OPENROUTER_MODEL", "")
+	cli, err = impl.CreateClientWithKey("OPENROUTER", "", "or-key")
+	if err != nil {
+		t.Fatalf("CreateClientWithKey (default): %v", err)
+	}
+	if cli == nil {
+		t.Fatal("nil client for default model")
 	}
 }
 

--- a/tools/qg/providerparity/providers.go
+++ b/tools/qg/providerparity/providers.go
@@ -196,6 +196,12 @@ func DefaultTouchPoints() []TouchPoint {
 			Pattern:     "cfg.sub.prov.{lower}",
 		},
 		{
+			ID:          "boot.model",
+			Description: "boot resolves the provider's model env/default via bootModelSources",
+			Path:        "cli/cli_config.go",
+			Pattern:     `"{Upper}":`,
+		},
+		{
 			ID:          "env.redactor",
 			Description: "env redactor marks {Upper}_API_KEY as a secret",
 			Path:        "cli/env_redactor.go",
@@ -288,6 +294,7 @@ func DefaultExemptions() Exemptions {
 			"cost.cli",        // proprietary, no public pricing
 			"operator.cost",   // ditto
 			"manager.refresh", // StackSpot uses TokenManager init path
+			"boot.model",      // model = agent (realm/agent-id), no *_MODEL env
 		},
 		"OLLAMA": {
 			"env.redactor",    // local, no API key


### PR DESCRIPTION
## Problema (reportado em produção)

Iniciar já configurado (`LLM_PROVIDER` + env de modelo) deixava `cli.Model` **vazio** para BEDROCK, OPENROUTER e DEVIN — a cadeia de `if`s do boot nunca ganhou esses providers. O client interno falava com o modelo certo, mas o sizing via catálogo resolvia `(provider, "")` para os fallbacks conservadores: a sessão inteira rodava com max-tokens e janela degradados. `/model` funcionava (preenche `cli.Model`), o que escondia a diferença.

## Correções

1. **Tabela declarativa `bootModelSources`** cobrindo todos os providers (env primária → env fallback → default), com a mesma precedência das factories do manager (env do processo → config persistido). STACKSPOT fora por desenho (modelo = agent).
2. **Enforcement no Floor 15**: novo touch point `boot.model` na matriz de provider-parity — provider futuro sem entrada no boot reprova o gate.
3. **Case**: `LLM_PROVIDER=bedrock` (minúsculo) furava todas as comparações exatas — agora normalizado.
4. **`OPENROUTER_MODEL`**: documentado no site desde o lançamento do provider, mas **nenhum código lia a env**. Agora lida no boot e no factory do manager, e exposta no `/config`.

## Catálogo Gemini + xAI (verificado nas docs oficiais)

- **Gemini 3.x** (ai.google.dev, páginas por modelo): `gemini-3.6-flash` (estável, workhorse atual), `gemini-3.5-flash`, `gemini-3.5-flash-lite`, `gemini-3.1-pro-preview` (+ alias customtools), `gemini-3.1-flash-lite`, `gemini-3-flash-preview` — perfil uniforme **1.048.576 / 65.536** confirmado individualmente em 4 páginas.
- **xAI 2026** (docs.x.ai): `grok-4.5` (500K), `grok-4.3` (1M, flagship), família `grok-4.20` reasoning/non-reasoning/multi-agent (1M), `grok-build-0.1` (256K); xAI segue sem documentar cap de saída → convenção de 16K do repo. Entradas novas antes das antigas para prefixo genérico não sombrear id específico (testado).

## Verificação

- Teste de regressão com o cenário exato do report: `LLM_PROVIDER=bedrock` + `BEDROCK_MODEL` de Opus 4.8 → 128K/1M no boot.
- Tabela de boot testada para TODOS os providers; cadeia de fallback do assistant preservada.
- `go test ./...` verde; gates locais: Floor 3 **90.7%**, Floor 4 pass, Floor 15 pass (0 violações com o touch point novo).