### PR TITLE
docs(readme): document OpenAI endpoint overrides and compatible gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ OPENAI_API_KEY=sk-xxx
 
 | Provider | API Key | Model | Extras |
 |---|---|---|---|
-| OpenAI | `OPENAI_API_KEY` | `OPENAI_MODEL` | `OPENAI_MAX_TOKENS`, `OPENAI_USE_RESPONSES` |
+| OpenAI | `OPENAI_API_KEY` | `OPENAI_MODEL` | `OPENAI_MAX_TOKENS`, `OPENAI_USE_RESPONSES`, `OPENAI_API_URL` |
 | Anthropic | `ANTHROPIC_API_KEY` | `ANTHROPIC_MODEL` | `ANTHROPIC_MAX_TOKENS` |
 | AWS Bedrock | IAM / Profile / credentials chain | `BEDROCK_MODEL` | `AWS_REGION`, `BEDROCK_CROSS_REGION` |
 | Google Gemini | `GOOGLEAI_API_KEY` | `GOOGLEAI_MODEL` | `GOOGLEAI_MAX_TOKENS` |
@@ -129,9 +129,15 @@ OPENAI_API_KEY=sk-xxx
 | GitHub Copilot | `GITHUB_COPILOT_TOKEN` | `COPILOT_MODEL` | or `/auth login github-copilot` |
 | GitHub Models | `GITHUB_TOKEN` | `GITHUB_MODELS_MODEL` | `GH_TOKEN`, `GITHUB_MODELS_TOKEN` |
 | StackSpot | `CLIENT_ID`, `CLIENT_KEY` | — | `STACKSPOT_REALM`, `STACKSPOT_AGENT_ID` |
-| OpenRouter | `OPENROUTER_API_KEY` | — | `OPENROUTER_MAX_TOKENS`, `OPENROUTER_FALLBACK_MODELS` |
+| OpenRouter | `OPENROUTER_API_KEY` | — | `OPENROUTER_MAX_TOKENS`, `OPENROUTER_FALLBACK_MODELS`, `OPENROUTER_API_URL` |
 | Ollama | — | `OLLAMA_MODEL` | `OLLAMA_ENABLED=true`, `OLLAMA_BASE_URL` |
 | OpenAI (Responses API) | `OPENAI_API_KEY` | `OPENAI_MODEL` | `OPENAI_RESPONSES_API_URL` |
+
+#### Custom endpoints and OpenAI-compatible gateways
+
+- `OPENAI_API_URL` overrides the OpenAI chat completions endpoint. It must be the **full** chat completions URL (e.g. `https://gateway.example.com/v1/chat/completions`) — the `/models` listing URL is derived from it.
+- `OPENAI_RESPONSES_API_URL` overrides the Responses API endpoint. Note that `OPENAI_USE_RESPONSES=false` does not force chat completions: OAuth logins and models whose catalog entry prefers the Responses API (e.g. `gpt-5.4`, the default) still use it. Effective precedence: OAuth > `OPENAI_USE_RESPONSES=true` > model catalog preference > `OPENAI_USE_RESPONSES=false`. When redirecting the OpenAI provider to a compatible endpoint, set **both** URLs.
+- To use a third-party OpenAI-compatible gateway as a provider **separate** from OpenAI (including in the server fallback chain), point the OpenRouter preset at it: `LLM_PROVIDER=OPENROUTER` with `OPENROUTER_API_KEY` and `OPENROUTER_API_URL=https://gateway.example.com/v1/chat/completions`. Unlike the OpenAI provider, its model listing does not filter by model family, so all gateway models appear in the autocomplete.
 
 </details>
 

--- a/README_PT.md
+++ b/README_PT.md
@@ -111,7 +111,7 @@ OPENAI_API_KEY=sk-xxx
 
 | Provider | API Key | Model | Extras |
 |---|---|---|---|
-| OpenAI | `OPENAI_API_KEY` | `OPENAI_MODEL` | `OPENAI_MAX_TOKENS`, `OPENAI_USE_RESPONSES` |
+| OpenAI | `OPENAI_API_KEY` | `OPENAI_MODEL` | `OPENAI_MAX_TOKENS`, `OPENAI_USE_RESPONSES`, `OPENAI_API_URL` |
 | Anthropic | `ANTHROPIC_API_KEY` | `ANTHROPIC_MODEL` | `ANTHROPIC_MAX_TOKENS` |
 | AWS Bedrock | IAM / Profile / credentials chain | `BEDROCK_MODEL` | `AWS_REGION`, `BEDROCK_CROSS_REGION` |
 | Google Gemini | `GOOGLEAI_API_KEY` | `GOOGLEAI_MODEL` | `GOOGLEAI_MAX_TOKENS` |
@@ -122,9 +122,15 @@ OPENAI_API_KEY=sk-xxx
 | GitHub Copilot | `GITHUB_COPILOT_TOKEN` | `COPILOT_MODEL` | ou `/auth login github-copilot` |
 | GitHub Models | `GITHUB_TOKEN` | `GITHUB_MODELS_MODEL` | `GH_TOKEN`, `GITHUB_MODELS_TOKEN` |
 | StackSpot | `CLIENT_ID`, `CLIENT_KEY` | — | `STACKSPOT_REALM`, `STACKSPOT_AGENT_ID` |
-| OpenRouter | `OPENROUTER_API_KEY` | — | `OPENROUTER_MAX_TOKENS`, `OPENROUTER_FALLBACK_MODELS` |
+| OpenRouter | `OPENROUTER_API_KEY` | — | `OPENROUTER_MAX_TOKENS`, `OPENROUTER_FALLBACK_MODELS`, `OPENROUTER_API_URL` |
 | Ollama | — | `OLLAMA_MODEL` | `OLLAMA_ENABLED=true`, `OLLAMA_BASE_URL` |
 | OpenAI (Responses API) | `OPENAI_API_KEY` | `OPENAI_MODEL` | `OPENAI_RESPONSES_API_URL` |
+
+#### Endpoints customizados e gateways compatíveis com OpenAI
+
+- `OPENAI_API_URL` sobrescreve o endpoint de chat completions da OpenAI. Deve ser a URL **completa** de chat completions (ex.: `https://gateway.example.com/v1/chat/completions`) — a URL de listagem `/models` é derivada dela.
+- `OPENAI_RESPONSES_API_URL` sobrescreve o endpoint da Responses API. Atenção: `OPENAI_USE_RESPONSES=false` não força chat completions — logins OAuth e modelos cuja entrada no catálogo prefere a Responses API (ex.: `gpt-5.4`, o default) continuam usando-a. Precedência efetiva: OAuth > `OPENAI_USE_RESPONSES=true` > preferência do catálogo do modelo > `OPENAI_USE_RESPONSES=false`. Ao redirecionar o provider OpenAI para um endpoint compatível, configure **as duas** URLs.
+- Para usar um gateway compatível com OpenAI como provider **separado** da OpenAI (inclusive na fallback chain do modo servidor), aponte o preset OpenRouter para ele: `LLM_PROVIDER=OPENROUTER` com `OPENROUTER_API_KEY` e `OPENROUTER_API_URL=https://gateway.example.com/v1/chat/completions`. Diferente do provider OpenAI, a listagem de modelos dele não filtra por família, então todos os modelos do gateway aparecem no autocomplete.
 
 </details>
 


### PR DESCRIPTION
## Summary

Follow-up to #1245. The discussion there surfaced real documentation gaps on our side:

- `OPENAI_API_URL` existed but was undocumented. It is now in the provider table and explained: it must be the **full** chat completions URL, since the `/models` listing URL is derived from it (`llm/openai/openai_client.go:244-245`).
- `OPENAI_USE_RESPONSES=false` does not force chat completions — OAuth and the model catalog's `PreferredAPI` override it (`llm/manager/llm_manager.go:405-412`), and the default model `gpt-5.4` prefers the Responses API. The effective precedence is now documented, along with the need to set `OPENAI_RESPONSES_API_URL` too when redirecting the provider.
- Generic guidance for third-party OpenAI-compatible gateways: use the OpenRouter preset with `OPENROUTER_API_URL` (no model-family filter in its listing), which works as a provider separate from OPENAI, including in the server fallback chain.

No specific third-party service is endorsed. PT and EN READMEs updated symmetrically.

## Validation
- Repo-wide grep confirms these envs are mentioned nowhere else in docs (no other files to sync).
- Docs-only change; no code touched.