### PR TITLE
feat(agent): live type-ahead preview while the coder spinner runs

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -125,6 +125,16 @@ type AgentMode struct {
 	// executions. Defaults to routing through the command handler.
 	sideCmdExec func(string)
 
+	// Live type-ahead preview: the partial line typed since the last
+	// Enter, published by the reader goroutine and rendered by the spinner
+	// and the dispatch panel. Only populated while the TTY is in cbreak
+	// mode (Unix); empty on Windows and non-TTY runs.
+	typeaheadMu   sync.Mutex
+	typeaheadLine string
+	// stdinCbreakRestore undoes the cbreak TTY state applied when the
+	// reader spawned. Guarded by stdinMu.
+	stdinCbreakRestore func()
+
 	// lastBoardNudge dedups the [BOARD SYNC] reconciliation block: the
 	// model gets one nudge per distinct stale-board state, not one per
 	// turn. Reset at Run() start.
@@ -200,6 +210,18 @@ func splitStdinChunk(chunk []byte, lineBuf *strings.Builder) []string {
 	var lines []string
 	for i := 0; i < len(chunk); i++ {
 		b := chunk[i]
+		if b == 0x08 || b == 0x7f {
+			// Backspace/DEL: in cbreak mode the kernel no longer edits the
+			// line for us, so the reader must — drop the last rune of the
+			// pending partial (rune-safe: multi-byte UTF-8 input is normal
+			// in pt-BR). Without this, "abc<BS>d" would submit "abc\x7fd".
+			if s := lineBuf.String(); s != "" {
+				_, size := utf8.DecodeLastRuneInString(s)
+				lineBuf.Reset()
+				lineBuf.WriteString(s[:len(s)-size])
+			}
+			continue
+		}
 		if b != '\n' && b != '\r' {
 			lineBuf.WriteByte(b)
 			continue
@@ -241,6 +263,10 @@ func (a *AgentMode) spawnStdinReaderLocked(ctx context.Context) {
 	a.stdinLines = make(chan string, 10)
 	a.stdinDone = make(chan struct{})
 	a.stdinCancel = newStdinReadCanceler()
+	// Own the line editing while the loop runs: without cbreak the kernel
+	// echoes typed characters on top of the spinner (where the repaint
+	// eats them) and only delivers the line on Enter.
+	a.stdinCbreakRestore = enableStdinCbreak()
 	a.stdinWg.Add(1)
 
 	// The goroutine works on local copies of the lifecycle values: after a
@@ -280,6 +306,7 @@ func (a *AgentMode) spawnStdinReaderLocked(ctx context.Context) {
 			}
 
 			lines := splitStdinChunk(buf[:n], &lineBuf)
+			a.setTypeaheadPreview(lineBuf.String())
 			for _, rawLine := range lines {
 				// Detect and clean paste content
 				cleaned, pasteInfo := paste.DetectInLine(rawLine)
@@ -365,6 +392,11 @@ func (a *AgentMode) teardownStdinReaderLocked() {
 		a.stdinLines = nil
 		a.stdinDone = nil
 	}
+	if a.stdinCbreakRestore != nil {
+		a.stdinCbreakRestore()
+		a.stdinCbreakRestore = nil
+	}
+	a.setTypeaheadPreview("")
 }
 
 // suspendStdinReader fully releases the stdin fd regardless of the refcount
@@ -429,6 +461,22 @@ func (a *AgentMode) withInteractiveStdin(ctx context.Context, fn func() error) e
 	}
 	a.resumeStdinReader(ctx)
 	return err
+}
+
+// reapplyStdinCbreak re-arms the cbreak TTY state after an interactive
+// consumer (security prompt, command-block menu) deliberately restored
+// cooked mode via stty sane. Cheap (one stty exec) and idempotent; no-op
+// when no reader is active.
+func (a *AgentMode) reapplyStdinCbreak() {
+	a.stdinMu.Lock()
+	defer a.stdinMu.Unlock()
+	if a.stdinLines == nil {
+		return
+	}
+	if a.stdinCbreakRestore != nil {
+		a.stdinCbreakRestore()
+	}
+	a.stdinCbreakRestore = enableStdinCbreak()
 }
 
 // handleAgentAsk drives the @ask / ask_user tool: it parses the question spec,
@@ -781,7 +829,11 @@ func (a *AgentMode) getInput(promptStr string) string {
 	fmt.Print(promptStr)
 
 	// Use centralized stdin reader (paste detection already handled there)
-	return a.readLine()
+	line := a.readLine()
+	// This helper forced cooked mode above for readable menu input; re-arm
+	// cbreak so the live type-ahead preview keeps working afterwards.
+	a.reapplyStdinCbreak()
+	return line
 }
 
 // clientAndCtxForTurn resolves the LLM client and context for a single ReAct
@@ -1766,6 +1818,11 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 		// recipient's inbox drain this same turn.
 		a.applySideCommands(ctx)
 
+		// Interactive consumers (security prompts, menus) restore cooked
+		// mode for themselves; re-arm cbreak each turn so the live
+		// type-ahead preview self-heals.
+		a.reapplyStdinCbreak()
+
 		// Mechanical board reconciliation: cards in doing whose linked runs
 		// all finished get a [BOARD SYNC] block so the orchestrator moves
 		// them THIS turn (prompt discipline alone reliably decays over a
@@ -1937,7 +1994,10 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 			if queued > 0 {
 				msg = "Processando... " + i18n.T("agent.queue.indicator", queued)
 			}
-			fmt.Print(metrics.FormatTimerStatus(d, modelName, msg))
+			// Live type-ahead: show what the user is typing right now so
+			// they never type blind under the spinner. \033[K clears
+			// leftovers when the preview shrinks (backspace).
+			fmt.Print(metrics.FormatTimerStatus(d, modelName, msg) + formatTypeaheadPreviewInline(a.typeaheadPreviewSnapshot(), 40) + "\033[K")
 		})
 
 		// Validate/repair tool result pairing on the PERSISTENT history —
@@ -2605,6 +2665,9 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 						progressState.SetLive(ac.ID, info.Turn, info.MaxTurns, info.Action, subLines)
 					}
 					output := metrics.FormatDispatchProgress(progressState, modelName)
+					if previewLine := formatTypeaheadPreviewLine(a.typeaheadPreviewSnapshot()); previewLine != "" {
+						output += previewLine + "\n"
+					}
 					fmt.Print(output)
 					// Count rendered lines directly — sub-lines make the
 					// panel height dynamic between ticks.
@@ -2617,6 +2680,7 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 				if a.policyAdapter != nil {
 					a.policyAdapter.setSpinner(a.turnTimer)
 					a.policyAdapter.setStdinCh(a.stdinLines)
+					a.policyAdapter.setRestoreInput(a.reapplyStdinCbreak)
 				}
 				agentResults := a.agentDispatcher.DispatchWithProgress(ctx, agentCalls, progressCh)
 				a.turnTimer.Stop()
@@ -2780,6 +2844,10 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 								zap.String("tool", tc.Name))
 						} else if action == coder.ActionAsk {
 							decision := coder.PromptSecurityCheckGuarded(ctx, tc.Name, tc.Args, a.stdinLines)
+							// The prompt forced cooked mode (stty sane); re-arm
+							// cbreak so live type-ahead survives the rest of
+							// the turn instead of degrading until the boundary.
+							a.reapplyStdinCbreak()
 							pattern := coder.GetSuggestedPattern(tc.Name, tc.Args)
 							switch decision {
 							case coder.DecisionAllowAlways:

--- a/cli/agent_typeahead.go
+++ b/cli/agent_typeahead.go
@@ -1,0 +1,104 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+/*
+ * agent_typeahead — live preview of the line being typed while the agent
+ * loop owns the terminal.
+ *
+ * With the TTY in cbreak mode (see stdin_cbreak_unix.go) the centralized
+ * reader receives bytes as they are typed; the residual partial line is
+ * published here and the spinner / dispatch panel renders it as a `❯ …▌`
+ * input line, so the user finally SEES what they are typing mid-run
+ * instead of the kernel echo being eaten by the repaint.
+ */
+package cli
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// setTypeaheadPreview publishes the current partial input line (what has
+// been typed since the last Enter). Called from the reader goroutine.
+func (a *AgentMode) setTypeaheadPreview(s string) {
+	a.typeaheadMu.Lock()
+	a.typeaheadLine = s
+	a.typeaheadMu.Unlock()
+}
+
+// typeaheadPreviewSnapshot returns the current partial input line.
+func (a *AgentMode) typeaheadPreviewSnapshot() string {
+	a.typeaheadMu.Lock()
+	defer a.typeaheadMu.Unlock()
+	return a.typeaheadLine
+}
+
+// typeaheadPreviewTailWidth bounds how much of the in-flight line the
+// display shows; when longer, the TAIL is shown (the user cares about the
+// characters around the cursor, not the start of a long instruction).
+const typeaheadPreviewTailWidth = 70
+
+// formatTypeaheadPreviewLine renders the input line appended under the
+// dispatch panel. Empty preview renders nothing. Control bytes (escape
+// sequences from arrow keys, etc.) are stripped from the DISPLAY only —
+// the submitted line is untouched, same contract as before.
+func formatTypeaheadPreviewLine(preview string) string {
+	text := sanitizeTypeaheadPreview(preview)
+	if text == "" {
+		return ""
+	}
+	if n := utf8.RuneCountInString(text); n > typeaheadPreviewTailWidth {
+		runes := []rune(text)
+		text = "…" + string(runes[n-typeaheadPreviewTailWidth:])
+	}
+	// \033[K clears repaint leftovers when the line shrinks (backspace).
+	return "  " + ColorCyan + "❯ " + text + "▌" + ColorReset + "\033[K"
+}
+
+// formatTypeaheadPreviewInline renders a compact suffix for the
+// single-line turn spinner.
+func formatTypeaheadPreviewInline(preview string, width int) string {
+	text := sanitizeTypeaheadPreview(preview)
+	if text == "" {
+		return ""
+	}
+	if n := utf8.RuneCountInString(text); n > width {
+		runes := []rune(text)
+		text = "…" + string(runes[n-width:])
+	}
+	return " " + ColorCyan + "❯ " + text + "▌" + ColorReset
+}
+
+// sanitizeTypeaheadPreview drops control bytes AND whole escape sequences
+// (arrow keys arrive as CSI like "\x1b[A" — stripping only the ESC would
+// leave a stray "[A" in the preview) so stray input never corrupts the
+// panel rendering. Display-only: the submitted line is untouched.
+func sanitizeTypeaheadPreview(s string) string {
+	var b strings.Builder
+	runes := []rune(s)
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
+		if r == 0x1b {
+			if i+1 < len(runes) && runes[i+1] == '[' {
+				// CSI: skip parameters until the final byte (@ through ~).
+				i++
+				for i+1 < len(runes) {
+					i++
+					if runes[i] >= 0x40 && runes[i] <= 0x7e {
+						break
+					}
+				}
+			} else if i+1 < len(runes) {
+				i++ // two-byte escape (ESC + one char)
+			}
+			continue
+		}
+		if r >= 0x20 && r != 0x7f {
+			b.WriteRune(r)
+		}
+	}
+	return strings.TrimLeft(b.String(), " ")
+}

--- a/cli/agent_typeahead_test.go
+++ b/cli/agent_typeahead_test.go
@@ -1,0 +1,88 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSplitStdinChunkBackspace pins the cbreak-mode line editing: without
+// kernel canonical processing the reader must apply backspace itself,
+// rune-safe for multi-byte input.
+func TestSplitStdinChunkBackspace(t *testing.T) {
+	var buf strings.Builder
+	lines := splitStdinChunk([]byte("abd\x7fc\n"), &buf)
+	if len(lines) != 1 || lines[0] != "abc\n" {
+		t.Errorf("DEL must erase the previous byte: got %q", lines)
+	}
+
+	buf.Reset()
+	lines = splitStdinChunk([]byte("olá\x7f\x7fi\n"), &buf)
+	if len(lines) != 1 || lines[0] != "oi\n" {
+		t.Errorf("backspace must be rune-safe over UTF-8: got %q", lines)
+	}
+
+	buf.Reset()
+	lines = splitStdinChunk([]byte("\x7f\x08x\n"), &buf)
+	if len(lines) != 1 || lines[0] != "x\n" {
+		t.Errorf("backspace on an empty buffer must be a no-op: got %q", lines)
+	}
+
+	// Partial chunk keeps the edited residue for the preview.
+	buf.Reset()
+	if got := splitStdinChunk([]byte("/boarf\x7fd"), &buf); len(got) != 0 {
+		t.Fatalf("no newline, no lines: got %q", got)
+	}
+	if buf.String() != "/board" {
+		t.Errorf("residual partial must reflect backspace edits, got %q", buf.String())
+	}
+}
+
+// TestFormatTypeaheadPreview pins the display contract: tail-biased
+// truncation, control-byte stripping and empty-input silence.
+func TestFormatTypeaheadPreview(t *testing.T) {
+	if formatTypeaheadPreviewLine("") != "" {
+		t.Error("empty preview must render nothing")
+	}
+	if formatTypeaheadPreviewLine("\x1b[A\x1b[B") != "" {
+		t.Error("control-only preview must render nothing")
+	}
+
+	line := formatTypeaheadPreviewLine("/mail send coder foca no login")
+	if !strings.Contains(line, "❯ /mail send coder foca no login▌") {
+		t.Errorf("preview must show the typed text with prompt and cursor: %q", line)
+	}
+	if !strings.Contains(line, "\033[K") {
+		t.Error("preview must clear to end of line so backspace never leaves residue")
+	}
+
+	long := strings.Repeat("a", 100) + "FIM"
+	tail := formatTypeaheadPreviewLine(long)
+	if !strings.Contains(tail, "…") || !strings.Contains(tail, "FIM▌") {
+		t.Errorf("long input must show the tail with ellipsis: %q", tail)
+	}
+
+	inline := formatTypeaheadPreviewInline("hello", 40)
+	if !strings.Contains(inline, "❯ hello▌") {
+		t.Errorf("inline preview must render prompt+cursor: %q", inline)
+	}
+	if formatTypeaheadPreviewInline("", 40) != "" {
+		t.Error("empty inline preview must render nothing")
+	}
+}
+
+// TestTypeaheadPreviewSnapshot pins the reader→display handoff.
+func TestTypeaheadPreviewSnapshot(t *testing.T) {
+	a := &AgentMode{}
+	if a.typeaheadPreviewSnapshot() != "" {
+		t.Error("zero value must be empty")
+	}
+	a.setTypeaheadPreview("/agents")
+	if got := a.typeaheadPreviewSnapshot(); got != "/agents" {
+		t.Errorf("snapshot = %q", got)
+	}
+}

--- a/cli/policy_adapter.go
+++ b/cli/policy_adapter.go
@@ -38,6 +38,11 @@ type workerPolicyAdapter struct {
 	// forever, so "ask" auto-approves (the operator opted into full autonomy;
 	// access is gated at the messaging edge). ActionDeny still blocks.
 	unattended bool
+
+	// restoreInput, when set, runs after each interactive prompt so the
+	// agent loop can re-arm its cbreak type-ahead TTY state (the prompt
+	// forces cooked mode to render/read cleanly).
+	restoreInput func()
 }
 
 // newWorkerPolicyAdapter creates a PolicyChecker backed by coder.PolicyManager.
@@ -56,6 +61,15 @@ func (a *workerPolicyAdapter) setSpinner(t *metrics.Timer) {
 }
 
 // setStdinCh sets the centralized stdin channel for security prompts.
+// setRestoreInput registers a callback invoked after each interactive
+// prompt finishes (the prompt forces cooked mode; the agent loop re-arms
+// its cbreak type-ahead state through this hook).
+func (a *workerPolicyAdapter) setRestoreInput(fn func()) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.restoreInput = fn
+}
+
 func (a *workerPolicyAdapter) setStdinCh(ch <-chan string) {
 	a.stdinCh = ch
 }
@@ -149,6 +163,9 @@ func (a *workerPolicyAdapter) CheckAndPrompt(ctx context.Context, toolName, args
 		// Clear the prompt area and resume spinner
 		fmt.Print(metrics.ClearLine())
 		a.resumeSpinner()
+		if a.restoreInput != nil {
+			a.restoreInput()
+		}
 
 		switch decision {
 		case coder.DecisionAllowAlways:

--- a/cli/stdin_cbreak_test.go
+++ b/cli/stdin_cbreak_test.go
@@ -1,0 +1,105 @@
+//go:build !windows
+
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"os"
+	"testing"
+)
+
+// TestEnableStdinCbreakNonTTY pins the safety guard: without a terminal
+// (tests, pipes, gateway daemon) the helper is a no-op returning a callable
+// restore func — never nil, never touching the process TTY state.
+func TestEnableStdinCbreakNonTTY(t *testing.T) {
+	// go test runs with stdin on /dev/null or a pipe — not a TTY.
+	restore := enableStdinCbreak()
+	if restore == nil {
+		t.Fatal("restore func must never be nil")
+	}
+	restore() // must be safely callable
+}
+
+// TestSttyHelpersOnNonTTY pins the error path: stty against a non-tty fd
+// fails without panicking, which is what lets enableStdinCbreak degrade to
+// a no-op on exotic stdin setups.
+func TestSttyHelpersOnNonTTY(t *testing.T) {
+	devnull, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("open devnull: %v", err)
+	}
+	defer func() { _ = devnull.Close() }()
+
+	if out, err := sttyOutput(devnull, "-g"); err == nil && out != "" {
+		t.Logf("stty -g unexpectedly succeeded on %s (platform quirk): %q", os.DevNull, out)
+	}
+	_ = sttyRun(devnull, "sane") // must not panic; error is expected and ignored
+}
+
+// TestReapplyStdinCbreak pins the re-arm lifecycle: no-op without an active
+// reader; with one, the previous restore runs before a fresh state is
+// captured.
+func TestReapplyStdinCbreak(t *testing.T) {
+	a := &AgentMode{}
+	a.reapplyStdinCbreak() // no reader — must be a silent no-op
+	if a.stdinCbreakRestore != nil {
+		t.Fatal("reapply without a reader must not arm cbreak")
+	}
+
+	restored := 0
+	a.stdinMu.Lock()
+	a.stdinLines = make(chan string, 1)
+	a.stdinCbreakRestore = func() { restored++ }
+	a.stdinMu.Unlock()
+
+	a.reapplyStdinCbreak()
+	if restored != 1 {
+		t.Fatalf("reapply must run the previous restore exactly once, got %d", restored)
+	}
+	if a.stdinCbreakRestore == nil {
+		t.Fatal("reapply must arm a fresh restore func")
+	}
+}
+
+// TestTeardownRestoresCbreak pins that tearing the reader down runs the
+// cbreak restore and clears the live preview.
+func TestTeardownRestoresCbreak(t *testing.T) {
+	a := &AgentMode{}
+	restored := false
+	a.stdinMu.Lock()
+	a.stdinDepth = 1
+	a.stdinLines = make(chan string, 1)
+	a.stdinDone = make(chan struct{})
+	a.stdinCbreakRestore = func() { restored = true }
+	a.stdinMu.Unlock()
+	a.setTypeaheadPreview("meio digitado")
+
+	a.stopStdinReader()
+	if !restored {
+		t.Fatal("teardown must run the cbreak restore")
+	}
+	if a.stdinCbreakRestore != nil {
+		t.Fatal("teardown must clear the restore func")
+	}
+	if a.typeaheadPreviewSnapshot() != "" {
+		t.Fatal("teardown must clear the live preview")
+	}
+}
+
+// TestPolicyAdapterRestoreInputHook pins the worker-prompt hook wiring.
+func TestPolicyAdapterRestoreInputHook(t *testing.T) {
+	a := &workerPolicyAdapter{}
+	called := false
+	a.setRestoreInput(func() { called = true })
+	if a.restoreInput == nil {
+		t.Fatal("setter must store the hook")
+	}
+	a.restoreInput()
+	if !called {
+		t.Fatal("stored hook must be invocable")
+	}
+}

--- a/cli/stdin_cbreak_unix.go
+++ b/cli/stdin_cbreak_unix.go
@@ -1,0 +1,66 @@
+//go:build !windows
+
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+
+	"golang.org/x/term"
+)
+
+// enableStdinCbreak switches the controlling TTY to a cbreak-style mode for
+// the centralized stdin reader: canonical line buffering and kernel echo go
+// OFF, signal generation (ISIG) stays ON so Ctrl+C keeps working. In cooked
+// mode the kernel held typed bytes until Enter and echoed them on top of
+// the spinner line, where the 100ms repaint ate them — the user typed
+// blind. In cbreak the reader receives bytes as they are typed and the
+// live display renders the in-flight line itself.
+//
+// Returns a restore func (never nil) that reinstates the exact prior
+// state captured with `stty -g`. Non-TTY stdin (gateway, tests, pipes) is
+// a no-op.
+func enableStdinCbreak() func() {
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return func() {}
+	}
+	tty, err := os.Open("/dev/tty")
+	if err != nil {
+		return func() {}
+	}
+	saved, err := sttyOutput(tty, "-g")
+	if err != nil || strings.TrimSpace(saved) == "" {
+		_ = tty.Close()
+		return func() {}
+	}
+	if err := sttyRun(tty, "-icanon", "-echo", "min", "1", "time", "0"); err != nil {
+		_ = tty.Close()
+		return func() {}
+	}
+	savedState := strings.TrimSpace(saved)
+	return func() {
+		_ = sttyRun(tty, savedState)
+		_ = tty.Close()
+	}
+}
+
+// sttyOutput runs stty against the tty and returns its stdout.
+func sttyOutput(tty *os.File, args ...string) (string, error) {
+	cmd := exec.Command("stty", args...)
+	cmd.Stdin = tty
+	out, err := cmd.Output()
+	return string(out), err
+}
+
+// sttyRun runs stty against the tty, discarding output.
+func sttyRun(tty *os.File, args ...string) error {
+	cmd := exec.Command("stty", args...)
+	cmd.Stdin = tty
+	return cmd.Run()
+}

--- a/cli/stdin_cbreak_unix.go
+++ b/cli/stdin_cbreak_unix.go
@@ -52,7 +52,7 @@ func enableStdinCbreak() func() {
 
 // sttyOutput runs stty against the tty and returns its stdout.
 func sttyOutput(tty *os.File, args ...string) (string, error) {
-	cmd := exec.Command("stty", args...)
+	cmd := exec.Command("stty", args...) // #nosec G204 -- fixed binary; args are stty mode tokens or the state string previously emitted by `stty -g` on this same tty, never user input
 	cmd.Stdin = tty
 	out, err := cmd.Output()
 	return string(out), err
@@ -60,7 +60,7 @@ func sttyOutput(tty *os.File, args ...string) (string, error) {
 
 // sttyRun runs stty against the tty, discarding output.
 func sttyRun(tty *os.File, args ...string) error {
-	cmd := exec.Command("stty", args...)
+	cmd := exec.Command("stty", args...) // #nosec G204 -- fixed binary; args are stty mode tokens or the state string previously emitted by `stty -g` on this same tty, never user input
 	cmd.Stdin = tty
 	return cmd.Run()
 }

--- a/cli/stdin_cbreak_windows.go
+++ b/cli/stdin_cbreak_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+// enableStdinCbreak is a no-op on Windows: the console keeps its cooked
+// line-input behavior, so mid-run typing works exactly as before (kernel
+// buffered, delivered on Enter). Live type-ahead preview stays a Unix
+// feature until console-mode handling is validated on-device — terminal
+// rendering changes on Windows have burned us before (see the coder
+// stdin/fspath post-mortem).
+func enableStdinCbreak() func() {
+	return func() {}
+}


### PR DESCRIPTION
## Problem

Typing `/board`, `/agents` (or any mid-run instruction) while the coder spinner or the dispatch panel is running was **blind**: the TTY stays in cooked mode, the kernel buffers the line until Enter, and whatever it echoes lands on the spinner line where the 100ms repaint eats it. The user only discovers what they typed when the ⚡ line appears after Enter.

## Fix

- **Cbreak while the reader runs (Unix)**: `enableStdinCbreak` saves the exact TTY state (`stty -g`), turns off `icanon`+`echo` (ISIG preserved — Ctrl+C intact) and the reader receives bytes as typed. Restored on teardown; suspend/resume (overlays, line-editing prompts) restore/re-arm automatically.
- **Live input line**: the partial line renders as `❯ texto▌` under the dispatch panel and inline next to the turn spinner — tail-biased truncation, `\033[K` cleanup so backspace never leaves residue.
- **Reader-side line editing**: backspace/DEL applied rune-safe in `splitStdinChunk` (multi-byte pt-BR input included); whole CSI escape sequences stripped from the display only.
- **Self-healing**: security prompts (orchestrator and worker paths) and command-block menus force cooked mode for themselves; they re-arm cbreak on exit (worker path via a `setRestoreInput` hook on the policy adapter), and every turn boundary re-applies as backstop.
- **Windows**: no-op — current behavior preserved until console-mode handling is validated on-device (per the coder stdin post-mortem).

## Validation

- New tests: backspace editing (incl. UTF-8 and empty-buffer no-op), preview rendering contract (tail truncation, CSI stripping, EOL clear), snapshot handoff
- Full `go test ./...` and `golangci-lint run` green