### PR TITLE
fix(acp): bound the permission dialog wait and raise the default to ten minutes

### DIFF
--- a/cli/agent_events_bridge.go
+++ b/cli/agent_events_bridge.go
@@ -402,7 +402,7 @@ func (a *AgentMode) unattendedAskBlocked(toolName, rawArgs string, pm *coder.Pol
 	if errors.Is(reqErr, agentevents.ErrPermissionTimeout) {
 		msg := i18n.T("agent.policy.ask_timeout", title)
 		feedback := fmt.Sprintf(
-			"SECURITY BLOCK: The permission request for %q got NO RESPONSE from the user (the approval dialog timed out — the client may not display permission dialogs). The action was NOT executed. DO NOT retry it; continue without it, or tell the user their MCP client did not surface the approval dialog and that they can set CHATCLI_MCP_ELICITATION=off to restore unattended auto-approval.",
+			"SECURITY BLOCK: The permission request for %q got NO RESPONSE from the user (the approval dialog timed out — the client may not display permission dialogs). The action was NOT executed. DO NOT retry it; continue without it, or tell the user their client did not surface the approval dialog and that session policy automode (the /policy command, or the manage_session policy_mode action over MCP) restores unattended auto-approval.",
 			title)
 		renderError(msg)
 		a.emitBlockedTool(toolName, rawArgs, msg)

--- a/cli/config_env_defaults.go
+++ b/cli/config_env_defaults.go
@@ -231,7 +231,7 @@ var envDefaults = map[string]envDefault{
 	"CHATCLI_MCP_DYNAMIC_TOOLS":             {Value: "true", IsBool: true, Source: "mcp.dynamicToolRefreshEnabled — refresh on tools/list_changed"},
 	"CHATCLI_MCP_DANGER":                    {Value: "allow", Source: "cmd/rpcserve.go (mcp-server unattended danger policy: allow|block)"},
 	"CHATCLI_MCP_ELICITATION":               {Value: "on", Source: "cli/rpcserve/mcp.go (permission dialogs via elicitation/create: on|off; off restores the legacy unattended contract)"},
-	"CHATCLI_MCP_PERMISSION_TIMEOUT":        {Value: "120s", Source: "cli/rpcserve/mcp.go (max wait for the client's permission dialog; duration or seconds; 0|off waits until the call dies)"},
+	"CHATCLI_MCP_PERMISSION_TIMEOUT":        {Value: "600s", Source: "cli/rpcserve (max wait for the client's permission dialog, MCP elicitation and ACP request_permission; duration or seconds; 0|off waits until the call dies; tune below MCP clients' own tools/call timeout)"},
 	"CHATCLI_MCP_RESOURCES":                 {Value: "on", Source: "cli/rpc_support_resources.go (chatcli:// read-only resources: on|off)"},
 	"CHATCLI_MCP_MAX_HISTORY":               {Value: "0", Source: "cmd/rpcserve.go (0 = token-aware compaction bounds the history)"},
 	"CHATCLI_MCP_SESSION_AUTOSAVE":          {Value: "true", IsBool: true, Source: "cmd/rpcserve.go (persist live MCP sessions as mcp-<session>; unset follows CHATCLI_SESSION_AUTOSAVE)"},

--- a/cli/rpcserve/acp_sink.go
+++ b/cli/rpcserve/acp_sink.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"strings"
 	"sync"
+	"time"
 	"unicode/utf8"
 
 	"github.com/diillson/chatcli/cli/agentevents"
@@ -40,13 +41,24 @@ type acpSink struct {
 	sessionID string
 	runCtx    context.Context
 
+	// permTimeout bounds each session/request_permission round-trip; 0 waits
+	// until runCtx dies (legacy). Shares the CHATCLI_MCP_PERMISSION_TIMEOUT
+	// knob with the MCP elicitation bridge — like CHATCLI_MCP_TOOLS, the env
+	// governs both RPC surfaces.
+	permTimeout time.Duration
+
 	mu         sync.Mutex
 	open       map[string]bool // tool_call ids announced and not yet closed
 	sawMessage bool
+	// permDead flips after a permission timeout: the client demonstrably does
+	// not answer the dialog, so later requests in this run fail fast instead
+	// of stalling the loop for another timeout per gated action.
+	permDead bool
 }
 
 func newACPSink(a *ACP, sessionID string, runCtx context.Context) *acpSink {
-	return &acpSink{acp: a, sessionID: sessionID, runCtx: runCtx, open: map[string]bool{}}
+	return &acpSink{acp: a, sessionID: sessionID, runCtx: runCtx, open: map[string]bool{},
+		permTimeout: mcpPermissionTimeout()}
 }
 
 var _ agentevents.Sink = (*acpSink)(nil)
@@ -177,11 +189,22 @@ func (s *acpSink) RequestPermissionDecision(req agentevents.PermissionRequest) (
 			map[string]interface{}{"optionId": "reject-always", "name": i18n.T("acp.permission.reject_always"), "kind": "reject_always"})
 	}
 
-	raw, err := s.acp.request(s.runCtx, "session/request_permission", map[string]interface{}{
+	s.mu.Lock()
+	dead := s.permDead
+	s.mu.Unlock()
+	if dead {
+		return agentevents.PermissionDenyOnce, agentevents.ErrPermissionTimeout
+	}
+	ctx, cancel := s.runCtx, func() {}
+	if s.permTimeout > 0 {
+		ctx, cancel = context.WithTimeout(s.runCtx, s.permTimeout)
+	}
+	raw, err := s.acp.request(ctx, "session/request_permission", map[string]interface{}{
 		"sessionId": s.sessionID,
 		"toolCall":  toolCall,
 		"options":   options,
 	})
+	cancel()
 	if err != nil {
 		// Minimal/wrapped clients may not implement the method at all;
 		// surface the typed sentinel so the loop applies its unattended
@@ -189,6 +212,15 @@ func (s *acpSink) RequestPermissionDecision(req agentevents.PermissionRequest) (
 		var rpcErr *RPCError
 		if errors.As(err, &rpcErr) && rpcErr.Code == CodeMethodNotFound {
 			return agentevents.PermissionDenyOnce, agentevents.ErrPermissionUnsupported
+		}
+		// Our own bound expired while the run is still alive: the dialog is
+		// unanswered (likely never rendered). Deny fail-safe and mark it dead
+		// so the run doesn't stall again on every gated action.
+		if errors.Is(err, context.DeadlineExceeded) && s.runCtx.Err() == nil {
+			s.mu.Lock()
+			s.permDead = true
+			s.mu.Unlock()
+			return agentevents.PermissionDenyOnce, agentevents.ErrPermissionTimeout
 		}
 		return agentevents.PermissionDenyOnce, err
 	}

--- a/cli/rpcserve/mcp.go
+++ b/cli/rpcserve/mcp.go
@@ -631,15 +631,21 @@ func (m *MCP) permissionsFor(ctx context.Context) agentevents.PermissionRequeste
 	return &mcpElicitRequester{ctx: ctx, request: request, timeout: mcpPermissionTimeout()}
 }
 
-// mcpPermissionTimeoutDefault bounds how long one elicitation round-trip may
-// wait for the human. It must stay comfortably under common MCP client
-// tools/call timeouts (typically 2–5 minutes): if the client kills the call
-// first, the whole run dies with it — the hang this bound exists to prevent.
-const mcpPermissionTimeoutDefault = 120 * time.Second
+// mcpPermissionTimeoutDefault bounds how long one permission round-trip may
+// wait for the human — generous enough to notice a dialog and decide, while
+// still guaranteeing the run never hangs forever on a client that swallowed
+// the request. Caveat for MCP clients that enforce their own tools/call
+// timeout shorter than this: the client kills the whole call first, so tune
+// CHATCLI_MCP_PERMISSION_TIMEOUT below the client's limit to keep the run
+// alive. ACP clients (IDEs) hold the prompt turn open, so the long default
+// is safe there.
+const mcpPermissionTimeoutDefault = 600 * time.Second
 
 // mcpPermissionTimeout resolves CHATCLI_MCP_PERMISSION_TIMEOUT: a Go
 // duration ("90s", "2m") or plain seconds; "0"/"off" disable the bound
 // (wait until the run's context dies). Unset or invalid keeps the default.
+// Like CHATCLI_MCP_TOOLS, the knob governs both RPC surfaces: MCP
+// elicitation/create and ACP session/request_permission (acpSink).
 func mcpPermissionTimeout() time.Duration {
 	v := strings.TrimSpace(os.Getenv("CHATCLI_MCP_PERMISSION_TIMEOUT"))
 	if v == "" {

--- a/cli/rpcserve/permission_test.go
+++ b/cli/rpcserve/permission_test.go
@@ -519,3 +519,74 @@ func TestMCPPermissionTimeoutParsing(t *testing.T) {
 		})
 	}
 }
+
+// TestACPSinkRequestDecision_TimeoutDeniesAndFailsFast: an ACP client that
+// implements session/request_permission but never renders or answers the
+// dialog must not wedge the run until the runCtx dies — the same "stuck in
+// the dark" hang fixed for MCP elicitation. The wait is bounded by the same
+// CHATCLI_MCP_PERMISSION_TIMEOUT knob (it governs both RPC surfaces, like
+// CHATCLI_MCP_TOOLS); on expiry the decision denies fail-safe with the typed
+// sentinel and later requests in the same run fail fast.
+func TestACPSinkRequestDecision_TimeoutDeniesAndFailsFast(t *testing.T) {
+	t.Setenv("CHATCLI_MCP_PERMISSION_TIMEOUT", "30ms")
+	a := NewACP(&fakeBackend{}, "test")
+	calls := 0
+	a.SetRequester(func(ctx context.Context, method string, params interface{}) (json.RawMessage, error) {
+		calls++
+		<-ctx.Done() // client never answers; only the ctx bounds the wait
+		return nil, ctx.Err()
+	})
+	s := newACPSink(a, "sess", context.Background())
+
+	start := time.Now()
+	d, err := s.RequestPermissionDecision(agentevents.PermissionRequest{
+		Tool: agentevents.ToolCall{ID: "c1", Name: "@coder", Title: "exec: rm x"},
+	})
+	if d.Allowed() {
+		t.Fatal("an unanswered dialog must never allow")
+	}
+	if !errors.Is(err, agentevents.ErrPermissionTimeout) {
+		t.Fatalf("err = %v, want ErrPermissionTimeout", err)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("timeout took %v, must be bounded by the configured 30ms", elapsed)
+	}
+
+	start = time.Now()
+	d, err = s.RequestPermissionDecision(agentevents.PermissionRequest{
+		Tool: agentevents.ToolCall{ID: "c2", Name: "@coder", Title: "write: y"},
+	})
+	if d.Allowed() || !errors.Is(err, agentevents.ErrPermissionTimeout) {
+		t.Fatalf("dead dialog must deny with timeout sentinel, got d=%q err=%v", d, err)
+	}
+	if calls != 1 {
+		t.Fatalf("dead dialog must not be consulted again, requester calls = %d", calls)
+	}
+	if elapsed := time.Since(start); elapsed > 10*time.Millisecond {
+		t.Fatalf("fail-fast took %v", elapsed)
+	}
+}
+
+// TestACPSinkRequestDecision_ContextCanceledStaysOpaque: the run's own
+// context dying (prompt turn cancelled via session/cancel, client gone) is
+// NOT a dialog timeout — the error stays opaque so upstream treats it as a
+// transport failure, exactly like the MCP bridge.
+func TestACPSinkRequestDecision_ContextCanceledStaysOpaque(t *testing.T) {
+	a := NewACP(&fakeBackend{}, "test")
+	a.SetRequester(func(ctx context.Context, method string, params interface{}) (json.RawMessage, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+	runCtx, cancel := context.WithCancel(context.Background())
+	s := newACPSink(a, "sess", runCtx)
+	go func() { time.Sleep(10 * time.Millisecond); cancel() }()
+	d, err := s.RequestPermissionDecision(agentevents.PermissionRequest{
+		Tool: agentevents.ToolCall{ID: "c1", Name: "@coder"},
+	})
+	if d.Allowed() {
+		t.Fatal("cancelled run must never allow")
+	}
+	if errors.Is(err, agentevents.ErrPermissionTimeout) || errors.Is(err, agentevents.ErrPermissionUnsupported) {
+		t.Fatalf("run cancellation must stay an opaque transport error, got %v", err)
+	}
+}


### PR DESCRIPTION
Extends #1305 to the ACP surface and raises the default wait.

## Problem

The unanswered-dialog hang fixed for MCP elicitation in #1305 had the same exposure on ACP: `acpSink.RequestPermissionDecision` waited on `session/request_permission` bounded only by the run context. An IDE client that implements the method but never renders/answers the dialog froze the run in the dark — which matches the original incident (the `mcp-<session>` autosave name comes from the shared `rpcBackend`, so the log was ambiguous about the surface; the run was actually ACP).

## Fix

- `session/request_permission` now honors the same bound as MCP elicitation, resolved from the shared `CHATCLI_MCP_PERMISSION_TIMEOUT` knob (precedent: `CHATCLI_MCP_TOOLS` already governs both RPC surfaces). Same contract: **fail-safe deny** with `ErrPermissionTimeout`, distinct **NO RESPONSE** feedback to the model, fail-fast on later requests once the dialog proved dead, and run-context death staying an opaque transport error.
- **Default raised 120s → 600s**: generous for a human to notice and decide, still guaranteeing the run never hangs forever. MCP clients enforcing a shorter tools/call timeout kill the call first — operators there tune the env below the client limit; ACP clients hold the prompt turn open, so the long default is safe.
- Timeout feedback now suggests **session policy automode** (exists on both surfaces) instead of the MCP-only `CHATCLI_MCP_ELICITATION=off`.

## Tests (red→green)

- `TestACPSinkRequestDecision_TimeoutDeniesAndFailsFast` — hung the suite before the fix; now deny + typed sentinel + single consult
- `TestACPSinkRequestDecision_ContextCanceledStaysOpaque` — run cancellation ≠ dialog timeout

Full suite, vet, gofmt and golangci-lint clean.