### PR TITLE
feat(models): add Claude Opus 5 to the Anthropic, Bedrock and OpenRouter

### DIFF
--- a/cli/cost_tracker.go
+++ b/cli/cost_tracker.go
@@ -470,6 +470,13 @@ func claudePricing(model string) (float64, float64, bool) {
 	case strings.Contains(model, "fable"):
 		// Fable 5: $10/$50 per MTok (tier above Opus).
 		return 10.0, 50.0, true
+	case strings.Contains(model, "opus-5"):
+		// Opus 5 (Jul 2026): keeps the $5/$25 Opus-tier price. Must match
+		// BEFORE the generic "opus" case below, which is the $15/$75
+		// legacy tier — the substring also covers the Bedrock
+		// (anthropic.claude-opus-5) and OpenRouter (anthropic/claude-opus-5)
+		// spellings.
+		return 5.0, 25.0, true
 	case strings.Contains(model, "opus-4-5"), strings.Contains(model, "opus-4-6"),
 		strings.Contains(model, "opus-4-7"), strings.Contains(model, "opus-4-8"):
 		// Opus 4.5 onward dropped to $5/$25 per MTok; the 1M context on

--- a/cli/cost_tracker_pricing_test.go
+++ b/cli/cost_tracker_pricing_test.go
@@ -21,6 +21,11 @@ func TestGetModelPricing(t *testing.T) {
 		{"claude opus 4.7", "CLAUDEAI", "claude-opus-4-7", 5.0, 25.0},
 		{"claude opus 4.6 bedrock id", "BEDROCK", "global.anthropic.claude-opus-4-6-20260115-v1:0", 5.0, 25.0},
 		{"claude opus 4.5", "CLAUDEAI", "claude-opus-4-5", 5.0, 25.0},
+		// Opus 5 keeps the $5/$25 tier in every spelling — the regression
+		// trap is the generic "opus" case right below it at $15/$75.
+		{"claude opus 5", "CLAUDEAI", "claude-opus-5", 5.0, 25.0},
+		{"claude opus 5 bedrock id", "BEDROCK", "anthropic.claude-opus-5", 5.0, 25.0},
+		{"claude opus 5 openrouter slug", "OPENROUTER", "anthropic/claude-opus-5", 5.0, 25.0},
 		{"claude opus legacy", "CLAUDEAI", "claude-3-opus", 15.0, 75.0},
 		{"claude opus 4.1 legacy", "CLAUDEAI", "claude-opus-4-1", 15.0, 75.0},
 		{"claude sonnet", "CLAUDEAI", "claude-sonnet-4-6", 3.0, 15.0},

--- a/llm/bedrock/mantle_test.go
+++ b/llm/bedrock/mantle_test.go
@@ -71,6 +71,10 @@ func TestUsesMantleEndpoint(t *testing.T) {
 	assert.True(t, usesMantleEndpoint("anthropic.claude-fable-5"))
 	assert.True(t, usesMantleEndpoint("us.anthropic.claude-fable-5"))
 	assert.True(t, usesMantleEndpoint("global.anthropic.claude-fable-5"))
+	assert.True(t, usesMantleEndpoint("anthropic.claude-opus-5"))
+	assert.True(t, usesMantleEndpoint("claude-opus-5"))
+	assert.True(t, usesMantleEndpoint("us.anthropic.claude-opus-5"))
+	assert.True(t, usesMantleEndpoint("global.anthropic.claude-opus-5"))
 	assert.False(t, usesMantleEndpoint("anthropic.claude-opus-4-8"))
 	assert.False(t, usesMantleEndpoint("global.anthropic.claude-opus-4-6-v1"))
 
@@ -101,8 +105,11 @@ func TestMantleModelID(t *testing.T) {
 		"us.anthropic.claude-sonnet-5-v1:0": "anthropic.claude-sonnet-5",
 		"us.anthropic.claude-fable-5":       "anthropic.claude-fable-5",
 		"global.anthropic.claude-fable-5":   "anthropic.claude-fable-5",
+		"us.anthropic.claude-opus-5":        "anthropic.claude-opus-5",
+		"global.anthropic.claude-opus-5":    "anthropic.claude-opus-5",
 		// Bare first-party id (users type it out of habit).
 		"claude-sonnet-5": "anthropic.claude-sonnet-5",
+		"claude-opus-5":   "anthropic.claude-opus-5",
 		// Catalog canonical is a global. profile for InvokeModel-era models
 		// (Opus 4.8/4.7): forced-mantle routing must still strip it down to
 		// the dateless id the Messages endpoint serves.

--- a/llm/bedrock/newmodels_test.go
+++ b/llm/bedrock/newmodels_test.go
@@ -47,11 +47,13 @@ func TestResolveFamilyBareClaudeIDs(t *testing.T) {
 		// ARN-versioned variants on Bedrock).
 		{"anthropic.claude-fable-5", familyAnthropic},
 		{"global.anthropic.claude-fable-5", familyAnthropic},
+		{"anthropic.claude-opus-5", familyAnthropic},
 		{"anthropic.claude-opus-4-8", familyAnthropic},
 		// Bare first-party IDs a user may pick out of habit: still Claude,
 		// still Anthropic schema. Converse would drop the cache markers.
 		{"claude-fable-5", familyAnthropic},
 		{"claude-sonnet-5", familyAnthropic},
+		{"claude-opus-5", familyAnthropic},
 		{"claude-opus-4-8", familyAnthropic},
 		// Non-Claude models keep the Converse default.
 		{"meta.llama3-70b-instruct-v1:0", familyConverse},

--- a/llm/catalog/catalog.go
+++ b/llm/catalog/catalog.go
@@ -370,6 +370,28 @@ var registry = []ModelMeta{
 		},
 	},
 	{
+		// Opus 5 (claude-opus-5, Jul 2026): the Opus-tier successor to 4.8,
+		// positioned for complex agentic coding and enterprise work (Fable 5
+		// remains the tier above). 1M context, 128K max output, $5/$25 per
+		// MTok — same price as Opus 4.5-4.8 (see cli/cost_tracker.go
+		// claudePricing, which needs the explicit opus-5 case to avoid the
+		// legacy $15/$75 generic-opus fallthrough). Same API surface as
+		// Opus 4.8: adaptive thinking only (budgeted thinking returns 400),
+		// no temperature/top_p/top_k; effort defaults to "high" server-side.
+		// No fast_mode (not documented for Opus 5) and no
+		// mid_conversation_system (documented for Opus 4.8 only). Dateless
+		// pinned-snapshot ID per the Jul 2026 models overview.
+		ID:              "claude-opus-5",
+		Aliases:         []string{"claude-opus-5", "opus-5", "claude-5-opus"},
+		DisplayName:     "Claude Opus 5 (1M context)",
+		Provider:        ProviderClaudeAI,
+		ContextWindow:   1000000,
+		MaxOutputTokens: 128000,
+		PreferredAPI:    APIAnthropicMessages,
+		APIVersion:      config.ClaudeAIAPIVersionDefault,
+		Capabilities:    []string{"vision", "json_mode", "tools", "adaptive_thinking"},
+	},
+	{
 		// Sonnet 5 (claude-sonnet-5, Jun 2026): the Sonnet-tier successor —
 		// Anthropic skipped a "Sonnet 4.7"/"4.8" and jumped straight to 5.
 		// 1M context, 128K max output, adaptive thinking (effort defaults to
@@ -1260,6 +1282,40 @@ var registry = []ModelMeta{
 		PreferredAPI:    APIChatCompletions,
 		Capabilities:    []string{"vision", "tools", "json_mode"},
 	},
+	// Anthropic 5-family on OpenRouter (dateless slugs, 1M context). Listed
+	// here so context-window sizing is right even before the dynamic
+	// ListModels catalog loads — an uncataloged model falls back to the
+	// 50K default and compacts constantly.
+	{
+		ID:              "anthropic/claude-opus-5",
+		Aliases:         []string{"openrouter-claude-opus-5"},
+		DisplayName:     "Claude Opus 5 (OpenRouter)",
+		Provider:        ProviderOpenRouter,
+		ContextWindow:   1000000,
+		MaxOutputTokens: 128000,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"vision", "tools", "json_mode"},
+	},
+	{
+		ID:              "anthropic/claude-sonnet-5",
+		Aliases:         []string{"openrouter-claude-sonnet-5"},
+		DisplayName:     "Claude Sonnet 5 (OpenRouter)",
+		Provider:        ProviderOpenRouter,
+		ContextWindow:   1000000,
+		MaxOutputTokens: 128000,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"vision", "tools", "json_mode"},
+	},
+	{
+		ID:              "anthropic/claude-fable-5",
+		Aliases:         []string{"openrouter-claude-fable-5"},
+		DisplayName:     "Claude Fable 5 (OpenRouter)",
+		Provider:        ProviderOpenRouter,
+		ContextWindow:   1000000,
+		MaxOutputTokens: 128000,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"vision", "tools", "json_mode"},
+	},
 	{
 		ID:              "anthropic/claude-sonnet-4",
 		Aliases:         []string{"openrouter-claude-sonnet-4"},
@@ -1366,6 +1422,21 @@ var registry = []ModelMeta{
 		ID:              "anthropic.claude-fable-5",
 		Aliases:         []string{"bedrock-fable-5", "global.anthropic.claude-fable-5", "claude-fable-5", "fable-5"},
 		DisplayName:     "Claude Fable 5 (Bedrock, 1M ctx)",
+		Provider:        ProviderBedrock,
+		ContextWindow:   1000000,
+		MaxOutputTokens: 128000,
+		PreferredAPI:    APIAnthropicMessages,
+		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking", "bedrock_mantle_only"},
+	},
+	// Opus 5 (Jul 2026). Like Sonnet 5 and Fable 5, served through the
+	// Claude-in-Amazon-Bedrock Messages endpoint (the models overview lists
+	// the Bedrock id anthropic.claude-opus-5 with the Messages-API Bedrock
+	// endpoint footnote) — bedrock_mantle_only routes it down the Mantle
+	// path instead of InvokeModel.
+	{
+		ID:              "anthropic.claude-opus-5",
+		Aliases:         []string{"bedrock-opus-5", "global.anthropic.claude-opus-5", "claude-opus-5", "opus-5"},
+		DisplayName:     "Claude Opus 5 (Bedrock, 1M ctx)",
 		Provider:        ProviderBedrock,
 		ContextWindow:   1000000,
 		MaxOutputTokens: 128000,

--- a/llm/catalog/catalog_devin.go
+++ b/llm/catalog/catalog_devin.go
@@ -31,6 +31,7 @@ func init() {
 	}
 	devinModels := []devinModel{
 		// Anthropic family (specs mirror the CLAUDEAI entries).
+		{"claude-opus-5", 1000000, 128000},
 		{"claude-sonnet-5", 1000000, 128000},
 		{"claude-opus-4.8", 1000000, 128000},
 		{"claude-opus-4.7", 1000000, 128000},

--- a/llm/catalog/catalog_test.go
+++ b/llm/catalog/catalog_test.go
@@ -242,6 +242,40 @@ func TestClaudeOpus48Specs(t *testing.T) {
 	assert.False(t, HasCapability(ProviderBedrock, "claude-opus-4-8", "mid_conversation_system"))
 }
 
+// TestClaudeOpus5Specs pins the published Opus 5 specs (models overview,
+// Jul 2026): 1M context, 128K max output, adaptive thinking, $5/$25 tier.
+// "opus-5" shorthand must resolve to it and must NOT be swallowed by any
+// opus-4.x alias (nor by 4.0's loose "opus-4" prefix).
+func TestClaudeOpus5Specs(t *testing.T) {
+	for _, id := range []string{"claude-opus-5", "opus-5"} {
+		meta, ok := Resolve(ProviderClaudeAI, id)
+		assert.True(t, ok, "expected %s to resolve on ProviderClaudeAI", id)
+		assert.Equal(t, "claude-opus-5", meta.ID, "alias %s must resolve to claude-opus-5", id)
+		assert.Equal(t, 1000000, meta.ContextWindow, "Opus 5 context window is 1M tokens")
+		assert.Equal(t, 128000, meta.MaxOutputTokens, "Opus 5 max output is 128K")
+		assert.Equal(t, APIAnthropicMessages, meta.PreferredAPI)
+	}
+	for _, capability := range []string{"tools", "json_mode", "vision", "adaptive_thinking"} {
+		assert.True(t,
+			HasCapability(ProviderClaudeAI, "claude-opus-5", capability),
+			"claude-opus-5 should advertise %q capability", capability)
+	}
+	assert.False(t,
+		HasCapability(ProviderClaudeAI, "claude-opus-5", "fast_mode"),
+		"claude-opus-5 must not advertise fast_mode (not documented for Opus 5)")
+	assert.False(t,
+		HasCapability(ProviderClaudeAI, "claude-opus-5", "mid_conversation_system"),
+		"mid_conversation_system is documented for Opus 4.8 only")
+	// Regression guards: the opus-4.x lookups must keep resolving to their
+	// own entries after the opus-5 entry lands, and vice-versa.
+	m48, ok := Resolve(ProviderClaudeAI, "claude-opus-4-8")
+	assert.True(t, ok)
+	assert.Equal(t, "claude-opus-4-8", m48.ID)
+	m40, ok := Resolve(ProviderClaudeAI, "opus-4")
+	assert.True(t, ok)
+	assert.NotEqual(t, "claude-opus-5", m40.ID, "generic opus-4 alias must not land on Opus 5")
+}
+
 // TestClaudeSonnet5Specs pins the published Sonnet 5 specs (models
 // overview, Jun 2026): 1M context, 128K max output, adaptive thinking,
 // $3/$15 tier. "sonnet-5" shorthand must resolve to it and must NOT be
@@ -297,6 +331,58 @@ func TestBedrockFable5Entry(t *testing.T) {
 		HasCapability(ProviderBedrock, "anthropic.claude-fable-5", "fast_mode"))
 	assert.False(t,
 		HasCapability(ProviderBedrock, "anthropic.claude-fable-5", "mid_conversation_system"))
+}
+
+// TestBedrockOpus5Entry pins Opus 5 on Bedrock. Like Sonnet 5 and Fable 5
+// it is served through the Claude-in-Amazon-Bedrock Messages endpoint,
+// advertised via bedrock_mantle_only so the client routes it to the
+// Mantle wire instead of InvokeModel.
+func TestBedrockOpus5Entry(t *testing.T) {
+	for _, id := range []string{
+		"anthropic.claude-opus-5",
+		"global.anthropic.claude-opus-5",
+		"claude-opus-5",
+		"bedrock-opus-5",
+	} {
+		meta, ok := Resolve(ProviderBedrock, id)
+		assert.True(t, ok, "expected %s to resolve on ProviderBedrock", id)
+		assert.Equal(t, "anthropic.claude-opus-5", meta.ID, "alias %s must resolve to the Bedrock Opus 5 entry", id)
+		assert.Equal(t, 1000000, meta.ContextWindow)
+		assert.Equal(t, 128000, meta.MaxOutputTokens)
+		assert.Equal(t, APIAnthropicMessages, meta.PreferredAPI)
+	}
+	assert.True(t,
+		HasCapability(ProviderBedrock, "anthropic.claude-opus-5", "adaptive_thinking"))
+	assert.True(t,
+		HasCapability(ProviderBedrock, "anthropic.claude-opus-5", "bedrock_mantle_only"),
+		"Opus 5 must be flagged mantle-only so the client picks the Messages endpoint")
+	assert.False(t,
+		HasCapability(ProviderBedrock, "anthropic.claude-opus-5", "fast_mode"))
+	assert.False(t,
+		HasCapability(ProviderBedrock, "anthropic.claude-opus-5", "mid_conversation_system"))
+	// Regression guard: the Bedrock opus-4.x entries keep resolving to
+	// their own IDs.
+	m48, ok := Resolve(ProviderBedrock, "anthropic.claude-opus-4-8")
+	assert.True(t, ok)
+	assert.Equal(t, "global.anthropic.claude-opus-4-8", m48.ID)
+}
+
+// TestOpenRouterAnthropic5Family pins the OpenRouter static defaults for
+// the Anthropic 5-family slugs. These entries exist so context-window
+// sizing is correct (1M, not the 50K unknown-model fallback) even before
+// the dynamic ListModels catalog loads.
+func TestOpenRouterAnthropic5Family(t *testing.T) {
+	for _, id := range []string{
+		"anthropic/claude-opus-5",
+		"anthropic/claude-sonnet-5",
+		"anthropic/claude-fable-5",
+	} {
+		meta, ok := Resolve(ProviderOpenRouter, id)
+		assert.True(t, ok, "expected %s to resolve on ProviderOpenRouter", id)
+		assert.Equal(t, id, meta.ID)
+		assert.Equal(t, 1000000, meta.ContextWindow, "%s context window is 1M on OpenRouter", id)
+		assert.Equal(t, 128000, meta.MaxOutputTokens)
+	}
 }
 
 // TestBedrockSonnet5Entry pins Sonnet 5 on Bedrock. The model is served
@@ -408,6 +494,7 @@ func TestGPT56FamilyEntries(t *testing.T) {
 // provider filter keeps DEVIN entries from shadowing other providers.
 func TestDevinCatalogEntries(t *testing.T) {
 	for id, wantCtx := range map[string]int{
+		"claude-opus-5":     1000000,
 		"claude-sonnet-5":   1000000,
 		"claude-sonnet-4.6": 1000000,
 		"claude-sonnet-4.5": 200000,


### PR DESCRIPTION
| Surface | ID | Notes |
|---|---|---|
| CLAUDEAI | `claude-opus-5` (aliases `opus-5`, `claude-5-opus`) | 1M context, 128K output, adaptive thinking only, effort defaults to high server-side |
| BEDROCK | `anthropic.claude-opus-5` | Served through the Claude-in-Amazon-Bedrock Messages endpoint — flagged `bedrock_mantle_only`, canonicalized from `us.`/`global.` profile spellings like Sonnet 5/Fable 5 |
| OPENROUTER | `anthropic/claude-opus-5` | Also gap-fills the missing `anthropic/claude-sonnet-5` and `anthropic/claude-fable-5` static defaults so 1M sizing applies before the dynamic ListModels catalog loads |
| DEVIN | `claude-opus-5` | Devin CLI now serves it; specs mirror the CLAUDEAI entry |

### Pricing

`cost_tracker.go` gets an explicit `opus-5` case at **$5/$25 per MTok** placed before the generic `opus` case — without it, Opus 5 would silently bill at the legacy Opus 3/4.0 tier of $15/$75. Regression-tested across all three provider spellings.

### Tests

Mirrors the Sonnet 5 launch coverage: catalog specs + alias resolution (including guards that `opus-4` prefixes don't shadow), Bedrock entry with mantle-only routing, `usesMantleEndpoint`/`mantleModelID` canonicalization, `resolveFamily` dispatch, Devin entry, and the pricing table. Full suite green; all local QG floors pass including provider parity.

Docs site (supported-models, bedrock feature page, env references, EN+PT) updated in lockstep.

Um detalhe: quando chequei agora, o único PR aberto que a API me devolveu era o do release-please (#1243) — o seu da feat/opus-5-catalogs ainda não apareceu na listagem, o que pode ser só o atraso do incidente do GitHub. Se ele não tiver sido criado de verdade, me avisa que eu tento de novo por aqui. Matei o retry em background pra não duplicar.