### PR TITLE
fix(agent): resolve model inherit hint to the session model in squad dispatch

### DIFF
--- a/cli/agent/workers/agents_custom.go
+++ b/cli/agent/workers/agents_custom.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/diillson/chatcli/llm/client"
 	"github.com/diillson/chatcli/pkg/coder/engine"
 	"github.com/diillson/chatcli/pkg/persona"
 )
@@ -68,6 +69,15 @@ func NewCustomAgent(pa *persona.Agent, personaSkills []*persona.Skill) *CustomAg
 	systemPrompt := buildCustomSystemPrompt(pa, personaSkills, commands, readOnly)
 	skillSet := buildCustomSkillSet(personaSkills)
 
+	// Claude Code-style `model: inherit` means "use the session's active
+	// model" — normalize it to the empty-string inherit contract so the
+	// hint never reaches the model router or the orchestrator's agent
+	// catalog as a literal model id.
+	modelHint := strings.TrimSpace(pa.Model)
+	if client.IsInheritHint(modelHint) {
+		modelHint = ""
+	}
+
 	return &CustomAgent{
 		agentType:    AgentType(strings.ToLower(pa.Name)),
 		name:         pa.Name,
@@ -76,7 +86,7 @@ func NewCustomAgent(pa *persona.Agent, personaSkills []*persona.Skill) *CustomAg
 		commands:     commands,
 		readOnly:     readOnly,
 		skills:       skillSet,
-		modelHint:    strings.TrimSpace(pa.Model),
+		modelHint:    modelHint,
 		effortHint:   strings.ToLower(strings.TrimSpace(pa.Effort)),
 	}
 }

--- a/cli/agent/workers/agents_custom_test.go
+++ b/cli/agent/workers/agents_custom_test.go
@@ -348,3 +348,31 @@ func TestSortedKeys_Empty(t *testing.T) {
 		t.Errorf("expected empty keys, got %v", keys)
 	}
 }
+
+// TestCustomAgent_InheritModelHint verifies that the Claude Code-style
+// `model: inherit` frontmatter normalizes to the empty-string inherit
+// contract, so the hint never reaches the model router or the
+// orchestrator's agent catalog as a literal model id.
+func TestCustomAgent_InheritModelHint(t *testing.T) {
+	pa := &persona.Agent{
+		Name:  "database-architect",
+		Tools: persona.StringList{"Read"},
+		Model: "inherit",
+	}
+	if got := NewCustomAgent(pa, nil).Model(); got != "" {
+		t.Errorf("model: inherit must normalize to empty, got %q", got)
+	}
+}
+
+// TestCustomAgent_ExplicitModelHintKept guards the inverse: a real model id
+// in frontmatter must survive normalization untouched.
+func TestCustomAgent_ExplicitModelHintKept(t *testing.T) {
+	pa := &persona.Agent{
+		Name:  "reviewer",
+		Tools: persona.StringList{"Read"},
+		Model: " claude-opus-5 ",
+	}
+	if got := NewCustomAgent(pa, nil).Model(); got != "claude-opus-5" {
+		t.Errorf("explicit model hint must be kept trimmed, got %q", got)
+	}
+}

--- a/llm/client/model_router.go
+++ b/llm/client/model_router.go
@@ -58,7 +58,7 @@ type ModelRoutingResolution struct {
 
 	// Note is a short machine-readable tag describing the branch taken.
 	//
-	//   ""                        — no hint / hint == user model
+	//   ""                        — no hint / hint == user model / "inherit"
 	//   "explicit-provider"       — hint carried a "PROVIDER:model" prefix
 	//   "api-cached"              — matched user provider's API cache
 	//   "catalog-same-provider"   — catalog hit on user's provider
@@ -93,6 +93,16 @@ type ResolveModelRoutingInput struct {
 	Logger *zap.Logger
 }
 
+// IsInheritHint reports whether a `model:` frontmatter value is the
+// Claude Code-style explicit "inherit" marker. Agent/skill definitions
+// written for Claude Code declare `model: inherit` to mean "use the
+// session's active model" — the value is a routing directive, never a
+// model id, so it must resolve to the no-hint fallback instead of being
+// sent to a provider API as a literal model name.
+func IsInheritHint(hint string) bool {
+	return strings.EqualFold(strings.TrimSpace(hint), "inherit")
+}
+
 // ResolveModelRouting runs the resolution pipeline. See file header for
 // the branch order and contracts.
 func ResolveModelRouting(in ResolveModelRoutingInput) ModelRoutingResolution {
@@ -109,7 +119,7 @@ func ResolveModelRouting(in ResolveModelRoutingInput) ModelRoutingResolution {
 	}
 
 	hint := strings.TrimSpace(in.Hint)
-	if hint == "" {
+	if hint == "" || IsInheritHint(hint) {
 		return fallback
 	}
 	if strings.EqualFold(hint, in.UserModel) {

--- a/llm/client/model_router_test.go
+++ b/llm/client/model_router_test.go
@@ -179,3 +179,52 @@ func TestResolveModelRoutingQualifiedHint(t *testing.T) {
 		}
 	})
 }
+
+// TestIsInheritHint pins the recognizer for the Claude Code-style
+// `model: inherit` frontmatter marker.
+func TestIsInheritHint(t *testing.T) {
+	for hint, want := range map[string]bool{
+		"inherit":         true,
+		"Inherit":         true,
+		" INHERIT ":       true,
+		"":                false,
+		"inherited":       false,
+		"claude-sonnet-5": false,
+	} {
+		if got := IsInheritHint(hint); got != want {
+			t.Errorf("IsInheritHint(%q) = %v, want %v", hint, got, want)
+		}
+	}
+}
+
+// TestResolveModelRoutingInheritHint pins `model: inherit` to the no-hint
+// fallback. Before this guard the literal string reached the optimistic
+// branch and was sent to the provider API as a model id, failing every
+// squad dispatch with "not_found_error: model: inherit".
+func TestResolveModelRoutingInheritHint(t *testing.T) {
+	for _, hint := range []string{"inherit", "Inherit", " INHERIT "} {
+		t.Run(hint, func(t *testing.T) {
+			router := &fakeRouter{available: []string{"CLAUDEAI"}}
+			user := &MockLLMClient{}
+			r := ResolveModelRouting(ResolveModelRoutingInput{
+				Router:       router,
+				UserProvider: "CLAUDEAI",
+				UserModel:    "claude-sonnet-5",
+				UserClient:   user,
+				Hint:         hint,
+			})
+			if r.Changed {
+				t.Fatalf("Hint=%q must be a no-op, got Changed=true Note=%q Model=%q", hint, r.Note, r.Model)
+			}
+			if r.Client != user || r.Provider != "CLAUDEAI" || r.Model != "claude-sonnet-5" {
+				t.Errorf("fallback must keep the user client/provider/model, got %s/%s", r.Provider, r.Model)
+			}
+			if r.UserMessage != "" {
+				t.Errorf("inherit is not a failure — UserMessage must stay empty, got %q", r.UserMessage)
+			}
+			if len(router.calls) != 0 {
+				t.Errorf("no client must be built for an inherit hint, got %v", router.calls)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Custom squad agents written in the Claude Code frontmatter format (`~/.chatcli/agents/*.md`) declare `model: inherit` to mean *use the session's active model*. The dispatcher passed the literal string to `ResolveModelRouting`, whose optimistic branch built a client with `model=inherit` — every dispatch to a specialized custom agent failed with:

```
API error: status 404 - {"type":"not_found_error","message":"model: inherit"}
```

The orchestrator then rerouted all work to built-in agents, defeating the specialists.

## Fix

- `client.IsInheritHint` recognizes the marker; `ResolveModelRouting` returns the no-hint fallback for it. This chokepoint also covers skills `model:` frontmatter, the `@model` tool and `CHATCLI_AGENT_<NAME>_MODEL=inherit`.
- `NewCustomAgent` normalizes the hint to `""` (the interface-wide inherit contract), so the orchestrator's agent catalog never advertises `model=inherit` as an LLM profile.

## Validation

- Red→green: new tests fail on main (`Model()` returns `"inherit"`), pass with the fix
- `go build ./...`, `go vet`, full `go test ./...` green