### PR TITLE
feat(catalog): add Kimi K3 to the Moonshot catalog with its own pricing tier

### DIFF
--- a/cli/cost_tracker.go
+++ b/cli/cost_tracker.go
@@ -590,17 +590,23 @@ func deepseekPricing(model string) (float64, float64, bool) {
 // or where the provider name is the most reliable signal (proprietary
 // wrappers like Copilot, local backends like Ollama).
 //
-// Moonshot (Kimi) — kimi-k2.6 public list price as of 2026-05 is $0.95/M
-// input (cache miss) and $4.00/M output. Cache-hit input is $0.16/M but
-// cost_tracker only models a single tier — we charge the miss price so
-// accounting stays conservative. K2.5 and moonshot-v1-* sit below K2.6;
-// we approximate with K2.6 numbers to avoid under-reporting.
+// Moonshot (Kimi) — kimi-k3 public list price as of 2026-07 is $3.00/M
+// input (cache miss; cache hit is $0.30/M) and $15.00/M output — priced
+// well above the K2 line, so it gets its own case BEFORE the generic kimi
+// match (specific beats generic, same ordering rule as claudePricing).
+// kimi-k2.6 as of 2026-05 is $0.95/M input (cache miss) and $4.00/M
+// output; cache-hit input is $0.16/M but cost_tracker only models a
+// single tier — we charge the miss price so accounting stays
+// conservative. K2.5 and moonshot-v1-* sit below K2.6; we approximate
+// with K2.6 numbers to avoid under-reporting.
 func providerFallbackPricing(provider, model string) (float64, float64) {
 	switch {
 	case strings.Contains(model, "minimax"), strings.Contains(provider, "minimax"):
 		return 0.20, 1.10
 	case strings.Contains(provider, "zai"), strings.Contains(model, "glm"):
 		return 0.50, 0.50
+	case strings.HasPrefix(model, "kimi-k3"):
+		return 3.00, 15.00
 	case strings.Contains(provider, "moonshot"), strings.HasPrefix(model, "kimi"), strings.HasPrefix(model, "moonshot"):
 		return 0.95, 4.00
 	case strings.Contains(provider, "copilot"):

--- a/cli/cost_tracker_pricing_test.go
+++ b/cli/cost_tracker_pricing_test.go
@@ -81,7 +81,10 @@ func TestGetModelPricing(t *testing.T) {
 		{"zai via provider", "ZAI", "anything", 0.50, 0.50},
 		{"zai legacy glm model", "OTHER", "glm-4.5", 0.50, 0.50},
 
-		// Moonshot (Kimi) — K2.6 list price, conservative single tier.
+		// Moonshot (Kimi) — K3 has its own list price (well above the K2
+		// line) and its specific case must win over the generic kimi match;
+		// everything else keeps the conservative K2.6 single tier.
+		{"kimi-k3 own tier", "MOONSHOT", "kimi-k3", 3.00, 15.00},
 		{"moonshot via provider", "MOONSHOT", "kimi-k2.6", 0.95, 4.00},
 		{"kimi-k2.5", "MOONSHOT", "kimi-k2.5", 0.95, 4.00},
 		{"moonshot-v1", "MOONSHOT", "moonshot-v1-128k", 0.95, 4.00},

--- a/llm/catalog/catalog.go
+++ b/llm/catalog/catalog.go
@@ -1173,11 +1173,24 @@ var registry = []ModelMeta{
 	},
 
 	// Moonshot (Kimi) Models.
-	// Native multimodal MoE family from Moonshot AI. K2.6 is the flagship
-	// (released Apr 2026): 1T total / 32B active params, 256K context, vision +
-	// agent swarm + thinking mode. K2.5 is the previous generation, still
-	// supported. moonshot-v1-* are the classic chat models split by context.
+	// Native multimodal MoE family from Moonshot AI. K3 is the flagship
+	// (released Jul 2026): 2.8T total / 104B active params, 1M context via
+	// Kimi Delta Attention, text+image+video input. Output stays at the
+	// K2.x 128K cap — aggregator listings that show output = context are an
+	// unbounded-listing artifact, not a real per-request cap. K2.6 (Apr
+	// 2026, 1T/32B, 256K) remains supported, K2.5 is the prior generation,
+	// moonshot-v1-* are the classic chat models split by context.
 	// Ordering: newest IDs first so generic aliases don't shadow specific tags.
+	{
+		ID:              "kimi-k3",
+		Aliases:         []string{"kimi-k3", "kimi-k-3", "k3", "k-3"},
+		DisplayName:     "Kimi K3",
+		Provider:        ProviderMoonshot,
+		ContextWindow:   1048576,
+		MaxOutputTokens: 131072,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"tools", "vision", "thinking", "json_mode"},
+	},
 	{
 		ID:              "kimi-k2.6",
 		Aliases:         []string{"kimi-k2.6", "kimi-k2-6", "k2.6", "k2-6"},

--- a/llm/catalog/catalog_test.go
+++ b/llm/catalog/catalog_test.go
@@ -134,6 +134,19 @@ func TestStackSpotCatalogEntry(t *testing.T) {
 }
 
 func TestMoonshotCatalogEntries(t *testing.T) {
+	// Kimi K3 (flagship, Jul 2026): 1M window via Kimi Delta Attention,
+	// output at the K2.x 128K cap. Alias "k3" must land on this entry and
+	// the dotted K2 ids must not shadow it.
+	k3, ok := Resolve(ProviderMoonshot, "kimi-k3")
+	assert.True(t, ok, "kimi-k3 must resolve")
+	assert.Equal(t, 1048576, k3.ContextWindow)
+	assert.Equal(t, 131072, k3.MaxOutputTokens)
+	assert.Contains(t, k3.Capabilities, "vision")
+	assert.Contains(t, k3.Capabilities, "thinking")
+	short, ok := Resolve(ProviderMoonshot, "k3")
+	assert.True(t, ok)
+	assert.Equal(t, "kimi-k3", short.ID)
+
 	// Pin the public specs of the Kimi K2.6/K2.5 entries so silent drift on
 	// the model card (e.g. catalog edits during a refactor) shows up here
 	// instead of at runtime.


### PR DESCRIPTION
## Summary
Follow-up from #1296: `kimi-k3` existed only in the DEVIN catalog — the direct MOONSHOT provider still had K2.6 as flagship.

- **Catalog**: `kimi-k3` entry (1,048,576 ctx via Kimi Delta Attention / 131,072 output — the K2.x cap; aggregator listings showing output = context are an unbounded-listing artifact), aliases `k3`/`k-3`, newest-first ordering, capabilities tools/vision/thinking/json_mode. Section comment updated (K3 flagship, K2.6 supported).
- **Cost tracker**: K3-specific case before the generic kimi match — $3.00/M input (cache miss) / $15.00/M output per the published list price; K2 line keeps the conservative $0.95/$4.00 tier.
- **Docs**: supported-models EN+PT updated with the K3 row and pricing (docs repo, direct to main).

## Testing
`TestMoonshotCatalogEntries` pins the K3 entry and the `k3` alias; `TestGetModelPricing` pins both Moonshot tiers. Full `go test ./...` green.