### PR TITLE
fix(agent): render the turn-spinner type-ahead preview below the line

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -2088,9 +2088,7 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 		// is still painted below the spinner — wipe it so the response
 		// doesn't interleave with a stale preview. (Safe read: Stop()
 		// already synchronized with the last tick.)
-		if spinnerHadPreview {
-			fmt.Print("\n\033[K\033[A\r")
-		}
+		fmt.Print(spinnerPreviewWipe(spinnerHadPreview))
 		fmt.Println()
 
 		// Helper para exibir métricas ao final do turno (após execução)

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -1983,6 +1983,10 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 		// e nada muda visualmente no spinner — só vê (1 na fila) na
 		// próxima iteração do turn.
 		modelName := turnClient.GetModelName()
+		// Tracks whether the previous tick painted a type-ahead line under
+		// the spinner. Written only by the ticker goroutine (under the
+		// timer mutex); read after Stop() for the final cleanup.
+		spinnerHadPreview := false
 		a.turnTimer.Start(ctx, func(d time.Duration) {
 			msg := "Processando..."
 			a.cli.messageQueueMu.Lock()
@@ -1994,10 +1998,12 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 			if queued > 0 {
 				msg = "Processando... " + i18n.T("agent.queue.indicator", queued)
 			}
-			// Live type-ahead: show what the user is typing right now so
-			// they never type blind under the spinner. \033[K clears
-			// leftovers when the preview shrinks (backspace).
-			fmt.Print(metrics.FormatTimerStatus(d, modelName, msg) + formatTypeaheadPreviewInline(a.typeaheadPreviewSnapshot(), 40) + "\033[K")
+			// Live type-ahead: what the user is typing renders on its own
+			// line BELOW the spinner (same placement as the dispatch
+			// panel), cursor returned to the spinner line each tick.
+			suffix, had := formatTypeaheadPreviewBelow(a.typeaheadPreviewSnapshot(), spinnerHadPreview)
+			spinnerHadPreview = had
+			fmt.Print(metrics.FormatTimerStatus(d, modelName, msg) + "\033[K" + suffix)
 		})
 
 		// Validate/repair tool result pairing on the PERSISTENT history —
@@ -2091,6 +2097,13 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 		// Para o timer e obtém a duração
 		turnDuration := a.turnTimer.Stop()
 		fmt.Print(metrics.ClearLine()) // Limpa a linha do timer
+		// If the user was mid-typing when the turn ended, a type-ahead line
+		// is still painted below the spinner — wipe it so the response
+		// doesn't interleave with a stale preview. (Safe read: Stop()
+		// already synchronized with the last tick.)
+		if spinnerHadPreview {
+			fmt.Print("\n\033[K\033[A\r")
+		}
 		fmt.Println()
 
 		// Helper para exibir métricas ao final do turno (após execução)

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -1988,22 +1988,9 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 		// timer mutex); read after Stop() for the final cleanup.
 		spinnerHadPreview := false
 		a.turnTimer.Start(ctx, func(d time.Duration) {
-			msg := "Processando..."
-			a.cli.messageQueueMu.Lock()
-			queued := len(a.cli.messageQueue)
-			a.cli.messageQueueMu.Unlock()
-			if a.stdinLines != nil {
-				queued += len(a.stdinLines)
-			}
-			if queued > 0 {
-				msg = "Processando... " + i18n.T("agent.queue.indicator", queued)
-			}
-			// Live type-ahead: what the user is typing renders on its own
-			// line BELOW the spinner (same placement as the dispatch
-			// panel), cursor returned to the spinner line each tick.
-			suffix, had := formatTypeaheadPreviewBelow(a.typeaheadPreviewSnapshot(), spinnerHadPreview)
-			spinnerHadPreview = had
-			fmt.Print(metrics.FormatTimerStatus(d, modelName, msg) + "\033[K" + suffix)
+			var frame string
+			frame, spinnerHadPreview = a.buildTurnSpinnerFrame(d, modelName, spinnerHadPreview)
+			fmt.Print(frame)
 		})
 
 		// Validate/repair tool result pairing on the PERSISTENT history —

--- a/cli/agent_mode_queue_test.go
+++ b/cli/agent_mode_queue_test.go
@@ -94,9 +94,9 @@ func TestQueueIndicator_FormatsCount(t *testing.T) {
 	// locale; instead, we verify the call site uses the indicator key and
 	// passes the count via Sprintf semantics. A minimal regex on the
 	// agent_mode.go source code itself catches accidental removals.
-	src := mustReadFile(t, "agent_mode.go")
+	src := mustReadFile(t, "agent_typeahead.go")
 	require.Contains(t, src, `i18n.T("agent.queue.indicator", queued)`,
-		"timer status must include queued count via i18n key")
+		"timer status must include queued count via i18n key (frame logic lives in buildTurnSpinnerFrame)")
 }
 
 // mustReadFile reads a sibling source file relative to the test file.

--- a/cli/agent_typeahead.go
+++ b/cli/agent_typeahead.go
@@ -118,6 +118,16 @@ func sanitizeTypeaheadPreview(s string) string {
 	return strings.TrimLeft(b.String(), " ")
 }
 
+// spinnerPreviewWipe returns the sequence that erases a type-ahead line
+// still painted below the spinner when the turn ends mid-typing ("" when
+// nothing was painted).
+func spinnerPreviewWipe(hadPreview bool) string {
+	if hadPreview {
+		return "\n\033[K\033[A\r"
+	}
+	return ""
+}
+
 // buildTurnSpinnerFrame composes one repaint of the single-line turn
 // spinner: status line (with the queued type-ahead indicator) plus the
 // live input line below when the user is typing. Extracted from the

--- a/cli/agent_typeahead.go
+++ b/cli/agent_typeahead.go
@@ -58,18 +58,29 @@ func formatTypeaheadPreviewLine(preview string) string {
 	return "  " + ColorCyan + "❯ " + text + "▌" + ColorReset + "\033[K"
 }
 
-// formatTypeaheadPreviewInline renders a compact suffix for the
-// single-line turn spinner.
-func formatTypeaheadPreviewInline(preview string, width int) string {
-	text := sanitizeTypeaheadPreview(preview)
-	if text == "" {
-		return ""
+// formatTypeaheadPreviewBelow renders the input line UNDER the single-line
+// turn spinner (same placement as the dispatch panel's preview, which
+// users found clearer than an inline suffix competing with the spinner
+// for horizontal space).
+//
+// The suffix paints the line below and returns the cursor to the spinner
+// line, so the spinner's plain `\r` repaint contract is preserved:
+//
+//	\n<preview>\033[A\r   — down, paint, back up
+//
+// hadPreview threads the previous tick's state: when typing stops (Enter
+// or backspace-to-empty) one final `\n\033[K\033[A\r` wipes the stale
+// line, and after that the dance stops entirely — a quiet spinner never
+// touches the row below it (which would scroll the screen when the
+// spinner sits on the terminal's bottom row).
+func formatTypeaheadPreviewBelow(preview string, hadPreview bool) (string, bool) {
+	if line := formatTypeaheadPreviewLine(preview); line != "" {
+		return "\n" + line + "\033[A\r", true
 	}
-	if n := utf8.RuneCountInString(text); n > width {
-		runes := []rune(text)
-		text = "…" + string(runes[n-width:])
+	if hadPreview {
+		return "\n\033[K\033[A\r", false
 	}
-	return " " + ColorCyan + "❯ " + text + "▌" + ColorReset
+	return "", false
 }
 
 // sanitizeTypeaheadPreview drops control bytes AND whole escape sequences

--- a/cli/agent_typeahead.go
+++ b/cli/agent_typeahead.go
@@ -18,7 +18,11 @@ package cli
 
 import (
 	"strings"
+	"time"
 	"unicode/utf8"
+
+	"github.com/diillson/chatcli/cli/metrics"
+	"github.com/diillson/chatcli/i18n"
 )
 
 // setTypeaheadPreview publishes the current partial input line (what has
@@ -112,4 +116,27 @@ func sanitizeTypeaheadPreview(s string) string {
 		}
 	}
 	return strings.TrimLeft(b.String(), " ")
+}
+
+// buildTurnSpinnerFrame composes one repaint of the single-line turn
+// spinner: status line (with the queued type-ahead indicator) plus the
+// live input line below when the user is typing. Extracted from the
+// ticker closure so the frame logic is directly testable — the ticker
+// itself only runs against a real TTY.
+func (a *AgentMode) buildTurnSpinnerFrame(d time.Duration, modelName string, hadPreview bool) (string, bool) {
+	msg := "Processando..."
+	a.cli.messageQueueMu.Lock()
+	queued := len(a.cli.messageQueue)
+	a.cli.messageQueueMu.Unlock()
+	if a.stdinLines != nil {
+		queued += len(a.stdinLines)
+	}
+	if queued > 0 {
+		msg = "Processando... " + i18n.T("agent.queue.indicator", queued)
+	}
+	// Live type-ahead: what the user is typing renders on its own line
+	// BELOW the spinner (same placement as the dispatch panel), cursor
+	// returned to the spinner line each tick.
+	suffix, had := formatTypeaheadPreviewBelow(a.typeaheadPreviewSnapshot(), hadPreview)
+	return metrics.FormatTimerStatus(d, modelName, msg) + "\033[K" + suffix, had
 }

--- a/cli/agent_typeahead_test.go
+++ b/cli/agent_typeahead_test.go
@@ -8,6 +8,9 @@ package cli
 import (
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/diillson/chatcli/i18n"
 )
 
 // TestSplitStdinChunkBackspace pins the cbreak-mode line editing: without
@@ -108,5 +111,45 @@ func TestTypeaheadPreviewSnapshot(t *testing.T) {
 	a.setTypeaheadPreview("/agents")
 	if got := a.typeaheadPreviewSnapshot(); got != "/agents" {
 		t.Errorf("snapshot = %q", got)
+	}
+}
+
+// TestBuildTurnSpinnerFrame pins the extracted spinner frame: queue
+// indicator, preview-below suffix and state threading.
+func TestBuildTurnSpinnerFrame(t *testing.T) {
+	a := &AgentMode{cli: &ChatCLI{}}
+
+	// Quiet: no queue indicator, no preview suffix.
+	frame, had := a.buildTurnSpinnerFrame(2*time.Second, "claude-sonnet-5", false)
+	if had {
+		t.Fatal("quiet frame must not report a preview")
+	}
+	if !strings.Contains(frame, "claude-sonnet-5") || !strings.Contains(frame, "Processando") {
+		t.Errorf("frame must carry model and status: %q", frame)
+	}
+	if strings.Contains(frame, "❯") {
+		t.Errorf("quiet frame must not paint an input line: %q", frame)
+	}
+
+	// Typing: the input line renders below and the cursor returns.
+	a.setTypeaheadPreview("/agents")
+	frame, had = a.buildTurnSpinnerFrame(2*time.Second, "m", false)
+	if !had {
+		t.Fatal("typing must report hadPreview=true")
+	}
+	if !strings.Contains(frame, "\n") || !strings.Contains(frame, "❯ /agents▌") || !strings.HasSuffix(frame, "\033[A\r") {
+		t.Errorf("typing frame must paint below and return the cursor: %q", frame)
+	}
+
+	// Queue indicator counts pending stdin lines and chat-queue items.
+	a.setTypeaheadPreview("")
+	a.stdinLines = make(chan string, 4)
+	a.stdinLines <- "queued line"
+	a.cli.messageQueueMu.Lock()
+	a.cli.messageQueue = append(a.cli.messageQueue, "older")
+	a.cli.messageQueueMu.Unlock()
+	frame, _ = a.buildTurnSpinnerFrame(time.Second, "m", false)
+	if !strings.Contains(frame, i18n.T("agent.queue.indicator", 2)) {
+		t.Errorf("frame must show the combined queue count: %q", frame)
 	}
 }

--- a/cli/agent_typeahead_test.go
+++ b/cli/agent_typeahead_test.go
@@ -153,3 +153,13 @@ func TestBuildTurnSpinnerFrame(t *testing.T) {
 		t.Errorf("frame must show the combined queue count: %q", frame)
 	}
 }
+
+// TestSpinnerPreviewWipe pins the turn-end cleanup sequence.
+func TestSpinnerPreviewWipe(t *testing.T) {
+	if got := spinnerPreviewWipe(true); got != "\n\033[K\033[A\r" {
+		t.Errorf("mid-typing turn end must wipe the row below: %q", got)
+	}
+	if got := spinnerPreviewWipe(false); got != "" {
+		t.Errorf("no preview means no wipe: %q", got)
+	}
+}

--- a/cli/agent_typeahead_test.go
+++ b/cli/agent_typeahead_test.go
@@ -66,12 +66,36 @@ func TestFormatTypeaheadPreview(t *testing.T) {
 		t.Errorf("long input must show the tail with ellipsis: %q", tail)
 	}
 
-	inline := formatTypeaheadPreviewInline("hello", 40)
-	if !strings.Contains(inline, "❯ hello▌") {
-		t.Errorf("inline preview must render prompt+cursor: %q", inline)
+}
+
+// TestFormatTypeaheadPreviewBelow pins the below-the-spinner placement: the
+// suffix paints the line under the spinner and restores the cursor; when
+// typing stops it wipes the stale line exactly once, and a quiet spinner
+// never touches the row below (which would scroll at the terminal's
+// bottom row).
+func TestFormatTypeaheadPreviewBelow(t *testing.T) {
+	suffix, had := formatTypeaheadPreviewBelow("/board", false)
+	if !had {
+		t.Fatal("non-empty preview must report hadPreview=true")
 	}
-	if formatTypeaheadPreviewInline("", 40) != "" {
-		t.Error("empty inline preview must render nothing")
+	if !strings.HasPrefix(suffix, "\n") || !strings.HasSuffix(suffix, "\033[A\r") {
+		t.Errorf("suffix must go down, paint and come back up: %q", suffix)
+	}
+	if !strings.Contains(suffix, "❯ /board▌") {
+		t.Errorf("suffix must carry the preview line: %q", suffix)
+	}
+
+	wipe, had := formatTypeaheadPreviewBelow("", true)
+	if had {
+		t.Fatal("cleared preview must report hadPreview=false")
+	}
+	if wipe != "\n\033[K\033[A\r" {
+		t.Errorf("transition to empty must wipe the stale line once: %q", wipe)
+	}
+
+	quiet, had := formatTypeaheadPreviewBelow("", false)
+	if quiet != "" || had {
+		t.Errorf("quiet spinner must not touch the row below, got %q", quiet)
 	}
 }
 


### PR DESCRIPTION
## Change

Field feedback on #1293: the live `❯` preview rendered **next to** the turn spinner, competing with model/elapsed/queue text for horizontal space. It now renders **below** the spinner — the same placement the dispatch panel already uses — via a down-paint-return cursor dance that preserves the spinner's plain `\r` repaint contract:

- typing → `\n<preview>\033[A\r` each tick
- typing stops → one final `\n\033[K\033[A\r` wipes the stale row
- quiet spinner → never touches the row below (no scroll at the terminal's bottom row)
- turn ends mid-typing → cleanup wipes the leftover before the response prints

## Validation

- Unit tests pin the three suffix states (paint+return, single wipe, quiet no-op)
- `go test ./cli/...` and `golangci-lint` green