### PR TITLE
feat(security): route unattended ask policy through client permission dialogs

### DIFF
--- a/cli/agent_events_bridge.go
+++ b/cli/agent_events_bridge.go
@@ -18,6 +18,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -26,6 +27,7 @@ import (
 	"github.com/diillson/chatcli/cli/agentevents"
 	"github.com/diillson/chatcli/cli/plugins"
 	"github.com/diillson/chatcli/i18n"
+	"github.com/diillson/chatcli/models"
 	"go.uber.org/zap"
 )
 
@@ -278,14 +280,21 @@ func (a *AgentMode) executeCommandBlocksUnattended(ctx context.Context, blocks [
 	return strings.TrimSpace(fb.String())
 }
 
-// requestActionPermission asks the sink's PermissionRequester (when the sink
-// provides one) to approve a dangerous action. tc should be the already
-// announced tool call when one exists, so the client can anchor its dialog to
-// the same toolCallId. ok reports whether the sink was consulted; allowed is
-// only meaningful when ok is true. Denials and transport errors both come
-// back allowed=false — fail-safe.
+// requestActionPermission asks the run's PermissionRequester to approve a
+// gated action: the sink's own capability when it has one (ACP), else the
+// per-run requester installed on the ChatCLI (MCP elicitation bridge). tc
+// should be the already announced tool call when one exists, so the client
+// can anchor its dialog to the same toolCallId. ok reports whether a
+// requester was consulted; allowed is only meaningful when ok is true.
+// Denials and transport errors both come back allowed=false — fail-safe. A
+// client that reports the round-trip unsupported (ErrPermissionUnsupported)
+// counts as NOT consulted: no dialog exists, so callers apply the same
+// contract as runs without a requester.
 func (a *AgentMode) requestActionPermission(tc agentevents.ToolCall, reason string) (allowed, ok bool) {
 	pr, has := a.events.(agentevents.PermissionRequester)
+	if !has && a.cli != nil && a.cli.rpcPermissions != nil {
+		pr, has = a.cli.rpcPermissions, true
+	}
 	if !has {
 		return false, false
 	}
@@ -295,10 +304,57 @@ func (a *AgentMode) requestActionPermission(tc agentevents.ToolCall, reason stri
 	tc.Status = agentevents.StatusPending
 	granted, err := pr.RequestPermission(tc, reason)
 	if err != nil {
+		if errors.Is(err, agentevents.ErrPermissionUnsupported) {
+			if a.logger != nil {
+				a.logger.Info("client does not support permission requests; applying unattended fallback")
+			}
+			return false, false
+		}
 		if a.logger != nil {
 			a.logger.Warn("permission request failed; denying action", zap.Error(err))
 		}
 		return false, true
 	}
 	return granted, true
+}
+
+// unattendedAskBlocked resolves a coder-policy ActionAsk verdict in an
+// unattended run. When the connected client offers a permission dialog (ACP
+// session/request_permission, MCP elicitation), the human decides: a denial
+// blocks the action, renders the refusal, tells the model (so it can replan)
+// and closes the tool_call for the client. Without a reachable dialog the
+// historical unattended contract holds — "ask" auto-approves (the operator
+// opted into autonomy; explicit deny rules still block upstream).
+func (a *AgentMode) unattendedAskBlocked(toolName, rawArgs string, renderError func(string)) bool {
+	title := agent.CompactToolLabel(extractSubcmdFromArgs(rawArgs), rawArgs)
+	if strings.TrimSpace(title) == "" {
+		title = toolName
+	}
+	kind, _ := classifyToolCall(toolName, nil)
+	allowed, asked := a.requestActionPermission(agentevents.ToolCall{
+		Name:     toolName,
+		Title:    title,
+		Kind:     kind,
+		RawInput: rawArgs,
+	}, i18n.T("agent.permission.policy_ask", toolName))
+	if !asked {
+		if a.logger != nil {
+			a.logger.Info("coder policy: 'ask' auto-approved (unattended, no permission dialog)",
+				zap.String("tool", toolName))
+		}
+		return false
+	}
+	if allowed {
+		return false
+	}
+	msg := i18n.T("agent.policy.ask_denied", title)
+	renderError(msg)
+	a.emitBlockedTool(toolName, rawArgs, msg)
+	a.cli.history = append(a.cli.history, models.Message{
+		Role: "user",
+		Content: fmt.Sprintf(
+			"SECURITY BLOCK: Action %q was DENIED by the user through the security-policy prompt. DO NOT retry it; choose a different approach or explain what you need.",
+			title),
+	})
+	return true
 }

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -2838,15 +2838,18 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 							break
 						}
 						if action == coder.ActionAsk && a.cli.unattended {
-							// Gateway/unattended: there is no human to answer the
-							// security prompt, and PromptSecurityCheck blocks on a
-							// dead stdin forever — which silently hung the run (the
-							// "started Docker but nothing happened" report). The
-							// operator opted into full autonomy (access is gated at
-							// the messaging edge), so an "ask" rule auto-approves
-							// here. An explicit ActionDeny above still blocks.
-							a.logger.Info("coder policy: 'ask' auto-approved (unattended gateway)",
-								zap.String("tool", tc.Name))
+							// Unattended: PromptSecurityCheck would block on a
+							// dead stdin forever (os.Stdin may even carry the
+							// JSON-RPC channel). When the connected client offers
+							// a permission dialog (ACP request_permission, MCP
+							// elicitation) the human decides there; without one,
+							// the historical contract holds — the operator opted
+							// into autonomy, so "ask" auto-approves. An explicit
+							// ActionDeny above still blocks either way.
+							if a.unattendedAskBlocked(tc.Name, tc.Args, renderError) {
+								batchHasError = true
+								break
+							}
 						} else if action == coder.ActionAsk {
 							decision := coder.PromptSecurityCheckGuarded(ctx, tc.Name, tc.Args, a.stdinLines)
 							// The prompt forced cooked mode (stty sane); re-arm

--- a/cli/agent_unattended_ask_test.go
+++ b/cli/agent_unattended_ask_test.go
@@ -1,0 +1,152 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/cli/agentevents"
+	"go.uber.org/zap"
+)
+
+// permRecorder is a sinkRecorder that also implements PermissionRequester,
+// with a scripted decision.
+type permRecorder struct {
+	sinkRecorder
+	grant   bool
+	err     error
+	asked   []agentevents.ToolCall
+	reasons []string
+}
+
+func (p *permRecorder) RequestPermission(tc agentevents.ToolCall, reason string) (bool, error) {
+	p.asked = append(p.asked, tc)
+	p.reasons = append(p.reasons, reason)
+	return p.grant, p.err
+}
+
+func newUnattendedAgent(sink agentevents.Sink) (*AgentMode, *ChatCLI) {
+	c := &ChatCLI{unattended: true}
+	a := NewAgentMode(c, zap.NewNop())
+	a.events = sink
+	return a, c
+}
+
+// TestUnattendedAskBlocked_DeniedByClient: with a PermissionRequester
+// installed (ACP), a policy "ask" rule must surface the client's dialog —
+// and a denial must block the action, tell the model, and close the
+// tool_call for the client.
+func TestUnattendedAskBlocked_DeniedByClient(t *testing.T) {
+	rec := &permRecorder{grant: false}
+	a, c := newUnattendedAgent(rec)
+
+	blocked := a.unattendedAskBlocked("@coder", `{"cmd":"exec","args":{"cmd":"docker rm x"}}`, func(string) {})
+	if !blocked {
+		t.Fatal("denied ask rule must block the action")
+	}
+	if len(rec.asked) != 1 {
+		t.Fatalf("requester consulted %d times, want 1", len(rec.asked))
+	}
+	found := false
+	for _, m := range c.history {
+		if strings.Contains(m.Content, "DENIED") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("denial must reach the model through history so it can replan")
+	}
+	if len(rec.ends) != 1 {
+		t.Fatalf("expected 1 blocked tool_call event for the client, got %d", len(rec.ends))
+	}
+	if !rec.ends[0].IsError {
+		t.Error("blocked tool_call must be reported as error")
+	}
+}
+
+// TestUnattendedAskBlocked_AllowedByClient: an explicit approval in the
+// client dialog runs the action.
+func TestUnattendedAskBlocked_AllowedByClient(t *testing.T) {
+	rec := &permRecorder{grant: true}
+	a, c := newUnattendedAgent(rec)
+
+	blocked := a.unattendedAskBlocked("@coder", `{"cmd":"write","args":{"file":"x"}}`, func(string) {})
+	if blocked {
+		t.Fatal("approved ask rule must not block")
+	}
+	if len(rec.asked) != 1 {
+		t.Fatalf("requester consulted %d times, want 1", len(rec.asked))
+	}
+	if len(c.history) != 0 {
+		t.Fatalf("approval must not pollute history, got %d messages", len(c.history))
+	}
+}
+
+// TestUnattendedAskBlocked_NoRequester: without any requester (gateway
+// daemon, MCP client without elicitation) the historical unattended contract
+// holds — ask auto-approves.
+func TestUnattendedAskBlocked_NoRequester(t *testing.T) {
+	a, c := newUnattendedAgent(&sinkRecorder{}) // sink without PermissionRequester
+	if a.unattendedAskBlocked("@coder", `{"cmd":"exec"}`, func(string) {}) {
+		t.Fatal("without a requester, ask must keep the legacy auto-approve")
+	}
+	if len(c.history) != 0 {
+		t.Fatal("legacy auto-approve must not touch history")
+	}
+}
+
+// TestUnattendedAskBlocked_UnsupportedClientFallsBack: a client that answers
+// "method not found" (wrapped/minimal ACP clients) falls back to the legacy
+// auto-approve instead of bricking every ask-gated action.
+func TestUnattendedAskBlocked_UnsupportedClientFallsBack(t *testing.T) {
+	rec := &permRecorder{err: agentevents.ErrPermissionUnsupported}
+	a, c := newUnattendedAgent(rec)
+	if a.unattendedAskBlocked("@coder", `{"cmd":"exec"}`, func(string) {}) {
+		t.Fatal("unsupported permission method must fall back to legacy auto-approve")
+	}
+	if len(c.history) != 0 {
+		t.Fatal("fallback must not touch history")
+	}
+}
+
+// TestUnattendedAskBlocked_TransportErrorDenies: any other requester failure
+// denies (fail-safe) — the user may have wanted to say no.
+func TestUnattendedAskBlocked_TransportErrorDenies(t *testing.T) {
+	rec := &permRecorder{err: errFixed("client disconnected")}
+	a, _ := newUnattendedAgent(rec)
+	if !a.unattendedAskBlocked("@coder", `{"cmd":"exec"}`, func(string) {}) {
+		t.Fatal("transport error must deny fail-safe")
+	}
+}
+
+// TestRequestActionPermission_UnsupportedNotAsked: ErrPermissionUnsupported
+// means "no dialog exists", which callers must treat as not-consulted — the
+// dangerous-exec guard then blocks in-band exactly like the MCP contract.
+func TestRequestActionPermission_UnsupportedNotAsked(t *testing.T) {
+	rec := &permRecorder{err: agentevents.ErrPermissionUnsupported}
+	a, _ := newUnattendedAgent(rec)
+	allowed, asked := a.requestActionPermission(agentevents.ToolCall{Name: "@coder"}, "r")
+	if allowed || asked {
+		t.Fatalf("unsupported must report not-consulted, got allowed=%v asked=%v", allowed, asked)
+	}
+}
+
+// TestRequestActionPermission_FallbackRequester: runs without an events sink
+// (MCP agent_task/coder_task) reach the per-run requester installed on the
+// ChatCLI (elicitation bridge).
+func TestRequestActionPermission_FallbackRequester(t *testing.T) {
+	rec := &permRecorder{grant: true}
+	c := &ChatCLI{unattended: true, rpcPermissions: rec}
+	a := NewAgentMode(c, zap.NewNop()) // a.events stays nil
+	allowed, asked := a.requestActionPermission(agentevents.ToolCall{Name: "@coder"}, "r")
+	if !allowed || !asked {
+		t.Fatalf("fallback requester must be consulted, got allowed=%v asked=%v", allowed, asked)
+	}
+	if len(rec.asked) != 1 {
+		t.Fatalf("requester consulted %d times, want 1", len(rec.asked))
+	}
+}

--- a/cli/agentevents/events.go
+++ b/cli/agentevents/events.go
@@ -19,7 +19,17 @@
  */
 package agentevents
 
-import "time"
+import (
+	"errors"
+	"time"
+)
+
+// ErrPermissionUnsupported reports that the connected client does not
+// implement the permission round-trip (e.g. an ACP client answering
+// "method not found" to session/request_permission). Callers treat it as
+// "no dialog exists" — the unattended fallback policy applies — which is
+// different from a denial or a transport failure (both fail-safe deny).
+var ErrPermissionUnsupported = errors.New("client does not support permission requests")
 
 // ToolKind classifies what a tool call does, using the ACP spec vocabulary so
 // protocol sinks can forward it verbatim.

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -196,7 +196,11 @@ type ChatCLI struct {
 	// coder ReAct loop (ACP structured bridge). Installed per-run by
 	// runLoopRPC under rpcStdoutMu and cleared on exit; never set by the
 	// interactive REPL, gateway or scheduler paths.
-	agentEventSink   agentevents.Sink
+	agentEventSink agentevents.Sink
+	// rpcPermissions, when set, approves policy-gated actions through the
+	// connected client even without an event sink (MCP elicitation bridge).
+	// Installed per-run by runLoopRPC under rpcStdoutMu, like agentEventSink.
+	rpcPermissions   agentevents.PermissionRequester
 	interactionState InteractionState
 	mu               sync.Mutex
 	operationCancel  context.CancelFunc

--- a/cli/rpc_support_full.go
+++ b/cli/rpc_support_full.go
@@ -344,6 +344,11 @@ type RPCRunOpts struct {
 	// transcript is captured and discarded, and the client consumes typed
 	// events plus the returned final answer instead of scraped lines.
 	Events agentevents.Sink
+	// Permissions, when non-nil, installs a per-run PermissionRequester so
+	// policy-gated actions can ask the connected client for approval even
+	// without an event sink (MCP elicitation bridge). Sinks implementing
+	// PermissionRequester themselves (ACP) take precedence.
+	Permissions agentevents.PermissionRequester
 	// Session scopes the run's /context attachments and knowledge bases
 	// (ctxmgr session id). Empty keeps the process default.
 	Session string
@@ -408,6 +413,13 @@ func (cli *ChatCLI) runLoopRPC(ctx context.Context, o RPCRunOpts, fn func(contex
 				cli.agentEventSink = prevSink
 				finalReply = strings.TrimSpace(cli.lastAgentReply)
 			}()
+		}
+		// Per-run permission bridge (MCP elicitation): same serialization
+		// argument as the sink — rpcStdoutMu holds for the whole run.
+		if o.Permissions != nil {
+			prevPerms := cli.rpcPermissions
+			cli.rpcPermissions = o.Permissions
+			defer func() { cli.rpcPermissions = prevPerms }()
 		}
 		// Scope the run to the caller's session so /context attachments and
 		// knowledge bases resolve like they would in the interactive REPL.

--- a/cli/rpcserve/acp_sink.go
+++ b/cli/rpcserve/acp_sink.go
@@ -19,6 +19,7 @@ package rpcserve
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"sync"
 	"unicode/utf8"
@@ -148,6 +149,13 @@ func (s *acpSink) RequestPermission(tc agentevents.ToolCall, reason string) (boo
 		},
 	})
 	if err != nil {
+		// Minimal/wrapped clients may not implement the method at all;
+		// surface the typed sentinel so the loop applies its unattended
+		// fallback instead of denying every gated action.
+		var rpcErr *RPCError
+		if errors.As(err, &rpcErr) && rpcErr.Code == CodeMethodNotFound {
+			return false, agentevents.ErrPermissionUnsupported
+		}
 		return false, err
 	}
 	var resp struct {

--- a/cli/rpcserve/mcp.go
+++ b/cli/rpcserve/mcp.go
@@ -8,7 +8,9 @@ package rpcserve
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
+	"sync"
 
 	"github.com/diillson/chatcli/cli/agentevents"
 )
@@ -39,6 +41,11 @@ type RunOpts struct {
 	// enrichment, no compaction) — the pre-parity ask_chatcli behavior, kept
 	// as an escape hatch for callers that want a cheap raw LLM turn.
 	Plain bool
+	// Permissions, when non-nil, lets the run ask the connected client to
+	// approve policy-gated actions (coder "ask" rules, dangerous commands)
+	// even without a structured event sink — the MCP elicitation bridge.
+	// Nil keeps the historical unattended contract.
+	Permissions agentevents.PermissionRequester
 }
 
 // ToolInfo describes a tool exposed over MCP.
@@ -159,11 +166,31 @@ type MCP struct {
 	backend MCPBackend
 	name    string
 	version string
+	// request is the server→client round-trip (Server.Request), used for
+	// elicitation/create. Wired by SetRequester after NewServer.
+	request func(ctx context.Context, method string, params interface{}) (json.RawMessage, error)
+	// mu guards elicits: initialize and tools/call dispatch concurrently.
+	mu      sync.Mutex
+	elicits bool
 }
 
 // NewMCP builds an MCP handler.
 func NewMCP(backend MCPBackend, name, version string) *MCP {
 	return &MCP{backend: backend, name: name, version: version}
+}
+
+// SetRequester wires the server's client-request round-trip (call after
+// NewServer). Without it, permission elicitation stays off.
+func (m *MCP) SetRequester(fn func(ctx context.Context, method string, params interface{}) (json.RawMessage, error)) {
+	m.request = fn
+}
+
+// clientElicits reports whether the connected client declared the
+// elicitation capability during initialize.
+func (m *MCP) clientElicits() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.elicits
 }
 
 // Handle dispatches an MCP method. Wire it into Server via the handlerFunc type.
@@ -195,9 +222,17 @@ func (m *MCP) Handle(ctx context.Context, method string, params json.RawMessage)
 // initialize negotiates the protocol revision and advertises capabilities.
 func (m *MCP) initialize(params json.RawMessage) map[string]interface{} {
 	var p struct {
-		ProtocolVersion string `json:"protocolVersion"`
+		ProtocolVersion string                     `json:"protocolVersion"`
+		Capabilities    map[string]json.RawMessage `json:"capabilities"`
 	}
 	_ = json.Unmarshal(params, &p)
+	// A client that declares elicitation understands elicitation/create
+	// regardless of the negotiated revision string; anything else (wrapped
+	// CLIs, older clients) never receives a server→client request.
+	_, hasElicit := p.Capabilities["elicitation"]
+	m.mu.Lock()
+	m.elicits = hasElicit
+	m.mu.Unlock()
 	version := MCPProtocolVersion
 	for _, v := range mcpSupportedVersions {
 		if p.ProtocolVersion == v {
@@ -501,7 +536,8 @@ func (m *MCP) callTool(ctx context.Context, params json.RawMessage) (interface{}
 	if session == "" {
 		session = "mcp"
 	}
-	opts := RunOpts{Provider: a.Provider, Model: a.Model, Quality: a.Quality, Plain: a.Plain}
+	opts := RunOpts{Provider: a.Provider, Model: a.Model, Quality: a.Quality, Plain: a.Plain,
+		Permissions: m.permissionsFor(ctx)}
 
 	switch p.Name {
 	case "ask_chatcli":
@@ -554,6 +590,67 @@ func (m *MCP) callTool(ctx context.Context, params json.RawMessage) (interface{}
 		}
 		return m.result(m.backend.CallTool(ctx, p.Name, a.Args))
 	}
+}
+
+// permissionsFor returns a PermissionRequester bridging approval prompts to
+// MCP elicitation/create, scoped to one tools/call context. Nil when the
+// client did not declare the elicitation capability or the requester is not
+// wired — the run then keeps the historical unattended contract.
+func (m *MCP) permissionsFor(ctx context.Context) agentevents.PermissionRequester {
+	if m.request == nil || !m.clientElicits() {
+		return nil
+	}
+	return &mcpElicitRequester{ctx: ctx, request: m.request}
+}
+
+// mcpElicitRequester implements agentevents.PermissionRequester over MCP
+// elicitation: the client renders a form with a single "approve" boolean.
+// Anything but an explicit accept+approve denies; a client answering
+// "method not found" maps to ErrPermissionUnsupported (legacy fallback).
+type mcpElicitRequester struct {
+	ctx     context.Context
+	request func(ctx context.Context, method string, params interface{}) (json.RawMessage, error)
+}
+
+func (e *mcpElicitRequester) RequestPermission(tc agentevents.ToolCall, reason string) (bool, error) {
+	action := strings.TrimSpace(tc.Title)
+	if action == "" {
+		action = tc.Name
+	}
+	msg := "ChatCLI requests permission to run: " + action
+	if strings.TrimSpace(reason) != "" {
+		msg += "\n" + reason
+	}
+	raw, err := e.request(e.ctx, "elicitation/create", map[string]interface{}{
+		"message": msg,
+		"requestedSchema": map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"approve": map[string]interface{}{
+					"type":        "boolean",
+					"description": "Approve running this action?",
+				},
+			},
+			"required": []string{"approve"},
+		},
+	})
+	if err != nil {
+		var rpcErr *RPCError
+		if errors.As(err, &rpcErr) && rpcErr.Code == CodeMethodNotFound {
+			return false, agentevents.ErrPermissionUnsupported
+		}
+		return false, err
+	}
+	var resp struct {
+		Action  string `json:"action"`
+		Content struct {
+			Approve bool `json:"approve"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return false, err
+	}
+	return resp.Action == "accept" && resp.Content.Approve, nil
 }
 
 // sessionSearchActions returns the action-list suffix for the search/fork

--- a/cli/rpcserve/mcp.go
+++ b/cli/rpcserve/mcp.go
@@ -166,31 +166,44 @@ type MCP struct {
 	backend MCPBackend
 	name    string
 	version string
+	// rt holds the mutable runtime wiring (server requester, client-declared
+	// capabilities). Kept behind a pointer so the exported struct stays
+	// comparable — a mutex or func field inline would be an incompatible
+	// API change.
+	rt *mcpRuntime
+}
+
+// mcpRuntime is the per-connection mutable state: initialize and tools/call
+// dispatch on concurrent goroutines, so access is mutex-guarded.
+type mcpRuntime struct {
+	mu sync.Mutex
 	// request is the server→client round-trip (Server.Request), used for
 	// elicitation/create. Wired by SetRequester after NewServer.
 	request func(ctx context.Context, method string, params interface{}) (json.RawMessage, error)
-	// mu guards elicits: initialize and tools/call dispatch concurrently.
-	mu      sync.Mutex
+	// elicits records whether the client declared the elicitation
+	// capability during initialize.
 	elicits bool
 }
 
 // NewMCP builds an MCP handler.
 func NewMCP(backend MCPBackend, name, version string) *MCP {
-	return &MCP{backend: backend, name: name, version: version}
+	return &MCP{backend: backend, name: name, version: version, rt: &mcpRuntime{}}
 }
 
 // SetRequester wires the server's client-request round-trip (call after
 // NewServer). Without it, permission elicitation stays off.
 func (m *MCP) SetRequester(fn func(ctx context.Context, method string, params interface{}) (json.RawMessage, error)) {
-	m.request = fn
+	m.rt.mu.Lock()
+	defer m.rt.mu.Unlock()
+	m.rt.request = fn
 }
 
 // clientElicits reports whether the connected client declared the
 // elicitation capability during initialize.
 func (m *MCP) clientElicits() bool {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return m.elicits
+	m.rt.mu.Lock()
+	defer m.rt.mu.Unlock()
+	return m.rt.elicits
 }
 
 // Handle dispatches an MCP method. Wire it into Server via the handlerFunc type.
@@ -230,9 +243,9 @@ func (m *MCP) initialize(params json.RawMessage) map[string]interface{} {
 	// regardless of the negotiated revision string; anything else (wrapped
 	// CLIs, older clients) never receives a server→client request.
 	_, hasElicit := p.Capabilities["elicitation"]
-	m.mu.Lock()
-	m.elicits = hasElicit
-	m.mu.Unlock()
+	m.rt.mu.Lock()
+	m.rt.elicits = hasElicit
+	m.rt.mu.Unlock()
 	version := MCPProtocolVersion
 	for _, v := range mcpSupportedVersions {
 		if p.ProtocolVersion == v {
@@ -597,10 +610,13 @@ func (m *MCP) callTool(ctx context.Context, params json.RawMessage) (interface{}
 // client did not declare the elicitation capability or the requester is not
 // wired — the run then keeps the historical unattended contract.
 func (m *MCP) permissionsFor(ctx context.Context) agentevents.PermissionRequester {
-	if m.request == nil || !m.clientElicits() {
+	m.rt.mu.Lock()
+	request, elicits := m.rt.request, m.rt.elicits
+	m.rt.mu.Unlock()
+	if request == nil || !elicits {
 		return nil
 	}
-	return &mcpElicitRequester{ctx: ctx, request: m.request}
+	return &mcpElicitRequester{ctx: ctx, request: request}
 }
 
 // mcpElicitRequester implements agentevents.PermissionRequester over MCP

--- a/cli/rpcserve/permission_test.go
+++ b/cli/rpcserve/permission_test.go
@@ -1,0 +1,163 @@
+package rpcserve
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/diillson/chatcli/cli/agentevents"
+)
+
+// TestACPSinkRequestPermission_MethodNotFoundMapsUnsupported: a client that
+// does not implement session/request_permission (wrapped/minimal ACP
+// frontends) answers -32601 — the sink must surface the typed sentinel so the
+// loop falls back to the legacy unattended contract instead of denying
+// everything.
+func TestACPSinkRequestPermission_MethodNotFoundMapsUnsupported(t *testing.T) {
+	a := NewACP(&fakeBackend{}, "test")
+	a.SetRequester(func(ctx context.Context, method string, params interface{}) (json.RawMessage, error) {
+		return nil, errf(CodeMethodNotFound, "no such method")
+	})
+	s := newACPSink(a, "sess", context.Background())
+	allowed, err := s.RequestPermission(agentevents.ToolCall{ID: "c1", Name: "@coder"}, "reason")
+	if allowed {
+		t.Fatal("method-not-found must never allow")
+	}
+	if !errors.Is(err, agentevents.ErrPermissionUnsupported) {
+		t.Fatalf("err = %v, want ErrPermissionUnsupported", err)
+	}
+}
+
+// TestACPSinkRequestPermission_OtherErrorsStayOpaque: transport failures must
+// NOT map to the unsupported sentinel — they deny fail-safe upstream.
+func TestACPSinkRequestPermission_OtherErrorsStayOpaque(t *testing.T) {
+	a := NewACP(&fakeBackend{}, "test")
+	a.SetRequester(func(ctx context.Context, method string, params interface{}) (json.RawMessage, error) {
+		return nil, errf(CodeInternalError, "client disconnected")
+	})
+	s := newACPSink(a, "sess", context.Background())
+	_, err := s.RequestPermission(agentevents.ToolCall{ID: "c1"}, "r")
+	if err == nil || errors.Is(err, agentevents.ErrPermissionUnsupported) {
+		t.Fatalf("internal error must stay opaque, got %v", err)
+	}
+}
+
+// TestMCPInitializeTracksElicitation: the initialize handshake records
+// whether the client declared the elicitation capability.
+func TestMCPInitializeTracksElicitation(t *testing.T) {
+	m := NewMCP(&fakeBackend{}, "chatcli", "test")
+	m.initialize(json.RawMessage(`{"protocolVersion":"2025-03-26","capabilities":{"elicitation":{}}}`))
+	if !m.clientElicits() {
+		t.Fatal("elicitation capability must be recorded")
+	}
+
+	m2 := NewMCP(&fakeBackend{}, "chatcli", "test")
+	m2.initialize(json.RawMessage(`{"protocolVersion":"2025-03-26","capabilities":{"sampling":{}}}`))
+	if m2.clientElicits() {
+		t.Fatal("absent elicitation capability must stay off")
+	}
+}
+
+// TestMCPAgentTaskCarriesPermissions: with elicitation declared and the
+// requester wired, agent_task/coder_task runs get a PermissionRequester that
+// round-trips elicitation/create.
+func TestMCPAgentTaskCarriesPermissions(t *testing.T) {
+	f := &fakeBackend{}
+	m := NewMCP(f, "chatcli", "test")
+	var gotMethod string
+	m.SetRequester(func(ctx context.Context, method string, params interface{}) (json.RawMessage, error) {
+		gotMethod = method
+		return json.RawMessage(`{"action":"accept","content":{"approve":true}}`), nil
+	})
+	m.initialize(json.RawMessage(`{"capabilities":{"elicitation":{}}}`))
+
+	params, _ := json.Marshal(map[string]interface{}{
+		"name":      "agent_task",
+		"arguments": map[string]interface{}{"task": "do x"},
+	})
+	if _, rpcErr := m.callTool(context.Background(), params); rpcErr != nil {
+		t.Fatalf("callTool: %v", rpcErr)
+	}
+	f.mu.Lock()
+	perms := f.lastOpts.Permissions
+	f.mu.Unlock()
+	if perms == nil {
+		t.Fatal("agent_task must carry a PermissionRequester when the client declared elicitation")
+	}
+	allowed, err := perms.RequestPermission(agentevents.ToolCall{Name: "@coder", Title: "exec: rm x"}, "policy ask")
+	if err != nil || !allowed {
+		t.Fatalf("accept+approve must allow, got allowed=%v err=%v", allowed, err)
+	}
+	if gotMethod != "elicitation/create" {
+		t.Fatalf("method = %q, want elicitation/create", gotMethod)
+	}
+}
+
+// TestMCPNoElicitationNoPermissions: clients that did not declare
+// elicitation (Devin and other wrapped CLIs) keep today's contract — no
+// server→client request is ever attempted.
+func TestMCPNoElicitationNoPermissions(t *testing.T) {
+	f := &fakeBackend{}
+	m := NewMCP(f, "chatcli", "test")
+	m.SetRequester(func(ctx context.Context, method string, params interface{}) (json.RawMessage, error) {
+		t.Fatal("requester must never be consulted without the capability")
+		return nil, nil
+	})
+	m.initialize(json.RawMessage(`{"capabilities":{}}`))
+
+	params, _ := json.Marshal(map[string]interface{}{
+		"name":      "coder_task",
+		"arguments": map[string]interface{}{"task": "do y"},
+	})
+	if _, rpcErr := m.callTool(context.Background(), params); rpcErr != nil {
+		t.Fatalf("callTool: %v", rpcErr)
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.lastOpts.Permissions != nil {
+		t.Fatal("no elicitation capability → Permissions must be nil")
+	}
+}
+
+// TestMCPElicitOutcomes: decline/cancel/accept-without-approve deny;
+// -32601 maps to the unsupported sentinel (legacy fallback upstream).
+func TestMCPElicitOutcomes(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		rpcErr  *RPCError
+		allowed bool
+		wantUns bool
+	}{
+		{"decline", `{"action":"decline"}`, nil, false, false},
+		{"cancel", `{"action":"cancel"}`, nil, false, false},
+		{"accept without approve", `{"action":"accept","content":{}}`, nil, false, false},
+		{"accept approve false", `{"action":"accept","content":{"approve":false}}`, nil, false, false},
+		{"accept approve true", `{"action":"accept","content":{"approve":true}}`, nil, true, false},
+		{"method not found", ``, errf(CodeMethodNotFound, "nope"), false, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewMCP(&fakeBackend{}, "chatcli", "test")
+			m.SetRequester(func(ctx context.Context, method string, params interface{}) (json.RawMessage, error) {
+				if tc.rpcErr != nil {
+					return nil, tc.rpcErr
+				}
+				return json.RawMessage(tc.raw), nil
+			})
+			m.initialize(json.RawMessage(`{"capabilities":{"elicitation":{}}}`))
+			pr := m.permissionsFor(context.Background())
+			if pr == nil {
+				t.Fatal("permissionsFor must return a requester")
+			}
+			allowed, err := pr.RequestPermission(agentevents.ToolCall{Name: "@coder"}, "r")
+			if allowed != tc.allowed {
+				t.Fatalf("allowed = %v, want %v", allowed, tc.allowed)
+			}
+			if tc.wantUns != errors.Is(err, agentevents.ErrPermissionUnsupported) {
+				t.Fatalf("err = %v, wantUnsupported=%v", err, tc.wantUns)
+			}
+		})
+	}
+}

--- a/cmd/rpcserve.go
+++ b/cmd/rpcserve.go
@@ -119,6 +119,10 @@ func runRPC(kind string, mgr manager.LLMManager, logger *zap.Logger) error {
 		m := rpcserve.NewMCP(backend, "chatcli", ver)
 		srv := rpcserve.NewServer(os.Stdin, os.Stdout, m.Handle)
 		defer quarantineStdout(logger)()
+		// Permission elicitation: server→client approval prompts for
+		// policy-gated actions, used only when the client declared the
+		// elicitation capability at initialize.
+		m.SetRequester(srv.Request)
 		// Relay catalog changes from ChatCLI's own MCP client (servers
 		// connecting after startup, dynamic refreshes, disconnects) to our
 		// client as notifications/tools/list_changed, so proxied tools show
@@ -746,7 +750,7 @@ func (b *rpcBackend) ProvidersJSON() (string, error) {
 
 // toRunOpts converts the wire options into the CLI run options.
 func toRunOpts(session string, o rpcserve.RunOpts) cli.RPCRunOpts {
-	return cli.RPCRunOpts{Provider: o.Provider, Model: o.Model, Quality: o.Quality, Emit: o.Emit, Events: o.Events, Session: session}
+	return cli.RPCRunOpts{Provider: o.Provider, Model: o.Model, Quality: o.Quality, Emit: o.Emit, Events: o.Events, Permissions: o.Permissions, Session: session}
 }
 
 // ACPCommands lists the slash commands advertised to ACP clients.

--- a/cmd/rpcserve_permissions_test.go
+++ b/cmd/rpcserve_permissions_test.go
@@ -1,0 +1,36 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cmd
+
+import (
+	"testing"
+
+	"github.com/diillson/chatcli/cli/agentevents"
+	"github.com/diillson/chatcli/cli/rpcserve"
+)
+
+type stubPermRequester struct{}
+
+func (stubPermRequester) RequestPermission(agentevents.ToolCall, string) (bool, error) {
+	return true, nil
+}
+
+// TestToRunOptsCarriesPermissions pins the RunOpts→RPCRunOpts mapping: the
+// MCP elicitation bridge only works if the per-call requester survives the
+// backend boundary into the loop options.
+func TestToRunOptsCarriesPermissions(t *testing.T) {
+	o := toRunOpts("sess", rpcserve.RunOpts{Permissions: stubPermRequester{}})
+	if o.Permissions == nil {
+		t.Fatal("toRunOpts must carry Permissions through to the loop options")
+	}
+	if o.Session != "sess" {
+		t.Fatalf("session = %q, want sess", o.Session)
+	}
+
+	if o := toRunOpts("s", rpcserve.RunOpts{}); o.Permissions != nil {
+		t.Fatal("absent requester must stay nil (legacy unattended contract)")
+	}
+}

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -2527,6 +2527,8 @@
   "rpc.session.store_unavailable": "the session store is not available in this ChatCLI instance",
   "acp.mode_switched": "Session mode switched to %s.",
   "agent.permission.dangerous_exec": "Dangerous command detected in @coder exec: %s",
+  "agent.permission.policy_ask": "Security policy requires your approval to run %s",
+  "agent.policy.ask_denied": "ACTION DENIED BY THE USER (security policy): %s",
   "acp.command_unsupported": "The command %s is not available over the IDE (ACP) connection. Type / to see the supported commands.",
   "acp.command_failed": "Command failed: %s",
   "acp.command_empty_output": "(command produced no output)",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -2527,6 +2527,8 @@
   "rpc.session.store_unavailable": "the session store is not available in this ChatCLI instance",
   "acp.mode_switched": "Session mode switched to %s.",
   "agent.permission.dangerous_exec": "Dangerous command detected in @coder exec: %s",
+  "agent.permission.policy_ask": "Security policy requires your approval to run %s",
+  "agent.policy.ask_denied": "ACTION DENIED BY THE USER (security policy): %s",
   "acp.command_unsupported": "The command %s is not available over the IDE (ACP) connection. Type / to see the supported commands.",
   "acp.command_failed": "Command failed: %s",
   "acp.command_empty_output": "(command produced no output)",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -2527,6 +2527,8 @@
   "rpc.session.store_unavailable": "o armazenamento de sessões não está disponível nesta instância do ChatCLI",
   "acp.mode_switched": "Modo da sessão alterado para %s.",
   "agent.permission.dangerous_exec": "Comando perigoso detectado no exec do @coder: %s",
+  "agent.permission.policy_ask": "A política de segurança exige sua aprovação para executar %s",
+  "agent.policy.ask_denied": "AÇÃO NEGADA PELO USUÁRIO (política de segurança): %s",
   "acp.command_unsupported": "O comando %s não está disponível pela conexão da IDE (ACP). Digite / para ver os comandos suportados.",
   "acp.command_failed": "Falha no comando: %s",
   "acp.command_empty_output": "(o comando não produziu saída)",


### PR DESCRIPTION
## Problem

In unattended runs (the shared ACP/MCP server boot calls SetUnattended(true)), every coder-policy `ask` rule was auto-approved with nothing but an Info log — including the default `@coder exec = ask` rule and safety-immune operations. Only explicit `deny` rules and the dangerous-command regex held. The auto-approve was designed for the gateway daemon (operator opted into full autonomy, access gated at the messaging edge); ACP and MCP inherited it through the shared `unattended` flag even though those surfaces DO have a human reachable on the other end.

## What changed

An `ask` verdict in an unattended run now consults the connected client whenever a permission dialog exists:

- **ACP**: routed through `session/request_permission` — the IDE shows its native approval dialog. A denial blocks the action, renders the refusal, closes the tool_call for the client, and appends a SECURITY BLOCK message so the model replans instead of retrying.
- **MCP**: same path via `elicitation/create`, gated by the `elicitation` capability the client declares at initialize. The requester travels through a new `Permissions` channel (`RunOpts` → `RPCRunOpts` → per-run install under `rpcStdoutMu`), deliberately separate from the Events sink so agent_task/coder_task output semantics stay untouched. Allow requires an explicit `accept` + `approve=true`; decline/cancel/anything else denies.

## Compatibility (no regressions)

- A client answering **method-not-found** (wrapped/minimal frontends) maps to a typed `ErrPermissionUnsupported` sentinel = "no dialog exists" → the historical unattended contract applies instead of denying everything. Any **other** transport failure denies fail-safe.
- MCP clients that do not declare elicitation never receive a server→client request — behavior is byte-identical to today.
- Gateway daemon, scheduler, interactive REPL and one-shot paths are untouched (no sink, no requester → legacy contract; interactive keeps the stdin prompt).
- Explicit `deny` rules and the dangerous-command guard block exactly as before; `CHATCLI_MCP_DANGER=block` still re-arms in-band refusal.

## Tests (red→green)

- `cli/agent_unattended_ask_test.go`: deny blocks + reaches history + closes tool_call; allow runs; no requester / unsupported client fall back to legacy; transport error denies; fallback requester consulted when the sink has no permission capability.
- `cli/rpcserve/permission_test.go`: ACP sink maps -32601 to the unsupported sentinel (other errors stay opaque); initialize records the elicitation capability; agent_task carries the requester only when declared; full elicitation outcome matrix.
- `cmd/rpcserve_permissions_test.go`: pins the RunOpts→RPCRunOpts mapping.

Full root-module suite green, golangci-lint clean, go vet clean, scripts/mcp_e2e.sh passes (protocol quarantine intact).
