### PR TITLE
fix(mcp): always register a fresh OAuth client when the server supports dynamic registration

### DIFF
--- a/cli/mcp/oauth.go
+++ b/cli/mcp/oauth.go
@@ -384,6 +384,26 @@ func wellKnownCandidates(issuer string) []string {
 	return out
 }
 
+// loginClientID resolves the client_id for one interactive login. When the AS
+// offers Dynamic Client Registration, it ALWAYS registers a fresh client:
+// dynamic registrations can be expired or purged server-side at any time
+// (observed on AWS signin — the authorize page then fails with an
+// invalid-redirect_uri error AFTER the user logs in, and every retry reuses
+// the same dead client, a loop with no recovery path). Registration is cheap
+// for public PKCE clients and an interactive login is rare, so fresh always
+// wins over stale. Without a registration endpoint the stored client is a
+// manual registration: reuse it when it was registered against this exact
+// redirect_uri, and fail actionably otherwise.
+func loginClientID(ctx context.Context, disc *oauthDiscoverer, asMeta *authServerMetadata, meta *oauthServerMeta, redirectURI, scope string) (string, error) {
+	if strings.TrimSpace(asMeta.RegistrationEndpoint) != "" {
+		return disc.registerClient(ctx, asMeta.RegistrationEndpoint, redirectURI, scope)
+	}
+	if meta != nil && meta.ClientID != "" && meta.RedirectURI == redirectURI {
+		return meta.ClientID, nil
+	}
+	return "", fmt.Errorf("%s", i18n.T("mcp.oauth.no_registration_endpoint"))
+}
+
 // registerClient performs RFC 7591 Dynamic Client Registration against the
 // authorization server, returning the issued client_id. Used only when we have
 // no client_id for the server yet.
@@ -482,17 +502,9 @@ func LoginServer(ctx context.Context, serverName, serverURL string, ch oauthChal
 	}
 	defer listener.Close() //nolint:errcheck // best-effort; server.Shutdown owns the listener
 
-	// Ensure we have a client_id. Reuse the stored one only if it was
-	// registered against the same redirect_uri; otherwise register fresh.
-	clientID := ""
-	if meta != nil && meta.ClientID != "" && meta.RedirectURI == redirectURI {
-		clientID = meta.ClientID
-	}
-	if clientID == "" {
-		clientID, err = disc.registerClient(ctx, asMeta.RegistrationEndpoint, redirectURI, scope)
-		if err != nil {
-			return err
-		}
+	clientID, err := loginClientID(ctx, disc, asMeta, meta, redirectURI, scope)
+	if err != nil {
+		return err
 	}
 
 	code, verifier, err := runLoopbackAuth(ctx, listener, loopbackAuthParams{

--- a/cli/mcp/oauth_test.go
+++ b/cli/mcp/oauth_test.go
@@ -199,3 +199,62 @@ func TestMCPRefreshFunc(t *testing.T) {
 		t.Errorf("expiry not set")
 	}
 }
+
+// TestLoginClientID_AlwaysRegistersFreshWhenDCRAvailable: a stored dynamic
+// client registration can be expired or purged by the AS at any time
+// (observed on AWS signin: authorize with the stale client_id fails on the
+// AS's own page with an invalid-redirect_uri error AFTER the user logs in,
+// and every retry reuses the same dead client — no recovery path). When the
+// AS offers a registration endpoint, an interactive login must therefore
+// ALWAYS register a fresh client, even when the stored one matches the
+// redirect_uri.
+func TestLoginClientID_AlwaysRegistersFreshWhenDCRAvailable(t *testing.T) {
+	registered := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		registered++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"client_id":"fresh-123"}`))
+	}))
+	defer srv.Close()
+
+	disc := newOAuthDiscoverer(zap.NewNop())
+	asMeta := &authServerMetadata{RegistrationEndpoint: srv.URL}
+	stored := &oauthServerMeta{ClientID: "stale-999", RedirectURI: "http://127.0.0.1:8765/callback"}
+
+	id, err := loginClientID(context.Background(), disc, asMeta, stored, "http://127.0.0.1:8765/callback", "scope")
+	if err != nil {
+		t.Fatalf("loginClientID: %v", err)
+	}
+	if id != "fresh-123" {
+		t.Fatalf("client id = %q, want fresh-123 (stale stored registration must never be reused when DCR is available)", id)
+	}
+	if registered != 1 {
+		t.Fatalf("registration endpoint hit %d times, want 1", registered)
+	}
+}
+
+// TestLoginClientID_ReusesStoredWithoutDCR: with no registration endpoint the
+// stored client is a manual registration — reuse it when the redirect_uri
+// matches, and fail with the actionable no-DCR error when it does not.
+func TestLoginClientID_ReusesStoredWithoutDCR(t *testing.T) {
+	disc := newOAuthDiscoverer(zap.NewNop())
+	asMeta := &authServerMetadata{} // no RegistrationEndpoint
+
+	stored := &oauthServerMeta{ClientID: "manual-42", RedirectURI: "http://127.0.0.1:8765/callback"}
+	id, err := loginClientID(context.Background(), disc, asMeta, stored, "http://127.0.0.1:8765/callback", "")
+	if err != nil || id != "manual-42" {
+		t.Fatalf("id=%q err=%v, want manual-42 nil (manual client must be reused)", id, err)
+	}
+
+	// redirect mismatch (e.g. fixed port busy, ephemeral fallback): the manual
+	// client cannot serve this redirect and there is no DCR — actionable error.
+	if _, err := loginClientID(context.Background(), disc, asMeta, stored, "http://127.0.0.1:54321/callback", ""); err == nil {
+		t.Fatal("redirect mismatch without DCR must error, not silently reuse a client bound to another redirect_uri")
+	}
+
+	// nothing stored and no DCR: same actionable error.
+	if _, err := loginClientID(context.Background(), disc, asMeta, nil, "http://127.0.0.1:8765/callback", ""); err == nil {
+		t.Fatal("no stored client and no DCR must error")
+	}
+}


### PR DESCRIPTION
## Problem

MCP OAuth login (`/mcp login` and `@mcp-login`) against AWS MCP started failing with **400 Bad Request about the redirect_uri right after the user completes the login page** — as if the loopback callback didn't exist. Retries always hit the same wall.

Root cause (evidence from the local app log):
- The last successful Dynamic Client Registration for `aws-mcp` was on **July 10** (3× HTTP 200 on `/v1/register`).
- Today's login attempts made **zero** registration calls: `LoginServer` reused the stored `client_id` because its recorded redirect_uri matched the loopback (`127.0.0.1:8765/callback`).
- AWS signin **expires/purges DCR clients server-side** (the server's refresh token had also expired — `TOKEN_EXPIRED`). With an unknown `client_id`, the authorize endpoint cannot validate the redirect_uri and fails on AWS's page **after** login with the redirect_uri error.
- The reuse condition is redirect-based only, so **every retry reuses the same dead client** — a loop with no recovery path.

Not a recent regression: `cli/mcp/oauth*.go` is untouched since #1161 — this is a latent design flaw (indefinite trust in a stored DCR registration) that only manifests once the AS purges the client.

## Fix

`loginClientID` (extracted, unit-tested): when the AS advertises a **registration endpoint, interactive logins always register a fresh client** — registration is a cheap unauthenticated call for public PKCE clients, and logins are rare, so fresh always beats stale. The stored `client_id` is reused **only** when there is no DCR endpoint (manually registered client) and it matches the exact redirect_uri; a mismatch there now fails with the actionable no-registration-endpoint error instead of authorizing with a client bound to another callback. Refresh flows untouched (post-login metadata carries the fresh client the tokens were issued to).

Side effect that also heals the retry UX: a failed attempt holds port 8765 for the 5-minute callback timeout, pushing retries to an ephemeral port — with fresh-always registration that ephemeral redirect is registered correctly and just works.

## Tests (red→green)

- `TestLoginClientID_AlwaysRegistersFreshWhenDCRAvailable` — stored stale client + DCR available ⇒ fresh client registered (failed before the fix)
- `TestLoginClientID_ReusesStoredWithoutDCR` — manual client reused on exact redirect match; mismatch and missing-client cases error actionably

Full suite, vet, gofmt and golangci-lint clean.