### PR TITLE
feat(memory): make cross-session memory visible and recallable from turn one

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -1298,6 +1298,14 @@ func (a *AgentMode) composeCoreText(isCoder, hasActivePersona bool) string {
 	// directive so the model drops preamble/restatement/ceremony. Empty when
 	// CHATCLI_OUTPUT_VERBOSITY=full.
 	coreText += verbosityDirectiveBlock()
+	// Persistent-memory bootstrap card: counts snapshot + navigation routes
+	// (@memory/@session/@board). Session-start stable, so it belongs in this
+	// CACHED core block. The gateway keeps its own GatewayMemoryDirective on
+	// top — the card adds the live counts and the saved-sessions route that
+	// directive predates.
+	if card := a.cli.memoryBootstrapCardAgent(); card != "" {
+		coreText += "\n\n" + card
+	}
 	return coreText
 }
 
@@ -1313,11 +1321,20 @@ func (a *AgentMode) buildWorkspaceBlocks(ctx context.Context, query string) (str
 	if len(a.cli.history) < hintWindow {
 		hintWindow = len(a.cli.history)
 	}
+	var recentTexts []string
 	if hintWindow > 0 {
-		var recentTexts []string
 		for _, msg := range a.cli.history[len(a.cli.history)-hintWindow:] {
 			recentTexts = append(recentTexts, msg.Content)
 		}
+	}
+	// The current query is appended to history only AFTER the system prompt
+	// is assembled, so it must feed the hints explicitly — otherwise the
+	// first turn of a fresh session (the moment recall matters most) runs
+	// hintless and every proactive recall block stays mute.
+	if q := strings.TrimSpace(query); q != "" {
+		recentTexts = append(recentTexts, q)
+	}
+	if len(recentTexts) > 0 {
 		hints = memory.ExtractKeywords(recentTexts)
 	}
 	// Memory injection mode: "index" (pull) keeps the per-turn payload
@@ -1362,7 +1379,15 @@ func (a *AgentMode) buildWorkspaceBlocks(ctx context.Context, query string) (str
 	// Proactive SESSION recall (own gate, orthogonal to the memory mode —
 	// saved sessions are a separate layer neither "index" nor "full"
 	// injects). Same cache discipline: uncached trailing block only.
-	if sr := a.cli.sessionAutoRecallBlock(hints, lastUserMessage(a.cli.history)); sr != "" {
+	// The CURRENT query is the referential text — lastUserMessage(history)
+	// here would test the referential regex against the PREVIOUS turn (or a
+	// synthetic tool-feedback message), so "lembra do que fizemos ontem?" as
+	// the opening /coder query never fired.
+	refText := strings.TrimSpace(query)
+	if refText == "" {
+		refText = lastUserMessage(a.cli.history)
+	}
+	if sr := a.cli.sessionAutoRecallBlock(hints, refText); sr != "" {
 		if dynamicText == "" {
 			dynamicText = sr
 		} else {
@@ -1370,6 +1395,32 @@ func (a *AgentMode) buildWorkspaceBlocks(ctx context.Context, query string) (str
 		}
 	}
 	return workspaceText, dynamicText
+}
+
+// followUpRecallBlocks re-runs the proactive recall surfaces for a mid-loop
+// user follow-up. The agent system prompt is assembled ONCE per Run, so the
+// boot-time [SESSION RECALL] / [MEMORY AUTO-RECALL] blocks freeze at their
+// turn-one state — a follow-up like "lembra do que fizemos ontem?" typed
+// mid-session would otherwise never trigger recall. Returns "" when nothing
+// matched. The caller injects the result append-only as a user-role message
+// at the turn boundary, the same protocol-safety contract as the mid-loop
+// skill blocks (never between a tool_use and its tool_result).
+func (a *AgentMode) followUpRecallBlocks(userMsg string) string {
+	userMsg = strings.TrimSpace(userMsg)
+	if userMsg == "" {
+		return ""
+	}
+	hints := memory.ExtractKeywords([]string{userMsg})
+	var parts []string
+	if loadMemoryMode() == memModeIndex {
+		if ar := a.cli.memoryAutoRecallBlock(hints); ar != "" {
+			parts = append(parts, ar)
+		}
+	}
+	if sr := a.cli.sessionAutoRecallBlock(hints, userMsg); sr != "" {
+		parts = append(parts, sr)
+	}
+	return strings.Join(parts, "\n\n")
 }
 
 // RunCoderOnce executa o modo coder de forma não-interativa (one-shot),
@@ -1900,6 +1951,11 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 					Meta:    &models.MessageMeta{SkillNames: models.JoinSkillNames(names)},
 				})
 				notifySkillActivation(names)
+			}
+			// Same trigger surface for proactive recall: a follow-up asking
+			// about past work re-ranks memory/sessions against ITS words.
+			if rb := a.followUpRecallBlocks(userMsg); rb != "" {
+				a.cli.history = append(a.cli.history, models.Message{Role: "user", Content: rb})
 			}
 		}
 
@@ -3699,6 +3755,11 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 					Meta:    &models.MessageMeta{SkillNames: models.JoinSkillNames(names)},
 				})
 				notifySkillActivation(names)
+			}
+			// And proactive recall against the follow-up's own words — the
+			// system prompt's recall blocks froze at Run() time.
+			if rb := a.followUpRecallBlocks(userInput); rb != "" {
+				a.cli.history = append(a.cli.history, models.Message{Role: "user", Content: rb})
 			}
 			continue
 		}

--- a/cli/board_adapter.go
+++ b/cli/board_adapter.go
@@ -19,6 +19,11 @@ import (
 // command renders its own i18n view for humans.
 type liveBoardAdapter struct {
 	store *board.Store
+	// onMutate fires after every successful board mutation. Wired to
+	// markGraphDirty so card nodes in the knowledge graph refresh promptly —
+	// the tool path never crosses the command handler, so without its own
+	// tap the graph would serve stale board state until the fingerprint TTL.
+	onMutate func()
 }
 
 // newLiveBoardAdapter builds the adapter (nil store = board.Default()).
@@ -27,6 +32,13 @@ func newLiveBoardAdapter(store *board.Store) *liveBoardAdapter {
 		store = board.Default()
 	}
 	return &liveBoardAdapter{store: store}
+}
+
+// mutated invokes the mutation tap, if any.
+func (a *liveBoardAdapter) mutated() {
+	if a.onMutate != nil {
+		a.onMutate()
+	}
 }
 
 // Create implements plugins.BoardAdapter.
@@ -43,6 +55,7 @@ func (a *liveBoardAdapter) Create(title, description, assignee, column string) (
 	if err != nil {
 		return "", err
 	}
+	a.mutated()
 	return "created " + formatCardLine(*card), nil
 }
 
@@ -126,6 +139,7 @@ func (a *liveBoardAdapter) Move(id, to, by string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	a.mutated()
 	return "moved " + formatCardLine(card), nil
 }
 
@@ -135,6 +149,7 @@ func (a *liveBoardAdapter) Assign(id, assignee string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	a.mutated()
 	return "assigned " + formatCardLine(card), nil
 }
 
@@ -147,6 +162,7 @@ func (a *liveBoardAdapter) Note(id, author, text string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	a.mutated()
 	return fmt.Sprintf("note added to %s (%d notes total)", card.ID, len(card.Notes)), nil
 }
 
@@ -164,6 +180,7 @@ func (a *liveBoardAdapter) Link(id, runID, jobID string) (string, error) {
 			return "", err
 		}
 	}
+	a.mutated()
 	return fmt.Sprintf("linked %s (runs=%s jobs=%s)", card.ID,
 		strings.Join(card.RunIDs, ","), strings.Join(card.JobIDs, ",")), nil
 }
@@ -182,6 +199,7 @@ func (a *liveBoardAdapter) Archive(olderThan string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	a.mutated()
 	return fmt.Sprintf("archived %d done card(s)", n), nil
 }
 

--- a/cli/chat_pipeline.go
+++ b/cli/chat_pipeline.go
@@ -110,7 +110,7 @@ func (cli *ChatCLI) assembleChatSystemPrompt(
 	}
 
 	// ── Stable cached prefix ──
-	out.parts = append(out.parts, modeAndLanguagePart())         // Part 0
+	out.parts = append(out.parts, cli.modeAndLanguagePart())     // Part 0
 	out.parts = append(out.parts, cli.attachedContextParts()...) // Part 1
 	if block, ok := pinnedSkillBlock(pinned); ok {               // Part 2
 		out.parts = append(out.parts, block)
@@ -121,8 +121,10 @@ func (cli *ChatCLI) assembleChatSystemPrompt(
 
 	// ── Volatile suffix (no cache hints) ──
 	// Hints are shared by the workspace retrieval (Part 4) and the proactive
-	// recall blocks (Parts 8b/8c) — computed once per turn.
-	hints := cli.recentHistoryHints()
+	// recall blocks (Parts 8b/8c) — computed once per turn, from recent
+	// history PLUS the current input. History alone left the first turn of a
+	// fresh session hintless — exactly when proactive recall matters most.
+	hints := cli.turnHints(userInput)
 	if part, ok := cli.workspaceContextPart(ctx, userInput, hints); ok { // Part 4
 		out.parts = append(out.parts, part)
 	}
@@ -168,13 +170,19 @@ func (cli *ChatCLI) assembleChatSystemPrompt(
 }
 
 // modeAndLanguagePart returns the Part 0 block — mode-awareness banner
-// concatenated with the i18n response-language directive. Always cacheable.
-func modeAndLanguagePart() models.ContentBlock {
+// concatenated with the i18n response-language directive and the
+// persistent-memory bootstrap card. Always cacheable: the card is a
+// session-start snapshot (memory_bootstrap.go), byte-stable across turns.
+func (cli *ChatCLI) modeAndLanguagePart() models.ContentBlock {
 	// Output-token reduction: the verbosity directive is a static string per
 	// level, so appending it keeps this Part 0 block cacheable.
+	text := ChatModeSystemHint + "\n" + i18n.T("ai.response_language") + verbosityDirectiveBlock()
+	if card := cli.memoryBootstrapCardChat(); card != "" {
+		text += "\n\n" + card
+	}
 	return models.ContentBlock{
 		Type:         "text",
-		Text:         ChatModeSystemHint + "\n" + i18n.T("ai.response_language") + verbosityDirectiveBlock(),
+		Text:         text,
 		CacheControl: &models.CacheControl{Type: "ephemeral"},
 	}
 }
@@ -263,17 +271,30 @@ func (cli *ChatCLI) retrieveWorkspaceContext(ctx context.Context, userInput stri
 // recentHistoryHints returns up to three keyword hints extracted from the
 // tail of cli.history. Empty slice when history is empty.
 func (cli *ChatCLI) recentHistoryHints() []string {
+	return cli.turnHints("")
+}
+
+// turnHints extracts keyword hints from the tail of cli.history PLUS the
+// current (not-yet-appended) user input. The history-only version left the
+// very first turn of a fresh session hintless — the user's opening question
+// is the only signal that exists at that point, and skipping it made
+// [MEMORY AUTO-RECALL] and ambient [SESSION RECALL] structurally mute on
+// turn one of every new session.
+func (cli *ChatCLI) turnHints(userInput string) []string {
 	const hintWindow = 3
 	window := hintWindow
 	if len(cli.history) < window {
 		window = len(cli.history)
 	}
-	if window == 0 {
-		return nil
-	}
-	texts := make([]string, 0, window)
+	texts := make([]string, 0, window+1)
 	for _, msg := range cli.history[len(cli.history)-window:] {
 		texts = append(texts, msg.Content)
+	}
+	if s := strings.TrimSpace(userInput); s != "" {
+		texts = append(texts, s)
+	}
+	if len(texts) == 0 {
+		return nil
 	}
 	return memory.ExtractKeywords(texts)
 }

--- a/cli/chat_pipeline_parts_test.go
+++ b/cli/chat_pipeline_parts_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestModeAndLanguagePart_HasCacheHintAndLanguageDirective(t *testing.T) {
-	part := modeAndLanguagePart()
+	part := (&ChatCLI{}).modeAndLanguagePart()
 	if part.Type != "text" {
 		t.Errorf("Type = %q, want text", part.Type)
 	}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -264,6 +264,15 @@ type ChatCLI struct {
 	contextBuilder *workspace.ContextBuilder
 	memoryStore    *workspace.MemoryStore
 
+	// Session-start snapshot of the persistent-memory bootstrap card
+	// (memory_bootstrap.go). Computed once per process so the card stays
+	// byte-stable across turns — it rides in the CACHED prefix of every
+	// surface's system prompt, and a per-turn count drift would bust that
+	// cache for no informational gain.
+	bootstrapCardOnce  sync.Once
+	bootstrapCardChat  string
+	bootstrapCardAgent string
+
 	// Content-aware, reversible context compression (CCR). Reduces verbose
 	// tool output (search/log/diff/JSON) before it reaches the model while
 	// keeping the full original recoverable via @recall. Shared across modes.
@@ -880,7 +889,9 @@ func NewChatCLI(ctx context.Context, manager manager.LLMManager, logger *zap.Log
 	plugins.SetAgentsAdapter(newLiveAgentsAdapter(nil))
 
 	// Wire the @board plugin adapter over the squad board store.
-	plugins.SetBoardAdapter(newLiveBoardAdapter(nil))
+	boardAdapter := newLiveBoardAdapter(nil)
+	boardAdapter.onMutate = cli.markGraphDirty
+	plugins.SetBoardAdapter(boardAdapter)
 
 	// Wire the @mail plugin adapter over the squad message bus.
 	plugins.SetMailAdapter(newLiveMailAdapter(nil))

--- a/cli/knowledge_graph.go
+++ b/cli/knowledge_graph.go
@@ -34,6 +34,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/diillson/chatcli/cli/board"
 	"github.com/diillson/chatcli/cli/ctxmgr"
 	"github.com/diillson/chatcli/config"
 	"github.com/diillson/chatcli/i18n"
@@ -128,8 +129,39 @@ func (cli *ChatCLI) buildKnowledgeGraph() *knowledge.Graph {
 	cli.addSessionNodes(g, st)
 	cli.addKBNodes(g)
 	cli.addSkillNodes(g)
+	addBoardNodes(g)
 	linkWikilinks(g)
 	return g
+}
+
+// addBoardNodes joins the work board ("card:" + Card.ID). The board used to
+// be a durable-on-disk silo no memory surface could see — a card left in
+// doing at the end of a session was invisible to the next one. Nodes carry
+// the column in the title so the index-card tally plus one neighbors call
+// tells the model what is in flight; @board show has the rest. Edges:
+// card↔tag(assignee) (1.0) so squad cards cluster by worker.
+func addBoardNodes(g *knowledge.Graph) {
+	cards, err := boardStore().List("")
+	if err != nil {
+		return
+	}
+	for _, c := range cards {
+		id := "card:" + c.ID
+		weight := 1.0
+		if c.Column == board.ColDoing {
+			weight = 2.0
+		}
+		g.AddNode(knowledge.Node{
+			ID: id, Kind: knowledge.KindCard,
+			Title:   "[" + string(c.Column) + "] " + graphTitle(c.Title),
+			Summary: c.Description,
+			Weight:  weight,
+		})
+		if c.Assignee != "" {
+			addTag(g, c.Assignee)
+			g.AddEdge(id, tagID(c.Assignee), 1)
+		}
+	}
 }
 
 func (cli *ChatCLI) addMemoryNodes(g *knowledge.Graph) *graphBuildState {
@@ -514,6 +546,7 @@ func (cli *ChatCLI) graphFingerprint() string {
 			statDir(mgr.Storage.GetStoragePath())
 		}
 	}
+	statFile(board.DefaultPath())
 	return hex.EncodeToString(h.Sum(nil))
 }
 

--- a/cli/knowledge_graph_kinds_test.go
+++ b/cli/knowledge_graph_kinds_test.go
@@ -136,6 +136,9 @@ func TestKnowledgeGraphAccessor_ServesCachedSnapshotWhenWired(t *testing.T) {
 	cli := newTestCLIWithMemory(t)
 	cli.memoryStore.Manager().Facts.AddFact("cached snapshot fact", "general", nil)
 	cli.wireMemoryGraph()
+	// The rebuild below schedules an async graph.json persist into the
+	// TempDir; quiesce it before cleanup or RemoveAll races the writer.
+	t.Cleanup(cli.memoryStore.Manager().WaitGraphPersist)
 
 	g1 := cli.knowledgeGraph()
 	g2 := cli.knowledgeGraph()

--- a/cli/memory_bootstrap.go
+++ b/cli/memory_bootstrap.go
@@ -1,0 +1,175 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+/*
+ * ChatCLI - memory_bootstrap.go
+ *
+ * The persistent-memory bootstrap card: a short, stable block that tells the
+ * model — in every surface's system prompt — that durable cross-session
+ * memory EXISTS on this machine and how to navigate it.
+ *
+ * Why it exists: the memory layers (facts, episodes, saved sessions, board)
+ * and their pull tools were all in place, yet a fresh session still opened
+ * with the model claiming "each session starts fresh — I have no memory of
+ * past interactions". Nothing in the system prompt ever said otherwise: the
+ * Memory Index digest lists facts/topics/projects but never mentions saved
+ * conversations, and the only anti-amnesia directive in the repo
+ * (GatewayMemoryDirective) was gated to the messaging gateway. The model's
+ * training prior ("assistants have no memory") wins by default — this card
+ * is the explicit counter-evidence, with live counts so it reads as data,
+ * not aspiration.
+ *
+ * Cache discipline: the card is computed ONCE per process (session-start
+ * snapshot) and then reused verbatim, so it can live in the CACHED stable
+ * prefix of the chat and agent/coder system prompts. Counts drifting
+ * mid-session (the memory worker adds facts continuously) must NOT re-render
+ * the card — that would invalidate the prompt-cache prefix every few turns.
+ *
+ * All strings are English model-facing constants, the same rationale as
+ * memoryRecallHint and the recall block headers.
+ */
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/diillson/chatcli/cli/board"
+)
+
+// bootstrapMaxBoardTitles caps how many doing-column card titles the board
+// line names. The board is a pointer here, not an inventory — @board list
+// has the rest.
+const bootstrapMaxBoardTitles = 3
+
+// boardStore resolves the work-board store for read-side surfaces (the
+// bootstrap card and the knowledge graph). A package variable because
+// board.Default() is a process-wide singleton over the user's real
+// ~/.chatcli/board.json — hermetic tests point this at a temp file instead.
+var boardStore = board.Default
+
+// bootstrapCardHeader opens both variants. The "REAL, CROSS-SESSION" framing
+// is deliberate: it must out-argue the model's trained default of denying
+// persistent memory.
+const bootstrapCardHeader = "[PERSISTENT MEMORY — REAL, CROSS-SESSION]\n" +
+	"This machine keeps durable memory for this user across sessions. " +
+	"Conversations are auto-saved: earlier sessions exist even when this one starts empty. " +
+	"Snapshot at session start:\n"
+
+// bootstrapCardAgentDirective teaches the pull routes agent/coder actually
+// have. Mirrors GatewayMemoryDirective's "never deny without pulling first"
+// contract, generalized beyond the gateway.
+const bootstrapCardAgentDirective = "Never claim you have no memory of past sessions or that each session starts fresh. " +
+	"Before answering that you don't know or don't remember something about this user or past work, pull first:\n" +
+	`- @session search {"cmd":"search","args":{"query":"<keywords>"}} then @session get — past conversations (including work discussed through MCP tools like Jira/ServiceNow).` + "\n" +
+	`- @memory recall {"cmd":"recall","args":{"query":"<keywords>"}} — long-term facts; {"cmd":"timeline"} for dated episodes.` + "\n" +
+	"- @board list — the local work board.\n" +
+	"If a pull returns nothing relevant, say what memory DOES contain — never deny that memory exists."
+
+// bootstrapCardChatDirective is the chat-mode wording: chat's only sanctioned
+// pull is the memory tool, and saved sessions are reachable through the user
+// (/session attach) — never through a tool chat does not have.
+const bootstrapCardChatDirective = "Never claim you have no memory of past sessions or that each session starts fresh. " +
+	"Before answering that you don't know or don't remember something about this user or past work:\n" +
+	`- call the memory tool ({"cmd":"recall","args":{"query":"<keywords>"}}) for long-term facts;` + "\n" +
+	"- for past conversations, name the saved session that looks relevant (see any [SESSION RECALL] block) and suggest `/session attach <name>`;\n" +
+	"- the user can inspect the local work board with /board.\n" +
+	"If recall returns nothing relevant, say what memory DOES contain — never deny that memory exists."
+
+// memoryBootstrapCards returns the (chat, agent) variants of the card,
+// computing the session-start snapshot on first use. Both are "" when every
+// memory surface is empty (a fresh install has nothing to navigate) or when
+// memory injection is off entirely.
+func (cli *ChatCLI) memoryBootstrapCards() (chatCard, agentCard string) {
+	cli.bootstrapCardOnce.Do(func() {
+		if loadMemoryMode() == memModeOff {
+			return
+		}
+		lines := cli.bootstrapSnapshotLines()
+		if len(lines) == 0 {
+			return
+		}
+		body := bootstrapCardHeader + strings.Join(lines, "\n") + "\n"
+		cli.bootstrapCardChat = body + bootstrapCardChatDirective
+		cli.bootstrapCardAgent = body + bootstrapCardAgentDirective
+	})
+	return cli.bootstrapCardChat, cli.bootstrapCardAgent
+}
+
+// memoryBootstrapCardChat is the chat-surface accessor.
+func (cli *ChatCLI) memoryBootstrapCardChat() string {
+	c, _ := cli.memoryBootstrapCards()
+	return c
+}
+
+// memoryBootstrapCardAgent is the agent/coder-surface accessor.
+func (cli *ChatCLI) memoryBootstrapCardAgent() string {
+	_, a := cli.memoryBootstrapCards()
+	return a
+}
+
+// bootstrapSnapshotLines renders the live counts, one line per surface that
+// actually has content. Every probe is best-effort: a failing store simply
+// drops its line.
+func (cli *ChatCLI) bootstrapSnapshotLines() []string {
+	var lines []string
+
+	if cli.memoryStore != nil {
+		if mgr := cli.memoryStore.Manager(); mgr != nil {
+			facts, episodes := 0, 0
+			if mgr.Facts != nil {
+				facts = len(mgr.Facts.GetAll())
+			}
+			if mgr.Episodes != nil {
+				episodes = mgr.Episodes.Count()
+			}
+			if facts > 0 || episodes > 0 {
+				lines = append(lines, fmt.Sprintf(
+					"- Long-term facts: %d · Episodes (dated work log): %d", facts, episodes))
+			}
+		}
+	}
+
+	if cli.sessionManager != nil {
+		if names, err := cli.sessionManager.ListSessions(); err == nil && len(names) > 0 {
+			line := fmt.Sprintf("- Saved conversations: %d", len(names))
+			if name, saved, title := cli.sessionManager.LatestSessionInfo(); name != "" {
+				line += fmt.Sprintf(" — latest: %q (%s", name, formatSessionAge(saved))
+				if title != "" {
+					line += fmt.Sprintf(", %q", title)
+				}
+				line += ")"
+			}
+			lines = append(lines, line)
+		}
+	}
+
+	if line := bootstrapBoardLine(); line != "" {
+		lines = append(lines, line)
+	}
+	return lines
+}
+
+// bootstrapBoardLine summarizes in-flight board work (doing column), the
+// state most likely to be orphaned by a restart — the in-memory run registry
+// that used to be the only reminder path zeroes on every boot.
+func bootstrapBoardLine() string {
+	cards, err := boardStore().List(board.ColDoing)
+	if err != nil || len(cards) == 0 {
+		return ""
+	}
+	titles := make([]string, 0, bootstrapMaxBoardTitles)
+	for _, c := range cards {
+		if len(titles) >= bootstrapMaxBoardTitles {
+			break
+		}
+		titles = append(titles, fmt.Sprintf("%q", c.Title))
+	}
+	line := fmt.Sprintf("- Work board: %d card(s) in doing: %s", len(cards), strings.Join(titles, ", "))
+	if len(cards) > bootstrapMaxBoardTitles {
+		line += ", …"
+	}
+	return line
+}

--- a/cli/memory_bootstrap_paths_test.go
+++ b/cli/memory_bootstrap_paths_test.go
@@ -1,0 +1,118 @@
+/*
+ * ChatCLI - Coverage for the first-turn memory navigation paths.
+ * Copyright (c) 2024 Edilson Freitas. License: Apache-2.0.
+ */
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/cli/board"
+	"github.com/diillson/chatcli/cli/workspace"
+	"github.com/diillson/chatcli/models"
+	"github.com/diillson/chatcli/pkg/knowledge"
+	"go.uber.org/zap"
+)
+
+func TestAddBoardNodes_JoinsCardsWithColumnAndAssignee(t *testing.T) {
+	store := withTempBoard(t)
+	doing, err := store.Create("migrate auth service", "", "coder", board.ColDoing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Create("write docs", "", "", board.ColBacklog); err != nil {
+		t.Fatal(err)
+	}
+
+	g := knowledge.New()
+	addBoardNodes(g)
+
+	node, ok := g.Node("card:" + doing.ID)
+	if !ok {
+		t.Fatalf("doing card missing from graph: %+v", g)
+	}
+	if !strings.Contains(node.Title, "[doing]") || !strings.Contains(node.Title, "migrate auth") {
+		t.Errorf("card title must carry column and title, got %q", node.Title)
+	}
+	if node.Weight != 2.0 {
+		t.Errorf("doing cards must outweigh backlog, got %v", node.Weight)
+	}
+	// Assignee clusters cards by worker via a tag edge.
+	if hood := g.Neighborhood("card:"+doing.ID, 1, 10); len(hood) == 0 {
+		t.Error("expected the assignee tag edge in the neighborhood")
+	}
+	// The index card tally now names cards — the boot-visibility signal.
+	if card := g.IndexCard(4); !strings.Contains(card, "card 2") {
+		t.Errorf("index card must tally board cards, got %q", card)
+	}
+}
+
+func TestOneShotSystemMessage_InjectsMemoryAndSessionRecall(t *testing.T) {
+	cli := newBootstrapCLI(t)
+	dir := t.TempDir()
+	cli.contextBuilder = workspace.NewContextBuilder(
+		workspace.NewBootstrapLoader(dir, dir, zap.NewNop()), cli.memoryStore, dir)
+	mgr := cli.memoryStore.Manager()
+	if !mgr.Facts.AddFact("The staging deploy runs through the blue pipeline", "architecture", []string{"deploy"}) {
+		t.Fatal("seed fact")
+	}
+	if err := cli.sessionManager.SaveSessionV2("autosave-deploy", &SessionData{
+		Version: 2,
+		ChatHistory: []models.Message{
+			{Role: "user", Content: "vamos revisar o deploy da staging"},
+			{Role: "assistant", Content: "pipeline azul atualizado"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	sys := cli.oneShotSystemMessage(context.Background(), "o que falamos anteriormente sobre o deploy?")
+	if !strings.Contains(sys, ChatModeSystemHint) {
+		t.Fatalf("one-shot must carry the chat baseline, got %q", sys)
+	}
+	if !strings.Contains(sys, "blue pipeline") {
+		t.Errorf("one-shot must push the memory retrieval (index promotes to full), got %q", sys)
+	}
+	if !strings.Contains(sys, "[SESSION RECALL]") || !strings.Contains(sys, "autosave-deploy") {
+		t.Errorf("one-shot must surface saved-session pointers, got %q", sys)
+	}
+}
+
+func TestOneShotSystemMessage_NilBuilderStillHasBaseline(t *testing.T) {
+	cli := newBootstrapCLI(t)
+	sys := cli.oneShotSystemMessage(context.Background(), "qualquer pergunta")
+	if !strings.Contains(sys, ChatModeSystemHint) {
+		t.Fatalf("baseline must survive a nil context builder, got %q", sys)
+	}
+}
+
+func TestFollowUpRecallBlocks_RefiresRecallMidLoop(t *testing.T) {
+	cli := newBootstrapCLI(t)
+	mgr := cli.memoryStore.Manager()
+	if !mgr.Facts.AddFact("Kimi tool_call ids must be paired positionally", "gotcha", []string{"kimi"}) {
+		t.Fatal("seed fact")
+	}
+	if err := cli.sessionManager.SaveSessionV2("autosave-kimi", &SessionData{
+		Version: 2,
+		ChatHistory: []models.Message{
+			{Role: "user", Content: "o pairing do kimi quebrou de novo"},
+			{Role: "assistant", Content: "corrigido com pairing posicional"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	a := &AgentMode{cli: cli}
+
+	block := a.followUpRecallBlocks("lembra do problema do kimi que resolvemos?")
+	if !strings.Contains(block, "[MEMORY AUTO-RECALL]") {
+		t.Errorf("mid-loop follow-up must re-rank facts, got %q", block)
+	}
+	if !strings.Contains(block, "[SESSION RECALL]") {
+		t.Errorf("mid-loop follow-up must re-rank sessions, got %q", block)
+	}
+	if got := a.followUpRecallBlocks("   "); got != "" {
+		t.Errorf("blank follow-up must inject nothing, got %q", got)
+	}
+}

--- a/cli/memory_bootstrap_paths_test.go
+++ b/cli/memory_bootstrap_paths_test.go
@@ -98,7 +98,7 @@ func TestFollowUpRecallBlocks_RefiresRecallMidLoop(t *testing.T) {
 		Version: 2,
 		ChatHistory: []models.Message{
 			{Role: "user", Content: "o pairing do kimi quebrou de novo"},
-			{Role: "assistant", Content: "corrigido com pairing posicional"},
+			{Role: "assistant", Content: "corrigido com pairing por ordem dos ids"},
 		},
 	}); err != nil {
 		t.Fatal(err)

--- a/cli/memory_bootstrap_test.go
+++ b/cli/memory_bootstrap_test.go
@@ -1,0 +1,183 @@
+/*
+ * ChatCLI - Persistent-memory bootstrap card tests.
+ * Copyright (c) 2024 Edilson Freitas. License: Apache-2.0.
+ */
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/cli/board"
+	"github.com/diillson/chatcli/cli/workspace/memory"
+	"github.com/diillson/chatcli/models"
+)
+
+// withTempBoard points the read-side board seam at a temp store for the test.
+func withTempBoard(t *testing.T) *board.Store {
+	t.Helper()
+	store := board.NewStore(filepath.Join(t.TempDir(), "board.json"))
+	prev := boardStore
+	boardStore = func() *board.Store { return store }
+	t.Cleanup(func() { boardStore = prev })
+	return store
+}
+
+func newBootstrapCLI(t *testing.T) *ChatCLI {
+	t.Helper()
+	cli := newTestCLIWithMemory(t)
+	cli.sessionManager = newTestSessionManager(t)
+	return cli
+}
+
+func TestMemoryBootstrapCard_CountsAndDirectives(t *testing.T) {
+	cli := newBootstrapCLI(t)
+	mgr := cli.memoryStore.Manager()
+	if !mgr.Facts.AddFact("Bedrock max tokens come from the family catalog", "architecture", nil) {
+		t.Fatal("seed fact")
+	}
+	if err := cli.sessionManager.SaveSessionV2("jira-sprint", &SessionData{
+		Version: 2,
+		Title:   "planning sprint 12",
+		ChatHistory: []models.Message{
+			{Role: "user", Content: "let's plan the Jira sprint"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	store := withTempBoard(t)
+	if _, err := store.Create("fix auth flow", "", "coder", board.ColDoing); err != nil {
+		t.Fatal(err)
+	}
+
+	chatCard, agentCard := cli.memoryBootstrapCards()
+
+	for name, card := range map[string]string{"chat": chatCard, "agent": agentCard} {
+		if !strings.Contains(card, "[PERSISTENT MEMORY") {
+			t.Fatalf("%s card missing header: %q", name, card)
+		}
+		if !strings.Contains(card, "Long-term facts: 1") {
+			t.Errorf("%s card missing fact count: %q", name, card)
+		}
+		if !strings.Contains(card, "Saved conversations: 1") {
+			t.Errorf("%s card missing session count: %q", name, card)
+		}
+		if !strings.Contains(card, `"jira-sprint"`) {
+			t.Errorf("%s card missing latest session name: %q", name, card)
+		}
+		if !strings.Contains(card, `"fix auth flow"`) {
+			t.Errorf("%s card missing doing-card title: %q", name, card)
+		}
+		if !strings.Contains(card, "Never claim you have no memory") {
+			t.Errorf("%s card missing the anti-amnesia directive: %q", name, card)
+		}
+	}
+
+	// Surface-appropriate pull routes: agent teaches its tools; chat must
+	// never instruct a tool it does not have.
+	if !strings.Contains(agentCard, "@session search") || !strings.Contains(agentCard, "@board list") {
+		t.Errorf("agent card missing pull routes: %q", agentCard)
+	}
+	if strings.Contains(chatCard, "@session") || strings.Contains(chatCard, "@board") {
+		t.Errorf("chat card must not reference agent-only tools: %q", chatCard)
+	}
+	if !strings.Contains(chatCard, "/session attach") {
+		t.Errorf("chat card missing the user-side attach route: %q", chatCard)
+	}
+}
+
+func TestMemoryBootstrapCard_EmptyStoresStaySilent(t *testing.T) {
+	cli := newBootstrapCLI(t)
+	withTempBoard(t)
+
+	chatCard, agentCard := cli.memoryBootstrapCards()
+	if chatCard != "" || agentCard != "" {
+		t.Fatalf("fresh install must not render a card, got chat=%q agent=%q", chatCard, agentCard)
+	}
+}
+
+func TestMemoryBootstrapCard_MemoryOff(t *testing.T) {
+	t.Setenv("CHATCLI_MEMORY_MODE", "off")
+	cli := newBootstrapCLI(t)
+	withTempBoard(t)
+	mgr := cli.memoryStore.Manager()
+	mgr.Facts.AddFact("some fact", "general", nil)
+
+	if chatCard, agentCard := cli.memoryBootstrapCards(); chatCard != "" || agentCard != "" {
+		t.Fatalf("memory off must suppress the card, got chat=%q agent=%q", chatCard, agentCard)
+	}
+}
+
+func TestTurnHints_FirstTurnUsesUserInput(t *testing.T) {
+	cli := newBootstrapCLI(t)
+
+	if got := cli.recentHistoryHints(); len(got) != 0 {
+		t.Fatalf("empty history must yield no history hints, got %v", got)
+	}
+	hints := cli.turnHints("kanban stories from the servicenow board")
+	if len(hints) == 0 {
+		t.Fatal("first-turn hints must derive from the current input")
+	}
+	joined := strings.Join(hints, " ")
+	if !strings.Contains(joined, "kanban") && !strings.Contains(joined, "servicenow") {
+		t.Errorf("expected content-bearing hints from the input, got %v", hints)
+	}
+}
+
+func TestSignificantSearchTerms_ReferentialFramingDrops(t *testing.T) {
+	// "o que falamos anteriormente?" is pure framing: with the framing set
+	// incomplete, the lone survivor "anteriormente" made BM25 rank the whole
+	// store on a framing word and surface months-old sessions.
+	norm := normalizeForSearch("o que falamos anteriormente?")
+	if terms := significantSearchTerms(strings.Fields(norm)); terms != nil {
+		t.Fatalf("pure referential framing must yield no significant terms, got %v", terms)
+	}
+	// Content-bearing words still survive framing removal.
+	norm = normalizeForSearch("configuração anterior do nginx")
+	terms := significantSearchTerms(strings.Fields(norm))
+	if len(terms) != 2 || terms[0] != "configuracao" || terms[1] != "nginx" {
+		t.Fatalf("expected [configuracao nginx], got %v", terms)
+	}
+}
+
+func TestSessionAutoRecall_ReferentialFirstTurnListsRecent(t *testing.T) {
+	cli := newBootstrapCLI(t)
+	if err := cli.sessionManager.SaveSessionV2("autosave-yesterday", &SessionData{
+		Version: 2,
+		Title:   "mcp aws login",
+		ChatHistory: []models.Message{
+			{Role: "user", Content: "faz login no aws-mcp"},
+			{Role: "assistant", Content: "token renovado com sucesso"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// First turn of a fresh session: no history, no hints — only the user's
+	// referential question. The block must still fire and point at the
+	// saved session.
+	block := cli.chatSessionAutoRecallBlock(nil, "o que falamos anteriormente?")
+	if !strings.Contains(block, "[SESSION RECALL]") {
+		t.Fatalf("referential first-turn question must fire session recall, got %q", block)
+	}
+	if !strings.Contains(block, "autosave-yesterday") {
+		t.Errorf("expected the saved session pointer, got %q", block)
+	}
+}
+
+func TestExtractKeywordsSeesCurrentInput(t *testing.T) {
+	// Guard for the shared hint contract: ExtractKeywords over the current
+	// input must produce hints Facts.Search can match — the first-turn
+	// auto-recall path depends on it end to end.
+	cli := newBootstrapCLI(t)
+	mgr := cli.memoryStore.Manager()
+	if !mgr.Facts.AddFact("ServiceNow stories are tracked on the sprint board", "project", []string{"servicenow"}) {
+		t.Fatal("seed fact")
+	}
+	hints := memory.ExtractKeywords([]string{"quais tarefas do servicenow estou tocando?"})
+	block := cli.memoryAutoRecallBlock(hints)
+	if !strings.Contains(block, "[MEMORY AUTO-RECALL]") || !strings.Contains(block, "ServiceNow") {
+		t.Fatalf("first-turn hints must reach the fact index, got %q", block)
+	}
+}

--- a/cli/memory_mode.go
+++ b/cli/memory_mode.go
@@ -40,15 +40,16 @@ const (
 // which follows English directives most reliably — the same rationale behind
 // the other system-prompt constants.
 const memoryRecallHint = "Only a compact index of long-term memory is shown above to save tokens. " +
-	"When you need the full detail behind any profile attribute, topic, or project, " +
-	`call the @memory tool with {"cmd":"recall","args":{"query":"<topic>"}} to pull the relevant facts on demand.`
+	"When you need the full detail behind any profile attribute, topic, project, stored fact or episode, " +
+	`call the @memory tool with {"cmd":"recall","args":{"query":"<topic>"}} to pull the relevant facts on demand ` +
+	`({"cmd":"timeline"} for dated episodes).`
 
 // chatMemoryRecallHint is the chat-mode counterpart of memoryRecallHint. Chat
 // reaches memory through the sanctioned "memory" tool exception
 // (chat_memory.go) rather than the agent's @memory plugin, so the wording
 // points at that surface. English constant for the same model-facing reason.
 const chatMemoryRecallHint = "Only a compact index of long-term memory is shown above to save tokens. " +
-	"When you need the full detail behind any profile attribute, topic, or project, " +
+	"When you need the full detail behind any profile attribute, topic, project, stored fact or episode, " +
 	`call the memory tool with {"cmd":"recall","args":{"query":"<topic>"}} to pull the relevant facts on demand.`
 
 // loadMemoryMode reads CHATCLI_MEMORY_MODE, normalizing to one of the three

--- a/cli/oneshot_mode.go
+++ b/cli/oneshot_mode.go
@@ -140,6 +140,14 @@ func (cli *ChatCLI) RunOnce(ctx context.Context, input string, disableAnimation 
 	images, visionDesc := cli.gateImagesForModel(ctx, images)
 	additionalContext += visionDesc
 
+	// One-shot used to send the bare user prompt with NO system message at
+	// all — no mode hint, no language directive, no memory. A user with
+	// months of persisted facts got a model with total amnesia ("each
+	// session starts fresh"). Inject the chat-mode baseline plus memory.
+	if sys := cli.oneShotSystemMessage(ctx, userInput); sys != "" {
+		cli.history = append(cli.history, models.Message{Role: "system", Content: sys})
+	}
+
 	cli.history = append(cli.history, models.Message{
 		Role:    "user",
 		Content: userInput + additionalContext,
@@ -192,6 +200,32 @@ func (cli *ChatCLI) RunOnce(ctx context.Context, input string, disableAnimation 
 		fmt.Println(rendered)
 	}
 	return nil
+}
+
+// oneShotSystemMessage builds the single system message for -p one-shot
+// chat. One-shot has NO pull surface (no tool loop), so the "index" memory
+// mode would inject a digest plus a directive to call a tool that cannot be
+// called — it therefore promotes to "full" (push the hint-relevant
+// retrieval), while "off" still suppresses memory entirely. Saved-session
+// pointers ride along with the chat-variant header, whose contract (surface
+// the pointer, suggest /session attach) needs no tools either.
+func (cli *ChatCLI) oneShotSystemMessage(ctx context.Context, userInput string) string {
+	sys := ChatModeSystemHint + "\n" + i18n.T("ai.response_language")
+
+	hints := cli.turnHints(userInput)
+	if cli.contextBuilder != nil {
+		mode := loadMemoryMode()
+		if mode == memModeIndex {
+			mode = memModeFull
+		}
+		if ws := cli.contextBuilder.BuildWorkspaceContextMode(ctx, userInput, hints, nil, mode, ""); strings.TrimSpace(ws) != "" {
+			sys += "\n\n" + ws
+		}
+	}
+	if sr := cli.chatSessionAutoRecallBlock(hints, userInput); sr != "" {
+		sys += "\n\n" + sr
+	}
+	return sys
 }
 
 // NewFlagSet cria um FlagSet isolado e as Options para parsing

--- a/cli/session_adapter.go
+++ b/cli/session_adapter.go
@@ -86,6 +86,22 @@ func getMessageCapFor(role string) int {
 	}
 }
 
+// sessionSystemOmitted replaces stored system prompts in @session output.
+// They are internal instructions, not conversation: echoing them wastes the
+// reply budget and — worse — reads as an answer ("here is what the session
+// contains: You are a senior software engineer…") while saying nothing about
+// what was actually discussed.
+const sessionSystemOmitted = "[system prompt omitted — internal instructions, not conversation]"
+
+// renderSessionMessage renders one message for @session output, masking
+// system prompts and truncating rune-safely to the role's cap.
+func renderSessionMessage(m models.Message, capBytes int) string {
+	if strings.EqualFold(m.Role, "system") {
+		return sessionSystemOmitted
+	}
+	return truncateRunesafe(strings.TrimSpace(m.Content), capBytes)
+}
+
 // Get implements plugins.SessionReader: one page of a saved session's
 // messages, with absolute indices so the model can paginate deterministically.
 // A non-empty query centers the page on the BM25-best-matching message.
@@ -103,8 +119,15 @@ func (a *sessionPluginAdapter) Get(_ context.Context, name string, offset, limit
 		if err != nil {
 			return "", err
 		}
+		// System messages are masked out of the ranking: a stored system
+		// prompt is huge and generic, so BM25 loved to center the page on it
+		// — the model asked "what did we discuss?" and got its own prompt
+		// back. Indices stay aligned because masking keeps positions.
 		contents := make([]string, len(all))
 		for i, m := range all {
+			if m.Role == "system" {
+				continue
+			}
 			contents[i] = m.Content
 		}
 		if hits := ctxmgr.RankDocsBM25(contents, q, 1); len(hits) > 0 {
@@ -127,7 +150,7 @@ func (a *sessionPluginAdapter) Get(_ context.Context, name string, offset, limit
 	b.WriteString(i18n.T("session.tool.get.header", name, offset, offset+len(page)-1, total))
 	b.WriteByte('\n')
 	for i, m := range page {
-		content := truncateRunesafe(strings.TrimSpace(m.Content), getMessageCapFor(m.Role))
+		content := renderSessionMessage(m, getMessageCapFor(m.Role))
 		fmt.Fprintf(&b, "\n[%d] %s: %s\n", offset+i, m.Role, content)
 	}
 	if next := offset + len(page); next < total {
@@ -152,7 +175,7 @@ func (a *sessionPluginAdapter) GetMessage(_ context.Context, name string, index 
 		return "", fmt.Errorf("%s", i18n.T("session.tool.get.bad_index", index, total, name))
 	}
 	m := all[index]
-	content := truncateRunesafe(strings.TrimSpace(m.Content), getSingleMessageCap)
+	content := renderSessionMessage(m, getSingleMessageCap)
 	header := i18n.T("session.tool.get.one_header", name, index, m.Role, total)
 	return header + "\n\n" + content, nil
 }

--- a/cli/session_adapter_system_test.go
+++ b/cli/session_adapter_system_test.go
@@ -1,0 +1,101 @@
+/*
+ * ChatCLI - @session system-message masking tests.
+ * Copyright (c) 2024 Edilson Freitas. License: Apache-2.0.
+ */
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+)
+
+// seedSessionWithSystem saves a session whose history carries a stored system
+// prompt — the shape every autosave has, and the exact payload @session get
+// used to echo back instead of the conversation.
+func seedSessionWithSystem(t *testing.T, sm *SessionManager) {
+	t.Helper()
+	if err := sm.SaveSessionV2("with-system", &SessionData{
+		Version: 2,
+		ChatHistory: []models.Message{
+			{Role: "system", Content: "You are a senior software engineer operating in coder mode. Respond with tool_call blocks and reasoning sections as discussed."},
+			{Role: "user", Content: "como resolvo o token expirado do aws-mcp?"},
+			{Role: "assistant", Content: "Rode @mcp-login para refazer o OAuth do aws-mcp."},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSessionGet_MasksSystemMessages(t *testing.T) {
+	cli := &ChatCLI{sessionManager: newTestSessionManager(t)}
+	seedSessionWithSystem(t, cli.sessionManager)
+	a := &sessionPluginAdapter{cli: cli}
+
+	out, err := a.Get(context.Background(), "with-system", 0, 10, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "senior software engineer") {
+		t.Fatalf("stored system prompt leaked into @session get output: %q", out)
+	}
+	if !strings.Contains(out, sessionSystemOmitted) {
+		t.Errorf("expected the omission marker in place of the system prompt, got %q", out)
+	}
+	if !strings.Contains(out, "token expirado") || !strings.Contains(out, "@mcp-login") {
+		t.Errorf("conversation content must remain, got %q", out)
+	}
+}
+
+func TestSessionGet_QueryNeverCentersOnSystemPrompt(t *testing.T) {
+	cli := &ChatCLI{sessionManager: newTestSessionManager(t)}
+	seedSessionWithSystem(t, cli.sessionManager)
+	a := &sessionPluginAdapter{cli: cli}
+
+	// The failure mode: a generic recap query matched the (huge, generic)
+	// system prompt best and the page opened with it. Masked ranking must
+	// land on the conversation instead.
+	out, err := a.Get(context.Background(), "with-system", 0, 1, "tool_call reasoning discussed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "senior software engineer") {
+		t.Fatalf("query-centered page must never render the system prompt: %q", out)
+	}
+}
+
+func TestSessionGetMessage_MasksSystemMessage(t *testing.T) {
+	cli := &ChatCLI{sessionManager: newTestSessionManager(t)}
+	seedSessionWithSystem(t, cli.sessionManager)
+	a := &sessionPluginAdapter{cli: cli}
+
+	out, err := a.GetMessage(context.Background(), "with-system", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "senior software engineer") {
+		t.Fatalf("GetMessage must mask system prompts too: %q", out)
+	}
+}
+
+func TestSearchSessions_IgnoresSystemMessages(t *testing.T) {
+	sm := newTestSessionManager(t)
+	seedSessionWithSystem(t, sm)
+
+	// Terms that appear ONLY in the stored system prompt must not qualify
+	// or rank the session.
+	hits, err := sm.SearchSessions("senior software engineer", 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 0 {
+		t.Fatalf("system-prompt-only terms must not match any session, got %+v", hits)
+	}
+	// Conversation terms still match.
+	hits, err = sm.SearchSessions("aws-mcp token", 3)
+	if err != nil || len(hits) != 1 {
+		t.Fatalf("conversation terms must match, got %+v err=%v", hits, err)
+	}
+}

--- a/cli/session_autorecall.go
+++ b/cli/session_autorecall.go
@@ -49,7 +49,9 @@ const (
 	// on every turn would be wasteful. Explicit recall questions (referential
 	// or temporal) search the ENTIRE store: "lembra do que fizemos há 2
 	// semanas?" must reach a two-week-old autosave, not just the tail.
-	sessionAutoRecallRecentWindow = 30
+	// 60, not 30: with autosave-per-exit plus MCP mirrors, 30 files can be
+	// just a few days of use — too short for "that thing from last week".
+	sessionAutoRecallRecentWindow = 60
 
 	// sessionAutoRecallMinMatches is the evidence floor for HINT-driven
 	// recall (no explicit reference by the user): at least this many

--- a/cli/session_manager.go
+++ b/cli/session_manager.go
@@ -556,6 +556,14 @@ func (sm *SessionManager) searchCorpus() (*sessionCorpus, error) {
 				if msg.Content == "" {
 					continue
 				}
+				// System messages are stored prompts, not conversation: they
+				// are near-identical across sessions and dense with generic
+				// words, so they both pollute BM25 ranking and let framing
+				// terms qualify every session. Recall searches conversation
+				// only.
+				if msg.Role == "system" {
+					continue
+				}
 				norm := normalizeForSearch(msg.Content)
 				c.docs = append(c.docs, sessionSearchDoc{session: fi.name, role: msg.Role, content: msg.Content, norm: norm})
 				b.WriteString(norm)

--- a/cli/session_search_normalize.go
+++ b/cli/session_search_normalize.go
@@ -82,6 +82,15 @@ var sessionSearchStopwords = map[string]struct{}{
 	"fez": {}, "faz": {}, "fazer": {}, "fizeram": {}, "falou": {}, "disse": {},
 	"vimos": {}, "combinamos": {}, "resolvemos": {}, "trocamos": {}, "papo": {},
 	"lembra": {}, "lembrar": {}, "sessao": {}, "sessoes": {}, "conversa": {}, "conversas": {},
+	// PT referential framing — words that point AT a past conversation
+	// without naming its content ("o que falamos anteriormente?"). Left in
+	// the query, a lone survivor like "anteriormente" makes BM25 rank the
+	// whole store on a framing word and surface months-old sessions over
+	// yesterday's; stripped, the query correctly degrades to the
+	// recent-sessions listing (newest first).
+	"anteriormente": {}, "anterior": {}, "anteriores": {}, "passada": {}, "passadas": {},
+	"passado": {}, "passados": {}, "ultima": {}, "ultimo": {}, "ultimas": {}, "ultimos": {},
+	"paramos": {}, "retomar": {}, "continuar": {}, "recente": {}, "recentes": {},
 	// EN grammatical
 	"the": {}, "an": {}, "of": {}, "in": {}, "on": {}, "at": {}, "to": {}, "for": {},
 	"with": {}, "without": {}, "and": {}, "or": {}, "but": {}, "that": {}, "this": {},
@@ -98,6 +107,8 @@ var sessionSearchStopwords = map[string]struct{}{
 	"discussed": {}, "talked": {}, "decided": {}, "mentioned": {}, "said": {},
 	"remember": {}, "recall": {}, "session": {}, "sessions": {}, "conversation": {},
 	"conversations": {}, "chat": {}, "left": {}, "off": {},
+	// EN referential framing — same rationale as the PT set above.
+	"previous": {}, "previously": {}, "last": {}, "prior": {}, "recent": {}, "recently": {},
 }
 
 // significantSearchTerms filters normalized query terms down to the ones

--- a/cli/workspace/memory/graph_cache.go
+++ b/cli/workspace/memory/graph_cache.go
@@ -69,6 +69,7 @@ type GraphCache struct {
 
 	path            string
 	persistInFlight atomic.Bool
+	persistWG       sync.WaitGroup
 	logger          *zap.Logger
 }
 
@@ -203,6 +204,17 @@ func (gc *GraphCache) Snapshot() *knowledge.Graph {
 	return g
 }
 
+// WaitPersist blocks until any in-flight graph.json write has finished.
+// The persist is deliberately async off the hot path; tests (and orderly
+// shutdown) need a way to quiesce it — a TempDir cleanup racing the writer
+// fails with "directory not empty" when the file lands mid-removal.
+func (gc *GraphCache) WaitPersist() {
+	if gc == nil {
+		return
+	}
+	gc.persistWG.Wait()
+}
+
 // checkFingerprintTTL recomputes the source fingerprint at most once per
 // graphFingerprintTTL (stat-only, no parsing) and marks the cache dirty on
 // change — the backstop for edits made outside this process.
@@ -235,7 +247,9 @@ func (gc *GraphCache) persistAsync(g *knowledge.Graph, fp string) {
 	if !gc.persistInFlight.CompareAndSwap(false, true) {
 		return
 	}
+	gc.persistWG.Add(1)
 	go func() {
+		defer gc.persistWG.Done()
 		defer gc.persistInFlight.Store(false)
 		payload, err := g.MarshalGraph()
 		if err != nil {

--- a/cli/workspace/memory/store.go
+++ b/cli/workspace/memory/store.go
@@ -365,6 +365,13 @@ func (m *Manager) KnowledgeGraph() *knowledge.Graph {
 	return m.graph.Snapshot()
 }
 
+// WaitGraphPersist quiesces any in-flight graph.json write. Tests that hand
+// the manager a TempDir must call this before cleanup — the async persist
+// otherwise races the directory removal.
+func (m *Manager) WaitGraphPersist() {
+	m.graph.WaitPersist()
+}
+
 // MarkGraphDirty flags the graph cache stale — for CLI-side mutations the
 // memory stores cannot observe (session saved, skill installed, context
 // created).

--- a/pkg/knowledge/card.go
+++ b/pkg/knowledge/card.go
@@ -20,7 +20,7 @@ import (
 // kindOrder fixes the display order so the card is byte-stable across turns.
 var kindOrder = []Kind{
 	KindProfile, KindProject, KindTopic, KindSkill,
-	KindEpisode, KindSession, KindKB,
+	KindEpisode, KindSession, KindKB, KindCard,
 	KindFact, KindTag,
 }
 

--- a/pkg/knowledge/graph.go
+++ b/pkg/knowledge/graph.go
@@ -45,6 +45,11 @@ const (
 	// "kb:", keyed by FileContext.ID). Never chunk-level: a corpus can hold
 	// tens of thousands of chunks and would drown the graph.
 	KindKB Kind = "kbcontext"
+	// KindCard is a work-board card (id prefix "card:", keyed by Card.ID).
+	// Board state used to be a silo invisible to every memory surface; the
+	// card tally in the index card is how a fresh session learns in-flight
+	// work exists at all.
+	KindCard Kind = "card"
 )
 
 // Node is one vertex. ID is unique and namespaced by kind (e.g. "topic:auth").


### PR DESCRIPTION
## Problem

Real-world test that motivated this: the user discussed Jira/ServiceNow stories via MCP in one session, opened a new session, asked what they were working on — and the model replied that it has no memory and every session starts fresh, while 500+ facts, 300 episodes and 50 saved sessions sat on disk. Forcing it with follow-ups made it tell the user to run /session attach manually; when it finally called the session tool, the tool returned the stored system prompt instead of the conversation.

Root causes found (all verified in code and reproduced):

1. No surface ever told the model that persistent memory exists. The only anti-amnesia directive was gated to the messaging gateway.
2. Turn hints were extracted from history before the current message was appended, so on turn one of a fresh session every proactive recall block was structurally mute — exactly the moment recall matters most.
3. Agent referential recall tested the regex against the previous turn's message, so a first-turn question like 'lembra do que fizemos ontem?' never fired.
4. Framing words like 'anteriormente' survived stopword filtering, making BM25 rank the whole store on a framing word and surface months-old sessions over yesterday's.
5. Session search and read included stored system prompts, which both polluted ranking and got echoed back as 'content'.
6. The work board was a silo invisible to every memory surface, and its only reminder path depended on an in-memory registry that zeroes on restart.
7. One-shot -p sent the bare prompt with no system message at all.

## Changes

- New persistent-memory bootstrap card (cli/memory_bootstrap.go): session-start snapshot with live counts (facts, episodes, saved sessions with the latest one named, in-flight board cards) plus surface-appropriate pull routes. Injected into the cached prefix of chat and agent/coder prompts. Chat variant never instructs tools chat does not have.
- Turn hints include the current user input (chat and agent); agent session recall uses the real query.
- Referential/framing vocabulary added to the search stopword set, so purely referential questions degrade to the recent-sessions listing, newest first.
- System messages masked out of @session search corpus, get ranking and rendering (omission marker, absolute indices preserved).
- Board cards join the knowledge graph (new kind 'card'), board mutations mark the graph dirty via an adapter tap, board.json joins the graph fingerprint.
- One-shot -p injects the chat baseline + memory context + session recall (index mode promotes to full there: one-shot has no pull path).
- Coder follow-ups re-run proactive recall append-only at the turn boundary (same protocol-safety contract as mid-loop skill blocks).
- Ambient session-recall window 30 → 60.

## Validation

- Full suite green both before-fix red cases covered: new tests for the bootstrap card variants, first-turn hints, referential framing degradation, first-turn referential session recall, and system-prompt masking in @session (get, get by index, search).
- End-to-end: the original failing prompt now answers from memory, names saved sessions with age, and offers the attach route instead of denying memory exists.

No new environment variables; no exported API changes (new graph kind constant is additive).