### PR TITLE
feat(memory): persisted knowledge graph participating in recall

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -760,6 +760,9 @@ func NewChatCLI(ctx context.Context, manager manager.LLMManager, logger *zap.Log
 		// Wire the @memory tool to this session's store so the agent can
 		// persist facts deterministically.
 		plugins.SetMemoryAdapter(&memoryPluginAdapter{cli: cli})
+		// Persisted knowledge-graph cache: adopt graph.json when current,
+		// rebuild on store mutations (see wireMemoryGraph).
+		cli.wireMemoryGraph()
 	}
 
 	// Build the content-aware compression layer (CCR store under ~/.chatcli/ccr)

--- a/cli/command_handler.go
+++ b/cli/command_handler.go
@@ -214,11 +214,22 @@ func (ch *CommandHandler) buildRoutes() {
 		{"/config", true, ch.cmdConfig},
 		{"/status", true, ch.cmdConfig},
 		{"/settings", true, ch.cmdConfig},
-		{"/session", false, func(ctx context.Context, in string) bool { ch.handleSessionCommand(ctx, in); return false }},
+		// /session and /skill mark the graph cache dirty after running: both
+		// mutate sources the graph derives from (session files, the skill
+		// catalog). Same human-frequency rationale as the /context tap.
+		{"/session", false, func(ctx context.Context, in string) bool {
+			ch.handleSessionCommand(ctx, in)
+			ch.cli.markGraphDirty()
+			return false
+		}},
 		{"/context", false, func(ctx context.Context, in string) bool { ch.handleContextCommand(ctx, in); return false }},
 		{"/auth", false, func(ctx context.Context, in string) bool { ch.handleAuthCommand(ctx, in); return false }},
 		{"/plugin", false, func(_ context.Context, in string) bool { ch.handlePluginCommand(in); return false }},
-		{"/skill", false, func(ctx context.Context, in string) bool { ch.handleSkillCommand(ctx, in); return false }},
+		{"/skill", false, func(ctx context.Context, in string) bool {
+			ch.handleSkillCommand(ctx, in)
+			ch.cli.markGraphDirty()
+			return false
+		}},
 		{"/connect", false, func(ctx context.Context, in string) bool { ch.handleConnectCommand(ctx, in); return false }},
 		{"/hub", false, func(ctx context.Context, in string) bool { c.handleHubCommand(ctx, in); return false }},
 		{"/watch", false, func(ctx context.Context, in string) bool { ch.handleWatchCommand(ctx, in); return false }},
@@ -280,6 +291,11 @@ func (ch *CommandHandler) handleContextCommand(ctx context.Context, userInput st
 	if err := ch.cli.contextHandler.HandleContextCommand(ctx, sessionID, userInput); err != nil {
 		fmt.Println(colorize(fmt.Sprintf(" ❌ %s", err.Error()), ColorYellow))
 	}
+	// Any /context subcommand may have created/updated/deleted a context the
+	// knowledge graph derives kb nodes from. Human-frequency command, so a
+	// spurious mark on a read-only subcommand costs at most one cheap
+	// rebuild — far simpler than re-parsing the subcommand here.
+	ch.cli.markGraphDirty()
 }
 
 // handleSessionCommand foi movido para cá para consolidar a lógica do handler

--- a/cli/config_env_defaults.go
+++ b/cli/config_env_defaults.go
@@ -177,6 +177,7 @@ var envDefaults = map[string]envDefault{
 	// ─── Memory / bootstrap ──────────────────────────────────────
 	"CHATCLI_MEMORY_ENABLED":    {Value: "true", IsBool: true, Source: "memory.go"},
 	"CHATCLI_MEMORY_MODE":       {Value: "index", Source: "memory_mode.go"},
+	"CHATCLI_MEMORY_GRAPH":      {Value: "true", IsBool: true, Source: "knowledge_graph.memoryGraphEnabled — persisted graph cache (graph.json) + recall neighborhood expansion; off = legacy derive-per-call"},
 	"CHATCLI_BOOTSTRAP_ENABLED": {Value: "true", IsBool: true, Source: "bootstrap.go"},
 
 	// ─── Gateway: voice transcription ────────────────────────────

--- a/cli/config_memory.go
+++ b/cli/config_memory.go
@@ -73,5 +73,20 @@ func (cli *ChatCLI) showConfigMemory() {
 	}
 	kv(p, config.GraphIndexEnv, graphVal)
 
+	// Persisted graph cache + recall expansion (PR: memory graph).
+	memGraphVal := i18n.T("cfg.val.disabled")
+	if memoryGraphEnabled() {
+		memGraphVal = i18n.T("cfg.val.enabled")
+	}
+	if os.Getenv(config.MemoryGraphEnv) == "" {
+		memGraphVal = defaultMarker + memGraphVal
+	}
+	kv(p, config.MemoryGraphEnv, memGraphVal)
+	if cli.memoryStore != nil {
+		if nodes, edges, ok := cli.memoryStore.Manager().GraphStats(); ok {
+			kv(p, i18n.T("cfg.kv.memory.graph_size"), i18n.T("cfg.kv.memory.graph_size_val", nodes, edges))
+		}
+	}
+
 	sectionEnd(ColorBlue)
 }

--- a/cli/context_adapter.go
+++ b/cli/context_adapter.go
@@ -86,6 +86,9 @@ func (a *contextPluginAdapter) Create(name, mode string, paths []string, descrip
 	if err != nil {
 		return "", err
 	}
+	// Tool-path mutation: the AI created a context without going through the
+	// /context command dispatch, so the graph cache must be marked here.
+	a.cli.markGraphDirty()
 	var b strings.Builder
 	fmt.Fprintf(&b, "Created context %q (mode=%s) — %d unit(s), %s.",
 		fc.Name, fc.Mode, fc.FileCount, humanMB(fc.TotalSize))
@@ -242,6 +245,8 @@ func (a *contextPluginAdapter) Delete(name string) (string, error) {
 	if err := mgr.DeleteContext(fc.ID); err != nil {
 		return "", err
 	}
+	// Tool-path mutation — same rationale as Create.
+	a.cli.markGraphDirty()
 	var b strings.Builder
 	fmt.Fprintf(&b, "Deleted context %q permanently.", fc.Name)
 	return b.String(), nil

--- a/cli/graph_command.go
+++ b/cli/graph_command.go
@@ -37,7 +37,7 @@ const (
 func (cli *ChatCLI) handleGraphCommand(ctx context.Context, input string) {
 	arg := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(input), "/graph"))
 
-	g := cli.buildKnowledgeGraph()
+	g := cli.knowledgeGraph()
 	if g.Len() == 0 {
 		fmt.Println(colorize("  "+i18n.T("graph.cmd.empty"), ColorYellow))
 		return
@@ -130,27 +130,12 @@ func graphToDOT(g *knowledge.Graph, include map[string]bool, title string) strin
 		fmt.Fprintf(&b, "  %q [label=%q, fillcolor=%q];\n", n.ID, wrapLabel(truncateForLog(label, 48), graphVizLabelWrap), kindColor(n.Kind))
 	}
 
-	seen := make(map[string]bool)
-	for _, n := range g.Nodes() {
-		if !include[n.ID] {
+	for _, e := range g.EdgeList() {
+		if !include[e.A] || !include[e.B] {
 			continue
 		}
-		for _, nb := range g.Neighbors(n.ID) {
-			if !include[nb.ID] {
-				continue
-			}
-			a, c := n.ID, nb.ID
-			if a > c {
-				a, c = c, a
-			}
-			key := a + "|" + c
-			if seen[key] {
-				continue
-			}
-			seen[key] = true
-			pw := 1.0 + math.Min(nb.Weight, 4.0)
-			fmt.Fprintf(&b, "  %q -- %q [penwidth=%.1f];\n", a, c, pw)
-		}
+		pw := 1.0 + math.Min(e.Weight, 4.0)
+		fmt.Fprintf(&b, "  %q -- %q [penwidth=%.1f];\n", e.A, e.B, pw)
 	}
 	b.WriteString("}\n")
 	return b.String()

--- a/cli/graphview_adapter.go
+++ b/cli/graphview_adapter.go
@@ -40,7 +40,7 @@ type graphViewPluginAdapter struct {
 
 // KnowledgeGraph converts the in-core knowledge graph to renderable data.
 func (a *graphViewPluginAdapter) KnowledgeGraph() (plugins.GraphData, error) {
-	g := a.cli.buildKnowledgeGraph()
+	g := a.cli.knowledgeGraph()
 	data := plugins.GraphData{
 		Nodes: make([]plugins.GraphNode, 0, g.Len()),
 		Edges: make([]plugins.GraphEdge, 0, g.Edges()),
@@ -58,20 +58,8 @@ func (a *graphViewPluginAdapter) KnowledgeGraph() (plugins.GraphData, error) {
 			Weight:  n.Weight,
 		})
 	}
-	seen := make(map[string]bool)
-	for _, n := range g.Nodes() {
-		for _, nb := range g.Neighbors(n.ID) {
-			x, y := n.ID, nb.ID
-			if x > y {
-				x, y = y, x
-			}
-			key := x + "\x00" + y
-			if seen[key] {
-				continue
-			}
-			seen[key] = true
-			data.Edges = append(data.Edges, plugins.GraphEdge{Source: x, Target: y, Weight: nb.Weight})
-		}
+	for _, e := range g.EdgeList() {
+		data.Edges = append(data.Edges, plugins.GraphEdge{Source: e.A, Target: e.B, Weight: e.Weight})
 	}
 	return data, nil
 }

--- a/cli/knowledge_graph.go
+++ b/cli/knowledge_graph.go
@@ -5,27 +5,43 @@
  */
 /*
  * knowledge_graph.go — derives the in-core knowledge graph from the existing
- * memory and skill stores, and implements the @graph tool's adapter.
+ * memory, skill, session and context stores, and implements the @graph tool's
+ * adapter.
  *
- * Nothing new is persisted: nodes and edges are computed on demand from facts,
- * topics, projects, profile and skills already on disk. Edges come from the
- * relationships those stores ALREADY record — topic↔fact links, a fact's source
- * project, shared tags, a skill's triggers — plus [[wikilinks]] parsed from
- * note text. This honors the index/pull discipline: the graph is a retrieval
- * structure, built fresh per query, never duplicated storage.
+ * The graph is a DERIVED index: nodes and edges are computed from data
+ * already on disk. Edges come from the relationships those stores ALREADY
+ * record — topic↔fact links, a fact's source project, an episode's project
+ * and date, shared tags, a skill's triggers — plus [[wikilinks]] parsed from
+ * note text.
+ *
+ * With CHATCLI_MEMORY_GRAPH on (default), the derivation is served through
+ * the persisted cache in cli/workspace/memory/graph_cache.go: consumers call
+ * cli.knowledgeGraph() and get an immutable snapshot that only rebuilds when
+ * a source store changed (dirty taps + fingerprint TTL), with graph.json
+ * carrying it across boots. Off, every call derives from scratch — the
+ * legacy behavior, byte-identical.
  */
 package cli
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
+	"time"
 
+	"github.com/diillson/chatcli/cli/ctxmgr"
 	"github.com/diillson/chatcli/config"
 	"github.com/diillson/chatcli/i18n"
 	"github.com/diillson/chatcli/pkg/knowledge"
 )
+
+// zeroTime is the open bound for EpisodeStore.Range queries.
+var zeroTime time.Time
 
 // graphRecallHint points the model at the pull tool. It is intentionally short
 // and stable so the injected block stays prompt-cache friendly.
@@ -41,44 +57,100 @@ func graphIndexEnabled() bool {
 	return true
 }
 
+// memoryGraphEnabled reports whether the persisted graph cache serves the
+// consumers (default on). Off restores the legacy derive-per-call behavior.
+// Distinct from CHATCLI_GRAPH_INDEX on purpose: that env gates the per-turn
+// card payload, this one gates the cache + recall expansion — "card off,
+// expansion on" is a legitimate lean-prompt setup.
+func memoryGraphEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(config.MemoryGraphEnv))) {
+	case "off", "false", "0", "no", "disabled":
+		return false
+	}
+	return true
+}
+
+// knowledgeGraph is the single accessor every graph consumer goes through:
+// the cached snapshot when the persisted-graph feature is live, else a fresh
+// derivation (feature off, or the cache was never wired — e.g. no memory
+// store). Callers must treat the returned graph as read-only.
+func (cli *ChatCLI) knowledgeGraph() *knowledge.Graph {
+	if memoryGraphEnabled() && cli.memoryStore != nil {
+		if g := cli.memoryStore.Manager().KnowledgeGraph(); g != nil {
+			return g
+		}
+	}
+	return cli.buildKnowledgeGraph()
+}
+
+// markGraphDirty flags the persisted graph cache stale after a CLI-side
+// mutation the memory stores cannot observe (session saved, skill installed,
+// context created/deleted). Nil-safe no-op when the cache is not wired.
+func (cli *ChatCLI) markGraphDirty() {
+	if cli.memoryStore != nil {
+		cli.memoryStore.Manager().MarkGraphDirty()
+	}
+}
+
 // graphIndexBlock renders the prompt block: the deterministic MOC card plus the
 // pull hint. Returns "" when disabled or the graph is empty, so quiet setups pay
 // nothing. The card itself is byte-stable between knowledge changes, so it does
-// not bust the prompt cache turn to turn.
+// not bust the prompt cache turn to turn. Routed through the memory threat
+// scanner — fact/topic titles flow into the hub list, and every other memory
+// injection is sanitized the same way.
 func (cli *ChatCLI) graphIndexBlock() string {
 	if !graphIndexEnabled() {
 		return ""
 	}
-	card := cli.buildKnowledgeGraph().IndexCard(graphIndexMaxHubs)
+	card := cli.knowledgeGraph().IndexCard(graphIndexMaxHubs)
 	if card == "" {
 		return ""
 	}
+	card = cli.memoryStore.SanitizeForPrompt(card)
 	return "# Knowledge Graph (index)\n" + card + "\n" + graphRecallHint
+}
+
+// graphBuildState carries the lookup maps the memory-node pass builds so the
+// episode/session passes can join against them without recomputation.
+type graphBuildState struct {
+	projByPath map[string]string   // workspace dir path → project node id
+	projByName map[string]string   // project name (slug) → project node id
+	factsByDay map[string][]string // sourceProject+"|"+YYYY-MM-DD → fact node ids
+	episByDay  map[string][]string // YYYY-MM-DD → episode node ids
 }
 
 // buildKnowledgeGraph assembles the graph from the live stores. Safe to call
 // with a nil memory store or persona handler — it simply yields a smaller graph.
 func (cli *ChatCLI) buildKnowledgeGraph() *knowledge.Graph {
 	g := knowledge.New()
-	cli.addMemoryNodes(g)
+	st := cli.addMemoryNodes(g)
+	cli.addEpisodeNodes(g, st)
+	cli.addSessionNodes(g, st)
+	cli.addKBNodes(g)
 	cli.addSkillNodes(g)
 	linkWikilinks(g)
 	return g
 }
 
-func (cli *ChatCLI) addMemoryNodes(g *knowledge.Graph) {
+func (cli *ChatCLI) addMemoryNodes(g *knowledge.Graph) *graphBuildState {
+	st := &graphBuildState{
+		projByPath: make(map[string]string),
+		projByName: make(map[string]string),
+		factsByDay: make(map[string][]string),
+		episByDay:  make(map[string][]string),
+	}
 	if cli.memoryStore == nil {
-		return
+		return st
 	}
 	m := cli.memoryStore.Manager()
 
 	// Projects first, so fact→project edges can resolve by path.
-	projByPath := make(map[string]string)
 	for _, p := range m.Projects.GetAll() {
 		id := "project:" + graphSlug(p.Name)
 		g.AddNode(knowledge.Node{ID: id, Kind: knowledge.KindProject, Title: p.Name, Summary: p.Description, Weight: float64(p.Priority)})
+		st.projByName[graphSlug(p.Name)] = id
 		if p.Path != "" {
-			projByPath[p.Path] = id
+			st.projByPath[p.Path] = id
 		}
 		for _, tech := range p.Technologies {
 			addTag(g, tech)
@@ -92,6 +164,11 @@ func (cli *ChatCLI) addMemoryNodes(g *knowledge.Graph) {
 		id := "fact:" + f.ID
 		g.AddNode(knowledge.Node{ID: id, Kind: knowledge.KindFact, Title: graphTitle(f.Content), Summary: f.Content, Weight: f.Score})
 		factByID[f.ID] = id
+		if f.SourceProject != "" {
+			day := f.CreatedAt.Format("2006-01-02")
+			key := f.SourceProject + "|" + day
+			st.factsByDay[key] = append(st.factsByDay[key], id)
+		}
 		for _, tag := range f.Tags {
 			addTag(g, tag)
 			g.AddEdge(id, tagID(tag), 1)
@@ -100,7 +177,7 @@ func (cli *ChatCLI) addMemoryNodes(g *knowledge.Graph) {
 			addTag(g, f.Category)
 			g.AddEdge(id, tagID(f.Category), 0.5)
 		}
-		if pid, ok := projByPath[f.SourceProject]; ok {
+		if pid, ok := st.projByPath[f.SourceProject]; ok {
 			g.AddEdge(id, pid, 2)
 		}
 	}
@@ -131,6 +208,135 @@ func (cli *ChatCLI) addMemoryNodes(g *knowledge.Graph) {
 		for _, goal := range prof.Goals {
 			addTag(g, goal)
 			g.AddEdge("profile:user", tagID(goal), 1)
+		}
+	}
+	return st
+}
+
+// graphMaxEpisodeNodes bounds how many recent episodes enter the graph — the
+// store caps at 2000 and a full year of timeline would drown the hubs.
+const graphMaxEpisodeNodes = 300
+
+// addEpisodeNodes joins the episodic timeline into the graph. Edges:
+// episode↔project (2.0) via the workspace-path keyspace both stores share
+// (Episode.Project IS a workspace dir, same as Fact.SourceProject), and
+// episode↔fact (1.0) for facts learned in the same project on the same day —
+// the durable "what happened while this was learned" bridge. Wikilinks in
+// episode summaries come free from linkWikilinks.
+func (cli *ChatCLI) addEpisodeNodes(g *knowledge.Graph, st *graphBuildState) {
+	if cli.memoryStore == nil {
+		return
+	}
+	m := cli.memoryStore.Manager()
+	for _, e := range m.Episodes.Range(zeroTime, zeroTime, "", "", graphMaxEpisodeNodes) {
+		day := e.Date.Format("2006-01-02")
+		id := "episode:" + e.ID
+		summary := e.Summary
+		if o := strings.TrimSpace(e.Outcome); o != "" {
+			summary += " → " + o
+		}
+		g.AddNode(knowledge.Node{
+			ID: id, Kind: knowledge.KindEpisode,
+			Title:   day + " " + graphTitle(e.Summary),
+			Summary: summary,
+		})
+		st.episByDay[day] = append(st.episByDay[day], id)
+		if pid, ok := st.projByPath[e.Project]; ok {
+			g.AddEdge(id, pid, 2)
+		}
+		for _, fid := range st.factsByDay[e.Project+"|"+day] {
+			g.AddEdge(id, fid, 1)
+		}
+	}
+}
+
+// graphMaxSessionNodes bounds saved-session nodes to the most recent by
+// mtime — with autosaves the store holds hundreds.
+const graphMaxSessionNodes = 50
+
+// addSessionNodes joins saved sessions via a LIGHTWEIGHT listing (name +
+// mtime stat only — never the search corpus, whose first build parses every
+// session JSON and would tax chat turns). Titles are enriched from the
+// corpus only when it is already warm. The session NAME is the identity;
+// renames orphan a node until the fingerprint TTL heals the derived cache.
+// Edges: session↔project (1.5) when the project name appears in the session
+// name/title, session↔episode (1.0) same calendar day.
+func (cli *ChatCLI) addSessionNodes(g *knowledge.Graph, st *graphBuildState) {
+	if cli.sessionManager == nil {
+		return
+	}
+	type sess struct {
+		name  string
+		mtime int64
+		day   string
+	}
+	entries, err := os.ReadDir(cli.sessionManager.sessionsDir)
+	if err != nil {
+		return
+	}
+	titles := cli.sessionManager.warmTitles()
+	all := make([]sess, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		all = append(all, sess{
+			name:  strings.TrimSuffix(e.Name(), ".json"),
+			mtime: info.ModTime().UnixNano(),
+			day:   info.ModTime().Format("2006-01-02"),
+		})
+	}
+	sort.Slice(all, func(i, j int) bool { return all[i].mtime > all[j].mtime })
+	if len(all) > graphMaxSessionNodes {
+		all = all[:graphMaxSessionNodes]
+	}
+	for _, s := range all {
+		id := "session:" + s.name
+		title := s.name
+		if t := strings.TrimSpace(titles[s.name]); t != "" {
+			title = t
+		}
+		g.AddNode(knowledge.Node{ID: id, Kind: knowledge.KindSession, Title: title, Summary: ""})
+		hay := graphSlug(s.name + " " + title)
+		for slug, pid := range st.projByName {
+			if slug != "" && strings.Contains(hay, slug) {
+				g.AddEdge(id, pid, 1.5)
+			}
+		}
+		for _, eid := range st.episByDay[s.day] {
+			g.AddEdge(id, eid, 1)
+		}
+	}
+}
+
+// addKBNodes joins knowledge-mode contexts at CONTEXT granularity ("kb:" +
+// FileContext.ID — chunk-level nodes would put tens of thousands of vertices
+// in the graph). Edges: kb↔tag (1.0) from the context's tags.
+func (cli *ChatCLI) addKBNodes(g *knowledge.Graph) {
+	if cli.contextHandler == nil {
+		return
+	}
+	mgr := cli.contextHandler.GetManager()
+	if mgr == nil {
+		return
+	}
+	ctxs, err := mgr.ListContexts(nil)
+	if err != nil {
+		return
+	}
+	for _, fc := range ctxs {
+		if fc == nil || fc.Mode != ctxmgr.ModeKnowledge {
+			continue
+		}
+		id := "kb:" + fc.ID
+		g.AddNode(knowledge.Node{ID: id, Kind: knowledge.KindKB, Title: fc.Name, Summary: fc.Description})
+		for _, tag := range fc.Tags {
+			addTag(g, tag)
+			g.AddEdge(id, tagID(tag), 1)
 		}
 	}
 }
@@ -217,18 +423,18 @@ const (
 
 // graphMapText renders the graph map-of-content (counts + hubs) for @memory map.
 func (cli *ChatCLI) graphMapText() (string, error) {
-	card := cli.buildKnowledgeGraph().IndexCard(graphIndexMaxHubs)
+	card := cli.knowledgeGraph().IndexCard(graphIndexMaxHubs)
 	if card == "" {
 		return "The knowledge graph is empty so far.", nil
 	}
-	return card, nil
+	return cli.memoryStore.SanitizeForPrompt(card), nil
 }
 
 // graphNeighborsText renders the local graph (backlinks + related notes) of the
 // node best matching idOrQuery, for @memory neighbors. Free text resolves to the
 // best-matching node, so the model can pass a subject rather than a node id.
 func (cli *ChatCLI) graphNeighborsText(idOrQuery string) (string, error) {
-	g := cli.buildKnowledgeGraph()
+	g := cli.knowledgeGraph()
 
 	seed, ok := g.Node(idOrQuery)
 	if !ok {
@@ -248,13 +454,77 @@ func (cli *ChatCLI) graphNeighborsText(idOrQuery string) (string, error) {
 	}
 	if len(hood) == 0 {
 		b.WriteString("  (no connected notes yet)")
-		return b.String(), nil
+		return cli.memoryStore.SanitizeForPrompt(b.String()), nil
 	}
 	b.WriteString("Connected:\n")
 	for _, n := range hood {
 		writeGraphNode(&b, n)
 	}
-	return strings.TrimRight(b.String(), "\n"), nil
+	// Fact/topic summaries flow verbatim into the conversation — same
+	// threatscan pass every other memory injection gets.
+	return cli.memoryStore.SanitizeForPrompt(strings.TrimRight(b.String(), "\n")), nil
+}
+
+// --- persisted-cache wiring (source builder + fingerprint) ---
+
+// graphFingerprint hashes stat lines (name, size, mtime) of every source the
+// derivation reads — memory JSONs, skill dirs, session files, context store.
+// Stat-only by design: tens to low hundreds of syscalls, no parsing, run at
+// boot and once per fingerprint TTL. Any change flips the hash and the cache
+// rebuilds.
+func (cli *ChatCLI) graphFingerprint() string {
+	h := sha256.New()
+	statFile := func(path string) {
+		if fi, err := os.Stat(path); err == nil {
+			fmt.Fprintf(h, "%s|%d|%d\n", path, fi.Size(), fi.ModTime().UnixNano())
+		}
+	}
+	statDir := func(dir string) {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return
+		}
+		for _, e := range entries {
+			if info, err := e.Info(); err == nil {
+				fmt.Fprintf(h, "%s/%s|%d|%d\n", dir, e.Name(), info.Size(), info.ModTime().UnixNano())
+			}
+		}
+	}
+	if cli.memoryStore != nil {
+		md := cli.memoryStore.Manager().MemoryDir()
+		for _, f := range []string{
+			"memory_index.json", "topics.json", "projects.json",
+			"user_profile.json", "episodes.json",
+		} {
+			statFile(filepath.Join(md, f))
+		}
+	}
+	if cli.personaHandler != nil {
+		if mgr := cli.personaHandler.GetManager(); mgr != nil {
+			for _, d := range mgr.SkillDirs() {
+				statDir(d)
+			}
+		}
+	}
+	if cli.sessionManager != nil {
+		statDir(cli.sessionManager.sessionsDir)
+	}
+	if cli.contextHandler != nil {
+		if mgr := cli.contextHandler.GetManager(); mgr != nil && mgr.Storage != nil {
+			statDir(mgr.Storage.GetStoragePath())
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// wireMemoryGraph attaches the graph derivation to the persisted cache.
+// Called once at startup after every source store exists; a no-op when the
+// feature is disabled (consumers then fall back to derive-per-call).
+func (cli *ChatCLI) wireMemoryGraph() {
+	if !memoryGraphEnabled() || cli.memoryStore == nil {
+		return
+	}
+	cli.memoryStore.Manager().SetGraphSource(cli.buildKnowledgeGraph, cli.graphFingerprint)
 }
 
 func writeGraphNode(b *strings.Builder, n *knowledge.Node) {

--- a/cli/knowledge_graph_kinds_test.go
+++ b/cli/knowledge_graph_kinds_test.go
@@ -1,0 +1,150 @@
+/*
+ * ChatCLI - Tests for the episode/session/kb graph builders (knowledge_graph.go)
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/diillson/chatcli/cli/workspace/memory"
+	"github.com/diillson/chatcli/models"
+	"github.com/diillson/chatcli/pkg/knowledge"
+)
+
+func TestAddEpisodeNodes_ProjectAndSameDayFactEdges(t *testing.T) {
+	cli := newTestCLIWithMemory(t)
+	m := cli.memoryStore.Manager()
+
+	m.Projects.Upsert(map[string]string{"name": "chatcli", "project_path": "/repo/chatcli"})
+	// Fact learned today in the project → same-day bridge to the episode.
+	m.Facts.AddFactWithSource("bedrock caps payload at fifty megabytes", "gotcha", nil, "/repo/chatcli")
+	facts := m.Facts.GetAll()
+	if len(facts) != 1 {
+		t.Fatalf("facts = %d, want 1", len(facts))
+	}
+	m.Episodes.Add(memory.Episode{
+		Summary: "shipped the payload cap fallback",
+		Outcome: "merged",
+		Project: "/repo/chatcli",
+		Date:    time.Now(),
+	})
+	eps := m.Episodes.Range(time.Time{}, time.Time{}, "", "", 0)
+	if len(eps) != 1 {
+		t.Fatalf("episodes = %d, want 1", len(eps))
+	}
+	epNode := "episode:" + eps[0].ID
+
+	g := cli.buildKnowledgeGraph()
+	n, ok := g.Node(epNode)
+	if !ok {
+		t.Fatal("episode node missing")
+	}
+	if n.Kind != knowledge.KindEpisode || !strings.Contains(n.Title, "shipped the payload") {
+		t.Fatalf("episode node malformed: %+v", n)
+	}
+	if !strings.Contains(n.Summary, "→ merged") {
+		t.Fatalf("outcome missing from summary: %q", n.Summary)
+	}
+
+	var gotProject, gotFact bool
+	for _, nb := range g.Neighbors(epNode) {
+		switch nb.ID {
+		case "project:chatcli":
+			gotProject = true
+			if nb.Weight != 2 {
+				t.Fatalf("episode↔project weight = %v, want 2", nb.Weight)
+			}
+		case "fact:" + facts[0].ID:
+			gotFact = true
+			if nb.Weight != 1 {
+				t.Fatalf("episode↔fact weight = %v, want 1", nb.Weight)
+			}
+		}
+	}
+	if !gotProject {
+		t.Fatal("episode↔project edge missing (path keyspace join)")
+	}
+	if !gotFact {
+		t.Fatal("episode↔fact same-day edge missing")
+	}
+}
+
+func TestAddSessionNodes_CapAndProjectEdge(t *testing.T) {
+	cli := newTestCLIWithMemory(t)
+	m := cli.memoryStore.Manager()
+	m.Projects.Upsert(map[string]string{"name": "chatcli", "project_path": "/repo/chatcli"})
+
+	sm := newTestSessionManager(t)
+	cli.sessionManager = sm
+	sd := func() *SessionData {
+		return &SessionData{Version: 2, ChatHistory: []models.Message{
+			{Role: "user", Content: "hello"}, {Role: "assistant", Content: "hi"},
+		}}
+	}
+	// One session whose name carries the project slug, plus filler beyond the cap.
+	if err := sm.SaveSessionV2("chatcli-auth-work", sd()); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	for i := 0; i < graphMaxSessionNodes+5; i++ {
+		name := fmt.Sprintf("filler-%03d", i)
+		if err := sm.SaveSessionV2(name, sd()); err != nil {
+			t.Fatalf("save filler: %v", err)
+		}
+	}
+
+	g := cli.buildKnowledgeGraph()
+	sessions := 0
+	for _, n := range g.Nodes() {
+		if n.Kind == knowledge.KindSession {
+			sessions++
+		}
+	}
+	if sessions == 0 || sessions > graphMaxSessionNodes {
+		t.Fatalf("session nodes = %d, want (0, %d]", sessions, graphMaxSessionNodes)
+	}
+	// The project-slug session must link to the project (1.5).
+	if n, ok := g.Node("session:chatcli-auth-work"); ok {
+		found := false
+		for _, nb := range g.Neighbors(n.ID) {
+			if nb.ID == "project:chatcli" && nb.Weight == 1.5 {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatal("session↔project slug edge missing")
+		}
+	}
+}
+
+func TestKnowledgeGraphAccessor_FallsBackWhenDisabled(t *testing.T) {
+	t.Setenv("CHATCLI_MEMORY_GRAPH", "off")
+	cli := newTestCLIWithMemory(t)
+	cli.memoryStore.Manager().Facts.AddFact("derive per call still works", "general", nil)
+	g := cli.knowledgeGraph()
+	if g == nil || g.Len() == 0 {
+		t.Fatal("disabled accessor must fall back to derive-per-call")
+	}
+}
+
+func TestKnowledgeGraphAccessor_ServesCachedSnapshotWhenWired(t *testing.T) {
+	t.Setenv("CHATCLI_MEMORY_GRAPH", "")
+	cli := newTestCLIWithMemory(t)
+	cli.memoryStore.Manager().Facts.AddFact("cached snapshot fact", "general", nil)
+	cli.wireMemoryGraph()
+
+	g1 := cli.knowledgeGraph()
+	g2 := cli.knowledgeGraph()
+	if g1 == nil || g1 != g2 {
+		t.Fatal("expected the same cached snapshot across clean reads")
+	}
+	// A mutation marks dirty → next access is a rebuilt (different) snapshot.
+	cli.memoryStore.Manager().Facts.AddFact("second fact invalidates", "general", nil)
+	if g3 := cli.knowledgeGraph(); g3 == g1 {
+		t.Fatal("mutation did not invalidate the cached snapshot")
+	}
+}

--- a/cli/session_adapter.go
+++ b/cli/session_adapter.go
@@ -229,6 +229,9 @@ func (a *sessionPluginAdapter) Save(_ context.Context, name string) (string, err
 	cli.currentSessionName = name
 	cli.boundRemoteOnly = false
 	cli.stampBoundSession()
+	// Tool-path mutation: a new/updated session file feeds the knowledge
+	// graph's session nodes; the /session command tap never sees this path.
+	cli.markGraphDirty()
 	return i18n.T("session.tool.save.ok", name), nil
 }
 
@@ -252,6 +255,8 @@ func (a *sessionPluginAdapter) Fork(_ context.Context, name string) (string, err
 	cli.currentSessionName = name
 	cli.boundRemoteOnly = false
 	cli.stampBoundSession()
+	// Tool-path mutation — same rationale as Save.
+	cli.markGraphDirty()
 	return i18n.T("session.tool.fork.ok", name), nil
 }
 

--- a/cli/session_manager.go
+++ b/cli/session_manager.go
@@ -484,6 +484,20 @@ type sessionSearchDoc struct {
 // cached on the SessionManager and invalidated by a cheap directory signature
 // (names + mtimes + sizes), so per-turn callers (session auto-recall) don't
 // re-parse hundreds of JSON files on every agent turn.
+// warmTitles returns the cached session-title map when the search corpus is
+// already built, or nil — it NEVER triggers a corpus build (the first build
+// parses every session JSON, a cost the graph derivation must not add to
+// chat turns). The returned map is a read-only snapshot: corpus rebuilds
+// swap in a fresh map rather than mutating this one.
+func (sm *SessionManager) warmTitles() map[string]string {
+	sm.corpusMu.Lock()
+	defer sm.corpusMu.Unlock()
+	if sm.corpus == nil {
+		return nil
+	}
+	return sm.corpus.titles
+}
+
 type sessionCorpus struct {
 	sig    string
 	docs   []sessionSearchDoc

--- a/cli/workspace/memory.go
+++ b/cli/workspace/memory.go
@@ -103,31 +103,42 @@ func (ms *MemoryStore) GetRecentDailyNotes(days int) []DailyNote {
 // GetMemoryContext builds the memory section for the system prompt.
 // Uses smart retrieval when no hints are provided.
 func (ms *MemoryStore) GetMemoryContext() string {
-	return ms.sanitizeForPrompt(ms.manager.GetMemoryContext())
+	return ms.threatscanPrompt(ms.manager.GetMemoryContext())
 }
 
 // GetRelevantContext returns memory tailored to conversation hints.
 func (ms *MemoryStore) GetRelevantContext(hints []string) string {
-	return ms.sanitizeForPrompt(ms.manager.GetRelevantContext(hints))
+	return ms.threatscanPrompt(ms.manager.GetRelevantContext(hints))
 }
 
 // GetMemoryIndex returns the compact, stable memory digest. See
 // memory.Manager.GetMemoryIndex.
 func (ms *MemoryStore) GetMemoryIndex(budget int) string {
-	return ms.sanitizeForPrompt(ms.manager.GetMemoryIndex(budget))
+	return ms.threatscanPrompt(ms.manager.GetMemoryIndex(budget))
 }
 
 // GetRelevantContextWithHyDE delegates to the manager's HyDE-aware
 // retrieval. See memory.Manager.GetRelevantContextWithHyDE.
 func (ms *MemoryStore) GetRelevantContextWithHyDE(ctx context.Context, query string, hints []string, augmenter *memory.HyDEAugmenter) string {
-	return ms.sanitizeForPrompt(ms.manager.GetRelevantContextWithHyDE(ctx, query, hints, augmenter))
+	return ms.threatscanPrompt(ms.manager.GetRelevantContextWithHyDE(ctx, query, hints, augmenter))
 }
 
-// sanitizeForPrompt neutralizes prompt-injection / exec / persistence
+// SanitizeForPrompt exposes the threatscan pass for graph text assembled at
+// the cli layer (index card, @memory neighbors output) — fact summaries flow
+// into both, and every other memory injection already goes through this.
+// Nil-safe so callers without a memory store pass text through unchanged.
+func (ms *MemoryStore) SanitizeForPrompt(s string) string {
+	if ms == nil {
+		return s
+	}
+	return ms.threatscanPrompt(s)
+}
+
+// threatscanPrompt neutralizes prompt-injection / exec / persistence
 // payloads in memory before it is injected into the system prompt. Memory
 // is auto-curated and should never carry shell scripts, so it uses the
 // stricter ScopeMemory. The on-disk store is never modified.
-func (ms *MemoryStore) sanitizeForPrompt(s string) string {
+func (ms *MemoryStore) threatscanPrompt(s string) string {
 	if s == "" || !threatscan.Enabled() {
 		return s
 	}

--- a/cli/workspace/memory/change_notify.go
+++ b/cli/workspace/memory/change_notify.go
@@ -1,0 +1,41 @@
+/*
+ * ChatCLI - Change notification for memory sub-stores
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * changeNotifier is the one-line "mark derived caches stale" seam each
+ * sub-store embeds. The callback is stored atomically so notifyChanged is
+ * safe to invoke while holding any store lock, and the downstream consumer
+ * (the graph cache) is a bare atomic-bool store — cheap enough to fire on
+ * every content mutation.
+ *
+ * Deliberate NON-callers (rebuild-storm guards, keep in sync with the tap
+ * list in graph_cache.go): FactIndex.MarkAccessed, bare persistLocked calls,
+ * ProjectTracker.Touch, UserProfileStore.RecordCommand.
+ */
+package memory
+
+import "sync/atomic"
+
+// changeNotifier is embedded by sub-stores whose content feeds derived
+// caches. Zero value is inert.
+type changeNotifier struct {
+	fn atomic.Pointer[func()]
+}
+
+// SetOnChanged registers the notifier callback (nil detaches). The callback
+// must be cheap and must not call back into the owning store.
+func (c *changeNotifier) SetOnChanged(fn func()) {
+	if fn == nil {
+		c.fn.Store(nil)
+		return
+	}
+	c.fn.Store(&fn)
+}
+
+// notifyChanged fires the callback if attached. Safe under any lock.
+func (c *changeNotifier) notifyChanged() {
+	if fn := c.fn.Load(); fn != nil {
+		(*fn)()
+	}
+}

--- a/cli/workspace/memory/episodes.go
+++ b/cli/workspace/memory/episodes.go
@@ -54,6 +54,10 @@ type EpisodeStore struct {
 	path     string
 	logger   *zap.Logger
 	maxCount int
+
+	// changeNotifier marks derived caches (knowledge graph) stale on
+	// content mutations. See change_notify.go for the non-caller list.
+	changeNotifier
 }
 
 // NewEpisodeStore creates the store and loads episodes.json from memoryDir.
@@ -103,12 +107,14 @@ func (es *EpisodeStore) Add(e Episode) bool {
 			changed = true
 		}
 		if changed {
+			es.notifyChanged()
 			es.persistLocked()
 		}
 		return false
 	}
 
 	es.episodes[e.ID] = &e
+	es.notifyChanged()
 	es.persistLocked()
 	return true
 }

--- a/cli/workspace/memory/facts.go
+++ b/cli/workspace/memory/facts.go
@@ -48,12 +48,22 @@ type FactIndex struct {
 	lastAccessFlush     time.Time
 	accessDirty         bool
 
-	// onRemoved, when set, is invoked for every explicit fact removal
-	// (forget, archive, replace/compaction, supersede, cap prune) so derived
-	// per-fact state — today the vector index — is dropped in lockstep and
-	// never orphans. Invoked synchronously with fi.mu held; the callback must
-	// not call back into the FactIndex.
-	onRemoved func(ids []string)
+	// removalHooks are invoked for every explicit fact removal (forget,
+	// archive, replace/compaction, supersede, cap prune) so derived
+	// per-fact state — the vector index, the knowledge-graph cache — is
+	// dropped in lockstep and never orphans. Keyed so independent consumers
+	// can attach and detach without clobbering each other (the vector index
+	// re-attaches on /config reload and must not silently drop the graph
+	// hook). Invoked synchronously with fi.mu held, in sorted key order for
+	// determinism; callbacks must not call back into the FactIndex.
+	removalHooks map[string]func(ids []string)
+
+	// changeNotifier fires after content mutations (add, reinforce,
+	// supersede, compaction replace) so derived caches can mark themselves
+	// stale. Deliberately NOT fired by access-metadata bumps (MarkAccessed)
+	// or bare persists — those happen every retrieval and would thrash the
+	// cache.
+	changeNotifier
 }
 
 // factAccessFlushInterval bounds how often bare access-metadata bumps rewrite
@@ -142,6 +152,7 @@ func (fi *FactIndex) AddFactWithMeta(content, category string, tags []string, so
 	// Exact duplicate (same content hash) — reinforce.
 	if existing, ok := fi.facts[id]; ok {
 		fi.reinforceLocked(existing, sourceProject, confidence, provenance)
+		fi.notifyChanged()
 		fi.persistLocked()
 		return false
 	}
@@ -150,6 +161,7 @@ func (fi *FactIndex) AddFactWithMeta(content, category string, tags []string, so
 	switch outcome, target := fi.reconcileLocked(content, category, confidence); outcome {
 	case reconcileReinforce:
 		fi.reinforceLocked(target, sourceProject, confidence, provenance)
+		fi.notifyChanged()
 		fi.persistLocked()
 		return false
 	case reconcileSupersede:
@@ -189,6 +201,7 @@ func (fi *FactIndex) AddFactWithMeta(content, category string, tags []string, so
 		fi.pruneLowestLocked(len(fi.facts) - fi.config.MaxFactsCount)
 	}
 
+	fi.notifyChanged()
 	fi.persistLocked()
 	return true
 }
@@ -519,6 +532,9 @@ func (fi *FactIndex) ReplaceFacts(facts []*Fact) {
 	}
 	fi.facts = next
 	fi.recordTombstonesLocked(droppedIDs...)
+	// The removal hook covers the dropped side; the consolidated facts that
+	// replaced them are a content change of their own.
+	fi.notifyChanged()
 	fi.persistLocked()
 }
 
@@ -981,13 +997,28 @@ func (fi *FactIndex) mergeFromDiskLocked() {
 	}
 }
 
-// SetOnRemoved registers the removal hook (see the field doc). Pass nil to
-// detach. Not safe to call concurrently with index operations — wire it at
-// construction/attach time.
+// SetOnRemoved registers the default removal hook. Pass nil to detach.
+// Kept for API stability — it delegates to SetRemovalHook under a fixed
+// key, so it composes with keyed consumers instead of clobbering them.
 func (fi *FactIndex) SetOnRemoved(fn func(ids []string)) {
+	fi.SetRemovalHook("default", fn)
+}
+
+// SetRemovalHook registers (fn != nil) or removes (fn == nil) a keyed
+// removal hook (see the removalHooks field doc). Not safe to call
+// concurrently with index operations — wire hooks at construction/attach
+// time.
+func (fi *FactIndex) SetRemovalHook(key string, fn func(ids []string)) {
 	fi.mu.Lock()
-	fi.onRemoved = fn
-	fi.mu.Unlock()
+	defer fi.mu.Unlock()
+	if fn == nil {
+		delete(fi.removalHooks, key)
+		return
+	}
+	if fi.removalHooks == nil {
+		fi.removalHooks = make(map[string]func(ids []string))
+	}
+	fi.removalHooks[key] = fn
 }
 
 // recordTombstonesLocked marks ids as explicitly deleted, persists the
@@ -999,8 +1030,15 @@ func (fi *FactIndex) recordTombstonesLocked(ids ...string) {
 	if len(ids) == 0 {
 		return
 	}
-	if fi.onRemoved != nil {
-		fi.onRemoved(ids)
+	if len(fi.removalHooks) > 0 {
+		keys := make([]string, 0, len(fi.removalHooks))
+		for k := range fi.removalHooks {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			fi.removalHooks[k](ids)
+		}
 	}
 	now := time.Now()
 	for _, id := range ids {

--- a/cli/workspace/memory/graph_cache.go
+++ b/cli/workspace/memory/graph_cache.go
@@ -1,0 +1,273 @@
+/*
+ * ChatCLI - Persisted knowledge-graph cache
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * The knowledge graph used to be derived from scratch on every consumer call
+ * — six call sites, each paying store copies plus a skills-directory
+ * filesystem walk. This cache makes the graph a first-class derived index:
+ *
+ *   - the built graph is held in memory behind an atomic pointer and served
+ *     as an IMMUTABLE snapshot (rebuilds construct a fresh graph and swap
+ *     the pointer; nothing ever mutates a served graph in place);
+ *   - content mutations in the source stores mark the cache dirty via the
+ *     changeNotifier taps (see change_notify.go) and the fact-removal hook;
+ *     the first reader after a write rebuilds, under single-flight;
+ *   - the graph is persisted to <memoryDir>/graph.json so the NEXT process/
+ *     boot adopts it instantly instead of paying the first build — guarded
+ *     by a schema version and a source fingerprint;
+ *   - staleness policy is the vindex one (discard + rebuild), NOT the
+ *     facts.go quarantine/tombstone protocol: every byte of the graph is
+ *     re-derivable from the source stores, so a corrupt, stale or
+ *     version-mismatched file is simply removed. Cross-process writes are
+ *     last-writer-wins for the same reason.
+ */
+package memory
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/diillson/chatcli/pkg/knowledge"
+	"go.uber.org/zap"
+)
+
+// graphSchemaVersion gates persisted files: any format/derivation change
+// bumps it, and older files are discarded and rebuilt.
+const graphSchemaVersion = 1
+
+// graphFingerprintTTL bounds how often the fast path re-checks the source
+// fingerprint. External edits (skills changed in an editor, sessions written
+// by another process) are picked up within this window even when no
+// in-process tap fired.
+const graphFingerprintTTL = 5 * time.Minute
+
+// graphFile is the on-disk envelope around the serialized graph.
+type graphFile struct {
+	SchemaVersion int             `json:"schema_version"`
+	Fingerprint   string          `json:"fingerprint"`
+	SavedAt       time.Time       `json:"saved_at"`
+	Graph         json.RawMessage `json:"graph"`
+}
+
+// GraphCache owns the cached graph snapshot and its persistence. Inert (all
+// methods no-ops returning nil) until SetSource attaches a builder.
+type GraphCache struct {
+	mu          sync.Mutex // guards rebuild + fingerprint bookkeeping
+	snap        atomic.Pointer[knowledge.Graph]
+	dirty       atomic.Bool
+	build       func() *knowledge.Graph
+	fingerprint func() string
+
+	lastFP        string
+	lastFPCheckMu sync.Mutex
+	lastFPCheck   time.Time
+
+	path            string
+	persistInFlight atomic.Bool
+	logger          *zap.Logger
+}
+
+// NewGraphCache creates an inert cache rooted at memoryDir. It becomes live
+// when SetSource wires a builder.
+func NewGraphCache(memoryDir string, logger *zap.Logger) *GraphCache {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &GraphCache{
+		path:   filepath.Join(memoryDir, "graph.json"),
+		logger: logger,
+	}
+}
+
+// MarkDirty flags the snapshot as stale. Cheap (one atomic store) — this is
+// what every changeNotifier tap and removal hook resolves to.
+func (gc *GraphCache) MarkDirty() {
+	if gc != nil {
+		gc.dirty.Store(true)
+	}
+}
+
+// SetSource wires the builder and fingerprint functions, then tries to adopt
+// the persisted file: a valid, fingerprint-matching, current-schema graph
+// becomes the initial snapshot (instant boot, zero build cost); anything
+// else is discarded and the cache starts dirty.
+func (gc *GraphCache) SetSource(build func() *knowledge.Graph, fingerprint func() string) {
+	if gc == nil || build == nil {
+		return
+	}
+	gc.mu.Lock()
+	defer gc.mu.Unlock()
+	gc.build = build
+	gc.fingerprint = fingerprint
+
+	fp := ""
+	if fingerprint != nil {
+		fp = fingerprint()
+	}
+	gc.lastFP = fp
+	gc.lastFPCheck = time.Now()
+
+	if g, ok := gc.loadPersisted(fp); ok {
+		gc.snap.Store(g)
+		gc.dirty.Store(false)
+		return
+	}
+	gc.dirty.Store(true)
+}
+
+// loadPersisted adopts graph.json when valid and current. Any failure mode
+// (missing, corrupt, wrong schema, stale fingerprint) discards the file —
+// the graph is re-derivable, so there is nothing to preserve.
+func (gc *GraphCache) loadPersisted(currentFP string) (*knowledge.Graph, bool) {
+	data, err := os.ReadFile(gc.path)
+	if err != nil {
+		return nil, false // missing is the common first-boot case
+	}
+	discard := func(reason string) {
+		gc.logger.Debug("memory graph cache discarded", zap.String("reason", reason))
+		_ = os.Remove(gc.path)
+	}
+	var env graphFile
+	if err := json.Unmarshal(data, &env); err != nil {
+		discard("corrupt envelope")
+		return nil, false
+	}
+	if env.SchemaVersion != graphSchemaVersion {
+		discard("schema version mismatch")
+		return nil, false
+	}
+	if env.Fingerprint != currentFP {
+		discard("stale fingerprint")
+		return nil, false
+	}
+	g, err := knowledge.UnmarshalGraph(env.Graph)
+	if err != nil {
+		discard("corrupt graph payload")
+		return nil, false
+	}
+	gc.logger.Debug("memory graph cache adopted from disk",
+		zap.Int("nodes", g.Len()), zap.Int("edges", g.Edges()))
+	return g, true
+}
+
+// Snapshot returns the current graph, rebuilding first when dirty or when
+// the periodic fingerprint re-check detects an external change. Returns nil
+// when no builder is wired (feature off). The returned graph is an immutable
+// snapshot — consumers must treat it as read-only (they all do; rebuilds
+// swap in a fresh graph rather than mutating).
+func (gc *GraphCache) Snapshot() *knowledge.Graph {
+	if gc == nil {
+		return nil
+	}
+	gc.mu.Lock()
+	build := gc.build
+	gc.mu.Unlock()
+	if build == nil {
+		return nil
+	}
+
+	gc.checkFingerprintTTL()
+
+	if !gc.dirty.Load() {
+		if g := gc.snap.Load(); g != nil {
+			return g
+		}
+	}
+
+	// Slow path: single-flight rebuild. Concurrent readers block briefly on
+	// mu and adopt the fresh snapshot via the double-check.
+	gc.mu.Lock()
+	defer gc.mu.Unlock()
+	if !gc.dirty.Load() {
+		if g := gc.snap.Load(); g != nil {
+			return g
+		}
+	}
+	g := gc.build()
+	if g == nil {
+		return gc.snap.Load()
+	}
+	gc.snap.Store(g)
+	gc.dirty.Store(false)
+	fp := ""
+	if gc.fingerprint != nil {
+		fp = gc.fingerprint()
+		gc.lastFP = fp
+	}
+	gc.persistAsync(g, fp)
+	return g
+}
+
+// checkFingerprintTTL recomputes the source fingerprint at most once per
+// graphFingerprintTTL (stat-only, no parsing) and marks the cache dirty on
+// change — the backstop for edits made outside this process.
+func (gc *GraphCache) checkFingerprintTTL() {
+	gc.lastFPCheckMu.Lock()
+	due := time.Since(gc.lastFPCheck) > graphFingerprintTTL
+	if due {
+		gc.lastFPCheck = time.Now()
+	}
+	gc.lastFPCheckMu.Unlock()
+	if !due {
+		return
+	}
+	gc.mu.Lock()
+	fingerprint := gc.fingerprint
+	last := gc.lastFP
+	gc.mu.Unlock()
+	if fingerprint == nil {
+		return
+	}
+	if fp := fingerprint(); fp != last {
+		gc.MarkDirty()
+	}
+}
+
+// persistAsync writes the envelope off the hot path. Single-flight via CAS;
+// a skipped write is harmless (the next rebuild persists again) and the
+// atomic rename keeps readers from ever seeing a partial file.
+func (gc *GraphCache) persistAsync(g *knowledge.Graph, fp string) {
+	if !gc.persistInFlight.CompareAndSwap(false, true) {
+		return
+	}
+	go func() {
+		defer gc.persistInFlight.Store(false)
+		payload, err := g.MarshalGraph()
+		if err != nil {
+			gc.logger.Warn("memory graph cache: marshal failed", zap.Error(err))
+			return
+		}
+		env := graphFile{
+			SchemaVersion: graphSchemaVersion,
+			Fingerprint:   fp,
+			SavedAt:       time.Now(),
+			Graph:         payload,
+		}
+		data, err := json.Marshal(env)
+		if err != nil {
+			gc.logger.Warn("memory graph cache: envelope marshal failed", zap.Error(err))
+			return
+		}
+		if err := atomicWriteFile(gc.path, data, 0o600); err != nil {
+			gc.logger.Warn("memory graph cache: persist failed", zap.Error(err))
+		}
+	}()
+}
+
+// Stats reports the cached snapshot's size without ever triggering a build
+// (safe to call from status screens). ok is false when no snapshot exists.
+func (gc *GraphCache) Stats() (nodes, edges int, ok bool) {
+	if gc == nil {
+		return 0, 0, false
+	}
+	g := gc.snap.Load()
+	if g == nil {
+		return 0, 0, false
+	}
+	return g.Len(), g.Edges(), true
+}

--- a/cli/workspace/memory/graph_cache_test.go
+++ b/cli/workspace/memory/graph_cache_test.go
@@ -1,0 +1,313 @@
+/*
+ * ChatCLI - Tests for the persisted knowledge-graph cache (graph_cache.go)
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package memory
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/diillson/chatcli/pkg/knowledge"
+	"go.uber.org/zap"
+)
+
+// drainPersist blocks until any in-flight async persist finished, so
+// TempDir cleanup never races the background write.
+func drainPersist(t *testing.T, gc *GraphCache) {
+	t.Helper()
+	t.Cleanup(func() {
+		deadline := time.Now().Add(3 * time.Second)
+		for gc.persistInFlight.Load() {
+			if time.Now().After(deadline) {
+				t.Error("async persist never finished")
+				return
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+	})
+}
+
+func testGraph(nodes int) *knowledge.Graph {
+	g := knowledge.New()
+	prev := ""
+	for i := 0; i < nodes; i++ {
+		id := "fact:" + string(rune('a'+i))
+		g.AddNode(knowledge.Node{ID: id, Kind: knowledge.KindFact, Title: id})
+		if prev != "" {
+			g.AddEdge(prev, id, 1)
+		}
+		prev = id
+	}
+	return g
+}
+
+func writeEnvelope(t *testing.T, dir string, version int, fp string, g *knowledge.Graph) string {
+	t.Helper()
+	payload, err := g.MarshalGraph()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(graphFile{
+		SchemaVersion: version, Fingerprint: fp, SavedAt: time.Now(), Graph: payload,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "graph.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestGraphCache_InertWithoutSource(t *testing.T) {
+	gc := NewGraphCache(t.TempDir(), zap.NewNop())
+	if got := gc.Snapshot(); got != nil {
+		t.Fatalf("inert cache returned a graph: %v", got)
+	}
+	if _, _, ok := gc.Stats(); ok {
+		t.Fatal("inert cache reported stats")
+	}
+	var nilCache *GraphCache
+	nilCache.MarkDirty() // must not panic
+	if nilCache.Snapshot() != nil {
+		t.Fatal("nil cache returned a graph")
+	}
+}
+
+func TestGraphCache_AdoptsValidPersistedFileWithoutBuilding(t *testing.T) {
+	dir := t.TempDir()
+	writeEnvelope(t, dir, graphSchemaVersion, "fp-1", testGraph(3))
+
+	var builds atomic.Int32
+	gc := NewGraphCache(dir, zap.NewNop())
+	drainPersist(t, gc)
+	gc.SetSource(func() *knowledge.Graph {
+		builds.Add(1)
+		return testGraph(3)
+	}, func() string { return "fp-1" })
+
+	g := gc.Snapshot()
+	if g == nil || g.Len() != 3 {
+		t.Fatalf("expected adopted 3-node graph, got %v", g)
+	}
+	if builds.Load() != 0 {
+		t.Fatalf("builder ran %d times, want 0 (file was valid)", builds.Load())
+	}
+}
+
+func TestGraphCache_StaleFingerprintDiscardsAndRebuilds(t *testing.T) {
+	dir := t.TempDir()
+	path := writeEnvelope(t, dir, graphSchemaVersion, "old-fp", testGraph(2))
+
+	var builds atomic.Int32
+	gc := NewGraphCache(dir, zap.NewNop())
+	drainPersist(t, gc)
+	gc.SetSource(func() *knowledge.Graph {
+		builds.Add(1)
+		return testGraph(5)
+	}, func() string { return "new-fp" })
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatal("stale file was not discarded")
+	}
+	g := gc.Snapshot()
+	if g == nil || g.Len() != 5 {
+		t.Fatalf("expected rebuilt 5-node graph, got %v", g)
+	}
+	if builds.Load() != 1 {
+		t.Fatalf("builder ran %d times, want 1", builds.Load())
+	}
+}
+
+func TestGraphCache_SchemaMismatchDiscards(t *testing.T) {
+	dir := t.TempDir()
+	path := writeEnvelope(t, dir, graphSchemaVersion+1, "fp", testGraph(2))
+	gc := NewGraphCache(dir, zap.NewNop())
+	drainPersist(t, gc)
+	gc.SetSource(func() *knowledge.Graph { return testGraph(1) }, func() string { return "fp" })
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatal("version-mismatched file was not discarded")
+	}
+}
+
+func TestGraphCache_CorruptFileDiscardedNoQuarantine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "graph.json")
+	if err := os.WriteFile(path, []byte("{corrupt"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gc := NewGraphCache(dir, zap.NewNop())
+	drainPersist(t, gc)
+	gc.SetSource(func() *knowledge.Graph { return testGraph(1) }, func() string { return "fp" })
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatal("corrupt file was not discarded")
+	}
+	// vindex policy: derived content is removed, never quarantined.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".corrupt" {
+			t.Fatalf("quarantine file created for derived cache: %s", e.Name())
+		}
+	}
+}
+
+func TestGraphCache_MarkDirtyTriggersExactlyOneRebuild(t *testing.T) {
+	var builds atomic.Int32
+	gc := NewGraphCache(t.TempDir(), zap.NewNop())
+	drainPersist(t, gc)
+	gc.SetSource(func() *knowledge.Graph {
+		builds.Add(1)
+		return testGraph(2)
+	}, nil)
+
+	gc.Snapshot() // first build
+	gc.Snapshot() // cached
+	gc.Snapshot() // cached
+	if builds.Load() != 1 {
+		t.Fatalf("clean snapshots rebuilt: %d builds", builds.Load())
+	}
+	gc.MarkDirty()
+	gc.Snapshot()
+	gc.Snapshot()
+	if builds.Load() != 2 {
+		t.Fatalf("dirty snapshot rebuilt %d times total, want 2", builds.Load())
+	}
+}
+
+func TestGraphCache_ConcurrentSnapshotSingleFlight(t *testing.T) {
+	var builds atomic.Int32
+	release := make(chan struct{})
+	gc := NewGraphCache(t.TempDir(), zap.NewNop())
+	drainPersist(t, gc)
+	gc.SetSource(func() *knowledge.Graph {
+		builds.Add(1)
+		<-release
+		return testGraph(2)
+	}, nil)
+
+	const readers = 8
+	var wg sync.WaitGroup
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if g := gc.Snapshot(); g == nil {
+				t.Error("nil snapshot from concurrent reader")
+			}
+		}()
+	}
+	time.Sleep(50 * time.Millisecond) // let readers pile up on the build
+	close(release)
+	wg.Wait()
+	if builds.Load() != 1 {
+		t.Fatalf("concurrent snapshots ran %d builds, want 1", builds.Load())
+	}
+}
+
+func TestGraphCache_PersistAsyncWritesEnvelope(t *testing.T) {
+	dir := t.TempDir()
+	gc := NewGraphCache(dir, zap.NewNop())
+	drainPersist(t, gc)
+	gc.SetSource(func() *knowledge.Graph { return testGraph(4) }, func() string { return "fp-x" })
+	gc.Snapshot()
+
+	path := filepath.Join(dir, "graph.json")
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if data, err := os.ReadFile(path); err == nil {
+			var env graphFile
+			if err := json.Unmarshal(data, &env); err != nil {
+				t.Fatalf("persisted envelope corrupt: %v", err)
+			}
+			if env.SchemaVersion != graphSchemaVersion || env.Fingerprint != "fp-x" {
+				t.Fatalf("envelope fields wrong: %+v", env)
+			}
+			g, err := knowledge.UnmarshalGraph(env.Graph)
+			if err != nil || g.Len() != 4 {
+				t.Fatalf("persisted graph bad: %v / %v", g, err)
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("graph.json never appeared")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func TestGraphCache_StatsNeverBuilds(t *testing.T) {
+	var builds atomic.Int32
+	gc := NewGraphCache(t.TempDir(), zap.NewNop())
+	drainPersist(t, gc)
+	gc.SetSource(func() *knowledge.Graph {
+		builds.Add(1)
+		return testGraph(2)
+	}, nil)
+
+	if _, _, ok := gc.Stats(); ok {
+		t.Fatal("Stats reported a snapshot before any build")
+	}
+	if builds.Load() != 0 {
+		t.Fatalf("Stats triggered %d builds, want 0", builds.Load())
+	}
+	gc.Snapshot()
+	nodes, edges, ok := gc.Stats()
+	if !ok || nodes != 2 || edges != 1 {
+		t.Fatalf("Stats = (%d, %d, %v), want (2, 1, true)", nodes, edges, ok)
+	}
+}
+
+func TestDirtyTaps_ContentMutationsMark(t *testing.T) {
+	mgr := NewManager(t.TempDir(), DefaultConfig(), zap.NewNop())
+	// Wire a counting builder so we can observe dirtiness through Snapshot.
+	var builds atomic.Int32
+	mgr.SetGraphSource(func() *knowledge.Graph {
+		builds.Add(1)
+		return knowledge.New()
+	}, nil)
+	settle := func() { mgr.KnowledgeGraph() } // consume dirtiness
+
+	steps := []struct {
+		name   string
+		mutate func()
+		marks  bool
+	}{
+		{"fact add", func() { mgr.Facts.AddFact("brand new fact content", "general", nil) }, true},
+		{"fact exact-dup reinforce", func() { mgr.Facts.AddFact("brand new fact content", "general", nil) }, true},
+		{"fact forget", func() { mgr.Facts.ForgetMatching("brand new fact") }, true},
+		{"topic record", func() { mgr.Topics.Record([]string{"deployment"}) }, true},
+		{"project upsert", func() { mgr.Projects.Upsert(map[string]string{"project_name": "chatcli"}) }, true},
+		{"profile update", func() { mgr.Profile.Update(map[string]string{"role": "engineer"}) }, true},
+		{"episode add", func() {
+			mgr.Episodes.Add(Episode{Summary: "did the thing", Project: "/tmp/p", Date: time.Now()})
+		}, true},
+		{"project touch (non-tap)", func() { mgr.Projects.Touch("chatcli") }, false},
+		{"fact mark-accessed (non-tap)", func() {
+			if all := mgr.Facts.GetAll(); len(all) > 0 {
+				mgr.Facts.MarkAccessed([]string{all[0].ID})
+			}
+		}, false},
+	}
+	for _, tt := range steps {
+		settle()
+		before := builds.Load()
+		tt.mutate()
+		mgr.KnowledgeGraph()
+		rebuilt := builds.Load() > before
+		if rebuilt != tt.marks {
+			t.Fatalf("%s: rebuilt=%v, want %v", tt.name, rebuilt, tt.marks)
+		}
+	}
+}

--- a/cli/workspace/memory/profile.go
+++ b/cli/workspace/memory/profile.go
@@ -17,6 +17,10 @@ type UserProfileStore struct {
 	mu      sync.RWMutex
 	path    string
 	logger  *zap.Logger
+
+	// changeNotifier marks derived caches (knowledge graph) stale on
+	// content mutations. See change_notify.go for the non-caller list.
+	changeNotifier
 }
 
 // NewUserProfileStore creates a new profile store and loads existing data.
@@ -113,6 +117,7 @@ func (ps *UserProfileStore) UpdateWithSource(updates map[string]string, source s
 		ps.profile.LastUpdated = time.Now()
 	}
 	if changed || metaDirty {
+		ps.notifyChanged()
 		ps.persist()
 	}
 	return changed

--- a/cli/workspace/memory/projects.go
+++ b/cli/workspace/memory/projects.go
@@ -17,6 +17,10 @@ type ProjectTracker struct {
 	mu       sync.RWMutex
 	path     string
 	logger   *zap.Logger
+
+	// changeNotifier marks derived caches (knowledge graph) stale on
+	// content mutations. See change_notify.go for the non-caller list.
+	changeNotifier
 }
 
 // NewProjectTracker creates a new project tracker.
@@ -79,6 +83,7 @@ func (pt *ProjectTracker) Upsert(updates map[string]string) bool {
 
 	if changed || !exists {
 		p.LastActive = time.Now()
+		pt.notifyChanged()
 		pt.persist()
 	}
 	return changed || !exists

--- a/cli/workspace/memory/removal_hooks_test.go
+++ b/cli/workspace/memory/removal_hooks_test.go
@@ -1,0 +1,80 @@
+/*
+ * ChatCLI - Tests for the keyed fact-removal hook registry (facts.go)
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package memory
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func newHookIndex(t *testing.T) *FactIndex {
+	t.Helper()
+	return NewFactIndex(t.TempDir(), DefaultConfig(), zap.NewNop())
+}
+
+func TestRemovalHooks_MultipleConsumersAllFire(t *testing.T) {
+	fi := newHookIndex(t)
+	var vector, graph [][]string
+	fi.SetRemovalHook("vector", func(ids []string) { vector = append(vector, ids) })
+	fi.SetRemovalHook("graph", func(ids []string) { graph = append(graph, ids) })
+
+	fi.AddFact("the deploy uses helm charts", "gotcha", nil)
+	if removed := fi.ForgetMatching("helm"); len(removed) == 0 {
+		t.Fatal("ForgetMatching found nothing")
+	}
+	if len(vector) != 1 || len(graph) != 1 {
+		t.Fatalf("hooks fired vector=%d graph=%d, want 1/1", len(vector), len(graph))
+	}
+}
+
+func TestRemovalHooks_DetachOneKeepsOther(t *testing.T) {
+	fi := newHookIndex(t)
+	var vector, graph int
+	fi.SetRemovalHook("vector", func([]string) { vector++ })
+	fi.SetRemovalHook("graph", func([]string) { graph++ })
+	fi.SetRemovalHook("vector", nil) // detach vector only
+
+	fi.AddFact("temporary fact to delete", "general", nil)
+	fi.ForgetMatching("temporary")
+	if vector != 0 {
+		t.Fatalf("detached vector hook fired %d times", vector)
+	}
+	if graph != 1 {
+		t.Fatalf("graph hook fired %d times, want 1 (must survive vector detach)", graph)
+	}
+}
+
+func TestSetOnRemovedLegacyDelegateStillWorks(t *testing.T) {
+	fi := newHookIndex(t)
+	var calls int
+	fi.SetOnRemoved(func([]string) { calls++ })
+	fi.AddFact("legacy hook fact", "general", nil)
+	fi.ForgetMatching("legacy")
+	if calls != 1 {
+		t.Fatalf("legacy SetOnRemoved hook fired %d times, want 1", calls)
+	}
+	fi.SetOnRemoved(nil)
+	fi.AddFact("second fact for round two", "general", nil)
+	fi.ForgetMatching("second")
+	if calls != 1 {
+		t.Fatalf("nil SetOnRemoved did not detach (calls=%d)", calls)
+	}
+}
+
+func TestAttachVectorIndexNilPreservesGraphHook(t *testing.T) {
+	mgr := NewManager(t.TempDir(), DefaultConfig(), zap.NewNop())
+	var graph int
+	mgr.Facts.SetRemovalHook("graph", func([]string) { graph++ })
+
+	mgr.AttachVectorIndex(nil) // /config reload with embeddings disabled
+
+	mgr.Facts.AddFact("fact that will be forgotten", "general", nil)
+	mgr.Facts.ForgetMatching("forgotten")
+	if graph != 1 {
+		t.Fatalf("graph hook fired %d times after AttachVectorIndex(nil), want 1", graph)
+	}
+}

--- a/cli/workspace/memory/retriever.go
+++ b/cli/workspace/memory/retriever.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 	"unicode/utf8"
+
+	"github.com/diillson/chatcli/pkg/knowledge"
 )
 
 // RelevanceRetriever selects the most relevant memories for the current conversation.
@@ -21,6 +23,19 @@ type RelevanceRetriever struct {
 	episodes     *EpisodeStore // optional; nil → no episode timeline section
 	config       Config
 	workspaceDir string // current session workspace for disambiguation
+
+	// graph, when set, supplies the knowledge-graph snapshot for the
+	// Related-section neighborhood expansion. Optional; nil (or a source
+	// yielding nil) → no graph section, no behavior change. An interface,
+	// not a func field, so RelevanceRetriever stays comparable (API
+	// contract checked by apidiff).
+	graph GraphSource
+}
+
+// GraphSource supplies an immutable knowledge-graph snapshot. Implemented by
+// GraphCache; test fixtures provide static stand-ins.
+type GraphSource interface {
+	Snapshot() *knowledge.Graph
 }
 
 // NewRelevanceRetriever creates a new retriever.
@@ -60,6 +75,13 @@ func (r *RelevanceRetriever) SetEpisodes(es *EpisodeStore) {
 // SetWorkspaceDir updates the current workspace directory for disambiguation.
 func (r *RelevanceRetriever) SetWorkspaceDir(dir string) {
 	r.workspaceDir = dir
+}
+
+// SetGraph attaches the knowledge-graph snapshot source so assemble can
+// add the Related (graph) expansion section. Same additive wiring as
+// SetRollups/SetEpisodes.
+func (r *RelevanceRetriever) SetGraph(src GraphSource) {
+	r.graph = src
 }
 
 // RetrieveWithHyDE runs the full HyDE retrieval path — Phase 3a
@@ -238,6 +260,14 @@ func (r *RelevanceRetriever) assemble(rankedFacts []*Fact) string {
 		remaining -= len(section)
 	}
 
+	// 5c. Graph neighborhood expansion — structurally adjacent memories the
+	// lexical/semantic ranking missed. Purely additive: it never displaces a
+	// ranked fact, only spends leftover budget.
+	if section, fits := r.relatedGraphSection(rankedFacts, remaining); fits {
+		sections = append(sections, section)
+		remaining -= len(section)
+	}
+
 	// 6. Long-range trajectory (latest monthly + recent weekly digests) —
 	// the narrative daily notes lose after their 30-day retention.
 	if section, fits := r.trajectorySection(remaining); fits {
@@ -276,6 +306,113 @@ func (r *RelevanceRetriever) episodesSection(remaining int) (string, bool) {
 		return "", false
 	}
 	return section, true
+}
+
+// Related-section tuning. Seeds are the strongest ranked facts (the model's
+// working set), the expansion stays at 1 hop so every surfaced item is a
+// direct structural neighbor, and the line cap keeps the section a nudge —
+// detail is pulled on demand.
+const (
+	relatedGraphSeeds    = 3
+	relatedGraphPerSeed  = 8
+	relatedGraphMaxLines = 6
+	relatedLineTrunc     = 160
+)
+
+// relatedGraphSection expands the top-ranked facts through the knowledge
+// graph and renders the structurally adjacent memories that lexical/semantic
+// ranking did NOT already surface. Additive by construction: everything the
+// ranking selected stays untouched; this section only spends leftover budget
+// on neighbors. Pointers use only surfaces every mode has (@memory) — never
+// mode-specific tools.
+func (r *RelevanceRetriever) relatedGraphSection(ranked []*Fact, remaining int) (string, bool) {
+	if r.graph == nil || remaining <= 250 || len(ranked) == 0 {
+		return "", false
+	}
+	g := r.graph.Snapshot()
+	if g == nil || g.Len() == 0 {
+		return "", false
+	}
+
+	rankedSet := make(map[string]bool, len(ranked))
+	for _, f := range ranked {
+		rankedSet[f.ID] = true
+	}
+
+	seeds := ranked
+	if len(seeds) > relatedGraphSeeds {
+		seeds = seeds[:relatedGraphSeeds]
+	}
+
+	var lines []string
+	var accessedIDs []string
+	seen := make(map[string]bool)
+	for _, seed := range seeds {
+		for _, n := range g.Neighborhood("fact:"+seed.ID, 1, relatedGraphPerSeed) {
+			if len(lines) >= relatedGraphMaxLines {
+				break
+			}
+			if seen[n.ID] {
+				continue
+			}
+			seen[n.ID] = true
+			switch n.Kind {
+			case knowledge.KindTag, knowledge.KindProfile:
+				// Tags are keyword glue and the profile is an always-present
+				// hub — neither adds information the model lacks.
+				continue
+			case knowledge.KindFact:
+				bareID := strings.TrimPrefix(n.ID, "fact:")
+				if rankedSet[bareID] {
+					continue // ranking already surfaced it
+				}
+				f, ok := r.facts.GetByID(bareID)
+				if !ok {
+					continue // graph snapshot older than the fact store
+				}
+				lines = append(lines, fmt.Sprintf("- [%s] %s", f.Category, truncateRunes(f.Content, relatedLineTrunc)))
+				accessedIDs = append(accessedIDs, f.ID)
+			case knowledge.KindEpisode:
+				lines = append(lines, fmt.Sprintf("- [episode] %s (details: @memory timeline)", truncateRunes(n.Title, relatedLineTrunc)))
+			default:
+				title := strings.TrimSpace(n.Title)
+				if title == "" {
+					title = n.ID
+				}
+				line := fmt.Sprintf("- [%s] %s", n.Kind, title)
+				if s := strings.TrimSpace(n.Summary); s != "" {
+					line += " — " + truncateRunes(s, relatedLineTrunc)
+				}
+				line += fmt.Sprintf(" (expand: @memory neighbors %s)", title)
+				lines = append(lines, line)
+			}
+		}
+		if len(lines) >= relatedGraphMaxLines {
+			break
+		}
+	}
+	if len(lines) == 0 {
+		return "", false
+	}
+
+	section := "## Related (graph)\n\n" + strings.Join(lines, "\n")
+	if len(section) >= remaining {
+		return "", false
+	}
+	if len(accessedIDs) > 0 {
+		r.facts.MarkAccessed(accessedIDs)
+	}
+	return section, true
+}
+
+// truncateRunes clips s to at most limit runes, appending an ellipsis when
+// it cut anything. Rune-safe so multi-byte content never splits mid-character.
+func truncateRunes(s string, limit int) string {
+	if utf8.RuneCountInString(s) <= limit {
+		return s
+	}
+	runes := []rune(s)
+	return string(runes[:limit]) + "…"
 }
 
 // trajectorySection renders the long-range rollup block under the same

--- a/cli/workspace/memory/retriever_graph_test.go
+++ b/cli/workspace/memory/retriever_graph_test.go
@@ -1,0 +1,161 @@
+/*
+ * ChatCLI - Tests for the Related (graph) recall expansion (retriever.go)
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package memory
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/pkg/knowledge"
+	"go.uber.org/zap"
+)
+
+// staticGraphSource is a fixed GraphSource for tests.
+type staticGraphSource struct{ g *knowledge.Graph }
+
+func (s staticGraphSource) Snapshot() *knowledge.Graph { return s.g }
+
+// graphFixture builds a manager with two linked facts plus an episode and a
+// topic hanging off the first fact, so expansion has something to surface.
+func graphFixture(t *testing.T) (*Manager, string, string) {
+	t.Helper()
+	mgr := NewManager(t.TempDir(), DefaultConfig(), zap.NewNop())
+	mgr.Facts.AddFact("the gateway daemon auto-approves tool calls", "architecture", nil)
+	mgr.Facts.AddFact("bedrock payload cap is learned from rejections", "gotcha", nil)
+
+	all := mgr.Facts.GetAll()
+	if len(all) != 2 {
+		t.Fatalf("fixture facts = %d, want 2", len(all))
+	}
+	var gatewayID, bedrockID string
+	for _, f := range all {
+		if strings.Contains(f.Content, "gateway") {
+			gatewayID = f.ID
+		} else {
+			bedrockID = f.ID
+		}
+	}
+
+	g := knowledge.New()
+	g.AddNode(knowledge.Node{ID: "fact:" + gatewayID, Kind: knowledge.KindFact, Title: "gateway"})
+	g.AddNode(knowledge.Node{ID: "fact:" + bedrockID, Kind: knowledge.KindFact, Title: "bedrock"})
+	g.AddNode(knowledge.Node{ID: "episode:e1", Kind: knowledge.KindEpisode, Title: "2026-08-01 fixed gateway"})
+	g.AddNode(knowledge.Node{ID: "topic:daemons", Kind: knowledge.KindTopic, Title: "daemons", Summary: "long-running processes"})
+	g.AddNode(knowledge.Node{ID: "tag:go", Kind: knowledge.KindTag, Title: "go"})
+	g.AddNode(knowledge.Node{ID: "profile:user", Kind: knowledge.KindProfile, Title: "user"})
+	g.AddEdge("fact:"+gatewayID, "fact:"+bedrockID, 2)
+	g.AddEdge("fact:"+gatewayID, "episode:e1", 1)
+	g.AddEdge("fact:"+gatewayID, "topic:daemons", 2)
+	g.AddEdge("fact:"+gatewayID, "tag:go", 1)
+	g.AddEdge("fact:"+gatewayID, "profile:user", 1)
+
+	mgr.retriever.SetGraph(staticGraphSource{g})
+	return mgr, gatewayID, bedrockID
+}
+
+func TestRelatedGraphSection_NilGraphAbsent(t *testing.T) {
+	mgr := NewManager(t.TempDir(), DefaultConfig(), zap.NewNop())
+	mgr.Facts.AddFact("some fact", "general", nil)
+	mgr.retriever.SetGraph(nil)
+	out := mgr.GetRelevantContext([]string{"some"})
+	if strings.Contains(out, "## Related (graph)") {
+		t.Fatal("section rendered with nil graph")
+	}
+}
+
+func TestRelatedGraphSection_ExpandsUnrankedNeighbors(t *testing.T) {
+	mgr, gatewayID, _ := graphFixture(t)
+	ranked, _ := mgr.Facts.GetByID(gatewayID)
+	section, ok := mgr.retriever.relatedGraphSection([]*Fact{ranked}, 4000)
+	if !ok {
+		t.Fatal("section not rendered")
+	}
+	if !strings.Contains(section, "bedrock payload cap") {
+		t.Fatalf("neighbor fact missing:\n%s", section)
+	}
+	if !strings.Contains(section, "[episode] 2026-08-01 fixed gateway") ||
+		!strings.Contains(section, "@memory timeline") {
+		t.Fatalf("episode pointer missing:\n%s", section)
+	}
+	if !strings.Contains(section, "[topic] daemons") ||
+		!strings.Contains(section, "@memory neighbors daemons") {
+		t.Fatalf("topic pointer missing:\n%s", section)
+	}
+}
+
+func TestRelatedGraphSection_FiltersTagProfileAndRanked(t *testing.T) {
+	mgr, gatewayID, bedrockID := graphFixture(t)
+	f1, _ := mgr.Facts.GetByID(gatewayID)
+	f2, _ := mgr.Facts.GetByID(bedrockID)
+	// Both facts ranked → the fact neighbor must NOT reappear.
+	section, ok := mgr.retriever.relatedGraphSection([]*Fact{f1, f2}, 4000)
+	if !ok {
+		t.Fatal("section not rendered (episode/topic still expandable)")
+	}
+	if strings.Contains(section, "bedrock payload cap") {
+		t.Fatalf("already-ranked fact resurfaced:\n%s", section)
+	}
+	if strings.Contains(section, "[tag]") || strings.Contains(section, "tag:go") {
+		t.Fatalf("tag glue leaked:\n%s", section)
+	}
+	if strings.Contains(section, "[profile]") {
+		t.Fatalf("profile hub leaked:\n%s", section)
+	}
+}
+
+func TestRelatedGraphSection_BudgetGuard(t *testing.T) {
+	mgr, gatewayID, _ := graphFixture(t)
+	f, _ := mgr.Facts.GetByID(gatewayID)
+	if _, ok := mgr.retriever.relatedGraphSection([]*Fact{f}, 250); ok {
+		t.Fatal("section rendered under the 250-char floor")
+	}
+}
+
+func TestRelatedGraphSection_NeverMentionsSessionTool(t *testing.T) {
+	mgr, gatewayID, _ := graphFixture(t)
+	// Add a session neighbor: pointers must stay on @memory surfaces.
+	g := mgr.retriever.graph.Snapshot()
+	g.AddNode(knowledge.Node{ID: "session:aug-work", Kind: knowledge.KindSession, Title: "aug-work"})
+	g.AddEdge("fact:"+gatewayID, "session:aug-work", 1.5)
+
+	f, _ := mgr.Facts.GetByID(gatewayID)
+	section, ok := mgr.retriever.relatedGraphSection([]*Fact{f}, 4000)
+	if !ok {
+		t.Fatal("section not rendered")
+	}
+	if !strings.Contains(section, "[session] aug-work") {
+		t.Fatalf("session pointer missing:\n%s", section)
+	}
+	if strings.Contains(section, "@session") {
+		t.Fatalf("chat mode has no @session tool — wording must stay universal:\n%s", section)
+	}
+}
+
+func TestRelatedGraphSection_RendersInBothRetrievalPaths(t *testing.T) {
+	mgr, _, _ := graphFixture(t)
+	plain := mgr.GetRelevantContext([]string{"gateway", "daemon"})
+	if !strings.Contains(plain, "## Related (graph)") {
+		t.Fatalf("plain Retrieve path missing section:\n%s", plain)
+	}
+	hyde := mgr.retriever.RetrieveWithHyDE(t.Context(), "how does the gateway work", []string{"gateway"}, nil, nil)
+	if !strings.Contains(hyde, "## Related (graph)") {
+		t.Fatalf("RetrieveWithHyDE path missing section:\n%s", hyde)
+	}
+}
+
+func TestTruncateRunes_MultibyteSafe(t *testing.T) {
+	s := strings.Repeat("çã", 100)
+	got := truncateRunes(s, 10)
+	if !strings.HasSuffix(got, "…") {
+		t.Fatalf("missing ellipsis: %q", got)
+	}
+	if strings.Count(got, "�") > 0 {
+		t.Fatalf("mid-rune split: %q", got)
+	}
+	if truncateRunes("short", 10) != "short" {
+		t.Fatal("short string modified")
+	}
+}

--- a/cli/workspace/memory/store.go
+++ b/cli/workspace/memory/store.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/diillson/chatcli/pkg/knowledge"
 	"go.uber.org/zap"
 
 	"github.com/diillson/chatcli/llm/embedding"
@@ -49,6 +50,12 @@ type Manager struct {
 	// launch overlapping backfills embedding the same facts — double the
 	// embedding bill for zero benefit.
 	backfillInFlight atomic.Bool
+
+	// graph is the persisted knowledge-graph cache (graph_cache.go). Always
+	// constructed; inert until the CLI layer wires a builder through
+	// SetGraphSource (the derivation needs skill/session/context stores the
+	// memory package must not import).
+	graph *GraphCache
 }
 
 // NewManager creates a new memory manager. The memoryDir should be the
@@ -80,6 +87,19 @@ func NewManager(memoryDir string, config Config, logger *zap.Logger) *Manager {
 	m.retriever.SetEpisodes(m.Episodes)
 	m.Rollups.SetEpisodes(m.Episodes)
 	m.migration = NewMigration(memoryDir, m.Facts, logger)
+
+	// Knowledge-graph cache: inert until the CLI layer wires a builder via
+	// SetGraphSource. Every content mutation in the source stores marks it
+	// dirty; fact deletions ride the keyed removal hook so the graph and
+	// the vector index drop derived state in lockstep.
+	m.graph = NewGraphCache(memoryDir, logger)
+	m.Facts.SetOnChanged(m.graph.MarkDirty)
+	m.Facts.SetRemovalHook("graph", func([]string) { m.graph.MarkDirty() })
+	m.Topics.SetOnChanged(m.graph.MarkDirty)
+	m.Projects.SetOnChanged(m.graph.MarkDirty)
+	m.Profile.SetOnChanged(m.graph.MarkDirty)
+	m.Episodes.SetOnChanged(m.graph.MarkDirty)
+	m.retriever.SetGraph(m.graph)
 
 	// Auto-migrate if needed
 	if m.migration.NeedsMigration() {
@@ -324,10 +344,37 @@ func (m *Manager) GetRelevantContextWithHyDE(ctx context.Context, query string, 
 func (m *Manager) AttachVectorIndex(v *VectorIndex) {
 	m.vectors = v
 	if v == nil {
-		m.Facts.SetOnRemoved(nil)
+		// Detach only the vector hook — other keyed consumers (the graph
+		// cache) must survive a vector re-attach on /config reload.
+		m.Facts.SetRemovalHook("vector", nil)
 		return
 	}
-	m.Facts.SetOnRemoved(func(ids []string) { v.Forget(ids...) })
+	m.Facts.SetRemovalHook("vector", func(ids []string) { v.Forget(ids...) })
+}
+
+// SetGraphSource wires the knowledge-graph builder and fingerprint into the
+// cache (see GraphCache.SetSource). Called once at CLI startup when the
+// persisted-graph feature is enabled.
+func (m *Manager) SetGraphSource(build func() *knowledge.Graph, fingerprint func() string) {
+	m.graph.SetSource(build, fingerprint)
+}
+
+// KnowledgeGraph returns the cached graph snapshot, rebuilding if stale.
+// nil when no builder was wired (feature off).
+func (m *Manager) KnowledgeGraph() *knowledge.Graph {
+	return m.graph.Snapshot()
+}
+
+// MarkGraphDirty flags the graph cache stale — for CLI-side mutations the
+// memory stores cannot observe (session saved, skill installed, context
+// created).
+func (m *Manager) MarkGraphDirty() {
+	m.graph.MarkDirty()
+}
+
+// GraphStats reports the cached graph's size without triggering a build.
+func (m *Manager) GraphStats() (nodes, edges int, ok bool) {
+	return m.graph.Stats()
 }
 
 // VectorIndex returns the attached vector index (may be nil).

--- a/cli/workspace/memory/topics.go
+++ b/cli/workspace/memory/topics.go
@@ -17,6 +17,10 @@ type TopicTracker struct {
 	mu     sync.RWMutex
 	path   string
 	logger *zap.Logger
+
+	// changeNotifier marks derived caches (knowledge graph) stale on
+	// content mutations. See change_notify.go for the non-caller list.
+	changeNotifier
 }
 
 // NewTopicTracker creates a new topic tracker.
@@ -63,6 +67,7 @@ func (tt *TopicTracker) Record(topicNames []string) {
 	}
 
 	if changed {
+		tt.notifyChanged()
 		tt.persist()
 	}
 }
@@ -110,6 +115,7 @@ func (tt *TopicTracker) RecordWithSummary(topics map[string]string) {
 	}
 
 	if changed {
+		tt.notifyChanged()
 		tt.persist()
 	}
 }
@@ -135,6 +141,7 @@ func (tt *TopicTracker) LinkFact(topicName string, factID string) {
 		}
 	}
 	t.RelatedFacts = append(t.RelatedFacts, factID)
+	tt.notifyChanged()
 	tt.persist()
 }
 

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -155,6 +155,15 @@ const (
 	// tool regardless of this flag.
 	GraphIndexEnv = "CHATCLI_GRAPH_INDEX"
 
+	// Persisted memory graph: serve every graph consumer from the cached,
+	// disk-persisted derivation (~/.chatcli/memory/graph.json) and expand
+	// recall with graph neighborhoods. On by default; a falsey value
+	// restores the legacy derive-per-call behavior with no recall
+	// expansion. Deliberately distinct from GraphIndexEnv: that one gates
+	// the per-turn CARD payload, this one gates the cache + recall
+	// expansion — "card off, expansion on" is a valid lean-prompt setup.
+	MemoryGraphEnv = "CHATCLI_MEMORY_GRAPH"
+
 	// UI / theme configuration. ThemeEnv selects the color theme applied
 	// across chat, coder and agent surfaces (cards, borders, markdown,
 	// spinners). DefaultTheme is the value used when ThemeEnv is unset.

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -2163,6 +2163,8 @@
   "cfg.kv.memory.mode_off": "off — inject no memory (bootstrap still applies)",
   "cfg.kv.memory.index_size": "Current index size",
   "cfg.kv.memory.episodes": "Episodic timeline",
+  "cfg.kv.memory.graph_size": "Graph cache",
+  "cfg.kv.memory.graph_size_val": "%d nodes, %d links (graph.json)",
   "cfg.kv.memory.episodes_val": "%d episode(s) stored (cap %d)",
   "cfg.section.hub.title": "Conversation Hub (cross-channel continuity)",
   "cfg.sub.hub.local": "Local mode (same machine, no /connect)",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -2163,6 +2163,8 @@
   "cfg.kv.memory.mode_off": "off — inject no memory (bootstrap still applies)",
   "cfg.kv.memory.index_size": "Current index size",
   "cfg.kv.memory.episodes": "Episodic timeline",
+  "cfg.kv.memory.graph_size": "Graph cache",
+  "cfg.kv.memory.graph_size_val": "%d nodes, %d links (graph.json)",
   "cfg.kv.memory.episodes_val": "%d episode(s) stored (cap %d)",
   "cfg.section.hub.title": "Conversation Hub (cross-channel continuity)",
   "cfg.sub.hub.local": "Local mode (same machine, no /connect)",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -2163,6 +2163,8 @@
   "cfg.kv.memory.mode_off": "off — não injeta memória (bootstrap ainda se aplica)",
   "cfg.kv.memory.index_size": "Tamanho atual do índice",
   "cfg.kv.memory.episodes": "Linha do tempo episódica",
+  "cfg.kv.memory.graph_size": "Cache do grafo",
+  "cfg.kv.memory.graph_size_val": "%d nós, %d ligações (graph.json)",
   "cfg.kv.memory.episodes_val": "%d episódio(s) armazenado(s) (limite %d)",
   "cfg.section.hub.title": "Hub de Conversa (continuidade cross-channel)",
   "cfg.sub.hub.local": "Modo local (mesma máquina, sem /connect)",

--- a/pkg/knowledge/card.go
+++ b/pkg/knowledge/card.go
@@ -18,7 +18,11 @@ import (
 )
 
 // kindOrder fixes the display order so the card is byte-stable across turns.
-var kindOrder = []Kind{KindProfile, KindProject, KindTopic, KindSkill, KindFact, KindTag}
+var kindOrder = []Kind{
+	KindProfile, KindProject, KindTopic, KindSkill,
+	KindEpisode, KindSession, KindKB,
+	KindFact, KindTag,
+}
 
 // IndexCard renders the map of content: a one-line tally by kind plus up to
 // maxHubs hub titles. Returns "" for an empty graph. The output is deterministic

--- a/pkg/knowledge/graph.go
+++ b/pkg/knowledge/graph.go
@@ -33,6 +33,18 @@ const (
 	KindSkill   Kind = "skill"
 	KindProfile Kind = "profile"
 	KindTag     Kind = "tag"
+
+	// KindEpisode is a timeline entry from the episodic memory layer
+	// (id prefix "episode:", keyed by Episode.ID).
+	KindEpisode Kind = "episode"
+	// KindSession is a saved conversation (id prefix "session:", keyed by
+	// session name — the name IS the identity; renames orphan the node,
+	// which is acceptable because the graph is a rebuildable derivation).
+	KindSession Kind = "session"
+	// KindKB is a knowledge-mode context at CONTEXT granularity (id prefix
+	// "kb:", keyed by FileContext.ID). Never chunk-level: a corpus can hold
+	// tens of thousands of chunks and would drown the graph.
+	KindKB Kind = "kbcontext"
 )
 
 // Node is one vertex. ID is unique and namespaced by kind (e.g. "topic:auth").

--- a/pkg/knowledge/serialize.go
+++ b/pkg/knowledge/serialize.go
@@ -1,0 +1,98 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+/*
+ * serialize.go — deterministic (de)serialization of the graph, plus the
+ * exported edge-list accessor. The Graph's internal maps stay unexported and
+ * Node grows no json tags (the wire shape is decoupled via DTOs, so the
+ * public API surface is untouched); MarshalGraph output is byte-stable for a
+ * given graph, which lets a persisted copy double as a change fingerprint.
+ */
+package knowledge
+
+import (
+	"encoding/json"
+	"sort"
+)
+
+// Edge is one undirected edge with its accumulated weight. Exposed so
+// consumers that need the full edge set (serialization, DOT rendering,
+// graph-view adapters) share one canonical walk instead of reimplementing
+// pair deduplication over Neighbors.
+type Edge struct {
+	A      string  `json:"a"`
+	B      string  `json:"b"`
+	Weight float64 `json:"w"`
+}
+
+// EdgeList returns every undirected edge exactly once (A < B), sorted by
+// (A, B) for deterministic output.
+func (g *Graph) EdgeList() []Edge {
+	out := make([]Edge, 0, g.Edges())
+	for a, nbrs := range g.adj {
+		for b, w := range nbrs {
+			if a < b {
+				out = append(out, Edge{A: a, B: b, Weight: w})
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].A != out[j].A {
+			return out[i].A < out[j].A
+		}
+		return out[i].B < out[j].B
+	})
+	return out
+}
+
+// nodeDTO mirrors Node for the wire. Kept unexported and separate so the
+// public Node type never grows serialization concerns (apidiff-neutral).
+type nodeDTO struct {
+	ID      string  `json:"id"`
+	Kind    Kind    `json:"kind"`
+	Title   string  `json:"title,omitempty"`
+	Summary string  `json:"summary,omitempty"`
+	Weight  float64 `json:"weight,omitempty"`
+}
+
+type graphDTO struct {
+	Nodes []nodeDTO `json:"nodes"`
+	Edges []Edge    `json:"edges"`
+}
+
+// MarshalGraph serializes the graph to compact, deterministic JSON: nodes
+// sorted by ID, edges by (A, B).
+func (g *Graph) MarshalGraph() ([]byte, error) {
+	nodes := g.Nodes() // sorted by ID
+	dto := graphDTO{
+		Nodes: make([]nodeDTO, 0, len(nodes)),
+		Edges: g.EdgeList(),
+	}
+	for _, n := range nodes {
+		dto.Nodes = append(dto.Nodes, nodeDTO{
+			ID: n.ID, Kind: n.Kind, Title: n.Title, Summary: n.Summary, Weight: n.Weight,
+		})
+	}
+	return json.Marshal(dto)
+}
+
+// UnmarshalGraph rebuilds a graph from MarshalGraph output. Edges are
+// replayed after every node exists (AddEdge drops edges with missing
+// endpoints), and each serialized edge carries the already-accumulated
+// weight, so a single AddEdge per pair reproduces the original exactly.
+func UnmarshalGraph(data []byte) (*Graph, error) {
+	var dto graphDTO
+	if err := json.Unmarshal(data, &dto); err != nil {
+		return nil, err
+	}
+	g := New()
+	for _, n := range dto.Nodes {
+		g.AddNode(Node(n))
+	}
+	for _, e := range dto.Edges {
+		g.AddEdge(e.A, e.B, e.Weight)
+	}
+	return g, nil
+}

--- a/pkg/knowledge/serialize_test.go
+++ b/pkg/knowledge/serialize_test.go
@@ -1,0 +1,141 @@
+/*
+ * ChatCLI - Tests for graph serialization (serialize.go)
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package knowledge
+
+import (
+	"bytes"
+	"testing"
+)
+
+func buildSampleGraph() *Graph {
+	g := New()
+	g.AddNode(Node{ID: "fact:1", Kind: KindFact, Title: "uses zap", Summary: "logging via zap", Weight: 2.5})
+	g.AddNode(Node{ID: "topic:logging", Kind: KindTopic, Title: "logging", Weight: 3})
+	g.AddNode(Node{ID: "tag:go", Kind: KindTag, Title: "go"})
+	g.AddNode(Node{ID: "episode:abc", Kind: KindEpisode, Title: "2026-08-01 fixed logger"})
+	g.AddEdge("fact:1", "topic:logging", 2)
+	g.AddEdge("fact:1", "tag:go", 1)
+	g.AddEdge("fact:1", "tag:go", 0.5) // accumulates to 1.5
+	g.AddEdge("episode:abc", "fact:1", 1)
+	return g
+}
+
+func TestMarshalUnmarshalRoundTrip(t *testing.T) {
+	g := buildSampleGraph()
+	data, err := g.MarshalGraph()
+	if err != nil {
+		t.Fatalf("MarshalGraph: %v", err)
+	}
+	got, err := UnmarshalGraph(data)
+	if err != nil {
+		t.Fatalf("UnmarshalGraph: %v", err)
+	}
+	if got.Len() != g.Len() || got.Edges() != g.Edges() {
+		t.Fatalf("shape mismatch: %d/%d nodes, %d/%d edges",
+			got.Len(), g.Len(), got.Edges(), g.Edges())
+	}
+	// Accumulated edge weight survives exactly.
+	for _, nb := range got.Neighbors("fact:1") {
+		if nb.ID == "tag:go" && nb.Weight != 1.5 {
+			t.Fatalf("accumulated weight = %v, want 1.5", nb.Weight)
+		}
+	}
+	// Node fields survive.
+	n, ok := got.Node("fact:1")
+	if !ok || n.Kind != KindFact || n.Summary != "logging via zap" || n.Weight != 2.5 {
+		t.Fatalf("node round-trip lost fields: %+v", n)
+	}
+}
+
+func TestMarshalGraphDeterministic(t *testing.T) {
+	a, err := buildSampleGraph().MarshalGraph()
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := buildSampleGraph().MarshalGraph()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(a, b) {
+		t.Fatal("two builds of the same graph marshaled differently")
+	}
+}
+
+func TestMarshalEmptyGraphRoundTrip(t *testing.T) {
+	data, err := New().MarshalGraph()
+	if err != nil {
+		t.Fatal(err)
+	}
+	g, err := UnmarshalGraph(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if g.Len() != 0 || g.Edges() != 0 {
+		t.Fatalf("empty round-trip produced %d nodes / %d edges", g.Len(), g.Edges())
+	}
+}
+
+func TestUnmarshalGraphCorruptInput(t *testing.T) {
+	if _, err := UnmarshalGraph([]byte("{not json")); err == nil {
+		t.Fatal("corrupt input must error")
+	}
+}
+
+func TestUnmarshalUnknownKindPreserved(t *testing.T) {
+	g := New()
+	g.AddNode(Node{ID: "widget:x", Kind: Kind("widget"), Title: "future kind"})
+	data, err := g.MarshalGraph()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := UnmarshalGraph(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n, ok := got.Node("widget:x"); !ok || n.Kind != Kind("widget") {
+		t.Fatalf("unknown kind lost in round-trip: %+v", n)
+	}
+}
+
+func TestEdgeListDedupAndOrder(t *testing.T) {
+	g := buildSampleGraph()
+	edges := g.EdgeList()
+	if len(edges) != g.Edges() {
+		t.Fatalf("EdgeList len = %d, want %d", len(edges), g.Edges())
+	}
+	seen := make(map[string]bool)
+	for i, e := range edges {
+		if e.A >= e.B {
+			t.Fatalf("edge %d not normalized: %q >= %q", i, e.A, e.B)
+		}
+		key := e.A + "|" + e.B
+		if seen[key] {
+			t.Fatalf("duplicate edge %s", key)
+		}
+		seen[key] = true
+		if i > 0 {
+			prev := edges[i-1]
+			if prev.A > e.A || (prev.A == e.A && prev.B > e.B) {
+				t.Fatalf("edges not sorted at %d: %+v after %+v", i, e, prev)
+			}
+		}
+	}
+}
+
+func TestIndexCardIncludesNewKinds(t *testing.T) {
+	g := New()
+	g.AddNode(Node{ID: "episode:1", Kind: KindEpisode, Title: "e"})
+	g.AddNode(Node{ID: "session:s", Kind: KindSession, Title: "s"})
+	g.AddNode(Node{ID: "kb:k", Kind: KindKB, Title: "k"})
+	card := g.IndexCard(3)
+	for _, want := range []string{"episode 1", "session 1", "kbcontext 1"} {
+		if !contains(card, want) {
+			t.Fatalf("card missing %q:\n%s", want, card)
+		}
+	}
+}
+
+func contains(s, sub string) bool { return bytes.Contains([]byte(s), []byte(sub)) }

--- a/pkg/persona/loader.go
+++ b/pkg/persona/loader.go
@@ -42,6 +42,17 @@ func NewLoader(logger *zap.Logger) *Loader {
 	}
 }
 
+// SkillDirs returns every directory ListSkills scans, project-local first.
+// Exposed so callers can fingerprint the skill catalog (stat-only) without
+// paying the full frontmatter-parsing walk.
+func (l *Loader) SkillDirs() []string {
+	var dirs []string
+	if l.projectDir != "" {
+		dirs = append(dirs, filepath.Join(l.projectDir, ".agent", "skills"))
+	}
+	return append(dirs, l.skillsDir)
+}
+
 // SetProjectDir sets an optional project-local directory for skills lookup
 // Priority: Project Local > Global
 func (l *Loader) SetProjectDir(dir string) {

--- a/pkg/persona/manager.go
+++ b/pkg/persona/manager.go
@@ -205,6 +205,12 @@ func (m *Manager) ListAgents() ([]*Agent, error) {
 	return m.loader.ListAgents()
 }
 
+// SkillDirs returns the directories the skill catalog is loaded from
+// (project-local first). Stat-only fingerprinting helper — see Loader.SkillDirs.
+func (m *Manager) SkillDirs() []string {
+	return m.loader.SkillDirs()
+}
+
 // ListSkills returns all available skills
 func (m *Manager) ListSkills() ([]*Skill, error) {
 	return m.loader.ListSkills()


### PR DESCRIPTION
## Summary

PR 2 of the context-efficiency pair (PR 1: #1321). Promotes the knowledge graph from a derive-per-call view — six call sites, each paying store copies plus a skills-directory filesystem walk, and zero participation in recall — to a first-class persisted memory index.

### Persisted derived cache (`cli/workspace/memory/graph_cache.go`)
- In-memory graph behind an atomic pointer, served as an **immutable snapshot** (rebuilds construct a fresh graph and swap — consumers are all read-only).
- **Dirty taps**: one-line `changeNotifier` marks in every memory sub-store mutation path (facts add/reinforce/supersede/replace, topics, projects, profile, episodes), plus fact deletions riding the removal hook. Explicit non-taps guard against rebuild storms: `MarkAccessed`, bare persists, `Projects.Touch`, `RecordCommand`.
- **Persistence**: `graph.json` written asynchronously (CAS single-flight, atomic rename) with schema version + stat-only source fingerprint → next boot adopts the graph instantly, zero skills walk. Corrupt/stale/version-mismatched files are **discarded and rebuilt** (vindex policy — the graph is 100% re-derivable, so no quarantine and no tombstone protocol). Cross-process writes are safe LWW behind the fingerprint gate.
- Rebuild is single-flight on the first reader after a write; a 5-minute fingerprint TTL heals external edits (skills changed in an editor, sessions written by another process).

### New node kinds
- **episode** (recent 300): joined to projects via the workspace-path keyspace both stores share, and to same-project **same-day** facts — the durable "what happened while this was learned" bridge.
- **session** (recent 50): lightweight stat listing only — never builds the session search corpus (titles enriched only when the corpus is already warm). Name is the identity; rename orphans heal via the TTL.
- **kbcontext**: knowledge contexts at CONTEXT granularity — never chunk-level (a corpus can hold 50K chunks).

### Recall expansion (`## Related (graph)`)
Inside the shared `assemble` path — so both plain `Retrieve` and `RetrieveWithHyDE` get it: top-3 ranked facts expand 1 hop; neighbors are deduplicated against **everything** ranked, tag/profile glue filtered, capped at 6 lines, budget-guarded, and worded only with surfaces every mode has (`@memory timeline/neighbors/recall` — never `@session`, which chat lacks). Purely additive: ranking untouched, zero regression risk, and the section only spends leftover budget.

### Robustness ride-alongs
- **Removal-hook registry**: the single-slot `SetOnRemoved` became keyed (`SetRemovalHook`) — `AttachVectorIndex(nil)` on /config reload no longer silently clobbers other consumers. Legacy setter delegates, signature preserved (apidiff clean; the `RelevanceRetriever` comparability break was caught locally and fixed via a `GraphSource` interface instead of a func field).
- **Tool-path parity**: mutations the AI makes through the `@context`/`@session` tools mark the cache dirty exactly like the user's `/context`/`/session`/`/skill` commands.
- **Threatscan**: graph card and `@memory neighbors` output now pass through the memory scanner (pre-existing gap — every other memory injection already did).
- The two duplicated edge-walk dedups (`graphview_adapter`, `graph_command`) collapsed onto the new canonical `Graph.EdgeList()`.

### Env
One new env: `CHATCLI_MEMORY_GRAPH` (default on; off = legacy derive-per-call, no expansion — byte-identical off-path). `CHATCLI_GRAPH_INDEX` keeps gating only the per-turn card; the split is deliberate ("card off, expansion on" is a valid lean-prompt setup). Registered in /config memory (with live nodes/edges stats row) and env defaults; i18n keys in all three locales.

## Testing
- `pkg/knowledge`: round-trip/determinism/EdgeList/corrupt-input; card with new kinds.
- `graph_cache`: adopt-without-build, fingerprint/schema discard (asserting NO quarantine file), exactly-one-rebuild, concurrent single-flight, async envelope, stats-never-builds — all under `-race`.
- Hook registry: multi-consumer fire, selective detach, legacy delegate, `AttachVectorIndex(nil)` survival.
- Dirty-tap table incl. explicit non-taps; retriever expansion (dedup vs full ranked set, tag/profile filter, budget floor, wording ban on `@session`, both retrieval paths); cli builders (episode path-keyspace join, same-day bridge, session cap + slug edge, accessor fallback/cache invalidation).
- Full `go build ./...` + `go test ./...` green; golangci-lint clean; local gates all pass (scope-budget at 2021 LOC carries the label).