### PR TITLE
feat(catalog): refresh Devin CLI model roster

### DIFF
--- a/llm/catalog/catalog_devin.go
+++ b/llm/catalog/catalog_devin.go
@@ -50,12 +50,19 @@ func init() {
 		{"gpt-5.4", 200000, 100000},
 		{"gpt-5.3-codex", 200000, 100000},
 		{"gpt-5.2", 200000, 100000},
+		{"gpt-5.1", 400000, 128000},
+		{"gpt-4.1", 1047576, 32768},
 		// Google family (Gemini 3.x: 1M window / 65K output).
+		{"gemini-3.6-flash", 1048576, 65536},
 		{"gemini-3.5-flash", 1048576, 65536},
 		{"gemini-3.1-pro", 1048576, 65536},
 		{"gemini-3-flash", 1048576, 65536},
-		// Others with published specs.
+		// Others with published specs. Kimi K3: 1M window (Kimi Delta
+		// Attention); output capped at the K2.x family's 128K — OpenRouter
+		// lists output = context, which is an unbounded-listing artifact,
+		// not a real per-request cap.
 		{"glm-5.2", 1000000, 128000},
+		{"kimi-k3", 1048576, 131072},
 		{"kimi-k2.7", 262144, 131072},
 		{"kimi-k2.6", 262144, 131072},
 		{"deepseek-v4-pro", 1000000, 32000},
@@ -65,7 +72,6 @@ func init() {
 		{"swe-1.7", 200000, 32000},
 		{"swe-1.6-fast", 200000, 32000},
 		{"swe-1.6", 200000, 32000},
-		{"swe-1.5", 200000, 32000},
 	}
 
 	entries := make([]ModelMeta, 0, len(devinModels))

--- a/llm/catalog/catalog_test.go
+++ b/llm/catalog/catalog_test.go
@@ -500,7 +500,11 @@ func TestDevinCatalogEntries(t *testing.T) {
 		"claude-sonnet-4.5": 200000,
 		"claude-sonnet-4":   200000,
 		"gpt-5.6-luna":      1050000,
+		"gpt-5.1":           400000,
+		"gpt-4.1":           1047576,
+		"gemini-3.6-flash":  1048576,
 		"swe-1.7-lightning": 200000,
+		"kimi-k3":           1048576,
 		"kimi-k2.7":         262144,
 		"deepseek-v4-pro":   1000000,
 	} {
@@ -516,6 +520,11 @@ func TestDevinCatalogEntries(t *testing.T) {
 	meta, ok := Resolve(ProviderClaudeAI, "claude-sonnet-4-6")
 	assert.True(t, ok)
 	assert.Equal(t, ProviderClaudeAI, meta.Provider)
+
+	// swe-1.5 left the enterprise CLI roster (Jul 2026): a non-exact
+	// lookup must fall back to provider defaults, not a stale entry.
+	_, ok = Resolve(ProviderDevin, "swe-1.5")
+	assert.False(t, ok, "swe-1.5 was removed from the Devin roster")
 
 	// Unknown model under DEVIN falls back to the conservative provider
 	// defaults instead of the generic 50K that causes compaction storms.


### PR DESCRIPTION
## Summary
Mirrors the updated enterprise Devin CLI roster in the DEVIN catalog.

- **Added**: `gpt-5.1` (400K/128K, mirrors the OpenAI `gpt-5` entry), `gpt-4.1` (1,047,576/32,768), `gemini-3.6-flash` (1,048,576/65,536, newest-first in the Google family), `kimi-k3` (1M context per published specs; output kept at the K2.x family 128K cap — the unbounded OpenRouter listing is an artifact, noted in a comment)
- **Removed**: `swe-1.5` (no longer served by the CLI)
- Total: 33 models

## Testing
`TestDevinCatalogEntries` pins the four new entries' context windows and asserts `swe-1.5` no longer resolves (falls back to the conservative provider defaults). Full `go test ./...` green.