### PR TITLE
feat(cli): announce new release at boot and resolve Devin CLI from known install dirs

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1112,9 +1112,12 @@ func (cli *ChatCLI) Start(ctx context.Context) {
 	if cli.sessionManager != nil {
 		go cli.sessionManager.CleanExpiredMachineSessions()
 	}
-	// Renova em background o cache de release que alimenta o hash de commit
-	// da tela de boas-vindas (builds go install) e, com CHATCLI_AUTO_UPDATE=
-	// auto, aplica o update silencioso por staging; o boot não espera rede.
+	// Cache de release vencido ganha um refresh síncrono de orçamento curto
+	// para a PRÓPRIA welcome anunciar release nova de imediato; o fluxo em
+	// background cobre o timeout (aviso drenado no turno seguinte), renova o
+	// cache que alimenta o hash de commit de builds go install e, com
+	// CHATCLI_AUTO_UPDATE=auto, aplica o update silencioso por staging.
+	cli.preWelcomeUpdateCheck(ctx)
 	go cli.backgroundUpdateFlow(ctx)
 	cli.PrintWelcomeScreen()
 	cli.printLastSessionNotice()

--- a/cli/update_command.go
+++ b/cli/update_command.go
@@ -148,6 +148,27 @@ func methodLabel(m update.Method) string {
 	return i18n.T("update.method." + m.String())
 }
 
+// bootUpdateCheckBudget limita quanto o boot espera pela consulta de release
+// antes de imprimir a welcome screen. Curto de propósito: rede lenta ou
+// ausente não pode segurar a abertura — no timeout, o backgroundUpdateFlow
+// completa o refresh e o aviso drena no turno seguinte. Com cache fresco
+// (≤1 consulta/dia) o custo é zero.
+const bootUpdateCheckBudget = 1500 * time.Millisecond
+
+// preWelcomeUpdateCheck renova o cache de release de forma SÍNCRONA e com
+// orçamento curto, antes da welcome screen ser impressa — é o que permite ao
+// banner anunciar uma release recém-publicada já neste boot, em vez de só no
+// próximo input (aviso drenado) ou no próximo boot. Política off e checagem
+// desabilitada retornam na hora, sem tocar a rede.
+func (cli *ChatCLI) preWelcomeUpdateCheck(ctx context.Context) {
+	if update.ResolveMode() == update.ModeOff {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, bootUpdateCheckBudget)
+	defer cancel()
+	version.RefreshReleaseCacheIfStale(ctx)
+}
+
 // backgroundUpdateFlow roda em goroutine no boot: limpa restos de updates
 // anteriores, renova o cache de release (que alimenta o welcome e o /version
 // offline) e, no modo auto, aplica o update silencioso por staging — o

--- a/cli/update_notice_test.go
+++ b/cli/update_notice_test.go
@@ -12,10 +12,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/diillson/chatcli/update"
+	"github.com/diillson/chatcli/version"
 )
 
 func TestBackgroundUpdateFlowQueuesNoticeInNotifyMode(t *testing.T) {
@@ -122,6 +124,71 @@ func TestWelcomeAnnouncesUpdateFromExpiredCache(t *testing.T) {
 
 	if !strings.Contains(out, "1.6.0") || !strings.Contains(out, "/update") {
 		t.Fatalf("cache vencido ainda é o último dado conhecido; welcome deve anunciar, saída: %q", out)
+	}
+}
+
+// TestPreWelcomeCheckAnnouncesReleaseOnFirstBoot pina o requisito de
+// imediatismo: sem cache nenhum (primeiro boot após uma release), o check
+// síncrono pré-welcome popula o cache e a PRÓPRIA welcome anuncia a versão
+// nova com o convite completo do /version — linha amarela + comando do canal.
+// Antes, o usuário só descobria no próximo input ou no próximo boot.
+func TestPreWelcomeCheckAnnouncesReleaseOnFirstBoot(t *testing.T) {
+	cli := minimalCLI(t)
+	withUpdateSeams(t, update.MethodHomebrew, "1.5.0", "1.6.0", nil)
+
+	cli.preWelcomeUpdateCheck(context.Background())
+	out := captureStdout(t, func() { cli.PrintWelcomeScreen() })
+
+	if !strings.Contains(out, "1.6.0") || !strings.Contains(out, "/update") {
+		t.Fatalf("welcome deve anunciar a release recém-descoberta, saída: %q", out)
+	}
+	if !strings.Contains(out, "brew upgrade diillson/chatcli/chatcli") {
+		t.Fatalf("welcome deve mostrar o comando do canal de instalação, saída: %q", out)
+	}
+
+	// A welcome anunciou — o fluxo em background não pode repetir no drain.
+	cli.backgroundUpdateFlow(context.Background())
+	if drain := captureStdout(t, cli.drainUpdateNotice); strings.TrimSpace(drain) != "" {
+		t.Fatalf("aviso mid-session seria redundante após o banner, saída: %q", drain)
+	}
+}
+
+// countingFetch instala um contador sobre o seam de fetch de release; o
+// cleanup do withUpdateSeams restaura o original.
+func countingFetch(t *testing.T) *atomic.Int32 {
+	t.Helper()
+	calls := &atomic.Int32{}
+	orig := version.FetchLatestReleaseImpl
+	version.FetchLatestReleaseImpl = func(ctx context.Context) (version.ReleaseInfo, error) {
+		calls.Add(1)
+		return orig(ctx)
+	}
+	return calls
+}
+
+func TestPreWelcomeCheckSkipsNetworkWhenOff(t *testing.T) {
+	cli := minimalCLI(t)
+	withUpdateSeams(t, update.MethodGoInstall, "1.5.0", "1.6.0", nil)
+	t.Setenv("CHATCLI_AUTO_UPDATE", "off")
+	calls := countingFetch(t)
+
+	cli.preWelcomeUpdateCheck(context.Background())
+
+	if calls.Load() != 0 {
+		t.Fatalf("política off não pode custar rede no boot, fetches: %d", calls.Load())
+	}
+}
+
+func TestPreWelcomeCheckFreshCacheSkipsNetwork(t *testing.T) {
+	cli := minimalCLI(t)
+	withUpdateSeams(t, update.MethodGoInstall, "1.5.0", "1.6.0", nil)
+
+	cli.preWelcomeUpdateCheck(context.Background()) // popula o cache
+	calls := countingFetch(t)
+	cli.preWelcomeUpdateCheck(context.Background())
+
+	if calls.Load() != 0 {
+		t.Fatalf("cache fresco dispensa nova consulta no boot, fetches: %d", calls.Load())
 	}
 }
 

--- a/cli/version_view.go
+++ b/cli/version_view.go
@@ -75,14 +75,24 @@ func FormatVersionReport(rep version.Report) string {
 		row(labels[3], colorize("v"+rep.Latest, ColorGray))
 		b.WriteString("\n")
 		if rep.NeedsUpdate {
-			b.WriteString("  " + colorize(i18n.T("welcome.update.available", rep.Latest), ColorYellow) + "\n")
-			if argv := update.CommandFor(info.Method); argv != nil {
-				b.WriteString("    " + colorize(i18n.T("version.card.channel_cmd", strings.Join(argv, " ")), ColorGray) + "\n")
-			}
+			b.WriteString(renderUpdateInvite(rep.Latest))
 			b.WriteString(renderReleaseNotes(rep, anchor))
 		} else {
 			b.WriteString("  " + colorize("✓ "+i18n.T("update.uptodate"), ColorGreen) + "\n")
 		}
+	}
+	return b.String()
+}
+
+// renderUpdateInvite é o convite de atualização compartilhado pelo /version e
+// pela welcome screen: a linha amarela com a versão nova e o /update, mais o
+// comando do canal de instalação detectado — o usuário sabe na hora COMO
+// atualizar, não só que existe versão nova.
+func renderUpdateInvite(latest string) string {
+	var b strings.Builder
+	b.WriteString("  " + colorize(i18n.T("welcome.update.available", latest), ColorYellow) + "\n")
+	if argv := update.CommandFor(detectInstallFn().Method); argv != nil {
+		b.WriteString("    " + colorize(i18n.T("version.card.channel_cmd", strings.Join(argv, " ")), ColorGray) + "\n")
 	}
 	return b.String()
 }

--- a/cli/welcome.go
+++ b/cli/welcome.go
@@ -138,11 +138,14 @@ func (cli *ChatCLI) PrintWelcomeScreen() {
 	}
 	// Primeiro boot após um auto-update em staging: anuncia a versão nova e
 	// consome o registro. Fora disso, cache indicando release mais nova vira
-	// o convite ao /update — suprimido quando a política é off.
+	// o mesmo convite ao /update do card de versão (linha amarela + comando
+	// do canal) — suprimido quando a política é off. O boot garante cache
+	// atual via preWelcomeUpdateCheck, então uma release recém-publicada
+	// aparece já neste banner, não só no próximo input ou boot.
 	if rec, ok := update.ConsumeStagedRecord(current.Version); ok {
 		fmt.Println("  " + colorize(i18n.T("welcome.update.applied", rec.To), ColorLime))
 	} else if rep.NeedsUpdate && update.ResolveMode() != update.ModeOff {
-		fmt.Println("  " + colorize(i18n.T("welcome.update.available", rep.Latest), ColorYellow))
+		fmt.Print(renderUpdateInvite(rep.Latest))
 		cli.markUpdateAnnounced(rep.Latest)
 	}
 	fmt.Println()

--- a/llm/devincli/devincli_client.go
+++ b/llm/devincli/devincli_client.go
@@ -33,6 +33,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -87,9 +88,10 @@ var ansiEscapes = regexp.MustCompile(`\x1b(?:\[[0-9;?]*[a-zA-Z]|\][^\x07\x1b]*(?
 var runMu sync.Mutex
 
 // ResolveBinary locates the Devin CLI: DEVIN_CLI_PATH when set (expanded,
-// must exist), otherwise PATH lookup of the default binary name. The manager
-// gates provider registration on this, so a machine without the CLI simply
-// doesn't list DEVIN — same UX as a provider without credentials.
+// must exist — an explicit path never falls back), otherwise PATH lookup of
+// the default binary name, otherwise a probe of well-known install dirs. The
+// manager gates provider registration on this, so a machine without the CLI
+// simply doesn't list DEVIN — same UX as a provider without credentials.
 func ResolveBinary() (string, error) {
 	if custom := strings.TrimSpace(os.Getenv("DEVIN_CLI_PATH")); custom != "" {
 		expanded, err := utils.ExpandPath(custom)
@@ -109,7 +111,61 @@ func ResolveBinary() (string, error) {
 		}
 		return expanded, nil
 	}
-	return exec.LookPath(config.DevinCLIDefaultBinary)
+	found, lookErr := exec.LookPath(config.DevinCLIDefaultBinary)
+	if lookErr == nil {
+		return found, nil
+	}
+	if probed, ok := probeKnownDirs(config.DevinCLIDefaultBinary, knownInstallDirs()); ok {
+		return probed, nil
+	}
+	return "", lookErr
+}
+
+// knownInstallDirs lists the well-known install locations probed when the
+// PATH lookup misses. The ACP/MCP servers are spawned by IDEs and other GUI
+// hosts that inherit the minimal session PATH (on macOS, launchd's
+// /usr/bin:/bin:…) instead of the user's shell profile, so a devin installed
+// via Homebrew or npm is visible in the terminal REPL but not to the server —
+// probing the standard install dirs keeps the provider available in both
+// without per-IDE env plumbing. Variable so tests can substitute the dirs.
+var knownInstallDirs = func() []string {
+	if runtime.GOOS == "windows" {
+		var dirs []string
+		if lad := os.Getenv("LOCALAPPDATA"); lad != "" {
+			dirs = append(dirs, filepath.Join(lad, "Programs", "devin"))
+		}
+		if ad := os.Getenv("APPDATA"); ad != "" {
+			dirs = append(dirs, filepath.Join(ad, "npm"))
+		}
+		if home, err := os.UserHomeDir(); err == nil {
+			dirs = append(dirs, filepath.Join(home, "scoop", "shims"))
+		}
+		return dirs
+	}
+	var dirs []string
+	if home, err := os.UserHomeDir(); err == nil {
+		dirs = append(dirs,
+			filepath.Join(home, ".local", "bin"),
+			filepath.Join(home, "bin"),
+			filepath.Join(home, ".devin", "bin"),
+		)
+	}
+	return append(dirs, "/opt/homebrew/bin", "/usr/local/bin", "/home/linuxbrew/.linuxbrew/bin")
+}
+
+// probeKnownDirs returns the first dir whose entry resolves to an executable.
+// exec.LookPath on a path containing a separator validates that exact file
+// (applying PATHEXT on Windows), so the same probe works on every platform.
+func probeKnownDirs(name string, dirs []string) (string, bool) {
+	for _, dir := range dirs {
+		if dir == "" {
+			continue
+		}
+		if p, err := exec.LookPath(filepath.Join(dir, name)); err == nil {
+			return p, true
+		}
+	}
+	return "", false
 }
 
 // Client implements client.LLMClient over the local Devin CLI subprocess.

--- a/llm/devincli/devincli_client_test.go
+++ b/llm/devincli/devincli_client_test.go
@@ -164,6 +164,50 @@ func TestResolveBinary_EnvOverrideAndMissing(t *testing.T) {
 	require.Error(t, err, "an explicit DEVIN_CLI_PATH that doesn't exist must fail loudly, not fall back")
 }
 
+// swapKnownInstallDirs substitutes the probe list for one test. Not parallel-
+// safe, matching the t.Setenv-based tests around it.
+func swapKnownInstallDirs(t *testing.T, dirs []string) {
+	t.Helper()
+	orig := knownInstallDirs
+	knownInstallDirs = func() []string { return dirs }
+	t.Cleanup(func() { knownInstallDirs = orig })
+}
+
+// TestResolveBinary_FallsBackToKnownInstallDirs pins the ACP/MCP scenario:
+// the server inherits the minimal GUI-session PATH (no Homebrew/npm dirs), so
+// the PATH lookup misses even though the CLI is installed — the well-known
+// install dirs probe must still resolve it.
+func TestResolveBinary_FallsBackToKnownInstallDirs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix-only fake binary")
+	}
+	bin := fakeDevin(t, `echo ok`)
+	t.Setenv("DEVIN_CLI_PATH", "")
+	t.Setenv("PATH", t.TempDir())
+	swapKnownInstallDirs(t, []string{"", filepath.Dir(bin)})
+
+	got, err := ResolveBinary()
+	require.NoError(t, err)
+	assert.Equal(t, bin, got)
+}
+
+// TestResolveBinary_MissingEverywhere pins that a non-executable file in a
+// known dir does not resolve and the original PATH lookup error surfaces.
+func TestResolveBinary_MissingEverywhere(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix permission bits")
+	}
+	nonexec := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(nonexec, "devin"), []byte("data"), 0o600))
+	t.Setenv("DEVIN_CLI_PATH", "")
+	t.Setenv("PATH", t.TempDir())
+	swapKnownInstallDirs(t, []string{nonexec, filepath.Join(t.TempDir(), "absent")})
+
+	_, err := ResolveBinary()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "PATH", "the PATH lookup error must surface, not a probe artifact")
+}
+
 func TestExtractReply_TakesLastSentinelPair(t *testing.T) {
 	raw := "noise " + replyBegin + " first " + replyEnd + " middle " + replyBegin + "\nfinal answer\n" + replyEnd + " tail"
 	assert.Equal(t, "final answer", extractReply(raw))

--- a/llm/manager/llm_manager.go
+++ b/llm/manager/llm_manager.go
@@ -737,7 +737,10 @@ func (m *LLMManagerImpl) configurarOpenRouterClient(maxRetries int, initialBacko
 func (m *LLMManagerImpl) configurarDevinCLIClient(maxRetries int, initialBackoff time.Duration) {
 	binPath, err := devincli.ResolveBinary()
 	if err != nil {
-		m.logger.Info(i18n.T("llm.devincli.not_available"), zap.Error(err))
+		// Warn, não Info: em servidores ACP/MCP spawnados por IDE o PATH é o
+		// mínimo da sessão GUI e este é o único diagnóstico do sumiço do
+		// provider — precisa aparecer no app.log em nível padrão.
+		m.logger.Warn(i18n.T("llm.devincli.not_available"), zap.Error(err))
 		return
 	}
 	m.logger.Info(i18n.T("llm.info.configuring_provider", "Devin CLI"), zap.String("bin", binPath))
@@ -881,7 +884,8 @@ func (m *LLMManagerImpl) GetStackSpotAgentID() string {
 }
 
 // RefreshProviders re-checks auth credentials and registers/updates providers.
-// Called after an OAuth login or token refresh at runtime.
+// Called after an OAuth login or token refresh at runtime, and after env
+// reloads that may change provider availability.
 // Closes the cached TokenProviders so the next call resolves from the fresh
 // store contents and starts a new background refresh goroutine.
 func (m *LLMManagerImpl) RefreshProviders() {
@@ -902,6 +906,11 @@ func (m *LLMManagerImpl) RefreshProviders() {
 	m.configurarMiniMaxClient(maxRetries, initialBackoff)
 	m.configurarMoonshotClient(maxRetries, initialBackoff)
 	m.configurarOpenRouterClient(maxRetries, initialBackoff)
+
+	// Binary-gated provider: re-probe so a runtime env fix (DEVIN_CLI_PATH is
+	// reloadable) surfaces DEVIN without a restart. Like the OAuth set above,
+	// a failed probe preserves an existing registration.
+	m.configurarDevinCLIClient(maxRetries, initialBackoff)
 }
 
 // CreateClientWithKey creates an LLM client using a caller-provided API key

--- a/llm/manager/llm_manager_create_test.go
+++ b/llm/manager/llm_manager_create_test.go
@@ -205,3 +205,46 @@ func TestDevinCLIProvider_AbsentBinary(t *testing.T) {
 		}
 	}
 }
+
+// TestDevinCLIProvider_RefreshRecoversAfterEnvFix pins the runtime recovery
+// path: a manager booted without the devin binary (e.g. an ACP/MCP server
+// spawned with the minimal GUI PATH) must list DEVIN after the env is fixed
+// and RefreshProviders re-probes — no restart required.
+func TestDevinCLIProvider_RefreshRecoversAfterEnvFix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("script-based fake devin binary is unix-only")
+	}
+	i18n.Init()
+	setupTestEnv(t, map[string]string{
+		"DEVIN_CLI_PATH": filepath.Join(t.TempDir(), "missing"),
+	})
+	logger, _ := zap.NewDevelopment()
+	mgr, err := NewLLMManager(logger)
+	if err != nil {
+		t.Fatalf("NewLLMManager: %v", err)
+	}
+	impl := mgr.(*LLMManagerImpl)
+	defer impl.Close()
+	for _, p := range impl.GetAvailableProviders() {
+		if p == "DEVIN" {
+			t.Fatal("DEVIN must not be listed before the env fix")
+		}
+	}
+
+	fake := filepath.Join(t.TempDir(), "devin")
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\necho ok\n"), 0o700); err != nil {
+		t.Fatalf("write fake devin: %v", err)
+	}
+	t.Setenv("DEVIN_CLI_PATH", fake)
+	impl.RefreshProviders()
+
+	found := false
+	for _, p := range impl.GetAvailableProviders() {
+		if p == "DEVIN" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("DEVIN must be listed after RefreshProviders re-probes, got %v", impl.GetAvailableProviders())
+	}
+}


### PR DESCRIPTION
## Summary

Two related availability fixes: the DEVIN provider vanishing from IDE-spawned ACP/MCP servers, and the update notice the user never saw at boot.

### DEVIN provider missing on ACP/MCP servers

IDEs spawn the ACP/MCP servers with the minimal GUI-session PATH (on macOS, launchd's `/usr/bin:/bin:…`), so `exec.LookPath("devin")` missed a CLI installed via Homebrew or npm and the provider silently never registered — while the terminal REPL, with the full shell PATH, listed it fine.

- `ResolveBinary` now probes well-known install directories when the PATH lookup misses (`~/.local/bin`, `~/bin`, `~/.devin/bin`, `/opt/homebrew/bin`, `/usr/local/bin`, linuxbrew; Windows: `LOCALAPPDATA\Programs\devin`, `APPDATA\npm`, scoop shims). An explicit `DEVIN_CLI_PATH` still never falls back.
- `RefreshProviders` re-probes the binary, so fixing the env at runtime recovers the provider without a restart.
- The unavailability log is now warn-level so the app.log explains the absence.

Verified end-to-end: `mcp-server` under `PATH=/usr/bin:/bin` — the main binary omits DEVIN from `list_providers`, this branch lists it.

### Update notice at boot

The welcome banner only showed the update invite when a previous `/version`//`/update` run had populated the release cache — the background refresh landed after the banner printed, so on the first boot after a release the user learned about it one input or one boot later, or never.

- The boot now gives the release-cache refresh a short synchronous budget (1.5s) before printing the welcome screen, so the banner itself announces a freshly published release. Fresh cache (≤1 query/day) costs nothing; off/disabled modes skip the network; on timeout the existing background flow still queues the mid-session notice.
- The welcome invite now shares the `/version` renderer: the yellow line plus the detected install-channel command, so the user immediately knows how to update.

## Tests

- `devincli`: fallback resolves from a known dir when PATH misses; non-executable files don't resolve; explicit `DEVIN_CLI_PATH` never falls back.
- `manager`: `RefreshProviders` recovers DEVIN after a runtime env fix.
- `cli`: first boot with no cache announces the release on the banner with the channel command; off mode costs no network at boot; fresh cache skips the fetch; background flow doesn't duplicate the banner announcement.
- Full suite green on both modules; `gofmt`/`go vet` clean.