### PR TITLE
fix(agent): recover ACP/MCP turns from dead OAuth tokens, orphaned parks and stdin contention

### DIFF
--- a/auth/login.go
+++ b/auth/login.go
@@ -4,14 +4,55 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/diillson/chatcli/utils"
 	"go.uber.org/zap"
 )
+
+// TokenExchangeError is returned by the token-endpoint round-trip when the
+// server answers with a non-2xx status. It preserves the HTTP status and the
+// OAuth error code from the JSON body so callers can distinguish a terminal
+// refresh failure (expired/revoked refresh token — only a new interactive
+// login can recover) from a transient one (network blip, 5xx, throttling).
+type TokenExchangeError struct {
+	StatusCode int
+	Status     string
+	Code       string // OAuth "error" field, e.g. "invalid_grant" or vendor codes like "TOKEN_EXPIRED"
+	Body       string // sanitized response body
+}
+
+func (e *TokenExchangeError) Error() string {
+	return fmt.Sprintf("token exchange failed (%s): %s", e.Status, e.Body)
+}
+
+// Terminal reports whether retrying the same exchange can ever succeed.
+// 401/403 mean the credential itself was rejected; the listed 400-codes are
+// the RFC 6749 §5.2 permanent failures. "TOKEN_EXPIRED" is the vendor code
+// AWS sign-in returns for a dead refresh token.
+func (e *TokenExchangeError) Terminal() bool {
+	if e.StatusCode == http.StatusUnauthorized || e.StatusCode == http.StatusForbidden {
+		return true
+	}
+	switch e.Code {
+	case "invalid_grant", "invalid_client", "unauthorized_client", "unsupported_grant_type", "invalid_scope":
+		return true
+	}
+	return strings.EqualFold(e.Code, "TOKEN_EXPIRED")
+}
+
+// IsTerminalTokenError reports whether err wraps a token-exchange failure
+// that retrying cannot fix, i.e. the stored refresh token is dead and the
+// user must log in again.
+func IsTerminalTokenError(err error) bool {
+	var te *TokenExchangeError
+	return errors.As(err, &te) && te.Terminal()
+}
 
 // exchangeOAuthToken sends a token exchange request with JSON body.
 // Used by providers that accept application/json (e.g. OpenAI).
@@ -68,7 +109,16 @@ func doTokenExchange(hc *http.Client, req *http.Request) (*OAuthTokenResponse, e
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		// Sanitize response body to prevent leaking tokens in error messages
 		sanitized := utils.SanitizeSensitiveText(string(raw))
-		return nil, fmt.Errorf("token exchange failed (%s): %s", resp.Status, sanitized)
+		var oauthErr struct {
+			Error string `json:"error"`
+		}
+		_ = json.Unmarshal(raw, &oauthErr)
+		return nil, &TokenExchangeError{
+			StatusCode: resp.StatusCode,
+			Status:     resp.Status,
+			Code:       strings.TrimSpace(oauthErr.Error),
+			Body:       sanitized,
+		}
 	}
 	var tr OAuthTokenResponse
 

--- a/auth/reuse_test.go
+++ b/auth/reuse_test.go
@@ -8,8 +8,10 @@ package auth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"go.uber.org/zap"
@@ -155,5 +157,73 @@ func TestNewOAuthTokenProviderNilRefreshFallback(t *testing.T) {
 	tok, err := p.Token(context.Background())
 	if err != nil || tok != "tok" {
 		t.Fatalf("Token = %q err=%v", tok, err)
+	}
+}
+
+func TestExchangeTokenForm_TypedErrorOnFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"TOKEN_EXPIRED","message":"The refresh token has expired."}`))
+	}))
+	defer srv.Close()
+
+	_, err := ExchangeTokenForm(context.Background(), zap.NewNop(), srv.URL, TokenExchangeRequest{
+		GrantType:    "refresh_token",
+		ClientID:     "cid",
+		RefreshToken: "rt",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var te *TokenExchangeError
+	if !errors.As(err, &te) {
+		t.Fatalf("error %T is not *TokenExchangeError: %v", err, err)
+	}
+	if te.StatusCode != http.StatusUnauthorized || te.Code != "TOKEN_EXPIRED" {
+		t.Errorf("got status=%d code=%q, want 401 TOKEN_EXPIRED", te.StatusCode, te.Code)
+	}
+	if !IsTerminalTokenError(err) {
+		t.Error("401 TOKEN_EXPIRED must classify as terminal")
+	}
+	// The rendered message keeps the historical format so logs stay stable.
+	if want := "token exchange failed ("; !strings.Contains(err.Error(), want) {
+		t.Errorf("error %q does not contain %q", err.Error(), want)
+	}
+}
+
+func TestTokenExchangeError_TerminalClassification(t *testing.T) {
+	cases := []struct {
+		name     string
+		status   int
+		code     string
+		terminal bool
+	}{
+		{"401 any", http.StatusUnauthorized, "", true},
+		{"403 any", http.StatusForbidden, "", true},
+		{"400 invalid_grant", http.StatusBadRequest, "invalid_grant", true},
+		{"400 invalid_client", http.StatusBadRequest, "invalid_client", true},
+		{"400 unknown code", http.StatusBadRequest, "slow_down", false},
+		{"400 vendor token_expired", http.StatusBadRequest, "token_expired", true},
+		{"429 throttled", http.StatusTooManyRequests, "", false},
+		{"500 server error", http.StatusInternalServerError, "", false},
+		{"503 unavailable", http.StatusServiceUnavailable, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := &TokenExchangeError{StatusCode: tc.status, Code: tc.code}
+			if got := e.Terminal(); got != tc.terminal {
+				t.Errorf("Terminal() = %v, want %v", got, tc.terminal)
+			}
+		})
+	}
+}
+
+func TestIsTerminalTokenError_NonTokenErrors(t *testing.T) {
+	if IsTerminalTokenError(nil) {
+		t.Error("nil must not be terminal")
+	}
+	if IsTerminalTokenError(errors.New("dial tcp: connection refused")) {
+		t.Error("plain network error must not be terminal")
 	}
 }

--- a/auth/token_provider.go
+++ b/auth/token_provider.go
@@ -206,6 +206,12 @@ type oauthTokenProvider struct {
 	lastErr     error
 	invalidated bool
 
+	// terminalErr latches the first refresh failure that retrying cannot fix
+	// (expired/revoked refresh token). Once set, Token fails fast without
+	// another network round-trip and the background loop stops — recovery
+	// requires a new interactive login, which builds a fresh provider.
+	terminalErr error
+
 	refreshLead         time.Duration
 	refreshMinWait      time.Duration
 	refreshErrorBackoff time.Duration
@@ -271,6 +277,12 @@ func (p *oauthTokenProvider) Token(ctx context.Context) (string, error) {
 		return token, nil
 	}
 
+	if p.terminalErr != nil {
+		err := p.terminalErr
+		p.mu.Unlock()
+		return "", err
+	}
+
 	if p.refreshing != nil {
 		done := p.refreshing
 		p.mu.Unlock()
@@ -301,6 +313,8 @@ func (p *oauthTokenProvider) Token(ctx context.Context) (string, error) {
 	p.lastErr = err
 	if err == nil {
 		p.invalidated = false
+	} else if IsTerminalTokenError(err) {
+		p.terminalErr = err
 	}
 	close(done)
 	token := p.cred.Access
@@ -384,6 +398,19 @@ func (p *oauthTokenProvider) backgroundLoop() {
 		}
 
 		if _, err := p.Token(p.bgCtx); err != nil {
+			p.mu.Lock()
+			terminal := p.terminalErr != nil
+			p.mu.Unlock()
+			if terminal {
+				// The refresh token is dead — retrying only hammers the
+				// authorization server. Stop; a new login builds a new provider.
+				if p.logger != nil {
+					p.logger.Warn(i18n.T("auth.token_provider.background_refresh_terminal"),
+						zap.String("provider", string(p.cred.Provider)),
+						zap.Error(err))
+				}
+				return
+			}
 			if p.logger != nil {
 				p.logger.Warn(i18n.T("auth.token_provider.background_refresh_failed"),
 					zap.String("provider", string(p.cred.Provider)),

--- a/auth/token_provider_test.go
+++ b/auth/token_provider_test.go
@@ -349,3 +349,119 @@ func TestOAuthTokenProvider_CloseStopsBackground(t *testing.T) {
 	// Close is idempotent.
 	p.Close()
 }
+
+func terminalRefreshErr() error {
+	return fmt.Errorf("mcp refresh failed: %w", &TokenExchangeError{
+		StatusCode: http.StatusUnauthorized,
+		Status:     "401 Unauthorized",
+		Code:       "TOKEN_EXPIRED",
+		Body:       `{"error":"TOKEN_EXPIRED"}`,
+	})
+}
+
+func TestOAuthTokenProvider_TerminalErrorFailsFast(t *testing.T) {
+	var refreshCount int32
+	p := &oauthTokenProvider{
+		cred: AuthProfileCredential{
+			Provider: ProviderAnthropic,
+			Access:   "stale",
+			Refresh:  "rt",
+			Expires:  time.Now().Add(-1 * time.Hour).UnixMilli(),
+		},
+		logger: zap.NewNop(),
+		refreshFn: func(_ context.Context, _ *AuthProfileCredential, _ *zap.Logger) (*AuthProfileCredential, error) {
+			atomic.AddInt32(&refreshCount, 1)
+			return nil, terminalRefreshErr()
+		},
+	}
+
+	if _, err := p.Token(context.Background()); !IsTerminalTokenError(err) {
+		t.Fatalf("first Token error = %v, want terminal token error", err)
+	}
+	// Subsequent calls must not hit the network again — the latched terminal
+	// error is returned without invoking refreshFn.
+	if _, err := p.Token(context.Background()); !IsTerminalTokenError(err) {
+		t.Fatalf("second Token error = %v, want terminal token error", err)
+	}
+	if got := atomic.LoadInt32(&refreshCount); got != 1 {
+		t.Errorf("refreshes = %d, want 1 (terminal error latched)", got)
+	}
+	// Invalidate must not clear the latch: the refresh token is dead until a
+	// new login builds a new provider.
+	p.Invalidate()
+	if _, err := p.Token(context.Background()); !IsTerminalTokenError(err) {
+		t.Fatalf("post-Invalidate Token error = %v, want terminal token error", err)
+	}
+	if got := atomic.LoadInt32(&refreshCount); got != 1 {
+		t.Errorf("refreshes after Invalidate = %d, want still 1", got)
+	}
+}
+
+func TestOAuthTokenProvider_TerminalErrorStopsBackgroundLoop(t *testing.T) {
+	var refreshCount int32
+	p := &oauthTokenProvider{
+		cred: AuthProfileCredential{
+			Provider: ProviderAnthropic,
+			Access:   "v1",
+			Refresh:  "rt",
+			Expires:  time.Now().Add(50 * time.Millisecond).UnixMilli(),
+		},
+		logger:              zap.NewNop(),
+		refreshLead:         10 * time.Millisecond,
+		refreshMinWait:      10 * time.Millisecond,
+		refreshErrorBackoff: 10 * time.Millisecond,
+		refreshFn: func(_ context.Context, _ *AuthProfileCredential, _ *zap.Logger) (*AuthProfileCredential, error) {
+			atomic.AddInt32(&refreshCount, 1)
+			return nil, terminalRefreshErr()
+		},
+	}
+	p.bgCtx, p.bgCancel = context.WithCancel(context.Background())
+	p.bgDone = make(chan struct{})
+	go p.backgroundLoop()
+	defer p.Close()
+
+	// The loop must exit on its own after the first terminal failure —
+	// without Close being called.
+	select {
+	case <-p.bgDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("background loop kept retrying a terminal refresh error")
+	}
+	if got := atomic.LoadInt32(&refreshCount); got != 1 {
+		t.Errorf("refreshes = %d, want 1 (no retry on terminal error)", got)
+	}
+}
+
+func TestOAuthTokenProvider_TransientErrorKeepsRetrying(t *testing.T) {
+	var refreshCount int32
+	retried := make(chan struct{})
+	var once sync.Once
+	p := &oauthTokenProvider{
+		cred: AuthProfileCredential{
+			Provider: ProviderAnthropic,
+			Access:   "v1",
+			Refresh:  "rt",
+			Expires:  time.Now().Add(50 * time.Millisecond).UnixMilli(),
+		},
+		logger:              zap.NewNop(),
+		refreshLead:         10 * time.Millisecond,
+		refreshMinWait:      10 * time.Millisecond,
+		refreshErrorBackoff: 10 * time.Millisecond,
+		refreshFn: func(_ context.Context, _ *AuthProfileCredential, _ *zap.Logger) (*AuthProfileCredential, error) {
+			if atomic.AddInt32(&refreshCount, 1) >= 2 {
+				once.Do(func() { close(retried) })
+			}
+			return nil, errors.New("connection reset by peer")
+		},
+	}
+	p.bgCtx, p.bgCancel = context.WithCancel(context.Background())
+	p.bgDone = make(chan struct{})
+	go p.backgroundLoop()
+	defer p.Close()
+
+	select {
+	case <-retried:
+	case <-time.After(5 * time.Second):
+		t.Fatal("background loop did not retry a transient refresh error")
+	}
+}

--- a/cli/acp_support.go
+++ b/cli/acp_support.go
@@ -146,16 +146,16 @@ func (cli *ChatCLI) RunSlashCommandRPC(ctx context.Context, line string) (string
 		line = "/provider"
 	}
 
-	// captureRPCStdout holds rpcStdoutMu, so a command can never interleave
+	// captureRPCStdout holds rpcStdoutSem, so a command can never interleave
 	// with an in-flight captured agent/coder run.
 	var panicErr error
-	out, err := captureRPCStdout(func() error {
+	out, err := captureRPCStdout(ctx, func() error {
 		// Stdin quarantine: on the ACP/MCP server, os.Stdin IS the JSON-RPC
 		// channel. Any handler that prompts for confirmation would fight the
-		// protocol scanner for bytes and block forever holding rpcStdoutMu —
+		// protocol scanner for bytes and block forever holding rpcStdoutSem —
 		// wedging every session. Swapping in /dev/null makes every stdin
 		// read return EOF instantly, and all confirm sites treat EOF as
-		// "no" (fail-safe deny). Serialized by rpcStdoutMu like the stdout
+		// "no" (fail-safe deny). Serialized by rpcStdoutSem like the stdout
 		// swap; the REPL is never inside a captured run.
 		if devnull, derr := os.Open(os.DevNull); derr == nil {
 			origStdin := os.Stdin

--- a/cli/agent_events_bridge.go
+++ b/cli/agent_events_bridge.go
@@ -409,6 +409,21 @@ func (a *AgentMode) unattendedAskBlocked(toolName, rawArgs string, pm *coder.Pol
 		a.cli.history = append(a.cli.history, models.Message{Role: "user", Content: feedback})
 		return true
 	}
+	// Any other round-trip failure (client disconnected mid-dialog, write
+	// error, the turn being cancelled) is not a human decision either — the
+	// user never saw or never answered the dialog. Block fail-safe, but never
+	// claim the USER denied it: that misattribution makes the model tell the
+	// user they refused something they were never shown.
+	if reqErr != nil {
+		msg := i18n.T("agent.policy.ask_failed", title)
+		feedback := fmt.Sprintf(
+			"SECURITY BLOCK: The permission request for %q could not be delivered or answered (the dialog round-trip failed: %v). This was NOT a user denial. The action was NOT executed. DO NOT retry it; continue without it, or tell the user the approval dialog failed and that session policy automode (the /policy command, or the manage_session policy_mode action over MCP) restores unattended auto-approval.",
+			title, reqErr)
+		renderError(msg)
+		a.emitBlockedTool(toolName, rawArgs, msg)
+		a.cli.history = append(a.cli.history, models.Message{Role: "user", Content: feedback})
+		return true
+	}
 	if decision.Persistent() && pm != nil && pattern != "" {
 		action := coder.ActionDeny
 		if decision.Allowed() {

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -1685,9 +1685,18 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 	a.setCancelSignal(ctx.Done())
 	defer a.setCancelSignal(prevCancel)
 
-	// Start centralized stdin reader for type-ahead queue support
-	a.startStdinReader(ctx)
-	defer a.stopStdinReader()
+	// Start centralized stdin reader for type-ahead queue support.
+	// NEVER on unattended surfaces: on the ACP/MCP stdio servers os.Stdin
+	// IS the JSON-RPC channel, and this reader would race the protocol
+	// scanner for bytes — swallowing the client's permission answers and
+	// cancel frames, then feeding the stolen JSON to the LLM as bogus user
+	// type-ahead. Same quarantine rationale as RunSlashCommandRPC, which
+	// swaps stdin for /dev/null on those surfaces. There is no human on
+	// the other side of stdin to type ahead there anyway.
+	if !a.cli.unattended {
+		a.startStdinReader(ctx)
+		defer a.stopStdinReader()
+	}
 
 	// Structured event sink for protocol frontends (ACP). Resolved per call
 	// and restored on exit because this loop is re-entrant (see cancelSignal

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -1166,17 +1166,9 @@ func (a *AgentMode) Run(ctx context.Context, query string, additionalContext str
 
 	// --- 2. O LOOP DE RACIOCÍNIO-AÇÃO (ReAct) ---
 	err := a.processAIResponseAndAct(ctx, maxTurns)
-	// Park is a successful suspension, not an error. On the REPL the user
-	// is back at the prompt and the scheduler fires the resume in due time.
-	// Unattended surfaces (ACP / MCP server / gateway) have no prompt loop
-	// to deliver that resume into — keep the turn open and wait for the
-	// wake in-process instead, streaming the resumed cycles on the same
-	// client request.
-	if errors.Is(err, errAgentParkedRequested) {
-		if !a.cli.unattended {
-			return nil
-		}
-		err = a.runParkedInline(ctx)
+	endRun, err := a.settleParkSentinel(ctx, err)
+	if endRun {
+		return err
 	}
 	// Mirror the user request + final answer onto the shared conversation so
 	// the turn shows up as context on other channels. No-op when hub sync is

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -70,6 +70,14 @@ type AgentMode struct {
 	isCoderMode      bool
 	isOneShot        bool
 	coderBannerShown bool
+	// inlineParkToken names the park this run is waiting on IN-TURN, set by
+	// handleAgentPark on unattended surfaces (ACP / MCP server / gateway)
+	// where no REPL exists to drain the resume queue. Run() sees the park
+	// sentinel, finds this token, and blocks in runParkedInline until the
+	// scheduler delivers the wake — keeping the client's request open and
+	// the event sink streaming instead of ending the turn into a resume
+	// that could never be delivered.
+	inlineParkToken string
 	// pendingUserImages carries vision attachments for the NEXT user turn,
 	// set by the caller right before Run/RunOnce and consumed (then cleared)
 	// when the user message is appended. Transient per-turn state — the Run
@@ -1158,10 +1166,17 @@ func (a *AgentMode) Run(ctx context.Context, query string, additionalContext str
 
 	// --- 2. O LOOP DE RACIOCÍNIO-AÇÃO (ReAct) ---
 	err := a.processAIResponseAndAct(ctx, maxTurns)
-	// Park is a successful suspension, not an error. The user is back at
-	// the prompt; the scheduler will fire the resume in due time.
+	// Park is a successful suspension, not an error. On the REPL the user
+	// is back at the prompt and the scheduler fires the resume in due time.
+	// Unattended surfaces (ACP / MCP server / gateway) have no prompt loop
+	// to deliver that resume into — keep the turn open and wait for the
+	// wake in-process instead, streaming the resumed cycles on the same
+	// client request.
 	if errors.Is(err, errAgentParkedRequested) {
-		return nil
+		if !a.cli.unattended {
+			return nil
+		}
+		err = a.runParkedInline(ctx)
 	}
 	// Mirror the user request + final answer onto the shared conversation so
 	// the turn shows up as context on other channels. No-op when hub sync is

--- a/cli/agent_park.go
+++ b/cli/agent_park.go
@@ -82,6 +82,15 @@ func (a *AgentMode) handleAgentPark(
 		return fmt.Errorf("park: save snapshot: %w", err)
 	}
 
+	// Unattended surfaces (ACP / MCP server / gateway) have no REPL loop to
+	// drain the resume queue — register the in-turn waiter BEFORE the job is
+	// enqueued so even an immediately-firing job cannot race the wake past
+	// the waiter. Run() blocks on it in runParkedInline.
+	if a.cli.unattended {
+		a.cli.registerParkWaiter(snap.Token)
+		a.inlineParkToken = snap.Token
+	}
+
 	// Enqueue the matching scheduler job. For pure timer parks we go
 	// straight to AgentResume; for polling parks we use ParkPoll which
 	// fans out to AgentResume on success/timeout.
@@ -89,6 +98,10 @@ func (a *AgentMode) handleAgentPark(
 	if err != nil {
 		// Cleanup: a snapshot without a scheduler job is dead weight.
 		_ = park.Delete(snap.Token)
+		if a.cli.unattended {
+			a.cli.unregisterParkWaiter(snap.Token)
+			a.inlineParkToken = ""
+		}
 		return fmt.Errorf("park: enqueue resume job: %w", err)
 	}
 	snap.SchedulerJobID = jobID
@@ -115,7 +128,12 @@ func (a *AgentMode) handleAgentPark(
 	//
 	// The box uses the same Unicode rounded-box characters as the agent
 	// renderer for visual consistency with the rest of the /coder UI.
-	renderParkBanner(snap, req)
+	// Unattended surfaces skip it: the turn stays open in runParkedInline,
+	// and the /resume - /cancel-park hints it advertises are REPL commands
+	// the remote client cannot type.
+	if !a.cli.unattended {
+		renderParkBanner(snap, req)
+	}
 
 	// Bus event so /jobs and /parked stay coherent (the scheduler bridge
 	// owns publication; we route through it instead of the scheduler
@@ -302,6 +320,23 @@ func (a *AgentMode) RunResumed(ctx context.Context, snap *park.Snapshot, outcome
 	}
 	defer a.runInflight.Store(false)
 
+	err := a.runResumedCore(ctx, snap, outcome, detail)
+	// Parking again mid-resume is a SUCCESSFUL suspension, exactly like the
+	// sentinel handling in Run(): a new snapshot + scheduler job were just
+	// created for the next cycle. Returning the sentinel here made
+	// runWithCancellation print it as "❌ Erro na execução" on every
+	// monitoring cycle (park → resume → park again).
+	if errors.Is(err, errAgentParkedRequested) {
+		return nil
+	}
+	return err
+}
+
+// runResumedCore is RunResumed without the reentrancy guard and without the
+// park-sentinel-to-nil mapping. runParkedInline calls it from INSIDE a Run()
+// that already holds runInflight, and needs the raw sentinel to know the
+// monitoring cycle re-parked.
+func (a *AgentMode) runResumedCore(ctx context.Context, snap *park.Snapshot, outcome, detail string) error {
 	a.logger.Info("agent resuming from park",
 		zap.String("token", snap.Token),
 		zap.String("outcome", outcome),
@@ -361,10 +396,15 @@ func (a *AgentMode) RunResumed(ctx context.Context, snap *park.Snapshot, outcome
 		snap.PendingUserDirectives = nil
 	}
 
-	// Banner so the user sees the resume start in their terminal.
-	fmt.Println()
-	fmt.Println(colorize("  ▶️  "+i18n.T("park.banner.resumed", snap.Token, outcome), ColorGreen+ColorBold))
-	fmt.Println()
+	// Banner so the user sees the resume start in their terminal. Skipped
+	// on unattended surfaces, where stdout is either captured transcript or
+	// a protocol channel — the resumed loop's own streaming reaches the
+	// client through the event sink.
+	if !a.cli.unattended {
+		fmt.Println()
+		fmt.Println(colorize("  ▶️  "+i18n.T("park.banner.resumed", snap.Token, outcome), ColorGreen+ColorBold))
+		fmt.Println()
+	}
 
 	// Audit checkpoint and snapshot bookkeeping. We keep the snapshot
 	// file on disk (with LastResumeAt updated) for forensic purposes;
@@ -380,13 +420,11 @@ func (a *AgentMode) RunResumed(ctx context.Context, snap *park.Snapshot, outcome
 	maxTurns := AgentMaxTurns()
 	err := a.processAIResponseAndAct(ctx, maxTurns)
 
-	// Parking again mid-resume is a SUCCESSFUL suspension, exactly like the
-	// sentinel handling in Run(): a new snapshot + scheduler job were just
-	// created for the next cycle. Returning the sentinel here made
-	// runWithCancellation print it as "❌ Erro na execução" on every
-	// monitoring cycle (park → resume → park again).
+	// Parking again mid-resume: propagate the sentinel untouched — the next
+	// cycle's snapshot + scheduler job already exist. RunResumed maps it to
+	// nil for the REPL drain; runParkedInline uses it to keep waiting.
 	if errors.Is(err, errAgentParkedRequested) {
-		return nil
+		return err
 	}
 	if err != nil {
 		// Deliberate abort (Ctrl+C): retire the snapshot. The scheduler job

--- a/cli/agent_park_inline.go
+++ b/cli/agent_park_inline.go
@@ -55,6 +55,23 @@ func (cli *ChatCLI) unregisterParkWaiter(token string) {
 	cli.parkWaiterMu.Unlock()
 }
 
+// settleParkSentinel resolves the park sentinel for the current surface.
+// Park is a successful suspension, not an error: on the REPL the run ends
+// (the prompt loop owns the resume and the scheduler fires it in due time),
+// so endRun reports that Run must return immediately with the given error.
+// Unattended surfaces (ACP / MCP server / gateway) have no prompt loop to
+// deliver that resume into — the turn stays open and waits for the wake
+// in-process, streaming the resumed cycles on the same client request.
+func (a *AgentMode) settleParkSentinel(ctx context.Context, err error) (endRun bool, out error) {
+	if !errors.Is(err, errAgentParkedRequested) {
+		return false, err
+	}
+	if !a.cli.unattended {
+		return true, nil
+	}
+	return false, a.runParkedInline(ctx)
+}
+
 // runParkedInline blocks the current run on the registered park waiter and
 // re-enters the loop when the scheduler delivers the wake. Re-parks inside
 // the resumed loop (the normal monitoring cycle) land back here, so one

--- a/cli/agent_park_inline.go
+++ b/cli/agent_park_inline.go
@@ -1,0 +1,135 @@
+/*
+ * ChatCLI - In-turn park wait for unattended surfaces.
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * On the REPL, a parked agent ends its run and the outer prompt loop later
+ * drains pendingResumeQueue to re-enter the loop. ACP (IDE), the MCP server
+ * and the gateway have no such loop: a park taken there used to end the turn
+ * with nothing ever consuming the resume — the monitor kept firing forever,
+ * invisible, and the client showed an eternally pending turn.
+ *
+ * This file keeps the park IN-TURN on those surfaces: handleAgentPark
+ * registers a waiter channel before enqueueing the scheduler job, Run()
+ * blocks in runParkedInline instead of returning, the bridge delivers the
+ * wake straight to the waiter, and the resumed loop continues on the same
+ * request with the same event sink. Cancelling the turn (IDE Stop /
+ * session/cancel) cancels the scheduler job and deletes the snapshot so
+ * nothing leaks.
+ */
+package cli
+
+import (
+	"context"
+	"errors"
+
+	"github.com/diillson/chatcli/cli/agent/park"
+	"github.com/diillson/chatcli/cli/scheduler"
+	"go.uber.org/zap"
+)
+
+// registerParkWaiter installs the in-turn wake channel for token. Buffered(1)
+// so the scheduler dispatcher's send never blocks.
+func (cli *ChatCLI) registerParkWaiter(token string) chan parkOutcome {
+	ch := make(chan parkOutcome, 1)
+	cli.parkWaiterMu.Lock()
+	if cli.parkWaiters == nil {
+		cli.parkWaiters = map[string]chan parkOutcome{}
+	}
+	cli.parkWaiters[token] = ch
+	cli.parkWaiterMu.Unlock()
+	return ch
+}
+
+// parkWaiter returns the registered wake channel for token, or nil.
+func (cli *ChatCLI) parkWaiter(token string) chan parkOutcome {
+	cli.parkWaiterMu.Lock()
+	defer cli.parkWaiterMu.Unlock()
+	return cli.parkWaiters[token]
+}
+
+// unregisterParkWaiter removes the wake channel for token.
+func (cli *ChatCLI) unregisterParkWaiter(token string) {
+	cli.parkWaiterMu.Lock()
+	delete(cli.parkWaiters, token)
+	cli.parkWaiterMu.Unlock()
+}
+
+// runParkedInline blocks the current run on the registered park waiter and
+// re-enters the loop when the scheduler delivers the wake. Re-parks inside
+// the resumed loop (the normal monitoring cycle) land back here, so one
+// client request covers the whole monitoring conversation. Returns when the
+// resumed loop completes without re-parking, fails, or ctx is cancelled.
+func (a *AgentMode) runParkedInline(ctx context.Context) error {
+	for {
+		token := a.inlineParkToken
+		if token == "" {
+			return nil
+		}
+		ch := a.cli.parkWaiter(token)
+		if ch == nil {
+			// Defensive: no waiter means the park was cancelled elsewhere.
+			a.inlineParkToken = ""
+			return nil
+		}
+
+		var wake parkOutcome
+		select {
+		case wake = <-ch:
+		case <-ctx.Done():
+			// IDE Stop / session cancel / client disconnect: retire the park
+			// completely — job, snapshot, waiter — so nothing keeps polling
+			// for a turn that no longer exists.
+			a.cancelInlinePark(token)
+			return ctx.Err()
+		}
+
+		a.cli.unregisterParkWaiter(token)
+		a.inlineParkToken = ""
+
+		snap, err := park.Load(token)
+		if err != nil {
+			// Snapshot gone (raced with an explicit cancel): clean end.
+			a.logger.Info("park: inline wake without snapshot; ending turn",
+				zap.String("token", token), zap.Error(err))
+			return nil
+		}
+
+		a.logger.Info("park: inline wake received; resuming in-turn",
+			zap.String("token", token),
+			zap.String("outcome", wake.Outcome))
+
+		err = a.runResumedCore(ctx, snap, wake.Outcome, wake.Detail)
+		if errors.Is(err, errAgentParkedRequested) {
+			// The monitoring cycle re-parked: handleAgentPark already
+			// registered the next waiter and set inlineParkToken.
+			continue
+		}
+		return err
+	}
+}
+
+// cancelInlinePark retires a park whose in-turn waiter was abandoned:
+// scheduler job cancelled, snapshot deleted, bridge bookkeeping cleared.
+// Mirrors /cancel-park, which is unreachable from unattended surfaces.
+func (a *AgentMode) cancelInlinePark(token string) {
+	if snap, err := park.Load(token); err == nil && snap.SchedulerJobID != "" && a.cli.scheduler != nil {
+		owner := scheduler.Owner{Kind: "park", ID: "agent", Tag: snap.Token}
+		if cerr := a.cli.scheduler.Cancel(scheduler.JobID(snap.SchedulerJobID), "unattended turn cancelled", owner); cerr != nil {
+			a.logger.Warn("park: cancel job on turn abort failed",
+				zap.String("token", token), zap.Error(cerr))
+		}
+	}
+	if err := park.Delete(token); err != nil {
+		a.logger.Warn("park: delete snapshot on turn abort failed",
+			zap.String("token", token), zap.Error(err))
+	}
+	a.cli.dropPendingResume(token)
+	a.cli.unregisterActivePark(token)
+	a.cli.unregisterParkWaiter(token)
+	a.cli.parkOutcomeMu.Lock()
+	delete(a.cli.parkOutcomes, token)
+	a.cli.parkOutcomeMu.Unlock()
+	a.inlineParkToken = ""
+	a.logger.Info("park: retired on turn cancellation", zap.String("token", token))
+}

--- a/cli/agent_park_inline_test.go
+++ b/cli/agent_park_inline_test.go
@@ -1,0 +1,102 @@
+/*
+ * ChatCLI - In-turn park wait tests (unattended surfaces).
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/diillson/chatcli/cli/agent/park"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestWakeParkedAgent_DeliversToInTurnWaiter(t *testing.T) {
+	cli := &ChatCLI{logger: zap.NewNop()}
+	bridge := &schedulerBridge{cli: cli}
+
+	ch := cli.registerParkWaiter("tok-inline-1")
+	err := bridge.wakeParkedAgent("tok-inline-1", "matched", "probe ok")
+	assert.NoError(t, err)
+
+	select {
+	case wake := <-ch:
+		assert.Equal(t, "matched", wake.Outcome)
+		assert.Equal(t, "probe ok", wake.Detail)
+	default:
+		t.Fatal("wake was not delivered to the in-turn waiter")
+	}
+	// The waiter path must bypass the REPL machinery entirely.
+	assert.Empty(t, cli.pendingResumeQueue, "waiter delivery must not also queue")
+	assert.Empty(t, cli.parkOutcomes, "waiter delivery must not stash an outcome")
+}
+
+func TestWakeParkedAgent_DuplicateWakeDoesNotBlock(t *testing.T) {
+	cli := &ChatCLI{logger: zap.NewNop()}
+	bridge := &schedulerBridge{cli: cli}
+
+	cli.registerParkWaiter("tok-inline-2")
+	// Two wakes for the same token (poll match + safety net): the buffered(1)
+	// channel absorbs the first, the second is dropped — never a deadlock.
+	assert.NoError(t, bridge.wakeParkedAgent("tok-inline-2", "matched", ""))
+	assert.NoError(t, bridge.wakeParkedAgent("tok-inline-2", "error", "job died"))
+}
+
+func TestWakeParkedAgent_UnattendedWithoutWaiterQueuesQuietly(t *testing.T) {
+	cli := &ChatCLI{logger: zap.NewNop(), unattended: true}
+	bridge := &schedulerBridge{cli: cli}
+
+	// No waiter registered (e.g. wake fired after the turn was torn down):
+	// the token must still land in the queue for forensics, without banner
+	// or TTY inject touching the protocol channel (would panic/corrupt).
+	assert.NoError(t, bridge.wakeParkedAgent("tok-inline-3", "elapsed", ""))
+	assert.Equal(t, []string{"tok-inline-3"}, cli.pendingResumeQueue)
+}
+
+func TestRunParkedInline_CtxCancelRetiresPark(t *testing.T) {
+	t.Setenv("CHATCLI_PARK_DIR", t.TempDir())
+	cli := &ChatCLI{logger: zap.NewNop(), unattended: true}
+	a := &AgentMode{cli: cli, logger: zap.NewNop()}
+
+	snap := &park.Snapshot{Token: park.NewToken()}
+	assert.NoError(t, snap.Save())
+	cli.registerParkWaiter(snap.Token)
+	a.inlineParkToken = snap.Token
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // IDE Stop before any wake arrives
+
+	err := a.runParkedInline(ctx)
+	assert.ErrorIs(t, err, context.Canceled)
+
+	// The park must be fully retired: snapshot gone, waiter gone.
+	_, loadErr := park.Load(snap.Token)
+	assert.Error(t, loadErr, "snapshot must be deleted on turn cancellation")
+	assert.Nil(t, cli.parkWaiter(snap.Token), "waiter must be unregistered")
+	assert.Empty(t, a.inlineParkToken)
+}
+
+func TestRunParkedInline_WakeWithoutSnapshotEndsCleanly(t *testing.T) {
+	t.Setenv("CHATCLI_PARK_DIR", t.TempDir())
+	cli := &ChatCLI{logger: zap.NewNop(), unattended: true}
+	a := &AgentMode{cli: cli, logger: zap.NewNop()}
+
+	ch := cli.registerParkWaiter("tok-inline-4")
+	a.inlineParkToken = "tok-inline-4"
+	ch <- parkOutcome{Outcome: "elapsed"}
+
+	// The wake races an explicit cancel that already deleted the snapshot:
+	// the turn ends cleanly instead of erroring.
+	err := a.runParkedInline(context.Background())
+	assert.NoError(t, err)
+	assert.Empty(t, a.inlineParkToken)
+}
+
+func TestRunParkedInline_NoTokenIsNoOp(t *testing.T) {
+	cli := &ChatCLI{logger: zap.NewNop()}
+	a := &AgentMode{cli: cli, logger: zap.NewNop()}
+	assert.NoError(t, a.runParkedInline(context.Background()))
+}

--- a/cli/agent_unattended_ask_test.go
+++ b/cli/agent_unattended_ask_test.go
@@ -334,3 +334,27 @@ func TestUnattendedAskBlocked_TimeoutDeniesWithDistinctFeedback(t *testing.T) {
 		t.Fatalf("blocked tool_call must close as error for the client, ends: %+v", rec.ends)
 	}
 }
+
+// TestUnattendedAskBlocked_TransportErrorIsNotUserDenial: a dialog round-trip
+// failure (client disconnected, write error, cancelled turn) blocks fail-safe
+// but must never be reported to the model as an explicit user denial — the
+// user never saw the dialog, and the misattribution made the model tell them
+// they refused something they were never shown.
+func TestUnattendedAskBlocked_TransportErrorIsNotUserDenial(t *testing.T) {
+	rec := &permRecorder{err: errFixed("client disconnected")}
+	a, c := newUnattendedAgent(rec)
+	if !a.unattendedAskBlocked("@coder", `{"cmd":"exec"}`, nil, func(string) {}) {
+		t.Fatal("transport error must deny fail-safe")
+	}
+	var feedback strings.Builder
+	for _, m := range c.history {
+		feedback.WriteString(m.Content)
+		feedback.WriteString("\n")
+	}
+	if strings.Contains(feedback.String(), "DENIED by the user") {
+		t.Fatal("transport failure must not be attributed to the user")
+	}
+	if !strings.Contains(feedback.String(), "could not be delivered") {
+		t.Fatalf("model feedback must state the dialog round-trip failed, got: %q", feedback.String())
+	}
+}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -200,12 +200,12 @@ type ChatCLI struct {
 	lastAgentReply string // last one-shot agent prose answer (command blocks stripped), captured for unattended callers
 	// agentEventSink, when set, receives structured events from the agent/
 	// coder ReAct loop (ACP structured bridge). Installed per-run by
-	// runLoopRPC under rpcStdoutMu and cleared on exit; never set by the
+	// runLoopRPC under rpcStdoutSem and cleared on exit; never set by the
 	// interactive REPL, gateway or scheduler paths.
 	agentEventSink agentevents.Sink
 	// rpcPermissions, when set, approves policy-gated actions through the
 	// connected client even without an event sink (MCP elicitation bridge).
-	// Installed per-run by runLoopRPC under rpcStdoutMu, like agentEventSink.
+	// Installed per-run by runLoopRPC under rpcStdoutSem, like agentEventSink.
 	rpcPermissions   agentevents.PermissionRequester
 	interactionState InteractionState
 	mu               sync.Mutex

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -418,6 +418,14 @@ type ChatCLI struct {
 	parkOutcomeMu sync.Mutex
 	parkOutcomes  map[string]parkOutcome
 
+	// parkWaiters holds the in-turn wake channels registered by parks taken
+	// on unattended surfaces (ACP / MCP server / gateway), where no REPL
+	// loop exists to drain pendingResumeQueue. The bridge delivers the wake
+	// directly to the blocked turn instead of queueing it. Keyed by token;
+	// channels are buffered(1) so the scheduler dispatcher never blocks.
+	parkWaiterMu sync.Mutex
+	parkWaiters  map[string]chan parkOutcome
+
 	// recentlyResumedTokens tracks tokens that drainPendingResumes
 	// just consumed, so the auto-injected "/resume <token>" command
 	// (fired by NotifyParkComplete via TTY inject) can short-circuit

--- a/cli/config_env_defaults.go
+++ b/cli/config_env_defaults.go
@@ -231,7 +231,7 @@ var envDefaults = map[string]envDefault{
 	"CHATCLI_MCP_DYNAMIC_TOOLS":             {Value: "true", IsBool: true, Source: "mcp.dynamicToolRefreshEnabled — refresh on tools/list_changed"},
 	"CHATCLI_MCP_DANGER":                    {Value: "allow", Source: "cmd/rpcserve.go (mcp-server unattended danger policy: allow|block)"},
 	"CHATCLI_MCP_ELICITATION":               {Value: "on", Source: "cli/rpcserve/mcp.go (permission dialogs via elicitation/create: on|off; off restores the legacy unattended contract)"},
-	"CHATCLI_MCP_PERMISSION_TIMEOUT":        {Value: "600s", Source: "cli/rpcserve (max wait for the client's permission dialog, MCP elicitation and ACP request_permission; duration or seconds; 0|off waits until the call dies; tune below MCP clients' own tools/call timeout)"},
+	"CHATCLI_MCP_PERMISSION_TIMEOUT":        {Value: "600s", Source: "cli/rpcserve (max wait for the client's permission dialog, MCP elicitation and ACP request_permission; duration or seconds; 0|off lifts the bound to a 24h ceiling — never truly unbounded; tune below MCP clients' own tools/call timeout)"},
 	"CHATCLI_MCP_OAUTH_PORT":                {Value: "8765", Source: "cli/mcp/oauth.go (fixed loopback port for the OAuth callback; keeps redirect_uri and client registration stable; falls back to an ephemeral port when busy)"},
 	"CHATCLI_MCP_RESOURCES":                 {Value: "on", Source: "cli/rpc_support_resources.go (chatcli:// read-only resources: on|off)"},
 	"CHATCLI_MCP_MAX_HISTORY":               {Value: "0", Source: "cmd/rpcserve.go (0 = token-aware compaction bounds the history)"},

--- a/cli/mcp/manager.go
+++ b/cli/mcp/manager.go
@@ -1229,6 +1229,15 @@ func (m *Manager) callTool(ctx context.Context, conn *ServerConnection, toolName
 
 	result, err := conn.transport.Call("tools/call", params)
 	if err != nil {
+		// A mid-session OAuth failure (dead refresh token, revoked grant)
+		// flags the server so /mcp status and the agent's auth note surface
+		// the login hint instead of advertising tools that can only fail.
+		if oe, ok := IsOAuthRequired(err); ok {
+			m.mu.Lock()
+			conn.Status.AuthRequired = true
+			conn.oauthChallenge = oe.Challenge
+			m.mu.Unlock()
+		}
 		return nil, err
 	}
 

--- a/cli/mcp/manager_oauth_test.go
+++ b/cli/mcp/manager_oauth_test.go
@@ -154,3 +154,34 @@ func TestAuthRequiredServersAndHasCredential(t *testing.T) {
 		t.Fatalf("expected no stored credential")
 	}
 }
+
+// oauthFailTransport always fails Call with the configured error. Stands in
+// for a live transport whose stored refresh token died mid-session.
+type oauthFailTransport struct{ err error }
+
+func (f *oauthFailTransport) Call(string, interface{}) (json.RawMessage, error) { return nil, f.err }
+func (f *oauthFailTransport) Close(context.Context) error                       { return nil }
+
+// TestCallToolMarksAuthRequiredOnOAuthError guards the mid-session path: when
+// a tool call fails because the OAuth refresh token is dead, the server must
+// be flagged AuthRequired so /mcp status and the agent's auth note offer the
+// login hint — previously only the startup handshake ever set the flag.
+func TestCallToolMarksAuthRequiredOnOAuthError(t *testing.T) {
+	m := managerWithServer(t, ServerConfig{
+		Name: "aws", Transport: TransportStreamableHTTP, URL: "http://unused", Enabled: true,
+	})
+	conn := m.servers["aws"]
+	conn.Status.Connected = true
+	conn.transport = &oauthFailTransport{err: &OAuthRequiredError{Server: "aws"}}
+
+	_, err := m.callTool(context.Background(), conn, "ping", nil)
+	if _, ok := IsOAuthRequired(err); !ok {
+		t.Fatalf("callTool error = %v, want *OAuthRequiredError", err)
+	}
+	if !conn.Status.AuthRequired {
+		t.Error("server must be flagged AuthRequired after a mid-session OAuth failure")
+	}
+	if got := m.AuthRequiredServers(); len(got) != 1 || got[0] != "aws" {
+		t.Errorf("AuthRequiredServers() = %v, want [aws]", got)
+	}
+}

--- a/cli/mcp/transport_http.go
+++ b/cli/mcp/transport_http.go
@@ -237,6 +237,15 @@ func (t *httpTransport) Call(method string, params interface{}) (json.RawMessage
 		if reqCtx.Err() == context.DeadlineExceeded {
 			return nil, fmt.Errorf("%s", i18n.T("mcp.transport.call_timeout", method, deadline))
 		}
+		if auth.IsTerminalTokenError(err) {
+			// The stored refresh token is dead; no retry can fix it. Surface
+			// the typed error so the agent gets the @mcp-login hint and the
+			// manager can flag the server as auth-required.
+			t.logger.Warn("MCP OAuth refresh token rejected; re-authorization required",
+				zap.String("server", t.serverName),
+				zap.Error(err))
+			return nil, &OAuthRequiredError{Server: t.serverName, Endpoint: t.endpoint}
+		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("mcp.transport.http_post_failed"), err)
 	}
 	defer resp.Body.Close()

--- a/cli/mcp/transport_http_test.go
+++ b/cli/mcp/transport_http_test.go
@@ -456,3 +456,46 @@ func TestTransportStreamableHTTPConstant(t *testing.T) {
 		t.Errorf("TransportStreamableHTTP = %q, want \"http\"", TransportStreamableHTTP)
 	}
 }
+
+// TestHTTPTransport_TerminalRefreshFailureReturnsOAuthRequired guards the
+// dead-refresh-token path: when the token endpoint rejects the refresh token
+// terminally (401 TOKEN_EXPIRED), the call must surface the actionable
+// *OAuthRequiredError — not a generic network failure — and must not retry
+// against the MCP server.
+func TestHTTPTransport_TerminalRefreshFailureReturnsOAuthRequired(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"TOKEN_EXPIRED","message":"The refresh token has expired."}`))
+	}))
+	defer tokenSrv.Close()
+
+	// The MCP server must never be reached — the token refresh fails first.
+	mcpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("MCP server must not be called when the refresh token is dead")
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer mcpSrv.Close()
+
+	cred := &auth.AuthProfileCredential{
+		CredType: auth.CredentialOAuth,
+		Provider: auth.ProviderMCP,
+		Access:   "stale-token",
+		Refresh:  "r1",
+		Expires:  1, // long expired → Token() must refresh before the call
+	}
+	provider := auth.NewOAuthTokenProviderWithRefresh(
+		cred, "", "test",
+		newMCPRefreshFunc(tokenSrv.URL, "client-1", "https://srv/mcp", "mcp"),
+		zap.NewNop(),
+	)
+	defer provider.Close()
+
+	tr := newTestTransport(t, mcpSrv, nil)
+	tr.tokenProvider = provider
+
+	_, err := tr.Call("tools/list", nil)
+	if _, ok := IsOAuthRequired(err); !ok {
+		t.Fatalf("Call error = %v, want *OAuthRequiredError", err)
+	}
+}

--- a/cli/mcp/transport_sse.go
+++ b/cli/mcp/transport_sse.go
@@ -142,21 +142,39 @@ func newSSETransport(ctx context.Context, cfg ServerConfig, logger *zap.Logger, 
 }
 
 // applyHeaders attaches the configured custom headers and auth to a
-// request. Safe on nil receivers — used for both the initial SSE GET
-// and the per-call POST so users only declare the header set once.
-func (t *sseTransport) applyHeaders(req *http.Request) {
+// request. Used for both the initial SSE GET and the per-call POST so
+// users only declare the header set once. Returns *OAuthRequiredError
+// when the stored OAuth refresh token is terminally dead — sending the
+// request without auth would only bounce off the server, so callers
+// surface the actionable re-login hint instead.
+func (t *sseTransport) applyHeaders(req *http.Request) error {
 	for k, v := range t.headers {
 		req.Header.Set(k, v)
 	}
 	// Prefer the refreshable OAuth token when a provider is wired; otherwise
 	// fall back to the static AuthConfig (bearer/basic/header).
 	if t.tokenProvider != nil {
-		if tok, err := t.tokenProvider.Token(req.Context()); err == nil && tok != "" {
+		tok, err := t.tokenProvider.Token(req.Context())
+		if err == nil && tok != "" {
 			req.Header.Set("Authorization", "Bearer "+tok)
-			return
+			return nil
+		}
+		if auth.IsTerminalTokenError(err) {
+			t.logger.Warn("MCP OAuth refresh token rejected; re-authorization required",
+				zap.String("server", t.serverName),
+				zap.Error(err))
+			return &OAuthRequiredError{Server: t.serverName, Endpoint: t.baseURL}
+		}
+		if err != nil {
+			// Transient refresh failure: fall through to the static auth so a
+			// network blip doesn't kill the stream; the server 401s if it matters.
+			t.logger.Warn("MCP OAuth token unavailable; falling back to static auth",
+				zap.String("server", t.serverName),
+				zap.Error(err))
 		}
 	}
 	t.auth.ApplyAuth(req)
+	return nil
 }
 
 // maxDuration returns the greater of a and b.
@@ -193,6 +211,15 @@ func (t *sseTransport) supervisor() {
 		if t.ctx.Err() != nil {
 			return
 		}
+		if _, required := IsOAuthRequired(err); required {
+			// Reconnecting cannot mint a new refresh token — stop instead of
+			// hammering the server. A new /mcp login rebuilds the transport.
+			t.logger.Warn("MCP SSE stream stopped: OAuth re-authorization required",
+				zap.String("server", t.serverName),
+				zap.Error(err))
+			t.failPendingLocked(err)
+			return
+		}
 		if err != nil {
 			t.logger.Warn("MCP SSE stream ended; reconnecting",
 				zap.String("server", t.serverName),
@@ -226,7 +253,9 @@ func (t *sseTransport) runOnce(ctx context.Context) error {
 		return fmt.Errorf("sse request build: %w", err)
 	}
 	req.Header.Set("Accept", "text/event-stream")
-	t.applyHeaders(req)
+	if err := t.applyHeaders(req); err != nil {
+		return err
+	}
 
 	// Use the package's default Transport so the connection respects
 	// HTTP_PROXY / NO_PROXY just like every other HTTP call. The
@@ -397,7 +426,9 @@ func (t *sseTransport) Call(method string, params interface{}) (json.RawMessage,
 		return nil, err
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
-	t.applyHeaders(httpReq)
+	if err := t.applyHeaders(httpReq); err != nil {
+		return nil, err
+	}
 
 	httpResp, err := t.httpClient.Do(httpReq)
 	if err != nil {

--- a/cli/mcp/transport_sse_extensions_test.go
+++ b/cli/mcp/transport_sse_extensions_test.go
@@ -26,7 +26,9 @@ func TestSseTransport_ApplyHeaders_InjectsCustomHeadersAndAuth(t *testing.T) {
 		auth: &AuthConfig{Type: "bearer", Token: "${MY_TOKEN}"},
 	}
 	req, _ := http.NewRequest("GET", "http://example/sse", nil)
-	tp.applyHeaders(req)
+	if err := tp.applyHeaders(req); err != nil {
+		t.Fatalf("applyHeaders: %v", err)
+	}
 
 	if got := req.Header.Get("X-Static"); got != "literal" {
 		t.Errorf("X-Static = %q, want literal", got)
@@ -42,7 +44,9 @@ func TestSseTransport_ApplyHeaders_InjectsCustomHeadersAndAuth(t *testing.T) {
 func TestSseTransport_ApplyHeaders_NoConfigIsNoop(t *testing.T) {
 	tp := &sseTransport{}
 	req, _ := http.NewRequest("GET", "http://example/sse", nil)
-	tp.applyHeaders(req) // must not panic
+	if err := tp.applyHeaders(req); err != nil { // must not panic
+		t.Fatalf("applyHeaders: %v", err)
+	}
 	if len(req.Header) != 0 {
 		t.Errorf("empty config should not add headers; got %v", req.Header)
 	}

--- a/cli/mcp/transport_sse_oauth_test.go
+++ b/cli/mcp/transport_sse_oauth_test.go
@@ -1,0 +1,89 @@
+/*
+ * ChatCLI - SSE transport OAuth header tests.
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package mcp
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/diillson/chatcli/auth"
+	"go.uber.org/zap"
+)
+
+// stubTokenProvider is a minimal auth.TokenProvider with a scripted answer.
+type stubTokenProvider struct {
+	tok string
+	err error
+}
+
+func (s *stubTokenProvider) Token(context.Context) (string, error) { return s.tok, s.err }
+func (s *stubTokenProvider) Mode() auth.AuthMode                   { return auth.AuthModeOAuth }
+func (s *stubTokenProvider) Provider() auth.ProviderID             { return auth.ProviderMCP }
+func (s *stubTokenProvider) ProfileID() string                     { return "" }
+func (s *stubTokenProvider) Source() string                        { return "test" }
+func (s *stubTokenProvider) Email() string                         { return "" }
+func (s *stubTokenProvider) Invalidate()                           {}
+func (s *stubTokenProvider) Close()                                {}
+
+func newHeaderTestTransport(p auth.TokenProvider) *sseTransport {
+	return &sseTransport{
+		baseURL:       "https://mcp.example",
+		serverName:    "aws",
+		logger:        zap.NewNop(),
+		tokenProvider: p,
+	}
+}
+
+func TestSSEApplyHeaders_BearerFromProvider(t *testing.T) {
+	tr := newHeaderTestTransport(&stubTokenProvider{tok: "live-token"})
+	req, _ := http.NewRequest(http.MethodGet, "https://mcp.example/sse", nil)
+
+	if err := tr.applyHeaders(req); err != nil {
+		t.Fatalf("applyHeaders: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer live-token" {
+		t.Errorf("Authorization = %q, want Bearer live-token", got)
+	}
+}
+
+func TestSSEApplyHeaders_TerminalTokenErrorSurfacesOAuthRequired(t *testing.T) {
+	terminal := &auth.TokenExchangeError{
+		StatusCode: http.StatusUnauthorized,
+		Status:     "401 Unauthorized",
+		Code:       "TOKEN_EXPIRED",
+	}
+	tr := newHeaderTestTransport(&stubTokenProvider{err: terminal})
+	req, _ := http.NewRequest(http.MethodPost, "https://mcp.example/messages", nil)
+
+	err := tr.applyHeaders(req)
+	oe, ok := IsOAuthRequired(err)
+	if !ok {
+		t.Fatalf("applyHeaders error = %v, want *OAuthRequiredError", err)
+	}
+	if oe.Server != "aws" {
+		t.Errorf("OAuthRequiredError.Server = %q, want aws", oe.Server)
+	}
+	if req.Header.Get("Authorization") != "" {
+		t.Error("no Authorization header must be sent with a dead refresh token")
+	}
+}
+
+func TestSSEApplyHeaders_TransientTokenErrorFallsBack(t *testing.T) {
+	tr := newHeaderTestTransport(&stubTokenProvider{err: errors.New("connection reset")})
+	req, _ := http.NewRequest(http.MethodGet, "https://mcp.example/sse", nil)
+
+	// A transient refresh failure must not kill the stream: no error, no
+	// bearer — the static auth fallback (nil here) applies and the server
+	// answers 401 if it cares.
+	if err := tr.applyHeaders(req); err != nil {
+		t.Fatalf("applyHeaders: %v", err)
+	}
+	if req.Header.Get("Authorization") != "" {
+		t.Error("transient failure must not fabricate an Authorization header")
+	}
+}

--- a/cli/rpc_chat.go
+++ b/cli/rpc_chat.go
@@ -17,7 +17,7 @@
  *
  * Concurrency: the pipeline reads and writes shared ChatCLI state
  * (cli.history, cli.currentSessionName), so turns run under the same
- * process-wide serialization as the captured agent/coder runs (rpcStdoutMu via
+ * process-wide serialization as the captured agent/coder runs (rpcStdoutSem via
  * captureRPCStdout). The backend owns the per-session histories; this method
  * swaps one in for the duration of the turn and always restores the previous
  * state, even on error.
@@ -61,7 +61,7 @@ func (cli *ChatCLI) RunChatTurnRPC(
 	history []models.Message, o RPCChatOpts,
 ) (RPCChatTurn, error) {
 	var turn RPCChatTurn
-	_, err := captureRPCStdout(func() error {
+	_, err := captureRPCStdout(ctx, func() error {
 		var innerErr error
 		turn, innerErr = cli.runChatTurnSerialized(ctx, sessionID, userInput, history, o)
 		return innerErr
@@ -69,7 +69,7 @@ func (cli *ChatCLI) RunChatTurnRPC(
 	return turn, err
 }
 
-// runChatTurnSerialized is the turn body. The caller holds rpcStdoutMu (via
+// runChatTurnSerialized is the turn body. The caller holds rpcStdoutSem (via
 // captureRPCStdout), so the shared-state swap below cannot interleave with
 // another captured run.
 func (cli *ChatCLI) runChatTurnSerialized(

--- a/cli/rpc_support.go
+++ b/cli/rpc_support.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"regexp"
 	"strings"
-	"sync"
 	"sync/atomic"
 
 	"github.com/diillson/chatcli/cli/plugins"
@@ -32,11 +31,28 @@ import (
 
 var ansiSeq = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
 
-// rpcStdoutMu serializes os.Stdout redirection. os.Stdout is process-global and
-// the agent/coder loops mutate shared ChatCLI state (e.g. cli.history), so only
-// one captured run may be in flight at a time. Concurrent callers (e.g. the
-// gateway fanning out messages) block here rather than corrupting each other.
-var rpcStdoutMu sync.Mutex
+// rpcStdoutSem serializes os.Stdout redirection. os.Stdout is process-global
+// and the agent/coder loops mutate shared ChatCLI state (e.g. cli.history), so
+// only one captured run may be in flight at a time. Concurrent callers (e.g.
+// the gateway fanning out messages) queue here rather than corrupting each
+// other. A channel semaphore instead of a mutex so QUEUED callers honor their
+// context: one session pinned in a long run (or an unanswered permission
+// dialog) must not make another session's cancel unresponsive — a queued
+// caller gives up when its ctx dies instead of blocking forever head-of-line.
+var rpcStdoutSem = make(chan struct{}, 1)
+
+// acquireRPCStdout takes the capture slot, or fails when ctx dies first.
+func acquireRPCStdout(ctx context.Context) error {
+	select {
+	case rpcStdoutSem <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// releaseRPCStdout frees the capture slot taken by acquireRPCStdout.
+func releaseRPCStdout() { <-rpcStdoutSem }
 
 // rpcCaptureActive is true while a captured run (MCP/ACP turn, gateway turn,
 // headless slash command) is in flight. The REPL's session write-through
@@ -56,18 +72,22 @@ func (cli *ChatCLI) SetRPCDangerPolicy(block bool) {
 }
 
 // captureRPCStdout runs fn with os.Stdout redirected and returns the captured
-// (ANSI-stripped) output. The pipe is always restored.
-func captureRPCStdout(fn func() error) (string, error) {
-	return captureStreaming(nil, fn)
+// (ANSI-stripped) output. The pipe is always restored. ctx bounds only the
+// WAIT for the capture slot — once acquired, fn owns its own lifetime.
+func captureRPCStdout(ctx context.Context, fn func() error) (string, error) {
+	return captureStreaming(ctx, nil, fn)
 }
 
 // captureStreaming runs fn with os.Stdout redirected to a pipe. As fn writes
 // lines, each is ANSI-stripped, appended to the returned transcript, and — when
 // emit is non-nil — forwarded to emit so callers can stream progress live. The
-// original stdout is always restored. Runs are serialized via rpcStdoutMu.
-func captureStreaming(emit func(string), fn func() error) (string, error) {
-	rpcStdoutMu.Lock()
-	defer rpcStdoutMu.Unlock()
+// original stdout is always restored. Runs are serialized via rpcStdoutSem;
+// ctx bounds only the wait for that slot.
+func captureStreaming(ctx context.Context, emit func(string), fn func() error) (string, error) {
+	if err := acquireRPCStdout(ctx); err != nil {
+		return "", err
+	}
+	defer releaseRPCStdout()
 	rpcCaptureActive.Store(true)
 	defer rpcCaptureActive.Store(false)
 
@@ -113,7 +133,7 @@ func captureStreaming(emit func(string), fn func() error) (string, error) {
 // RunAgentCaptured runs the full agent (ReAct) loop one-shot on task,
 // capturing its transcript. Used by the MCP agent_task tool.
 func (cli *ChatCLI) RunAgentCaptured(ctx context.Context, task string) (string, error) {
-	out, err := captureRPCStdout(func() error {
+	out, err := captureRPCStdout(ctx, func() error {
 		return cli.RunAgentFullOnce(ctx, task)
 	})
 	if err != nil {
@@ -130,7 +150,7 @@ func (cli *ChatCLI) RunAgentCaptured(ctx context.Context, task string) (string, 
 // and returning the full transcript. Used by the messaging gateway to
 // narrate task execution back to the chat platform.
 func (cli *ChatCLI) RunAgentStreaming(ctx context.Context, task string, emit func(string)) (string, error) {
-	out, err := captureStreaming(emit, func() error {
+	out, err := captureStreaming(ctx, emit, func() error {
 		return cli.RunAgentFullOnce(ctx, task)
 	})
 	if err != nil {
@@ -149,7 +169,7 @@ func (cli *ChatCLI) RunAgentStreaming(ctx context.Context, task string, emit fun
 // while answering as concise chat prose. The clean final answer is captured
 // into cli.lastAgentReply during the run.
 func (cli *ChatCLI) RunGatewayCoderStreaming(ctx context.Context, task string, emit func(string)) (string, error) {
-	out, err := captureStreaming(emit, func() error {
+	out, err := captureStreaming(ctx, emit, func() error {
 		return cli.RunGatewayCoderOnce(ctx, task)
 	})
 	if err != nil {
@@ -163,7 +183,7 @@ func (cli *ChatCLI) RunGatewayCoderStreaming(ctx context.Context, task string, e
 
 // RunCoderCaptured runs the coder loop one-shot on task, capturing output.
 func (cli *ChatCLI) RunCoderCaptured(ctx context.Context, task string) (string, error) {
-	out, err := captureRPCStdout(func() error {
+	out, err := captureRPCStdout(ctx, func() error {
 		return cli.RunCoderOnce(ctx, "/coder "+task)
 	})
 	if err != nil {

--- a/cli/rpc_support_full.go
+++ b/cli/rpc_support_full.go
@@ -190,7 +190,7 @@ func (cli *ChatCLI) RunAnyRPCToolArgv(ctx context.Context, name string, argv []s
 	// output is appended to the result so nothing the tool said is lost.
 	var result string
 	var execErr error
-	captured, _ := captureRPCStdout(func() error {
+	captured, _ := captureRPCStdout(ctx, func() error {
 		result, execErr = execBuiltin(ctx, p, argv)
 		return nil
 	})
@@ -385,7 +385,7 @@ func (cli *ChatCLI) RunCoderRPC(ctx context.Context, task string, o RPCRunOpts) 
 }
 
 // runLoopRPC wraps a captured loop run with provider/model and quality-env
-// overrides. captureStreaming serializes runs process-wide (rpcStdoutMu), so
+// overrides. captureStreaming serializes runs process-wide (rpcStdoutSem), so
 // the save/mutate/restore of shared state below cannot interleave with
 // another captured run.
 func (cli *ChatCLI) runLoopRPC(ctx context.Context, o RPCRunOpts, fn func(context.Context) error) (string, error) {
@@ -395,19 +395,19 @@ func (cli *ChatCLI) runLoopRPC(ctx context.Context, o RPCRunOpts, fn func(contex
 	if o.Events != nil {
 		emit = nil
 	}
-	// finalReply is captured INSIDE the closure — i.e. while rpcStdoutMu is
+	// finalReply is captured INSIDE the closure — i.e. while rpcStdoutSem is
 	// still held — because the moment captureStreaming returns, another
 	// queued run may acquire the lock and reset cli.lastAgentReply; reading
 	// the shared field afterwards could observe the other run's state.
 	var finalReply string
-	out, err := captureStreaming(emit, func() error {
+	out, err := captureStreaming(ctx, emit, func() error {
 		restore, oerr := cli.applyRPCOverrides(ctx, o)
 		if oerr != nil {
 			return oerr
 		}
 		defer restore()
 		// Install the structured sink for this run only. Safe without extra
-		// locking: captureStreaming holds rpcStdoutMu, which serializes every
+		// locking: captureStreaming holds rpcStdoutSem, which serializes every
 		// captured run process-wide, and the interactive REPL never sets it.
 		// lastAgentReply is reset ONLY on the structured path so the value
 		// left standing is provably this run's final answer; the gateway
@@ -422,7 +422,7 @@ func (cli *ChatCLI) runLoopRPC(ctx context.Context, o RPCRunOpts, fn func(contex
 			}()
 		}
 		// Per-run permission bridge (MCP elicitation): same serialization
-		// argument as the sink — rpcStdoutMu holds for the whole run.
+		// argument as the sink — rpcStdoutSem holds for the whole run.
 		if o.Permissions != nil {
 			prevPerms := cli.rpcPermissions
 			cli.rpcPermissions = o.Permissions

--- a/cli/rpc_support_test.go
+++ b/cli/rpc_support_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestCaptureRPCStdout(t *testing.T) {
-	out, err := captureRPCStdout(func() error {
+	out, err := captureRPCStdout(context.Background(), func() error {
 		fmt.Print("hello\x1b[31m world\x1b[0m") // includes ANSI codes
 		return nil
 	})
@@ -28,7 +28,7 @@ func TestCaptureRPCStdout(t *testing.T) {
 
 func TestCaptureStreaming_ForwardsLines(t *testing.T) {
 	var got []string
-	out, err := captureStreaming(func(s string) { got = append(got, s) }, func() error {
+	out, err := captureStreaming(context.Background(), func(s string) { got = append(got, s) }, func() error {
 		fmt.Println("first line")
 		fmt.Print("\x1b[32msecond\x1b[0m line\n") // ANSI must be stripped
 		fmt.Println("   ")                        // whitespace-only: emitted? no
@@ -140,4 +140,36 @@ func TestRunAnyRPCTool_JSONEnvelopeArgv(t *testing.T) {
 	if !strings.Contains(out, "rpcToolPolicy") {
 		t.Fatalf("coder must read through the JSON envelope, got: %.120q", out)
 	}
+}
+
+// TestCaptureStreaming_QueuedCallerHonorsContext: with the capture slot held
+// by another run, a queued caller must give up when its ctx dies instead of
+// blocking forever head-of-line — that cancel-immunity is how one stuck ACP
+// session used to wedge every other session in the process.
+func TestCaptureStreaming_QueuedCallerHonorsContext(t *testing.T) {
+	release := make(chan struct{})
+	holderDone := make(chan struct{})
+	holderIn := make(chan struct{})
+	go func() {
+		defer close(holderDone)
+		_, _ = captureStreaming(context.Background(), nil, func() error {
+			close(holderIn)
+			<-release
+			return nil
+		})
+	}()
+	<-holderIn // slot is now held
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := captureStreaming(ctx, nil, func() error {
+		t.Error("queued fn must not run after its ctx died")
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "context canceled") {
+		t.Fatalf("queued caller error = %v, want context canceled", err)
+	}
+
+	close(release)
+	<-holderDone
 }

--- a/cli/rpcserve/acp_sink.go
+++ b/cli/rpcserve/acp_sink.go
@@ -163,7 +163,11 @@ func (s *acpSink) RequestPermission(tc agentevents.ToolCall, reason string) (boo
 // (fail-safe).
 func (s *acpSink) RequestPermissionDecision(req agentevents.PermissionRequest) (agentevents.PermissionDecision, error) {
 	if s.acp.request == nil {
-		return agentevents.PermissionDenyOnce, nil
+		// No client requester wired (embedders/tests): there is no dialog to
+		// consult, so report "unsupported" — the loop then applies the same
+		// unattended fallback as a client without the method, instead of
+		// counting a dialog nobody saw as an explicit user denial.
+		return agentevents.PermissionDenyOnce, agentevents.ErrPermissionUnsupported
 	}
 	tc := req.Tool
 	title := tc.Title

--- a/cli/rpcserve/acp_sink_nilreq_test.go
+++ b/cli/rpcserve/acp_sink_nilreq_test.go
@@ -1,0 +1,31 @@
+/*
+ * ChatCLI - acpSink nil-requester fallback test.
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package rpcserve
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/diillson/chatcli/cli/agentevents"
+)
+
+// TestACPSinkDecision_NilRequesterReportsUnsupported: without a client
+// requester wired there is no dialog to consult — the sink must report
+// "unsupported" so the loop applies the unattended fallback, not a fake
+// user denial for a dialog nobody could ever see.
+func TestACPSinkDecision_NilRequesterReportsUnsupported(t *testing.T) {
+	s := newACPSink(&ACP{}, "sess", context.Background())
+	d, err := s.RequestPermissionDecision(agentevents.PermissionRequest{
+		Tool: agentevents.ToolCall{Name: "@coder"},
+	})
+	if !errors.Is(err, agentevents.ErrPermissionUnsupported) {
+		t.Fatalf("err = %v, want ErrPermissionUnsupported", err)
+	}
+	if d.Allowed() {
+		t.Error("nil requester must not allow")
+	}
+}

--- a/cli/rpcserve/mcp.go
+++ b/cli/rpcserve/mcp.go
@@ -641,23 +641,38 @@ func (m *MCP) permissionsFor(ctx context.Context) agentevents.PermissionRequeste
 // is safe there.
 const mcpPermissionTimeoutDefault = 600 * time.Second
 
+// mcpPermissionTimeoutDisabledCeiling is what "off"/"0" resolve to. A wait
+// with no bound at all left the turn pinned forever when a client kept the
+// pipe open but died without EOF (no dialog, no cancel, no disconnect) —
+// 24h is unlimited for any human decision while guaranteeing the run
+// eventually frees its resources (and, process-wide, the capture slot that
+// serializes RPC runs).
+const mcpPermissionTimeoutDisabledCeiling = 24 * time.Hour
+
 // mcpPermissionTimeout resolves CHATCLI_MCP_PERMISSION_TIMEOUT: a Go
-// duration ("90s", "2m") or plain seconds; "0"/"off" disable the bound
-// (wait until the run's context dies). Unset or invalid keeps the default.
-// Like CHATCLI_MCP_TOOLS, the knob governs both RPC surfaces: MCP
-// elicitation/create and ACP session/request_permission (acpSink).
+// duration ("90s", "2m") or plain seconds; "0"/"off" lift the bound to a
+// 24h ceiling (effectively "wait for the human", never "wait forever").
+// Unset or invalid keeps the default. Like CHATCLI_MCP_TOOLS, the knob
+// governs both RPC surfaces: MCP elicitation/create and ACP
+// session/request_permission (acpSink).
 func mcpPermissionTimeout() time.Duration {
 	v := strings.TrimSpace(os.Getenv("CHATCLI_MCP_PERMISSION_TIMEOUT"))
 	if v == "" {
 		return mcpPermissionTimeoutDefault
 	}
 	if strings.EqualFold(v, "off") {
-		return 0
+		return mcpPermissionTimeoutDisabledCeiling
 	}
 	if d, err := time.ParseDuration(v); err == nil && d >= 0 {
+		if d == 0 {
+			return mcpPermissionTimeoutDisabledCeiling
+		}
 		return d
 	}
 	if secs, err := strconv.Atoi(v); err == nil && secs >= 0 {
+		if secs == 0 {
+			return mcpPermissionTimeoutDisabledCeiling
+		}
 		return time.Duration(secs) * time.Second
 	}
 	return mcpPermissionTimeoutDefault

--- a/cli/rpcserve/permission_test.go
+++ b/cli/rpcserve/permission_test.go
@@ -495,7 +495,9 @@ func TestMCPPermissionsElicitationKillSwitch(t *testing.T) {
 }
 
 // TestMCPPermissionTimeoutParsing: env accepts Go durations and plain
-// seconds; 0/off disable the bound; garbage falls back to the default.
+// seconds; 0/off lift the bound to the 24h ceiling (a truly unbounded wait
+// let a dead-but-connected client pin the turn and the process-wide capture
+// slot forever); garbage falls back to the default.
 func TestMCPPermissionTimeoutParsing(t *testing.T) {
 	cases := []struct {
 		env  string
@@ -505,8 +507,10 @@ func TestMCPPermissionTimeoutParsing(t *testing.T) {
 		{"90s", 90 * time.Second},
 		{"2m", 2 * time.Minute},
 		{"45", 45 * time.Second},
-		{"0", 0},
-		{"off", 0},
+		{"0", mcpPermissionTimeoutDisabledCeiling},
+		{"0s", mcpPermissionTimeoutDisabledCeiling},
+		{"off", mcpPermissionTimeoutDisabledCeiling},
+		{"OFF", mcpPermissionTimeoutDisabledCeiling},
 		{"garbage", mcpPermissionTimeoutDefault},
 		{"-5s", mcpPermissionTimeoutDefault},
 	}

--- a/cli/scheduler/tool_adapter.go
+++ b/cli/scheduler/tool_adapter.go
@@ -103,10 +103,22 @@ type ToolOutput struct {
 // callable tools. Used by the ReAct loop and (via IPC) by the daemon.
 type ToolAdapter struct {
 	s *Scheduler
+	// progress, when set, receives a heartbeat during synchronous WaitUntil
+	// so long waits are visible instead of minutes of dead silence.
+	progress func(id JobID, status JobStatus, elapsed, remaining time.Duration)
 }
 
 // NewToolAdapter builds the adapter.
 func NewToolAdapter(s *Scheduler) *ToolAdapter { return &ToolAdapter{s: s} }
+
+// WithWaitProgress installs the synchronous-wait heartbeat callback.
+func (t *ToolAdapter) WithWaitProgress(fn func(id JobID, status JobStatus, elapsed, remaining time.Duration)) *ToolAdapter {
+	t.progress = fn
+	return t
+}
+
+// waitProgressInterval paces the WaitUntil heartbeat.
+const waitProgressInterval = 30 * time.Second
 
 // ScheduleJob implements the schedule_job tool.
 func (t *ToolAdapter) ScheduleJob(ctx context.Context, owner Owner, rawIn string) (string, error) {
@@ -169,10 +181,23 @@ func (t *ToolAdapter) WaitUntil(ctx context.Context, owner Owner, rawIn string) 
 	defer cancel()
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
+	start := time.Now()
+	nextBeat := start.Add(waitProgressInterval)
 	for {
 		select {
 		case <-ctx2.Done():
-			return jsonError(ctx2.Err())
+			// Caller cancelled (Ctrl+C, IDE Stop): report the plain cause.
+			if ctx.Err() != nil {
+				return jsonError(ctx.Err())
+			}
+			// Our own wait budget elapsed. The job was NOT cancelled — it
+			// keeps running in the scheduler — so tell the model exactly how
+			// to pick it up instead of a bare "context deadline exceeded".
+			status := created.Status
+			if j, qerr := t.s.Query(created.ID); qerr == nil {
+				status = j.Status
+			}
+			return jsonError(waitGaveUpError(timeout, created.ID, status))
 		case <-ticker.C:
 			j, err := t.s.Query(created.ID)
 			if err != nil {
@@ -185,6 +210,14 @@ func (t *ToolAdapter) WaitUntil(ctx context.Context, owner Owner, rawIn string) 
 					out.Details = j.LastResult.Output
 				}
 				return jsonOK(out)
+			}
+			// Heartbeat: a synchronous wait can legitimately run for many
+			// minutes — surface life signs instead of dead silence.
+			if t.progress != nil && time.Now().After(nextBeat) {
+				elapsed := time.Since(start).Round(time.Second)
+				remaining := (timeout - time.Since(start)).Round(time.Second)
+				t.progress(j.ID, j.Status, elapsed, remaining)
+				nextBeat = time.Now().Add(waitProgressInterval)
 			}
 		}
 	}
@@ -359,6 +392,15 @@ func jsonOK(v ToolOutput) (string, error) {
 		return "", err
 	}
 	return string(b), nil
+}
+
+// waitGaveUpError builds the actionable wait_until timeout message: the job
+// keeps running, so the model must learn how to pick the result up later —
+// a bare "context deadline exceeded" taught it nothing.
+func waitGaveUpError(timeout time.Duration, id JobID, status JobStatus) error {
+	return fmt.Errorf(
+		"wait_until: gave up waiting after %s; job %s is still %s and KEEPS RUNNING in background. Check it later with query_job {\"id\":%q}, or re-issue the wait with \"async\":true and react to the job event in a future turn",
+		timeout.Round(time.Second), id, status, id)
 }
 
 func jsonError(err error) (string, error) {

--- a/cli/scheduler/tool_adapter.go
+++ b/cli/scheduler/tool_adapter.go
@@ -104,8 +104,10 @@ type ToolOutput struct {
 type ToolAdapter struct {
 	s *Scheduler
 	// progress, when set, receives a heartbeat during synchronous WaitUntil
-	// so long waits are visible instead of minutes of dead silence.
-	progress func(id JobID, status JobStatus, elapsed, remaining time.Duration)
+	// so long waits are visible instead of minutes of dead silence. Held
+	// behind a pointer so the exported struct stays comparable (a bare func
+	// field would be a breaking API change).
+	progress *func(id JobID, status JobStatus, elapsed, remaining time.Duration)
 }
 
 // NewToolAdapter builds the adapter.
@@ -113,7 +115,7 @@ func NewToolAdapter(s *Scheduler) *ToolAdapter { return &ToolAdapter{s: s} }
 
 // WithWaitProgress installs the synchronous-wait heartbeat callback.
 func (t *ToolAdapter) WithWaitProgress(fn func(id JobID, status JobStatus, elapsed, remaining time.Duration)) *ToolAdapter {
-	t.progress = fn
+	t.progress = &fn
 	return t
 }
 
@@ -216,7 +218,7 @@ func (t *ToolAdapter) WaitUntil(ctx context.Context, owner Owner, rawIn string) 
 			if t.progress != nil && time.Now().After(nextBeat) {
 				elapsed := time.Since(start).Round(time.Second)
 				remaining := (timeout - time.Since(start)).Round(time.Second)
-				t.progress(j.ID, j.Status, elapsed, remaining)
+				(*t.progress)(j.ID, j.Status, elapsed, remaining)
 				nextBeat = time.Now().Add(waitProgressInterval)
 			}
 		}

--- a/cli/scheduler/tool_adapter_wait_test.go
+++ b/cli/scheduler/tool_adapter_wait_test.go
@@ -1,0 +1,23 @@
+/*
+ * ChatCLI - wait_until timeout messaging tests.
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package scheduler
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestWaitGaveUpError_IsActionable: the wait_until timeout must teach the
+// model how to recover (query_job / async), never a bare deadline error.
+func TestWaitGaveUpError_IsActionable(t *testing.T) {
+	err := waitGaveUpError(35*time.Minute, JobID("job-42"), StatusRunning)
+	for _, want := range []string{"job-42", "KEEPS RUNNING", "query_job", `"async":true`, "35m0s"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("timeout message misses %q: %s", want, err.Error())
+		}
+	}
+}

--- a/cli/scheduler_adapter.go
+++ b/cli/scheduler_adapter.go
@@ -10,10 +10,13 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sort"
+	"time"
 
 	"github.com/diillson/chatcli/cli/plugins"
 	"github.com/diillson/chatcli/cli/scheduler"
+	"github.com/diillson/chatcli/i18n"
 )
 
 // schedulerPluginAdapter is the concrete plugins.SchedulerAdapter.
@@ -138,7 +141,14 @@ func (a *schedulerPluginAdapter) dispatch(
 		Tag:  owner.Tag,
 	}
 	if a.cli.scheduler != nil {
-		tool := scheduler.NewToolAdapter(a.cli.scheduler)
+		// The heartbeat prints through stdout: on the REPL it lands above the
+		// spinner; on RPC surfaces captureStreaming forwards it live to the
+		// client, so a long synchronous wait shows life signs instead of
+		// minutes of "thinking" silence.
+		tool := scheduler.NewToolAdapter(a.cli.scheduler).WithWaitProgress(
+			func(id scheduler.JobID, status scheduler.JobStatus, elapsed, remaining time.Duration) {
+				fmt.Println(colorize("  ⏳ "+i18n.T("scheduler.wait.progress", string(id), string(status), elapsed, remaining), ColorGray))
+			})
 		return local(tool, so)
 	}
 	if a.cli.schedulerRemote != nil {

--- a/cli/scheduler_bridge.go
+++ b/cli/scheduler_bridge.go
@@ -767,6 +767,25 @@ func (b *schedulerBridge) wakeParkedAgent(token, outcome, detail string) error {
 	if b.cli == nil {
 		return fmt.Errorf("park: bridge not bound to CLI")
 	}
+
+	// In-turn waiter first (unattended surfaces): the park's own turn is
+	// blocked in runParkedInline waiting for this wake — deliver directly
+	// and skip the REPL machinery (queue, banner, TTY inject), none of
+	// which can reach a remote client. Buffered(1) send never blocks; a
+	// duplicate wake for the same token is dropped on the floor, matching
+	// the idempotent-resume semantics of the queue path.
+	if ch := b.cli.parkWaiter(token); ch != nil {
+		select {
+		case ch <- parkOutcome{Outcome: outcome, Detail: detail}:
+		default:
+		}
+		b.cli.logger.Info("park: wake delivered to in-turn waiter",
+			zap.String("token", token),
+			zap.String("outcome", outcome))
+		b.cli.markSchedulerDirty()
+		return nil
+	}
+
 	b.cli.pendingResumeMu.Lock()
 	b.cli.pendingResumeQueue = append(b.cli.pendingResumeQueue, token)
 	b.cli.pendingResumeMu.Unlock()
@@ -786,12 +805,16 @@ func (b *schedulerBridge) wakeParkedAgent(token, outcome, detail string) error {
 	// Print a banner so the user sees the readiness immediately. fmt
 	// writes from this goroutine appear above the go-prompt input line
 	// — go-prompt redraws the prompt at the bottom on its next tick.
-	fmt.Println()
-	fmt.Println(colorize("  🔔 "+
-		fmt.Sprintf("park ready: token=%s outcome=%s — auto-resuming…",
-			token, outcome),
-		ColorCyan+ColorBold))
-	fmt.Println()
+	// Never on unattended surfaces: there stdout is a protocol channel
+	// or a quarantine pipe, and there is no prompt to redraw.
+	if !b.cli.unattended {
+		fmt.Println()
+		fmt.Println(colorize("  🔔 "+
+			fmt.Sprintf("park ready: token=%s outcome=%s — auto-resuming…",
+				token, outcome),
+			ColorCyan+ColorBold))
+		fmt.Println()
+	}
 
 	b.cli.markSchedulerDirty()
 	b.cli.logger.Info("park: notified ready",
@@ -819,6 +842,13 @@ func (b *schedulerBridge) wakeParkedAgent(token, outcome, detail string) error {
 	// as soon as the foreground work returns to the idle prompt.
 	if b.cli.isExecuting.Load() {
 		b.cli.logger.Debug("park: run active, skipping TTY inject (resume stays queued)",
+			zap.String("token", token))
+		return nil
+	}
+	if b.cli.unattended {
+		// No controlling TTY and no REPL drain — the token stays queued for
+		// forensics, but injecting would write into the protocol channel.
+		b.cli.logger.Debug("park: unattended surface, skipping TTY inject",
 			zap.String("token", token))
 		return nil
 	}

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -1999,6 +1999,7 @@
   "auth.token_provider.empty_token": "auth token is empty",
   "auth.token_provider.persist_failed": "Failed to persist refreshed OAuth token to auth store",
   "auth.token_provider.background_refresh_failed": "Proactive OAuth refresh failed; will retry",
+  "auth.token_provider.background_refresh_terminal": "OAuth refresh token was rejected (expired or revoked); automatic renewal stopped — log in again to recover",
   "auth.login.anthropic_opening": "\nAUTH [Anthropic] Opening browser for authentication...",
   "auth.login.browser_failed": "Could not open browser automatically. Open this URL manually:",
   "auth.login.anthropic_browser_ok": "Browser opened. After authorizing, copy the code shown on the page and paste it below.",

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -2540,6 +2540,7 @@
   "agent.policy.ask_denied": "ACTION DENIED BY THE USER (security policy): %s",
   "agent.policy.ask_denied_always": "ACTION PERMANENTLY BLOCKED BY THE USER (deny rule recorded): %s",
   "agent.policy.ask_timeout": "ACTION BLOCKED \u2014 the permission request timed out with no user response (the client may not display approval dialogs): %s",
+  "agent.policy.ask_failed": "ACTION BLOCKED \u2014 the permission request failed before the user could answer (transport error or cancelled turn): %s",
   "acp.permission.allow_once": "Allow",
   "acp.permission.allow_always": "Always allow",
   "acp.permission.reject_once": "Reject",

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -2541,6 +2541,7 @@
   "agent.policy.ask_denied_always": "ACTION PERMANENTLY BLOCKED BY THE USER (deny rule recorded): %s",
   "agent.policy.ask_timeout": "ACTION BLOCKED \u2014 the permission request timed out with no user response (the client may not display approval dialogs): %s",
   "agent.policy.ask_failed": "ACTION BLOCKED \u2014 the permission request failed before the user could answer (transport error or cancelled turn): %s",
+  "scheduler.wait.progress": "wait_until: job %s still %s — %v elapsed, giving up in %v",
   "acp.permission.allow_once": "Allow",
   "acp.permission.allow_always": "Always allow",
   "acp.permission.reject_once": "Reject",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1999,6 +1999,7 @@
   "auth.token_provider.empty_token": "auth token is empty",
   "auth.token_provider.persist_failed": "Failed to persist refreshed OAuth token to auth store",
   "auth.token_provider.background_refresh_failed": "Proactive OAuth refresh failed; will retry",
+  "auth.token_provider.background_refresh_terminal": "OAuth refresh token was rejected (expired or revoked); automatic renewal stopped — log in again to recover",
   "auth.login.anthropic_opening": "\nAUTH [Anthropic] Opening browser for authentication...",
   "auth.login.browser_failed": "Could not open browser automatically. Open this URL manually:",
   "auth.login.anthropic_browser_ok": "Browser opened. After authorizing, copy the code shown on the page and paste it below.",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -2540,6 +2540,7 @@
   "agent.policy.ask_denied": "ACTION DENIED BY THE USER (security policy): %s",
   "agent.policy.ask_denied_always": "ACTION PERMANENTLY BLOCKED BY THE USER (deny rule recorded): %s",
   "agent.policy.ask_timeout": "ACTION BLOCKED \u2014 the permission request timed out with no user response (the client may not display approval dialogs): %s",
+  "agent.policy.ask_failed": "ACTION BLOCKED \u2014 the permission request failed before the user could answer (transport error or cancelled turn): %s",
   "acp.permission.allow_once": "Allow",
   "acp.permission.allow_always": "Always allow",
   "acp.permission.reject_once": "Reject",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -2541,6 +2541,7 @@
   "agent.policy.ask_denied_always": "ACTION PERMANENTLY BLOCKED BY THE USER (deny rule recorded): %s",
   "agent.policy.ask_timeout": "ACTION BLOCKED \u2014 the permission request timed out with no user response (the client may not display approval dialogs): %s",
   "agent.policy.ask_failed": "ACTION BLOCKED \u2014 the permission request failed before the user could answer (transport error or cancelled turn): %s",
+  "scheduler.wait.progress": "wait_until: job %s still %s — %v elapsed, giving up in %v",
   "acp.permission.allow_once": "Allow",
   "acp.permission.allow_always": "Always allow",
   "acp.permission.reject_once": "Reject",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -2540,6 +2540,7 @@
   "agent.policy.ask_denied": "AÇÃO NEGADA PELO USUÁRIO (política de segurança): %s",
   "agent.policy.ask_denied_always": "AÇÃO BLOQUEADA PERMANENTEMENTE PELO USUÁRIO (regra de negação registrada): %s",
   "agent.policy.ask_timeout": "AÇÃO BLOQUEADA — a solicitação de permissão expirou sem resposta do usuário (o cliente pode não exibir dialogs de aprovação): %s",
+  "agent.policy.ask_failed": "AÇÃO BLOQUEADA — a solicitação de permissão falhou antes de o usuário responder (erro de transporte ou turno cancelado): %s",
   "acp.permission.allow_once": "Permitir",
   "acp.permission.allow_always": "Permitir sempre",
   "acp.permission.reject_once": "Negar",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -1999,6 +1999,7 @@
   "auth.token_provider.empty_token": "token de autenticação vazio",
   "auth.token_provider.persist_failed": "Falha ao persistir token OAuth renovado no auth store",
   "auth.token_provider.background_refresh_failed": "Refresh proativo de OAuth falhou; tentando de novo",
+  "auth.token_provider.background_refresh_terminal": "O refresh token OAuth foi rejeitado (expirado ou revogado); renovação automática interrompida — faça login novamente para recuperar",
   "auth.login.anthropic_opening": "\nAUTH [Anthropic] Abrindo o navegador para autenticação...",
   "auth.login.browser_failed": "Não foi possível abrir o navegador automaticamente. Abra esta URL manualmente:",
   "auth.login.anthropic_browser_ok": "Navegador aberto. Após autorizar, copie o código mostrado na página e cole abaixo.",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -2541,6 +2541,7 @@
   "agent.policy.ask_denied_always": "AÇÃO BLOQUEADA PERMANENTEMENTE PELO USUÁRIO (regra de negação registrada): %s",
   "agent.policy.ask_timeout": "AÇÃO BLOQUEADA — a solicitação de permissão expirou sem resposta do usuário (o cliente pode não exibir dialogs de aprovação): %s",
   "agent.policy.ask_failed": "AÇÃO BLOQUEADA — a solicitação de permissão falhou antes de o usuário responder (erro de transporte ou turno cancelado): %s",
+  "scheduler.wait.progress": "wait_until: job %s ainda %s — %v decorridos, desiste em %v",
   "acp.permission.allow_once": "Permitir",
   "acp.permission.allow_always": "Permitir sempre",
   "acp.permission.reject_once": "Negar",


### PR DESCRIPTION
## Problem

Driving /coder from IntelliJ over ACP, the session would intermittently freeze in an eternal "thinking" state with no feedback, recovering only after Stop + a new prompt. Log forensics from a real incident plus a code audit found four independent defects, all specific to unattended surfaces (ACP, MCP server, gateway):

1. **Dead MCP OAuth refresh token retried forever.** TOKEN_EXPIRED / invalid_grant on the refresh grant is terminal — only a new interactive login can recover — but the background refresher retried every ~90s indefinitely, tool calls surfaced generic network errors, and the server status kept advertising tools that could only fail. AuthRequired was only ever set during the startup handshake, never mid-session.

2. **Parks never resume outside the REPL.** The resume wake lands in a queue drained only by the interactive prompt loop. A park taken over ACP ended the turn with a failed park tool call and no prose (rendered by the IDE as eternal thinking), while the scheduler kept polling invisibly forever. Stopping the turn leaked the WAL-persisted job and the snapshot; the cancel commands are excluded from the remote allowlist.

3. **Coder stdin reader raced the JSON-RPC scanner.** The type-ahead reader was spawned unconditionally, but on the ACP/MCP stdio servers stdin IS the protocol channel: the reader could swallow permission answers and cancel frames, then feed the stolen JSON to the LLM as user type-ahead. The slash-command path already quarantined stdin for exactly this reason.

4. **Dialog transport failures misattributed as user denial.** A failed permission round-trip (client disconnect, write error, cancelled turn) told the model the USER denied the action — so the model told the user they refused a dialog they were never shown.

## Fix

- Token exchange returns a typed error carrying HTTP status + OAuth error code; the provider latches terminal failures (fail-fast, background loop stops with an actionable log), HTTP/SSE transports map them to the authorization-required error with the @mcp-login hint, the SSE supervisor stops reconnect-hammering, and the manager flags AuthRequired on mid-session failures.
- Unattended surfaces register an in-turn park waiter before the job is enqueued; Run blocks on it instead of returning, resumed cycles stream on the same client request with the event sink installed, re-parks loop in place, and turn cancellation retires job + snapshot + bookkeeping. Banners and TTY injects are suppressed off-REPL. REPL behavior unchanged.
- The coder loop skips the stdin reader when unattended.
- Failed permission round-trips get their own honest feedback message, mirroring the timeout wording.

## Tests

- Terminal-vs-transient classification, fail-fast latching, background-loop stop/retry, typed exchange errors (auth).
- Transport terminal-refresh → OAuthRequiredError without touching the MCP server; mid-session AuthRequired marking; SSE applyHeaders three-way decision (mcp).
- In-turn waiter delivery (no queue/banner), duplicate-wake safety, cancel-retires-park, wake-races-cancel, misattribution regression (cli).

Local gates: build, vet, full cli/mcp/auth/rpcserve suites with -race, i18n-parity, cyclo-new, commit-lint, license-headers, api-breaking, ai-smells, scope-budget, patch coverage 63.9% (>=60).