### PR TITLE
feat(providers): list all gateway models when endpoint URL is customized

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,10 @@ OPENAI_API_KEY=sk-xxx
 #### Custom endpoints and OpenAI-compatible gateways
 
 - `OPENAI_API_URL` overrides the OpenAI chat completions endpoint. It must be the **full** chat completions URL (e.g. `https://gateway.example.com/v1/chat/completions`) — the `/models` listing URL is derived from it.
+- Authentication is unchanged: requests carry `Authorization: Bearer $OPENAI_API_KEY`, so when redirecting to a gateway set `OPENAI_API_KEY` to the **gateway's** key. Do not combine a third-party URL with an OAuth login (`/auth login openai`) — the OAuth token would be sent to the gateway.
 - `OPENAI_RESPONSES_API_URL` overrides the Responses API endpoint. Note that `OPENAI_USE_RESPONSES=false` does not force chat completions: OAuth logins and models whose catalog entry prefers the Responses API (e.g. `gpt-5.4`, the default) still use it. Effective precedence: OAuth > `OPENAI_USE_RESPONSES=true` > model catalog preference > `OPENAI_USE_RESPONSES=false`. When redirecting the OpenAI provider to a compatible endpoint, set **both** URLs.
-- To use a third-party OpenAI-compatible gateway as a provider **separate** from OpenAI (including in the server fallback chain), point the OpenRouter preset at it: `LLM_PROVIDER=OPENROUTER` with `OPENROUTER_API_KEY` and `OPENROUTER_API_URL=https://gateway.example.com/v1/chat/completions`. Unlike the OpenAI provider, its model listing does not filter by model family, so all gateway models appear in the autocomplete.
+- When the endpoint URL points to a custom host, the model listing is **not** filtered by model family — every model the gateway returns on `/models` appears in the autocomplete and `/switch --model`. Against the official endpoint, the listing keeps only chat-capable families (hiding embeddings, whisper, tts, dall-e, moderation). The same rule applies to `ZAI_API_URL`, `MOONSHOT_API_URL` and `MINIMAX_API_URL`.
+- To use a third-party OpenAI-compatible gateway as a provider **separate** from OpenAI (including in the server fallback chain), point the OpenRouter preset at it: `LLM_PROVIDER=OPENROUTER` with `OPENROUTER_API_KEY` and `OPENROUTER_API_URL=https://gateway.example.com/v1/chat/completions`.
 
 </details>
 

--- a/README_PT.md
+++ b/README_PT.md
@@ -129,8 +129,10 @@ OPENAI_API_KEY=sk-xxx
 #### Endpoints customizados e gateways compatíveis com OpenAI
 
 - `OPENAI_API_URL` sobrescreve o endpoint de chat completions da OpenAI. Deve ser a URL **completa** de chat completions (ex.: `https://gateway.example.com/v1/chat/completions`) — a URL de listagem `/models` é derivada dela.
+- A autenticação não muda: as requisições levam `Authorization: Bearer $OPENAI_API_KEY`, então ao redirecionar para um gateway configure `OPENAI_API_KEY` com a key **do gateway**. Não combine URL de terceiros com login OAuth (`/auth login openai`) — o token OAuth seria enviado ao gateway.
 - `OPENAI_RESPONSES_API_URL` sobrescreve o endpoint da Responses API. Atenção: `OPENAI_USE_RESPONSES=false` não força chat completions — logins OAuth e modelos cuja entrada no catálogo prefere a Responses API (ex.: `gpt-5.4`, o default) continuam usando-a. Precedência efetiva: OAuth > `OPENAI_USE_RESPONSES=true` > preferência do catálogo do modelo > `OPENAI_USE_RESPONSES=false`. Ao redirecionar o provider OpenAI para um endpoint compatível, configure **as duas** URLs.
-- Para usar um gateway compatível com OpenAI como provider **separado** da OpenAI (inclusive na fallback chain do modo servidor), aponte o preset OpenRouter para ele: `LLM_PROVIDER=OPENROUTER` com `OPENROUTER_API_KEY` e `OPENROUTER_API_URL=https://gateway.example.com/v1/chat/completions`. Diferente do provider OpenAI, a listagem de modelos dele não filtra por família, então todos os modelos do gateway aparecem no autocomplete.
+- Quando a URL do endpoint aponta para um host customizado, a listagem de modelos **não** é filtrada por família — todos os modelos que o gateway retornar em `/models` aparecem no autocomplete e no `/switch --model`. Contra o endpoint oficial, a listagem mantém apenas as famílias de chat (ocultando embeddings, whisper, tts, dall-e, moderation). A mesma regra vale para `ZAI_API_URL`, `MOONSHOT_API_URL` e `MINIMAX_API_URL`.
+- Para usar um gateway compatível com OpenAI como provider **separado** da OpenAI (inclusive na fallback chain do modo servidor), aponte o preset OpenRouter para ele: `LLM_PROVIDER=OPENROUTER` com `OPENROUTER_API_KEY` e `OPENROUTER_API_URL=https://gateway.example.com/v1/chat/completions`.
 
 </details>
 

--- a/llm/minimax/minimax_client.go
+++ b/llm/minimax/minimax_client.go
@@ -377,6 +377,17 @@ func (c *MiniMaxClient) processAnthropicResponse(resp *http.Response) (string, e
 	return strings.Join(texts, ""), nil
 }
 
+// keepModel reports whether a model id from /models should be listed.
+// The official endpoint is filtered to known chat-capable families; a custom
+// endpoint exposes whatever the gateway serves, so everything is kept.
+func keepModel(id string, custom bool) bool {
+	if custom {
+		return true
+	}
+	id = strings.ToLower(id)
+	return strings.HasPrefix(id, "minimax") || strings.HasPrefix(id, "abab")
+}
+
 // ListModels fetches available models from the MiniMax API.
 func (c *MiniMaxClient) ListModels(ctx context.Context) ([]client.ModelInfo, error) {
 	apiURL := utils.GetEnvOrDefault("MINIMAX_API_URL", c.apiURL)
@@ -423,10 +434,10 @@ func (c *MiniMaxClient) ListModels(ctx context.Context) ([]client.ModelInfo, err
 		return nil, fmt.Errorf("%s: %w", i18n.T("llm.error.decode_response_for", "MiniMax"), err)
 	}
 
+	custom := utils.IsCustomEndpoint(apiURL, config.MiniMaxAPIURL)
 	modelsList := make([]client.ModelInfo, 0, len(result.Data))
 	for _, m := range result.Data {
-		id := strings.ToLower(m.ID)
-		if !strings.HasPrefix(id, "minimax") && !strings.HasPrefix(id, "abab") {
+		if !keepModel(m.ID, custom) {
 			continue
 		}
 		modelsList = append(modelsList, client.ModelInfo{

--- a/llm/minimax/minimax_client_test.go
+++ b/llm/minimax/minimax_client_test.go
@@ -373,8 +373,18 @@ func TestMiniMaxClient_ListModels_Success(t *testing.T) {
 	modelsList, err := c.ListModels(context.Background())
 
 	require.NoError(t, err)
-	// speech-2.8-hd should be filtered out (not minimax/abab prefix)
-	assert.Len(t, modelsList, 3)
+	// custom endpoint (httptest URL) → no family filter, gateway decides
+	assert.Len(t, modelsList, 4)
+}
+
+func TestKeepModel_OfficialEndpointFiltersFamilies(t *testing.T) {
+	assert.True(t, keepModel("MiniMax-M2.7", false))
+	assert.True(t, keepModel("abab6.5s-chat", false))
+	assert.False(t, keepModel("speech-2.8-hd", false))
+
+	// custom endpoint keeps everything
+	assert.True(t, keepModel("speech-2.8-hd", true))
+	assert.True(t, keepModel("claude-opus-5", true))
 }
 
 func TestMiniMaxClient_GetModelName(t *testing.T) {

--- a/llm/moonshot/moonshot_client.go
+++ b/llm/moonshot/moonshot_client.go
@@ -264,6 +264,17 @@ func (c *MoonshotClient) processResponse(resp *http.Response) (string, error) {
 	return firstChoice.Message.Content, nil
 }
 
+// keepModel reports whether a model id from /models should be listed.
+// The official endpoint is filtered to known chat-capable families; a custom
+// endpoint exposes whatever the gateway serves, so everything is kept.
+func keepModel(id string, custom bool) bool {
+	if custom {
+		return true
+	}
+	id = strings.ToLower(id)
+	return strings.HasPrefix(id, "kimi") || strings.HasPrefix(id, "moonshot")
+}
+
 // ListModels fetches available models from the Moonshot /models endpoint.
 // Registers any unknown Kimi/Moonshot models into the catalog so they become
 // auto-completable without a code change.
@@ -303,10 +314,10 @@ func (c *MoonshotClient) ListModels(ctx context.Context) ([]client.ModelInfo, er
 		return nil, fmt.Errorf("%s: %w", i18n.T("llm.error.decode_response_for", "MOONSHOT"), err)
 	}
 
+	custom := utils.IsCustomEndpoint(apiURL, config.MoonshotAPIURL)
 	modelsList := make([]client.ModelInfo, 0, len(result.Data))
 	for _, m := range result.Data {
-		id := strings.ToLower(m.ID)
-		if !strings.HasPrefix(id, "kimi") && !strings.HasPrefix(id, "moonshot") {
+		if !keepModel(m.ID, custom) {
 			continue
 		}
 		modelsList = append(modelsList, client.ModelInfo{

--- a/llm/moonshot/moonshot_client_test.go
+++ b/llm/moonshot/moonshot_client_test.go
@@ -429,8 +429,8 @@ func TestMoonshotClient_ListModels_Success(t *testing.T) {
 	modelsList, err := c.ListModels(context.Background())
 
 	require.NoError(t, err)
-	// embedding-3 must be filtered (not kimi-/moonshot- prefix).
-	assert.Len(t, modelsList, 3)
+	// custom endpoint (httptest URL) → no family filter, gateway decides
+	assert.Len(t, modelsList, 4)
 
 	// Unknown kimi-* must be registered into the catalog for completion.
 	ids := make(map[string]bool)
@@ -438,6 +438,16 @@ func TestMoonshotClient_ListModels_Success(t *testing.T) {
 		ids[m.ID] = true
 	}
 	assert.True(t, ids["kimi-future-v9"])
+}
+
+func TestKeepModel_OfficialEndpointFiltersFamilies(t *testing.T) {
+	assert.True(t, keepModel("kimi-k2.6", false))
+	assert.True(t, keepModel("moonshot-v1-128k", false))
+	assert.False(t, keepModel("embedding-3", false))
+
+	// custom endpoint keeps everything
+	assert.True(t, keepModel("embedding-3", true))
+	assert.True(t, keepModel("claude-opus-5", true))
 }
 
 func TestMoonshotClient_ListModels_HTTPError(t *testing.T) {

--- a/llm/openai/openai_client.go
+++ b/llm/openai/openai_client.go
@@ -238,6 +238,20 @@ func (c *OpenAIClient) processResponse(resp *http.Response) (string, error) {
 	return content, nil
 }
 
+// keepModel reports whether a model id from /models should be listed.
+// The official endpoint also returns non-chat models (embeddings, whisper,
+// tts, dall-e, moderation), so it is filtered to chat-capable families;
+// a custom endpoint exposes whatever the gateway serves, so everything is kept.
+func keepModel(id string, custom bool) bool {
+	if custom {
+		return true
+	}
+	id = strings.ToLower(id)
+	return strings.HasPrefix(id, "gpt-") || strings.HasPrefix(id, "o1") ||
+		strings.HasPrefix(id, "o3") || strings.HasPrefix(id, "o4") ||
+		strings.HasPrefix(id, "chatgpt-")
+}
+
 // ListModels fetches available models from the OpenAI /v1/models endpoint.
 func (c *OpenAIClient) ListModels(ctx context.Context) ([]client.ModelInfo, error) {
 	// Derive base URL from the chat completions URL
@@ -283,13 +297,10 @@ func (c *OpenAIClient) ListModels(ctx context.Context) ([]client.ModelInfo, erro
 		return nil, fmt.Errorf("%s: %w", i18n.T("llm.error.decode_response_for", "OpenAI"), err)
 	}
 
+	custom := utils.IsCustomEndpoint(apiURL, config.OpenAIAPIURL)
 	models := make([]client.ModelInfo, 0, len(result.Data))
 	for _, m := range result.Data {
-		// Filter to chat-capable models (gpt, o1, o3, o4, chatgpt)
-		id := strings.ToLower(m.ID)
-		if !strings.HasPrefix(id, "gpt-") && !strings.HasPrefix(id, "o1") &&
-			!strings.HasPrefix(id, "o3") && !strings.HasPrefix(id, "o4") &&
-			!strings.HasPrefix(id, "chatgpt-") {
+		if !keepModel(m.ID, custom) {
 			continue
 		}
 		models = append(models, client.ModelInfo{

--- a/llm/openai/openai_client_test.go
+++ b/llm/openai/openai_client_test.go
@@ -44,3 +44,46 @@ func TestOpenAIClient_SendPrompt_Success(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "Hello from OpenAI!", resp)
 }
+
+func TestOpenAIClient_ListModels_CustomEndpointNoFilter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "Bearer test-api-key", r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"data": [
+				{"id": "gpt-5.4", "owned_by": "openai"},
+				{"id": "claude-opus-5", "owned_by": "anthropic"},
+				{"id": "gemini-3-pro", "owned_by": "google"}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	os.Setenv("OPENAI_API_URL", server.URL+"/chat/completions")
+	defer os.Unsetenv("OPENAI_API_URL")
+
+	logger, _ := zap.NewDevelopment()
+	client := NewOpenAIClient(testProvider("test-api-key"), "gpt-5.4", logger, 1, 0)
+	list, err := client.ListModels(context.Background())
+
+	assert.NoError(t, err)
+	// custom endpoint (gateway) → no family filter, all models listed
+	assert.Len(t, list, 3)
+}
+
+func TestKeepModel_OfficialEndpointFiltersFamilies(t *testing.T) {
+	assert.True(t, keepModel("gpt-5.4", false))
+	assert.True(t, keepModel("o1-preview", false))
+	assert.True(t, keepModel("o3-mini", false))
+	assert.True(t, keepModel("o4-mini", false))
+	assert.True(t, keepModel("chatgpt-4o-latest", false))
+	assert.False(t, keepModel("text-embedding-3", false))
+	assert.False(t, keepModel("whisper-1", false))
+	assert.False(t, keepModel("dall-e-3", false))
+	assert.False(t, keepModel("claude-opus-5", false))
+
+	// custom endpoint keeps everything
+	assert.True(t, keepModel("text-embedding-3", true))
+	assert.True(t, keepModel("claude-opus-5", true))
+}

--- a/llm/openairesponses/openai_responses_client.go
+++ b/llm/openairesponses/openai_responses_client.go
@@ -455,10 +455,24 @@ func (c *OpenAIResponsesClient) ListModels(ctx context.Context) ([]client.ModelI
 	return c.listModelsAPIKey(ctx)
 }
 
+// keepModel reports whether a model id from /models should be listed.
+// The official endpoint also returns non-chat models (embeddings, whisper,
+// tts, dall-e, moderation), so it is filtered to chat-capable families;
+// a custom endpoint exposes whatever the gateway serves, so everything is kept.
+func keepModel(id string, custom bool) bool {
+	if custom {
+		return true
+	}
+	id = strings.ToLower(id)
+	return strings.HasPrefix(id, "gpt-") || strings.HasPrefix(id, "o1") ||
+		strings.HasPrefix(id, "o3") || strings.HasPrefix(id, "o4") ||
+		strings.HasPrefix(id, "chatgpt-")
+}
+
 // listModelsAPIKey fetches models from the standard OpenAI /v1/models endpoint.
 func (c *OpenAIResponsesClient) listModelsAPIKey(ctx context.Context) ([]client.ModelInfo, error) {
-	modelsURL := utils.GetEnvOrDefault("OPENAI_API_URL", config.OpenAIAPIURL)
-	modelsURL = strings.TrimSuffix(modelsURL, "/chat/completions") + "/models"
+	apiURL := utils.GetEnvOrDefault("OPENAI_API_URL", config.OpenAIAPIURL)
+	modelsURL := strings.TrimSuffix(apiURL, "/chat/completions") + "/models"
 
 	resp, err := auth.DoWithRefresh(ctx, c.provider, func(token string) (*http.Response, error) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, modelsURL, nil)
@@ -498,12 +512,10 @@ func (c *OpenAIResponsesClient) listModelsAPIKey(ctx context.Context) ([]client.
 		return nil, fmt.Errorf("%s: %w", i18n.T("llm.error.decode_response_for", "OpenAI"), err)
 	}
 
+	custom := utils.IsCustomEndpoint(apiURL, config.OpenAIAPIURL)
 	modelList := make([]client.ModelInfo, 0, len(result.Data))
 	for _, m := range result.Data {
-		id := strings.ToLower(m.ID)
-		if !strings.HasPrefix(id, "gpt-") && !strings.HasPrefix(id, "o1") &&
-			!strings.HasPrefix(id, "o3") && !strings.HasPrefix(id, "o4") &&
-			!strings.HasPrefix(id, "chatgpt-") {
+		if !keepModel(m.ID, custom) {
 			continue
 		}
 		modelList = append(modelList, client.ModelInfo{

--- a/llm/openairesponses/openai_responses_client_test.go
+++ b/llm/openairesponses/openai_responses_client_test.go
@@ -86,8 +86,20 @@ func TestOpenAIResponsesClient_ListModels_APIKey(t *testing.T) {
 	client := NewOpenAIResponsesClient(testProvider("test-api-key"), "gpt-5", logger, 1, 0)
 	list, err := client.ListModels(context.Background())
 	assert.NoError(t, err)
-	// only gpt-* models pass the prefix filter
-	assert.Equal(t, 1, len(list))
+	// custom endpoint (httptest URL) → no family filter, gateway decides
+	assert.Equal(t, 2, len(list))
+}
+
+func TestKeepModel_OfficialEndpointFiltersFamilies(t *testing.T) {
+	assert.True(t, keepModel("gpt-5", false))
+	assert.True(t, keepModel("o3-mini", false))
+	assert.True(t, keepModel("chatgpt-4o-latest", false))
+	assert.False(t, keepModel("text-embedding-3", false))
+	assert.False(t, keepModel("claude-opus-5", false))
+
+	// custom endpoint keeps everything
+	assert.True(t, keepModel("text-embedding-3", true))
+	assert.True(t, keepModel("claude-opus-5", true))
 }
 
 func TestOpenAIResponsesClient_ListModels_OAuthSkips(t *testing.T) {

--- a/llm/zai/zai_client.go
+++ b/llm/zai/zai_client.go
@@ -269,6 +269,18 @@ func (c *ZAIClient) processResponse(resp *http.Response) (string, error) {
 	return firstChoice.Message.Content, nil
 }
 
+// keepModel reports whether a model id from /models should be listed.
+// The official endpoint is filtered to known chat-capable families; a custom
+// endpoint exposes whatever the gateway serves, so everything is kept.
+func keepModel(id string, custom bool) bool {
+	if custom {
+		return true
+	}
+	id = strings.ToLower(id)
+	return strings.HasPrefix(id, "glm-") || strings.HasPrefix(id, "codegeex") ||
+		strings.HasPrefix(id, "cogview") || strings.HasPrefix(id, "charglm")
+}
+
 // ListModels fetches available models from the ZAI /models endpoint.
 func (c *ZAIClient) ListModels(ctx context.Context) ([]client.ModelInfo, error) {
 	apiURL := utils.GetEnvOrDefault("ZAI_API_URL", c.apiURL)
@@ -305,11 +317,10 @@ func (c *ZAIClient) ListModels(ctx context.Context) ([]client.ModelInfo, error) 
 		return nil, fmt.Errorf("%s: %w", i18n.T("llm.error.decode_response_for", "ZAI"), err)
 	}
 
+	custom := utils.IsCustomEndpoint(apiURL, config.ZAIAPIURL)
 	modelsList := make([]client.ModelInfo, 0, len(result.Data))
 	for _, m := range result.Data {
-		id := strings.ToLower(m.ID)
-		if !strings.HasPrefix(id, "glm-") && !strings.HasPrefix(id, "codegeex") &&
-			!strings.HasPrefix(id, "cogview") && !strings.HasPrefix(id, "charglm") {
+		if !keepModel(m.ID, custom) {
 			continue
 		}
 		modelsList = append(modelsList, client.ModelInfo{

--- a/llm/zai/zai_client_test.go
+++ b/llm/zai/zai_client_test.go
@@ -315,8 +315,18 @@ func TestZAIClient_ListModels_Success(t *testing.T) {
 	modelsList, err := c.ListModels(context.Background())
 
 	require.NoError(t, err)
-	// embedding-3 should be filtered out (not glm-/codegeex/cogview/charglm prefix)
-	assert.Len(t, modelsList, 3)
+	// custom endpoint (httptest URL) → no family filter, gateway decides
+	assert.Len(t, modelsList, 4)
+}
+
+func TestKeepModel_OfficialEndpointFiltersFamilies(t *testing.T) {
+	assert.True(t, keepModel("glm-5", false))
+	assert.True(t, keepModel("codegeex-4", false))
+	assert.False(t, keepModel("embedding-3", false))
+
+	// custom endpoint keeps everything
+	assert.True(t, keepModel("embedding-3", true))
+	assert.True(t, keepModel("claude-opus-5", true))
 }
 
 func TestZAIClient_GetModelName(t *testing.T) {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"regexp"
 	"runtime"
@@ -26,6 +27,22 @@ func GetEnvOrDefault(key, defaultValue string) string {
 		return defaultValue
 	}
 	return value
+}
+
+// IsCustomEndpoint reporta se uma URL de API resolvida aponta para um endpoint
+// diferente do oficial do provider (ex.: um gateway OpenAI-compatible).
+// Variações cosméticas da URL oficial (esquema, barra final, path alternativo
+// no mesmo host) NÃO contam como custom — apenas host diferente conta.
+func IsCustomEndpoint(resolvedURL, officialURL string) bool {
+	if resolvedURL == officialURL {
+		return false
+	}
+	ru, errResolved := url.Parse(resolvedURL)
+	ou, errOfficial := url.Parse(officialURL)
+	if errResolved != nil || errOfficial != nil {
+		return true
+	}
+	return !strings.EqualFold(ru.Hostname(), ou.Hostname())
 }
 
 // GetEnvVariablesSanitized retorna variáveis de ambiente com valores sensíveis redigidos.

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -132,3 +132,25 @@ func TestExpandPath(t *testing.T) {
 		})
 	}
 }
+
+func TestIsCustomEndpoint(t *testing.T) {
+	official := "https://api.openai.com/v1/chat/completions"
+	testCases := []struct {
+		name     string
+		resolved string
+		custom   bool
+	}{
+		{"exact official URL", official, false},
+		{"official host, trailing slash", "https://api.openai.com/v1/chat/completions/", false},
+		{"official host, alternate path", "https://api.openai.com/v2/chat/completions", false},
+		{"official host, different scheme", "http://API.OPENAI.COM/v1/chat/completions", false},
+		{"gateway host", "https://gateway.example.com/v1/chat/completions", true},
+		{"localhost mock", "http://127.0.0.1:8080/v1/chat/completions", true},
+		{"unparsable resolved URL", "://bad-url", true},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.custom, IsCustomEndpoint(tc.resolved, official))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The model listing (`ListModels`) of the **OpenAI**, **OpenAI Responses**, **ZAI**, **Moonshot** and **MiniMax** clients filtered the `/models` response to known chat-capable model families unconditionally. That is correct against each official endpoint — which also returns non-chat models (embeddings, whisper, tts, dall-e, moderation) — but wrong when the endpoint URL env (`OPENAI_API_URL`, `ZAI_API_URL`, `MOONSHOT_API_URL`, `MINIMAX_API_URL`) points to an OpenAI-compatible gateway serving other families: those models never appeared in autocomplete, `/switch --model`, the `@model` tool or the MCP `list_providers` surface, and were never registered in the dynamic catalog.

Addresses **limitation 1** discussed in #1245 (the dedicated-preset decision there stands — the OpenRouter preset remains the path for a gateway as a *separate* provider).

## Behavior

- **Official endpoint (default URL or same host):** unchanged — family filter applies, non-chat models stay hidden.
- **Custom host:** no family filter — everything the gateway returns on `/models` is listed and registered in the dynamic catalog (unknown models keep the chat-completions default routing), matching the OpenRouter preset behavior.
- Detection is centralized in `utils.IsCustomEndpoint(resolvedURL, officialURL)`: cosmetic variations of the official URL (trailing slash, scheme, alternate path on the same host) do **not** count as custom, so the default experience keeps its protection.

## Non-degradation cross-check

- Full `go test ./...` green; `go vet` and `golangci-lint` clean; local quality-gate floors (patch-coverage, api-breaking, ai-smells, cyclo-new, commit-lint, scope-budget, i18n-parity) all pass against main.
- `catalog.Resolve`/`GetPreferredAPI` are provider-scoped, so gateway ids registered under one provider cannot leak into other providers' lookups.
- All `ListModels` consumers go through `LLMManagerImpl.ListModelsForProvider` (merge + dedup with the static catalog) — none assumes a family-filtered list.
- MiniMax `anthropic`-compat `/models` fallback to the native URL still resolves as official.
- `llm/openai` had **no** `ListModels` coverage at all — added (custom-endpoint httptest + pure-function unit tests for the official path, replicated per provider).

## Docs

- READMEs (EN/PT): the gateway section from #1262 now documents the unfiltered listing on custom hosts and that `OPENAI_API_KEY` is still sent as the Bearer token (set it to the gateway's key; do not combine a third-party URL with an OAuth login).
- chatcli.ai: same notes on `reference/configuration` and `reference/environment-variables` (EN+PT), including previously undocumented `ZAI_API_URL`/`MINIMAX_API_URL` rows.