### PR TITLE
ci(release): inject release notes into the changelog pages instead of the introductions

### DIFF
--- a/.github/workflows/3-publish-release.yml
+++ b/.github/workflows/3-publish-release.yml
@@ -773,9 +773,10 @@ jobs:
           fi
 
           # 3) "Atualizações recentes" / "Recent updates" Update block
-          #    in introduction.mdx (EN, site root) and pt/introduction.mdx
-          #    (PT-BR). English moved to the root when it became the
-          #    site's default language.
+          #    in changelog.mdx (EN, site root) and pt/changelog.mdx
+          #    (PT-BR). The release history moved out of the introduction
+          #    pages (Aug 2026): they only keep a card linking here, so
+          #    they stop growing by one block per release.
           #    Driven by release-please's CHANGELOG.md from the chatcli
           #    source repo (checked out above into _chatcli_src). We
           #    extract the latest release section (between the first
@@ -830,7 +831,7 @@ jobs:
 
               # Inject before the FIRST existing <Update label="..."> block.
               # Idempotent: skip if a block with this label already exists.
-              for f in introduction.mdx pt/introduction.mdx; do
+              for f in changelog.mdx pt/changelog.mdx; do
                 if [ ! -f "$f" ]; then continue; fi
                 if grep -q "<Update label=\"${MAJOR_MINOR}\"" "$f"; then
                   echo "  ${f}: already has Update label=${MAJOR_MINOR}, skipping"


### PR DESCRIPTION
## Summary
The docs-site introductions (EN + PT) were growing one `<Update>` block per release — 69 blocks / 558 lines each and counting. The release history moved to dedicated `changelog.mdx` + `pt/changelog.mdx` pages on the docs site (Mintlify-native changelog layout, committed there directly); the introductions now keep a single card linking to the changelog and stop growing.

This PR retargets the `update_docs_version` injection loop from `introduction.mdx pt/introduction.mdx` to `changelog.mdx pt/changelog.mdx`. Insertion point (before the first existing `<Update>`), idempotency guard and the version/banner seds are unchanged — the global `*.mdx` version sed covers the new pages automatically.

## Testing
Docs-site side already live: both changelog pages carry the 69 migrated blocks verbatim, introductions slimmed 558→221 lines, `docs.json` navigation updated in both languages (JSON validated). The next release exercises the new injection path; the idempotency guard makes a re-run harmless.