### PR TITLE
feat(memory): graph expansion line in the auto-recall block

### DIFF
--- a/cli/memory_autorecall.go
+++ b/cli/memory_autorecall.go
@@ -28,6 +28,8 @@ package cli
 import (
 	"os"
 	"strings"
+
+	"github.com/diillson/chatcli/pkg/knowledge"
 )
 
 const (
@@ -35,8 +37,16 @@ const (
 	// not a retrieval; the model pulls detail via @memory recall.
 	autoRecallMaxFacts = 3
 
-	// autoRecallBudget caps the block size in bytes.
+	// autoRecallBudget caps the fact lines in bytes.
 	autoRecallBudget = 700
+
+	// autoRecallRelatedBudget is the extra allowance for the one-line graph
+	// expansion appended after the facts. Separate from autoRecallBudget so
+	// the graph line never displaces a fact.
+	autoRecallRelatedBudget = 220
+
+	// autoRecallRelatedMax caps how many graph neighbors the line names.
+	autoRecallRelatedMax = 3
 )
 
 // autoRecallHeader is an English model-facing constant, like memoryRecallHint.
@@ -89,5 +99,58 @@ func (cli *ChatCLI) memoryAutoRecallBlock(hints []string) string {
 		return ""
 	}
 	mgr.Facts.MarkAccessed(accessed)
+
+	// Graph expansion: one compact line naming what is structurally adjacent
+	// to the facts above, so the model knows there is MORE to pull before it
+	// claims ignorance. Cache-only on purpose — Manager().KnowledgeGraph()
+	// is nil when the persisted graph is off (CHATCLI_MEMORY_GRAPH), and this
+	// nudge must never pay a derive-per-call rebuild.
+	if line := autoRecallRelatedLine(mgr.KnowledgeGraph(), accessed); line != "" &&
+		len(line)+1 <= autoRecallRelatedBudget {
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
 	return strings.TrimRight(b.String(), "\n")
+}
+
+// autoRecallRelatedLine renders "Related (graph): ..." from the 1-hop
+// neighborhood of the shown facts. Tag and profile nodes are filtered (glue
+// and ever-present hub), already-shown facts are skipped, and the pointer
+// uses only surfaces every mode has (@memory neighbors) — never @session.
+// Returns "" when there is nothing new to point at.
+func autoRecallRelatedLine(g *knowledge.Graph, shownFactIDs []string) string {
+	if g == nil || g.Len() == 0 {
+		return ""
+	}
+	shown := make(map[string]bool, len(shownFactIDs))
+	for _, id := range shownFactIDs {
+		shown["fact:"+id] = true
+	}
+	var names []string
+	seen := make(map[string]bool)
+	for _, id := range shownFactIDs {
+		for _, n := range g.Neighborhood("fact:"+id, 1, autoRecallRelatedMax*2) {
+			if len(names) >= autoRecallRelatedMax {
+				break
+			}
+			if seen[n.ID] || shown[n.ID] ||
+				n.Kind == knowledge.KindTag || n.Kind == knowledge.KindProfile {
+				continue
+			}
+			seen[n.ID] = true
+			title := strings.TrimSpace(n.Title)
+			if title == "" {
+				title = n.ID
+			}
+			names = append(names, title+" ("+string(n.Kind)+")")
+		}
+		if len(names) >= autoRecallRelatedMax {
+			break
+		}
+	}
+	if len(names) == 0 {
+		return ""
+	}
+	return "Related (graph): " + strings.Join(names, ", ") +
+		" — expand with @memory neighbors <title>."
 }

--- a/cli/memory_autorecall_test.go
+++ b/cli/memory_autorecall_test.go
@@ -5,8 +5,13 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/diillson/chatcli/pkg/knowledge"
 )
 
 func newAutoRecallCLI(t *testing.T) *ChatCLI {
@@ -77,5 +82,85 @@ func TestMemoryAutoRecallBlock_CapsFactCount(t *testing.T) {
 	}
 	if lines > autoRecallMaxFacts {
 		t.Errorf("block must cap at %d facts, got %d:\n%s", autoRecallMaxFacts, lines, block)
+	}
+}
+
+func TestMemoryAutoRecallBlock_NoGraphNoRelatedLine(t *testing.T) {
+	cli := newAutoRecallCLI(t)
+	// Cache never wired → KnowledgeGraph() is nil → no Related line, and
+	// crucially no derive-per-call fallback for this nudge.
+	block := cli.memoryAutoRecallBlock([]string{"embed", "windows"})
+	if strings.Contains(block, "Related (graph)") {
+		t.Fatalf("Related line rendered without a cached graph:\n%s", block)
+	}
+}
+
+func TestMemoryAutoRecallBlock_GraphExpansionLine(t *testing.T) {
+	cli := newAutoRecallCLI(t)
+	mgr := cli.memoryStore.Manager()
+
+	var embedID string
+	for _, f := range mgr.Facts.GetAll() {
+		if strings.Contains(f.Content, "embed.FS") {
+			embedID = f.ID
+		}
+	}
+	g := knowledge.New()
+	g.AddNode(knowledge.Node{ID: "fact:" + embedID, Kind: knowledge.KindFact, Title: "embed gotcha"})
+	g.AddNode(knowledge.Node{ID: "episode:e1", Kind: knowledge.KindEpisode, Title: "2026-08-01 windows fix"})
+	g.AddNode(knowledge.Node{ID: "topic:windows", Kind: knowledge.KindTopic, Title: "windows"})
+	g.AddNode(knowledge.Node{ID: "tag:go", Kind: knowledge.KindTag, Title: "go"})
+	g.AddNode(knowledge.Node{ID: "profile:user", Kind: knowledge.KindProfile, Title: "user"})
+	g.AddEdge("fact:"+embedID, "episode:e1", 2)
+	g.AddEdge("fact:"+embedID, "topic:windows", 1.5)
+	g.AddEdge("fact:"+embedID, "tag:go", 1)
+	g.AddEdge("fact:"+embedID, "profile:user", 1)
+	mgr.SetGraphSource(func() *knowledge.Graph { return g }, nil)
+	// The first Snapshot kicks off the async graph.json persist; wait for the
+	// atomic rename to land so TempDir cleanup never races the write.
+	t.Cleanup(func() {
+		path := filepath.Join(mgr.MemoryDir(), "graph.json")
+		deadline := time.Now().Add(3 * time.Second)
+		for {
+			if _, err := os.Stat(path); err == nil || time.Now().After(deadline) {
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	})
+
+	block := cli.memoryAutoRecallBlock([]string{"embed", "windows"})
+	if !strings.Contains(block, "Related (graph): ") {
+		t.Fatalf("Related line missing:\n%s", block)
+	}
+	if !strings.Contains(block, "2026-08-01 windows fix (episode)") ||
+		!strings.Contains(block, "windows (topic)") {
+		t.Fatalf("neighbors missing from Related line:\n%s", block)
+	}
+	if strings.Contains(block, "(tag)") || strings.Contains(block, "(profile)") {
+		t.Fatalf("tag/profile glue leaked:\n%s", block)
+	}
+	if !strings.Contains(block, "@memory neighbors") || strings.Contains(block, "@session") {
+		t.Fatalf("pointer wording wrong:\n%s", block)
+	}
+	// The Related line rides within its own allowance; facts stay intact.
+	if !strings.Contains(block, "forward slashes") {
+		t.Fatalf("graph line displaced a fact:\n%s", block)
+	}
+}
+
+func TestAutoRecallRelatedLine_FiltersShownFacts(t *testing.T) {
+	g := knowledge.New()
+	g.AddNode(knowledge.Node{ID: "fact:a", Kind: knowledge.KindFact, Title: "fact a"})
+	g.AddNode(knowledge.Node{ID: "fact:b", Kind: knowledge.KindFact, Title: "fact b"})
+	g.AddEdge("fact:a", "fact:b", 1)
+	// Both facts already shown in the block → nothing new to point at.
+	if line := autoRecallRelatedLine(g, []string{"a", "b"}); line != "" {
+		t.Fatalf("shown facts must not resurface: %q", line)
+	}
+	// Only "a" shown → "b" is a legitimate unshown pointer.
+	line := autoRecallRelatedLine(g, []string{"a"})
+	if !strings.Contains(line, "fact b (fact)") {
+		t.Fatalf("unshown fact neighbor missing: %q", line)
 	}
 }


### PR DESCRIPTION
Follow-up to #1322 (planned there): the index-mode `[MEMORY AUTO-RECALL]` block now appends one compact `Related (graph):` line naming up to 3 one-hop neighbors of the shown facts, with the universal `@memory neighbors` pointer.

- **Cache-only**: reads the persisted graph snapshot; skipped entirely when `CHATCLI_MEMORY_GRAPH` is off — the nudge never pays a derive-per-call rebuild.
- Tag/profile glue filtered; already-shown facts never resurface; separate byte allowance so the line can never displace a fact; wording bans `@session` (chat-safe).
- No new envs; rides the existing `CHATCLI_MEMORY_AUTORECALL` gate.

With this, the graph participates in all three recall surfaces: full-mode push (`## Related (graph)` section), every `@memory recall` pull, and now the index-mode per-turn nudge.

Tests: no-graph → no line; expansion content/filters/wording; shown-fact filtering; async-persist drain. Full suite + lint + local gates green.