### PR TITLE
docs(readme): slash-command templates in Core Features and Highlights (en + pt)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@
 | **Semantic convergence** | char → Jaccard → embedding cosine cascade for Self-Refine, with LRU/TTL cache and quality regression detection. |
 | **Production-ready** | gRPC + TLS 1.3, JWT + RBAC, AES-256-GCM, rate limiting, audit logging, 50+ Prometheus metrics. |
 | **Kubernetes-native** | Operator with 17 CRDs and an autonomous AIOps pipeline (54+ remediation actions), SLO monitoring, post-mortems. |
-| **Extensible** | Plugins with Ed25519 signature verification, multi-registry skills (skills.sh, ClawHub, ChatCLI.dev), lifecycle hooks, MCP client (stdio, SSE, HTTP + OAuth). |
+| **Extensible** | Plugins with Ed25519 signature verification, multi-registry skills (skills.sh, ClawHub, ChatCLI.dev), slash-command templates with 9-CLI interop (Claude Code, Devin, Gemini, Codex, …), lifecycle hooks, MCP client (stdio, SSE, HTTP + OAuth). |
 
 ---
 
@@ -559,6 +559,7 @@ Credentials are stored with **AES-256-GCM** at `~/.chatcli/auth-profiles.json`.
 | **Knowledge graph (Obsidian in the core)** | Facts, topics, projects, skills and tags become an on-demand graph: `@memory neighbors <subject>` / `map` pull backlinks and related notes, a tiny index card rides each turn, and `/graph [subject]` renders the graph to an image (embedded go-graphviz). `CHATCLI_GRAPH_INDEX=on\|off`. |
 | **Plugins** | Auto-detection, schema validation, Ed25519 signatures, remote plugins. |
 | **Skills** | Self-authoring (`@skill`), multi-registry (skills.sh, ClawHub, ChatCLI.dev), fuzzy search, security audits, source preferences, atomic install. |
+| **Slash commands** | Markdown prompt templates invoked as `/name args` on EVERY surface (REPL, coder mid-run, one-shot, gateway, ACP, MCP prompts) and with every provider — expansion is pure prompt rewriting. Project `.chatcli/commands/` + personal `~/.chatcli/commands/`, with **zero-migration interop** for Claude Code, Devin, Windsurf, Cursor, opencode, Codex, Gemini CLI, Qwen Code and GitHub Copilot command files (their placeholder and TOML dialects included). `!` pre-execution runs through the coder security gate; `allowed-tools` scopes the run; the model discovers the catalog via `@commands`. Panel under `/config commands`. |
 | **Custom personas** | Markdown with YAML frontmatter (model, tools, skills). |
 | **Hooks** | PreToolUse, PostToolUse, SessionStart/End, UserPromptSubmit, Pre/PostCompact — shell or webhook. |
 | **WebFetch / WebSearch** | DuckDuckGo + fetch with text extraction. |

--- a/README_PT.md
+++ b/README_PT.md
@@ -65,7 +65,7 @@
 | **Convergência semântica** | Cascade char → Jaccard → embedding cosine para Self-Refine, com cache LRU/TTL e quality regression detection. |
 | **Production-ready** | gRPC + TLS 1.3, JWT + RBAC, AES-256-GCM, rate limiting, audit logging, 50+ métricas Prometheus. |
 | **Kubernetes-native** | Operador com 17 CRDs e pipeline AIOps autônomo (54+ ações de remediação), SLO monitoring, post-mortems. |
-| **Extensível** | Plugins com verificação Ed25519, skills multi-registry (skills.sh, ClawHub, ChatCLI.dev), hooks de lifecycle, MCP client (stdio, SSE, HTTP + OAuth). |
+| **Extensível** | Plugins com verificação Ed25519, skills multi-registry (skills.sh, ClawHub, ChatCLI.dev), templates de slash commands com interop de 9 CLIs (Claude Code, Devin, Gemini, Codex, …), hooks de lifecycle, MCP client (stdio, SSE, HTTP + OAuth). |
 
 ---
 
@@ -550,6 +550,7 @@ Credenciais armazenadas com **AES-256-GCM** em `~/.chatcli/auth-profiles.json`.
 | **Grafo de conhecimento (Obsidian no core)** | Facts, tópicos, projetos, skills e tags viram um grafo derivado on-demand: `@memory neighbors <assunto>` / `map` puxam backlinks e notas conectadas, um index card minúsculo entra por turno, e `/graph [assunto]` renderiza o grafo em imagem (go-graphviz embarcado). `CHATCLI_GRAPH_INDEX=on\|off`. |
 | **Plugins** | Auto-detecção, schema validation, assinatura Ed25519, plugins remotos. |
 | **Skills** | Auto-autoria (`@skill`), registry multi-source (skills.sh, ClawHub, ChatCLI.dev), busca fuzzy, auditorias de segurança, preferências e instalação atômica. |
+| **Slash commands** | Templates de prompt em markdown invocados como `/nome args` em TODAS as superfícies (REPL, coder mid-run, one-shot, gateway, ACP, MCP prompts) e com qualquer provider — a expansão é pura reescrita de prompt. Projeto `.chatcli/commands/` + pessoal `~/.chatcli/commands/`, com **interop de migração zero** para arquivos de comando do Claude Code, Devin, Windsurf, Cursor, opencode, Codex, Gemini CLI, Qwen Code e GitHub Copilot (incluindo seus dialetos de placeholder e TOML). Pré-execução `!` passa pelo gate de segurança do coder; `allowed-tools` escopa o run; o modelo descobre o catálogo via `@commands`. Painel em `/config commands`. |
 | **Personas customizáveis** | Markdown com frontmatter YAML (model, tools, skills). |
 | **Hooks** | PreToolUse, PostToolUse, SessionStart/End, UserPromptSubmit, Compact pre/post — shell ou webhook. |
 | **WebFetch / WebSearch** | DuckDuckGo + fetch com extração de texto. |


### PR DESCRIPTION
Adds the slash-commands feature to both READMEs, mirrored en/pt:

- New Core Features row (next to Skills, its sibling concept): what commands are, the surfaces and provider-agnostic guarantee, the 9-ecosystem zero-migration interop (Claude Code, Devin, Windsurf, Cursor, opencode, Codex, Gemini CLI, Qwen Code, GitHub Copilot), the gated pre-execution and allowed-tools scoping, @commands discovery and the /config commands panel.
- Extensible highlight row now mentions the interop matrix.

Docs-only; no code changes.