### PR TITLE
fix(cli): complete /update check and close completer and palette gaps

### DIFF
--- a/cli/cli_completer.go
+++ b/cli/cli_completer.go
@@ -76,6 +76,28 @@ var slashPrefixRoutes = []slashPrefixRoute{
 	{"/export", (*ChatCLI).getExportSuggestions},
 	{"/gateway", (*ChatCLI).getGatewaySuggestions},
 	{"/lsp", (*ChatCLI).getLSPSuggestions},
+	{"/update", (*ChatCLI).getUpdateSuggestions},
+	{"/graph", (*ChatCLI).getGraphSuggestions},
+}
+
+// getUpdateSuggestions completes `/update <sub>`: check (and its --check
+// alias) previews the available release without applying it.
+func (cli *ChatCLI) getUpdateSuggestions(d prompt.Document) []prompt.Suggest {
+	word := d.GetWordBeforeCursor()
+	return prompt.FilterHasPrefix([]prompt.Suggest{
+		{Text: "check", Description: i18n.T("complete.update.check")},
+		{Text: "--check", Description: i18n.T("complete.update.check")},
+	}, word, true)
+}
+
+// getGraphSuggestions completes `/graph <scope>`: the literal full/all render
+// the whole knowledge graph; any other text seeds a subject search.
+func (cli *ChatCLI) getGraphSuggestions(d prompt.Document) []prompt.Suggest {
+	word := d.GetWordBeforeCursor()
+	return prompt.FilterHasPrefix([]prompt.Suggest{
+		{Text: "full", Description: i18n.T("complete.graph.full")},
+		{Text: "all", Description: i18n.T("complete.graph.full")},
+	}, word, true)
 }
 
 // getLSPSuggestions completes the file path argument of /lsp.

--- a/cli/cli_completer_dispatch_test.go
+++ b/cli/cli_completer_dispatch_test.go
@@ -62,6 +62,7 @@ func TestRouteSlashPrefix_KnownPrefixesMatch(t *testing.T) {
 		"/plan", "/refine", "/verify", "/reflect",
 		"/thinking", "/schedule", "/wait", "/jobs",
 		"/parked", "/resume foo", "/cancel-park foo",
+		"/update ", "/graph ",
 	}
 	for _, line := range cases {
 		t.Run(line, func(t *testing.T) {
@@ -71,6 +72,30 @@ func TestRouteSlashPrefix_KnownPrefixesMatch(t *testing.T) {
 				t.Errorf("expected route to match for %q", line)
 			}
 		})
+	}
+}
+
+func TestUpdateAndGraphArgumentSuggestions(t *testing.T) {
+	cli := newCompleterTestCLI(t)
+
+	// "/update " must offer the check-only forms.
+	d := docWithCursor("/update ", 8)
+	sugs := cli.getUpdateSuggestions(d)
+	if !containsText(sugs, "check") || !containsText(sugs, "--check") {
+		t.Errorf("/update suggestions missing check forms: %v", extractTexts(sugs))
+	}
+	// Prefix filtering: "--c" narrows to the flag form.
+	d = docWithCursor("/update --c", 11)
+	sugs = cli.getUpdateSuggestions(d)
+	if !containsText(sugs, "--check") || containsText(sugs, "check") {
+		t.Errorf("/update --c should narrow to --check: %v", extractTexts(sugs))
+	}
+
+	// "/graph " must offer the full-graph literals.
+	d = docWithCursor("/graph ", 7)
+	sugs = cli.getGraphSuggestions(d)
+	if !containsText(sugs, "full") || !containsText(sugs, "all") {
+		t.Errorf("/graph suggestions missing full/all: %v", extractTexts(sugs))
 	}
 }
 

--- a/cli/palette/registry.go
+++ b/cli/palette/registry.go
@@ -90,6 +90,7 @@ var rootCommands = []RootCommand{
 	{"/switch", CatModel, "complete.root.switch"},
 	{"/provider", CatModel, "complete.root.provider"},
 	{"/model", CatModel, "complete.root.model"},
+	{"/model-image", CatModel, "complete.root.model_image"},
 	{"/max-tokens", CatModel, "complete.root.maxtokens"},
 
 	// ── Session ─────────────────────────────────────────────────────────
@@ -101,6 +102,7 @@ var rootCommands = []RootCommand{
 	// ── Context ─────────────────────────────────────────────────────────
 	{"/context", CatContext, "complete.root.context"},
 	{"/memory", CatContext, "complete.root.memory"},
+	{"/graph", CatContext, "complete.root.graph"},
 
 	// ── Agent / build ───────────────────────────────────────────────────
 	{"/agent", CatAgent, "complete.root.agent"},
@@ -137,6 +139,7 @@ var rootCommands = []RootCommand{
 	{"/parked", CatScheduler, "help.command.parked"},
 	{"/resume", CatScheduler, "help.command.resume"},
 	{"/cancel-park", CatScheduler, "help.command.cancel_park"},
+	{"/park-note", CatScheduler, "help.command.park_note"},
 
 	// ── System ──────────────────────────────────────────────────────────
 	{"/config", CatSystem, "complete.config.root_desc"},

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -2641,6 +2641,8 @@
   "complete.root.rewind": "Rewind to a previous conversation checkpoint",
   "complete.root.memory": "View/load memory notes (today, yesterday, week, load <date>, longterm, list)",
   "complete.root.graph": "Visualize the knowledge graph as an image (/graph or /graph <subject>)",
+  "complete.update.check": "Only check for a new release and show its notes, without applying",
+  "complete.graph.full": "Render the full knowledge graph",
   "graph.cmd.empty": "The knowledge graph is empty so far.",
   "graph.cmd.no_node": "No graph node found for %q.",
   "graph.cmd.rendered": "Rendered the knowledge graph:",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -2641,6 +2641,8 @@
   "complete.root.rewind": "Rewind to a previous conversation checkpoint",
   "complete.root.memory": "View/load memory notes (today, yesterday, week, load <date>, longterm, list)",
   "complete.root.graph": "Visualize the knowledge graph as an image (/graph or /graph <subject>)",
+  "complete.update.check": "Only check for a new release and show its notes, without applying",
+  "complete.graph.full": "Render the full knowledge graph",
   "graph.cmd.empty": "The knowledge graph is empty so far.",
   "graph.cmd.no_node": "No graph node found for %q.",
   "graph.cmd.rendered": "Rendered the knowledge graph:",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -2641,6 +2641,8 @@
   "complete.root.rewind": "Volta a um checkpoint anterior da conversa",
   "complete.root.memory": "Ver/carregar anotações de memória (today, yesterday, week, load <data>, longterm, list)",
   "complete.root.graph": "Visualizar o grafo de conhecimento como imagem (/graph ou /graph <assunto>)",
+  "complete.update.check": "Só verifica se há release nova e mostra as notas, sem aplicar",
+  "complete.graph.full": "Renderiza o grafo de conhecimento completo",
   "graph.cmd.empty": "O grafo de conhecimento ainda está vazio.",
   "graph.cmd.no_node": "Nenhum nó do grafo encontrado para %q.",
   "graph.cmd.rendered": "Grafo de conhecimento renderizado:",


### PR DESCRIPTION
## Summary

`/update check` / `/update --check` existed since the auto-update feature but the inline completer had no argument route for `/update`, so nothing was ever suggested — the gap reported from daily use. Auditing the command routing table against the completer routes and the palette registry surfaced the remaining strays, all fixed here:

**Completer (argument suggestion routes)**
- `/update` → suggests `check` and `--check` (check-only release preview)
- `/graph` → suggests the `full` / `all` literals (whole-graph render; any other text remains a subject search)

**Palette registry (missing root commands)**
- `/model-image` (Model), `/graph` (Context), `/park-note` (Scheduler) — all using their existing localized summary keys

`/moa` was checked and intentionally left without argument completion: its argument is a free-text prompt.

## Test plan
- New `TestUpdateAndGraphArgumentSuggestions` (suggestion content + prefix narrowing) and both prefixes added to `TestRouteSlashPrefix_KnownPrefixesMatch`.
- Palette registry well-formedness tests cover the new entries.
- `go test ./...` green; golangci-lint and i18n-parity clean; new descriptions localized in en, en-US and pt-BR.