### PR TITLE
feat(agents): squad worker context navigation, recall and policy parity

### DIFF
--- a/cli/agent/microcompact.go
+++ b/cli/agent/microcompact.go
@@ -132,10 +132,12 @@ func ApplyMicrocompact(history []models.Message, currentTurn int, config Microco
 		turnMap[i] = turnNumber
 	}
 
-	// Process each tool result
+	// Process each tool result — plus squad feedback blocks, which are tool
+	// output injected under a user role (see models.MessageMeta.AgentFeedback).
 	for i := range history {
 		msg := &history[i]
-		if msg.Role != "tool" {
+		isAgentFeedback := msg.Role == "user" && msg.Meta != nil && msg.Meta.AgentFeedback
+		if msg.Role != "tool" && !isAgentFeedback {
 			continue
 		}
 		if len(msg.Content) < config.MinContentSize {

--- a/cli/agent/microcompact_test.go
+++ b/cli/agent/microcompact_test.go
@@ -108,3 +108,58 @@ func TestApplyMicrocompact_NilCCRKeepsLegacyBehavior(t *testing.T) {
 		t.Error("without a CCR layer no marker must be emitted")
 	}
 }
+
+func TestApplyMicrocompact_AgentFeedbackAged(t *testing.T) {
+	// Squad results are injected as a user-role message flagged AgentFeedback;
+	// microcompact must age them like tool results.
+	layer := compress.NewLayer(compress.Config{Mode: compress.ModeLossyWithCCR, Store: compress.NewMemoryStore()})
+	cfg := DefaultMicrocompactConfig()
+	cfg.CCR = layer
+
+	original := "--- Agent Results ---\n\n" + strings.Repeat("[coder] finding line\n", 400)
+	h := []models.Message{
+		{Role: "user", Content: "do the task"},
+		{Role: "assistant", Content: "dispatching"},
+		{Role: "user", Content: original, Meta: &models.MessageMeta{AgentFeedback: true}},
+	}
+	for i := 0; i < cfg.TurnsBeforeTruncate; i++ {
+		h = append(h,
+			models.Message{Role: "user", Content: "next"},
+			models.Message{Role: "assistant", Content: "ok"},
+		)
+	}
+
+	got, report := ApplyMicrocompact(h, cfg.TurnsBeforeTruncate, cfg, zap.NewNop())
+	if report.Truncated != 1 {
+		t.Fatalf("agent feedback must be truncated at level 1, got %+v", report)
+	}
+	keys := compress.ExtractKeys(got[2].Content)
+	if len(keys) != 1 {
+		t.Fatalf("stub must carry a recall marker, got %q", got[2].Content)
+	}
+	if recovered, ok := layer.Recall(keys[0]); !ok || recovered != original {
+		t.Error("original squad feedback must be recoverable via the marker")
+	}
+}
+
+func TestApplyMicrocompact_PlainUserMessageUntouched(t *testing.T) {
+	cfg := DefaultMicrocompactConfig()
+	long := strings.Repeat("user context the model must keep seeing\n", 400)
+	h := []models.Message{
+		{Role: "user", Content: long},
+		{Role: "assistant", Content: "ok"},
+	}
+	for i := 0; i < cfg.TurnsBeforeSummarize; i++ {
+		h = append(h,
+			models.Message{Role: "user", Content: "next"},
+			models.Message{Role: "assistant", Content: "ok"},
+		)
+	}
+	got, report := ApplyMicrocompact(h, cfg.TurnsBeforeSummarize, cfg, zap.NewNop())
+	if report.Truncated != 0 || report.Summarized != 0 {
+		t.Fatalf("plain user messages must never be compacted, got %+v", report)
+	}
+	if got[0].Content != long {
+		t.Error("plain user message content changed")
+	}
+}

--- a/cli/agent/workers/agents_custom.go
+++ b/cli/agent/workers/agents_custom.go
@@ -197,8 +197,14 @@ func mapPersonaTools(tools []string) personaToolMapping {
 		case "write":
 			cmdSet["write"] = true
 			mapping.writable = true
-		case "edit", "patch", "multiedit":
+		case "edit", "patch":
 			cmdSet["patch"] = true
+			mapping.writable = true
+		case "multiedit":
+			// Docs contract: MultiEdit grants the transactional multi-file
+			// edit (multipatch) plus the single-file patch it builds on.
+			cmdSet["patch"] = true
+			cmdSet["multipatch"] = true
 			mapping.writable = true
 		case "agent", "task":
 			// Meta-tool, ignored for worker commands
@@ -263,6 +269,7 @@ func buildCustomSystemPrompt(
 		"read":                     "Read file contents. Args: {\"file\":\"path/to/file\"}",
 		"write":                    "Create/overwrite file. Args: {\"file\":\"path\",\"content\":\"BASE64\",\"encoding\":\"base64\"}",
 		"patch":                    "Search/replace edit. Args: {\"file\":\"path\",\"search\":\"old\",\"replace\":\"new\"}",
+		"multipatch":               "Transactional multi-file edit (all-or-nothing). Args: {\"edits\":\"[{\\\"file\\\":\\\"path\\\",\\\"search\\\":\\\"old\\\",\\\"replace\\\":\\\"new\\\"}]\"}",
 		"tree":                     "Directory listing. Args: {\"dir\":\".\",\"max-depth\":3}",
 		"search":                   "Search patterns in files. Args: {\"term\":\"pattern\",\"dir\":\".\"}",
 		"exec":                     "Execute command. Args: {\"cmd\":\"go build ./...\"}",

--- a/cli/agent/workers/agents_custom.go
+++ b/cli/agent/workers/agents_custom.go
@@ -55,17 +55,27 @@ type CustomAgent struct {
 	skills       *SkillSet
 	modelHint    string
 	effortHint   string
+
+	// unknownTools are frontmatter tools: tokens that matched no known tool
+	// name; fellBackReadOnly marks a non-empty tools: list that produced zero
+	// commands (silent-degradation case). Both exist so LoadCustomAgents can
+	// warn the user instead of silently registering a crippled agent.
+	unknownTools     []string
+	fellBackReadOnly bool
 }
 
 // NewCustomAgent creates a CustomAgent from a persona Agent and its resolved skills.
 func NewCustomAgent(pa *persona.Agent, personaSkills []*persona.Skill) *CustomAgent {
-	commands := MapToolsToCommands(pa.Tools)
+	mapping := mapPersonaTools(pa.Tools)
+	commands := mapping.commands
+	fellBack := false
 	if len(commands) == 0 {
 		// Default: read-only if no tools specified
 		commands = []string{"read", "search", "tree"}
+		fellBack = len(pa.Tools) > 0
 	}
 
-	readOnly := isReadOnlyToolSet(pa.Tools)
+	readOnly := !mapping.writable
 	systemPrompt := buildCustomSystemPrompt(pa, personaSkills, commands, readOnly)
 	skillSet := buildCustomSkillSet(personaSkills)
 
@@ -79,15 +89,17 @@ func NewCustomAgent(pa *persona.Agent, personaSkills []*persona.Skill) *CustomAg
 	}
 
 	return &CustomAgent{
-		agentType:    AgentType(strings.ToLower(pa.Name)),
-		name:         pa.Name,
-		description:  pa.Description,
-		systemPrompt: systemPrompt,
-		commands:     commands,
-		readOnly:     readOnly,
-		skills:       skillSet,
-		modelHint:    modelHint,
-		effortHint:   strings.ToLower(strings.TrimSpace(pa.Effort)),
+		agentType:        AgentType(strings.ToLower(pa.Name)),
+		name:             pa.Name,
+		description:      pa.Description,
+		systemPrompt:     systemPrompt,
+		commands:         commands,
+		readOnly:         readOnly,
+		skills:           skillSet,
+		modelHint:        modelHint,
+		effortHint:       strings.ToLower(strings.TrimSpace(pa.Effort)),
+		unknownTools:     mapping.unknown,
+		fellBackReadOnly: fellBack,
 	}
 }
 
@@ -128,54 +140,95 @@ func (a *CustomAgent) Execute(ctx context.Context, task string, deps *WorkerDeps
 //	Write → write
 //	Edit  → patch
 //	Agent → ignored (meta-tool)
+//
+// Matching is case-insensitive, tolerates common aliases (Shell → Bash,
+// Patch/MultiEdit → Edit) and Claude Code argument specifiers
+// ("Bash(go build:*)" counts as Bash). Memory/Session/Knowledge grant the
+// read-only worker context tools (memory-recall, session-search/get,
+// knowledge-search/get).
 func MapToolsToCommands(tools []string) []string {
+	return mapPersonaTools(tools).commands
+}
+
+// personaToolMapping is the detailed result of parsing a persona frontmatter
+// tools: list. commands is sorted; unknown preserves input order.
+type personaToolMapping struct {
+	commands []string
+	unknown  []string
+	writable bool
+}
+
+// canonicalPersonaTool normalizes one frontmatter tool token: whitespace is
+// trimmed, a Claude Code argument specifier ("Bash(go build:*)") is stripped,
+// and the result is lowercased. Empty tokens normalize to "".
+func canonicalPersonaTool(tool string) string {
+	name := strings.TrimSpace(tool)
+	if idx := strings.IndexByte(name, '('); idx >= 0 {
+		name = name[:idx]
+	}
+	return strings.ToLower(strings.TrimSpace(name))
+}
+
+// mapPersonaTools is the tolerant engine behind MapToolsToCommands: it maps
+// each recognized token to its worker subcommands, records write capability,
+// and collects unrecognized tokens so callers can warn instead of silently
+// degrading the agent to the read-only default.
+func mapPersonaTools(tools []string) personaToolMapping {
 	cmdSet := make(map[string]bool)
-	hasBash := false
+	var mapping personaToolMapping
 
 	for _, tool := range tools {
-		switch strings.TrimSpace(tool) {
-		case "Read":
+		switch canonicalPersonaTool(tool) {
+		case "":
+			// Empty token (stray comma) — not worth a warning.
+		case "read":
 			cmdSet["read"] = true
-		case "Grep":
+		case "grep", "search":
 			cmdSet["search"] = true
-		case "Glob":
+		case "glob":
 			cmdSet["tree"] = true
-		case "Bash":
+		case "bash", "shell", "exec", "run", "terminal":
 			cmdSet["exec"] = true
 			cmdSet["test"] = true
-			hasBash = true
-		case "Write":
+			for _, gc := range []string{"git-status", "git-diff", "git-log", "git-changed", "git-branch"} {
+				cmdSet[gc] = true
+			}
+			mapping.writable = true
+		case "write":
 			cmdSet["write"] = true
-		case "Edit":
+			mapping.writable = true
+		case "edit", "patch", "multiedit":
 			cmdSet["patch"] = true
-		case "Agent":
+			mapping.writable = true
+		case "agent", "task":
 			// Meta-tool, ignored for worker commands
+		case "memory":
+			cmdSet[ContextToolMemoryRecall] = true
+		case "session":
+			cmdSet[ContextToolSessionSearch] = true
+			cmdSet[ContextToolSessionGet] = true
+		case "knowledge":
+			cmdSet[ContextToolKnowledgeSearch] = true
+			cmdSet[ContextToolKnowledgeGet] = true
+		default:
+			mapping.unknown = append(mapping.unknown, strings.TrimSpace(tool))
 		}
 	}
 
-	if hasBash {
-		for _, gc := range []string{"git-status", "git-diff", "git-log", "git-changed", "git-branch"} {
-			cmdSet[gc] = true
-		}
-	}
-
-	result := make([]string, 0, len(cmdSet))
+	mapping.commands = make([]string, 0, len(cmdSet))
 	for cmd := range cmdSet {
-		result = append(result, cmd)
+		mapping.commands = append(mapping.commands, cmd)
 	}
-	sort.Strings(result)
-	return result
+	sort.Strings(mapping.commands)
+	if len(mapping.commands) == 0 {
+		mapping.commands = nil
+	}
+	return mapping
 }
 
 // isReadOnlyToolSet returns true if the tools list contains only read-related tools.
 func isReadOnlyToolSet(tools []string) bool {
-	for _, tool := range tools {
-		switch strings.TrimSpace(tool) {
-		case "Write", "Edit", "Bash":
-			return false
-		}
-	}
-	return true
+	return !mapPersonaTools(tools).writable
 }
 
 // buildCustomSystemPrompt assembles the system prompt for a custom persona agent
@@ -207,18 +260,23 @@ func buildCustomSystemPrompt(
 	b.WriteString("Use <tool_call name=\"@coder\" args='{\"cmd\":\"COMMAND\",\"args\":{...}}' /> syntax.\n\n")
 
 	cmdDescriptions := map[string]string{
-		"read":        "Read file contents. Args: {\"file\":\"path/to/file\"}",
-		"write":       "Create/overwrite file. Args: {\"file\":\"path\",\"content\":\"BASE64\",\"encoding\":\"base64\"}",
-		"patch":       "Search/replace edit. Args: {\"file\":\"path\",\"search\":\"old\",\"replace\":\"new\"}",
-		"tree":        "Directory listing. Args: {\"dir\":\".\",\"max-depth\":3}",
-		"search":      "Search patterns in files. Args: {\"term\":\"pattern\",\"dir\":\".\"}",
-		"exec":        "Execute command. Args: {\"cmd\":\"go build ./...\"}",
-		"test":        "Run tests. Args: {\"dir\":\".\"}",
-		"git-status":  "Git status. Args: {\"dir\":\".\"}",
-		"git-diff":    "Git diff. Args: {\"staged\":true}",
-		"git-log":     "Git log. Args: {\"limit\":10}",
-		"git-changed": "Git changed files. Args: {}",
-		"git-branch":  "Git branch operations. Args: {}",
+		"read":                     "Read file contents. Args: {\"file\":\"path/to/file\"}",
+		"write":                    "Create/overwrite file. Args: {\"file\":\"path\",\"content\":\"BASE64\",\"encoding\":\"base64\"}",
+		"patch":                    "Search/replace edit. Args: {\"file\":\"path\",\"search\":\"old\",\"replace\":\"new\"}",
+		"tree":                     "Directory listing. Args: {\"dir\":\".\",\"max-depth\":3}",
+		"search":                   "Search patterns in files. Args: {\"term\":\"pattern\",\"dir\":\".\"}",
+		"exec":                     "Execute command. Args: {\"cmd\":\"go build ./...\"}",
+		"test":                     "Run tests. Args: {\"dir\":\".\"}",
+		"git-status":               "Git status. Args: {\"dir\":\".\"}",
+		"git-diff":                 "Git diff. Args: {\"staged\":true}",
+		"git-log":                  "Git log. Args: {\"limit\":10}",
+		"git-changed":              "Git changed files. Args: {}",
+		"git-branch":               "Git branch operations. Args: {}",
+		ContextToolMemoryRecall:    "Search persistent cross-session memory (read-only). Args: {\"query\":\"what to look for\"}",
+		ContextToolSessionSearch:   "Search saved past conversations (read-only). Args: {\"query\":\"topic\"}",
+		ContextToolSessionGet:      "Read one saved session page by page (read-only). Args: {\"name\":\"session\",\"query\":\"topic\"} or {\"name\":\"session\",\"message\":42}",
+		ContextToolKnowledgeSearch: "Search attached knowledge bases (read-only). Args: {\"query\":\"topic\",\"top_k\":5}",
+		ContextToolKnowledgeGet:    "Read a knowledge-base document paginated (read-only). Args: {\"source\":\"doc\",\"offset\":0}",
 	}
 
 	for _, cmd := range commands {

--- a/cli/agent/workers/context_tools.go
+++ b/cli/agent/workers/context_tools.go
@@ -53,8 +53,9 @@ var (
 	// ccrRecaller expands one CCR key to its original content.
 	ccrRecaller func(key string) (string, bool)
 
-	// contextToolRunner executes one read-only context tool call.
-	contextToolRunner func(ctx context.Context, tool string, args map[string]interface{}) (string, error)
+	// contextToolRunner executes one read-only context tool call. Args travel
+	// as a JSON object string so the hook boundary stays on concrete types.
+	contextToolRunner func(ctx context.Context, tool string, argsJSON string) (string, error)
 
 	// workerContextProvider returns the proactive recall block ([MEMORY
 	// AUTO-RECALL] / [SESSION RECALL]) for a worker task, or "".
@@ -74,8 +75,9 @@ func RegisterCCRRecaller(fn func(key string) (string, bool)) {
 }
 
 // RegisterContextToolRunner wires (or clears, with nil) the executor for the
-// read-only worker context tools (memory/session/knowledge).
-func RegisterContextToolRunner(fn func(ctx context.Context, tool string, args map[string]interface{}) (string, error)) {
+// read-only worker context tools (memory/session/knowledge). argsJSON is the
+// tool call's argument object serialized as JSON.
+func RegisterContextToolRunner(fn func(ctx context.Context, tool string, argsJSON string) (string, error)) {
 	workerHooksMu.Lock()
 	contextToolRunner = fn
 	workerHooksMu.Unlock()
@@ -103,7 +105,7 @@ func currentCCRRecaller() func(string) (string, bool) {
 	return ccrRecaller
 }
 
-func currentContextToolRunner() func(context.Context, string, map[string]interface{}) (string, error) {
+func currentContextToolRunner() func(context.Context, string, string) (string, error) {
 	workerHooksMu.RLock()
 	defer workerHooksMu.RUnlock()
 	return contextToolRunner
@@ -409,7 +411,13 @@ func executeContextTool(ctx context.Context, v validatedTC) execResult {
 		return execResult{index: v.index, record: record, output: fmt.Sprintf("[%s] %v\n", v.rtc.Subcmd, err), failed: true, toolID: v.rtc.ID}
 	}
 
-	output, err := runner(ctx, v.rtc.Subcmd, resolvedCallArgs(v.rtc))
+	argsJSON := "{}"
+	if args := resolvedCallArgs(v.rtc); len(args) > 0 {
+		if data, err := json.Marshal(args); err == nil {
+			argsJSON = string(data)
+		}
+	}
+	output, err := runner(ctx, v.rtc.Subcmd, argsJSON)
 	if err != nil {
 		record := ToolCallRecord{Name: v.rtc.Subcmd, Args: v.rtc.RawArgs, Error: err}
 		return execResult{index: v.index, record: record, output: fmt.Sprintf("[%s] %v\n", v.rtc.Subcmd, err), failed: true, toolID: v.rtc.ID}

--- a/cli/agent/workers/context_tools.go
+++ b/cli/agent/workers/context_tools.go
@@ -1,0 +1,421 @@
+/*
+ * ChatCLI - Worker context tools (recall + read-only memory/session/knowledge)
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Workers run in isolated ReAct loops with a small engine-subcommand toolset.
+ * This file gives them the same context-navigation surfaces a human (and the
+ * orchestrator) already has, without importing the cli package:
+ *
+ *   - recall: expand <<ccr:KEY>> markers left by the shared CCR compression
+ *     layer on truncated tool output (the counterpart of @recall).
+ *   - memory-recall / session-search / session-get / knowledge-search /
+ *     knowledge-get: read-only views over persistent memory, saved sessions
+ *     and attached knowledge bases, granted per-agent (persona frontmatter
+ *     tools: Memory, Session, Knowledge) or per-delegation.
+ *
+ * The cli package wires the actual implementations at startup via the
+ * Register* hooks below (same pattern as RegisterToolOutputCompressor); when
+ * a hook is absent the corresponding tool is not offered to the model.
+ */
+package workers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/diillson/chatcli/cli/compress"
+	"github.com/diillson/chatcli/models"
+)
+
+// Worker context tool subcommand names. These are NOT coder engine
+// subcommands: classifyToolCalls admits them via the allowlist and
+// executeToolCall routes them to the registered runner instead of the engine.
+const (
+	ContextToolMemoryRecall    = "memory-recall"
+	ContextToolSessionSearch   = "session-search"
+	ContextToolSessionGet      = "session-get"
+	ContextToolKnowledgeSearch = "knowledge-search"
+	ContextToolKnowledgeGet    = "knowledge-get"
+
+	// recallSubcmd is the universal CCR-expansion tool (like mail, offered to
+	// every worker whenever a recaller is registered).
+	recallSubcmd = "recall"
+)
+
+var (
+	workerHooksMu sync.RWMutex
+
+	// ccrRecaller expands one CCR key to its original content.
+	ccrRecaller func(key string) (string, bool)
+
+	// contextToolRunner executes one read-only context tool call.
+	contextToolRunner func(ctx context.Context, tool string, args map[string]interface{}) (string, error)
+
+	// workerContextProvider returns the proactive recall block ([MEMORY
+	// AUTO-RECALL] / [SESSION RECALL]) for a worker task, or "".
+	workerContextProvider func(task string) string
+
+	// squadCompressionLayer is the session CCR layer, shared so worker-loop
+	// microcompact preserves dropped bytes exactly like the orchestrator's.
+	squadCompressionLayer *compress.Layer
+)
+
+// RegisterCCRRecaller wires (or clears, with nil) the CCR key expander used
+// by the worker recall tool. Safe to call at startup.
+func RegisterCCRRecaller(fn func(key string) (string, bool)) {
+	workerHooksMu.Lock()
+	ccrRecaller = fn
+	workerHooksMu.Unlock()
+}
+
+// RegisterContextToolRunner wires (or clears, with nil) the executor for the
+// read-only worker context tools (memory/session/knowledge).
+func RegisterContextToolRunner(fn func(ctx context.Context, tool string, args map[string]interface{}) (string, error)) {
+	workerHooksMu.Lock()
+	contextToolRunner = fn
+	workerHooksMu.Unlock()
+}
+
+// RegisterWorkerContextProvider wires (or clears, with nil) the provider of
+// the proactive recall block injected into each worker's initial context.
+func RegisterWorkerContextProvider(fn func(task string) string) {
+	workerHooksMu.Lock()
+	workerContextProvider = fn
+	workerHooksMu.Unlock()
+}
+
+// RegisterSquadCompressionLayer shares the session CCR layer with the worker
+// ReAct loop so its microcompact archives originals instead of dropping them.
+func RegisterSquadCompressionLayer(layer *compress.Layer) {
+	workerHooksMu.Lock()
+	squadCompressionLayer = layer
+	workerHooksMu.Unlock()
+}
+
+func currentCCRRecaller() func(string) (string, bool) {
+	workerHooksMu.RLock()
+	defer workerHooksMu.RUnlock()
+	return ccrRecaller
+}
+
+func currentContextToolRunner() func(context.Context, string, map[string]interface{}) (string, error) {
+	workerHooksMu.RLock()
+	defer workerHooksMu.RUnlock()
+	return contextToolRunner
+}
+
+func currentWorkerContextProvider() func(string) string {
+	workerHooksMu.RLock()
+	defer workerHooksMu.RUnlock()
+	return workerContextProvider
+}
+
+func currentSquadCompressionLayer() *compress.Layer {
+	workerHooksMu.RLock()
+	defer workerHooksMu.RUnlock()
+	return squadCompressionLayer
+}
+
+// isContextToolSubcmd reports whether subcmd is one of the read-only worker
+// context tools served by the registered runner.
+func isContextToolSubcmd(subcmd string) bool {
+	switch subcmd {
+	case ContextToolMemoryRecall, ContextToolSessionSearch, ContextToolSessionGet,
+		ContextToolKnowledgeSearch, ContextToolKnowledgeGet:
+		return true
+	}
+	return false
+}
+
+// RecallToolDefinition is the native tool definition for CCR expansion.
+// Offered to every worker whenever a recaller is registered (universal, like
+// send_mail): compressed/truncated tool output carries <<ccr:KEY>> markers
+// and the worker must be able to walk them back.
+func RecallToolDefinition() models.ToolDefinition {
+	return models.ToolDefinition{
+		Type: "function",
+		Function: models.ToolFunctionDef{
+			Name: "recall_output",
+			Description: "Expand compressed or truncated tool output back to its original form. " +
+				"Whenever a result contains one or more <<ccr:KEY>> markers, pass them here to retrieve the full original content. " +
+				"Accepts a single key, a marker, or a string containing several markers.",
+			Parameters: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"keys": map[string]interface{}{
+						"type":        "string",
+						"description": "One or more CCR keys or <<ccr:KEY>> markers (any surrounding text is tolerated).",
+					},
+				},
+				"required": []string{"keys"},
+			},
+		},
+	}
+}
+
+// contextToolDefinitionsCatalog builds the native definitions for the
+// read-only context tools, keyed by subcommand name.
+func contextToolDefinitionsCatalog() map[string]models.ToolDefinition {
+	return map[string]models.ToolDefinition{
+		ContextToolMemoryRecall: {
+			Type: "function",
+			Function: models.ToolFunctionDef{
+				Name: "memory_recall",
+				Description: "Search the user's persistent cross-session memory (facts, preferences, project history) for entries relevant to a query. " +
+					"Read-only. Use when the task references prior decisions, conventions or context you do not see in the current conversation.",
+				Parameters: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"query": map[string]interface{}{
+							"type":        "string",
+							"description": "What to look for (keywords or a short question).",
+						},
+					},
+					"required": []string{"query"},
+				},
+			},
+		},
+		ContextToolSessionSearch: {
+			Type: "function",
+			Function: models.ToolFunctionDef{
+				Name: "session_search",
+				Description: "Search saved past conversations for a query; returns matching session names with snippets. " +
+					"Read-only. Follow up with session_get to read the matching part.",
+				Parameters: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"query": map[string]interface{}{
+							"type":        "string",
+							"description": "Free-text search across saved sessions.",
+						},
+						"limit": map[string]interface{}{
+							"type":        "integer",
+							"description": "Max snippets per session (default 3).",
+						},
+					},
+					"required": []string{"query"},
+				},
+			},
+		},
+		ContextToolSessionGet: {
+			Type: "function",
+			Function: models.ToolFunctionDef{
+				Name: "session_get",
+				Description: "Read one saved session page by page. Read-only. " +
+					"query jumps to the best-matching message; message=<index> returns that single message nearly in full (use for truncated entries).",
+				Parameters: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"name": map[string]interface{}{
+							"type":        "string",
+							"description": "Saved session name (from session_search).",
+						},
+						"offset": map[string]interface{}{
+							"type":        "integer",
+							"description": "0-based message offset (default 0).",
+						},
+						"limit": map[string]interface{}{
+							"type":        "integer",
+							"description": "Messages per page (default 20).",
+						},
+						"query": map[string]interface{}{
+							"type":        "string",
+							"description": "Jump to the best-matching message instead of using offset.",
+						},
+						"message": map[string]interface{}{
+							"type":        "integer",
+							"description": "Absolute message index: return THAT message alone, nearly untruncated.",
+						},
+					},
+					"required": []string{"name"},
+				},
+			},
+		},
+		ContextToolKnowledgeSearch: {
+			Type: "function",
+			Function: models.ToolFunctionDef{
+				Name:        "knowledge_search",
+				Description: "Search the session's attached knowledge bases (indexed docs/corpora) for relevant segments. Read-only.",
+				Parameters: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"query": map[string]interface{}{
+							"type":        "string",
+							"description": "What to look for.",
+						},
+						"top_k": map[string]interface{}{
+							"type":        "integer",
+							"description": "Number of segments to return (default 5).",
+						},
+						"kb": map[string]interface{}{
+							"type":        "string",
+							"description": "Knowledge base name (optional when only one is attached).",
+						},
+					},
+					"required": []string{"query"},
+				},
+			},
+		},
+		ContextToolKnowledgeGet: {
+			Type: "function",
+			Function: models.ToolFunctionDef{
+				Name:        "knowledge_get",
+				Description: "Read a whole document from an attached knowledge base, paginated by offset. Read-only. Use after knowledge_search.",
+				Parameters: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"source": map[string]interface{}{
+							"type":        "string",
+							"description": "Document source path/name (from knowledge_search results).",
+						},
+						"offset": map[string]interface{}{
+							"type":        "integer",
+							"description": "Pagination offset (default 0; the previous page reports the next offset).",
+						},
+						"kb": map[string]interface{}{
+							"type":        "string",
+							"description": "Knowledge base name (optional when only one is attached).",
+						},
+					},
+					"required": []string{"source"},
+				},
+			},
+		},
+	}
+}
+
+// ContextToolDefinitions returns the native tool definitions for the
+// read-only context tools present in allowedCmds. Tools are only offered
+// when a runner is registered — a definition without an executor would
+// guarantee a failing call.
+func ContextToolDefinitions(allowedCmds []string) []models.ToolDefinition {
+	if currentContextToolRunner() == nil {
+		return nil
+	}
+	catalog := contextToolDefinitionsCatalog()
+	result := make([]models.ToolDefinition, 0, 2)
+	for _, cmd := range allowedCmds {
+		if td, ok := catalog[cmd]; ok {
+			result = append(result, td)
+		}
+	}
+	return result
+}
+
+// resolvedCallArgs returns the structured args of a resolved tool call,
+// tolerating the XML-mode {"cmd":X,"args":{...}} envelope and flat JSON.
+func resolvedCallArgs(rtc resolvedToolCall) map[string]interface{} {
+	if len(rtc.NativeArgs) > 0 {
+		return rtc.NativeArgs
+	}
+	raw := strings.TrimSpace(rtc.RawArgs)
+	if raw == "" {
+		return nil
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return nil
+	}
+	if inner, ok := parsed["args"].(map[string]interface{}); ok {
+		return inner
+	}
+	return parsed
+}
+
+// executeRecall handles the recall tool call: it extracts every CCR key from
+// the args (lenient — bare keys, markers, or text containing markers) and
+// expands each via the registered recaller. Recalled content bypasses the
+// CCR compressor (re-compressing what the model explicitly asked to see
+// would loop) but still overflows to disk past the inline limit.
+func executeRecall(v validatedTC) execResult {
+	fail := func(err error) execResult {
+		record := ToolCallRecord{Name: recallSubcmd, Args: v.rtc.RawArgs, Error: err}
+		return execResult{index: v.index, record: record, output: fmt.Sprintf("[recall] %v\n", err), failed: true, toolID: v.rtc.ID}
+	}
+
+	recaller := currentCCRRecaller()
+	if recaller == nil {
+		return fail(errors.New("recall is not available in this session"))
+	}
+
+	args := resolvedCallArgs(v.rtc)
+	var raw strings.Builder
+	for _, k := range []string{"keys", "key", "marker", "markers", "content"} {
+		if s, ok := args[k].(string); ok && strings.TrimSpace(s) != "" {
+			raw.WriteString(s)
+			raw.WriteString(" ")
+		}
+	}
+	if raw.Len() == 0 {
+		// Last resort: scan the raw args string itself for markers/keys.
+		raw.WriteString(v.rtc.RawArgs)
+	}
+
+	keys := compress.ExtractKeys(raw.String())
+	if len(keys) == 0 {
+		// Tolerate bare keys without the <<ccr:>> wrapper: pick tokens that
+		// look like CCR keys (16 lowercase hex chars).
+		for _, tok := range strings.FieldsFunc(raw.String(), func(r rune) bool {
+			return !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f'))
+		}) {
+			if len(tok) == 16 {
+				keys = append(keys, tok)
+			}
+		}
+	}
+	if len(keys) == 0 {
+		return fail(errors.New(`no CCR keys found in args — pass "keys" with one or more <<ccr:KEY>> markers`))
+	}
+
+	var out strings.Builder
+	misses := 0
+	for i, key := range keys {
+		content, ok := recaller(key)
+		if !ok {
+			misses++
+			fmt.Fprintf(&out, "[recall %s] not found (expired or unknown key)\n", key)
+			continue
+		}
+		if len(keys) > 1 {
+			fmt.Fprintf(&out, "--- recalled %s (%d/%d) ---\n", key, i+1, len(keys))
+		}
+		out.WriteString(content)
+		if !strings.HasSuffix(content, "\n") {
+			out.WriteString("\n")
+		}
+	}
+
+	output := overflowToDisk(recallSubcmd, out.String(), MaxInlineResultBytes)
+	record := ToolCallRecord{Name: recallSubcmd, Args: v.rtc.RawArgs, Output: output}
+	if misses == len(keys) {
+		record.Error = errors.New("no CCR key could be expanded")
+		return execResult{index: v.index, record: record, output: "[recall] " + output, failed: true, toolID: v.rtc.ID}
+	}
+	return execResult{index: v.index, record: record, output: "[recall] " + output, toolID: v.rtc.ID}
+}
+
+// executeContextTool handles one read-only context tool call via the
+// registered runner, applying the standard result truncation policy.
+func executeContextTool(ctx context.Context, v validatedTC) execResult {
+	runner := currentContextToolRunner()
+	if runner == nil {
+		err := fmt.Errorf("%s is not available in this session", v.rtc.Subcmd)
+		record := ToolCallRecord{Name: v.rtc.Subcmd, Args: v.rtc.RawArgs, Error: err}
+		return execResult{index: v.index, record: record, output: fmt.Sprintf("[%s] %v\n", v.rtc.Subcmd, err), failed: true, toolID: v.rtc.ID}
+	}
+
+	output, err := runner(ctx, v.rtc.Subcmd, resolvedCallArgs(v.rtc))
+	if err != nil {
+		record := ToolCallRecord{Name: v.rtc.Subcmd, Args: v.rtc.RawArgs, Error: err}
+		return execResult{index: v.index, record: record, output: fmt.Sprintf("[%s] %v\n", v.rtc.Subcmd, err), failed: true, toolID: v.rtc.ID}
+	}
+
+	output = TruncateToolResult(v.rtc.Subcmd, output)
+	record := ToolCallRecord{Name: v.rtc.Subcmd, Args: v.rtc.RawArgs, Output: output}
+	return execResult{index: v.index, record: record, output: fmt.Sprintf("[%s] %s\n", v.rtc.Subcmd, output), toolID: v.rtc.ID}
+}

--- a/cli/agent/workers/context_tools_test.go
+++ b/cli/agent/workers/context_tools_test.go
@@ -1,0 +1,291 @@
+package workers
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/pkg/persona"
+)
+
+// --- mapPersonaTools tolerance tests ---
+
+func TestMapToolsToCommands_CaseInsensitive(t *testing.T) {
+	cmds := MapToolsToCommands([]string{"read", "BASH", "wRiTe"})
+	set := toSet(cmds)
+	for _, want := range []string{"read", "exec", "test", "write", "git-status"} {
+		if !set[want] {
+			t.Errorf("expected %q in commands, got %v", want, cmds)
+		}
+	}
+}
+
+func TestMapToolsToCommands_ArgumentSpecifier(t *testing.T) {
+	cmds := MapToolsToCommands([]string{"Bash(go build:*)", "Read"})
+	set := toSet(cmds)
+	if !set["exec"] || !set["read"] {
+		t.Errorf("Bash(go build:*) should grant exec; got %v", cmds)
+	}
+}
+
+func TestMapToolsToCommands_Aliases(t *testing.T) {
+	cmds := MapToolsToCommands([]string{"Shell", "Patch", "MultiEdit", "Search"})
+	set := toSet(cmds)
+	for _, want := range []string{"exec", "patch", "search"} {
+		if !set[want] {
+			t.Errorf("expected %q via alias, got %v", want, cmds)
+		}
+	}
+}
+
+func TestMapToolsToCommands_ContextTools(t *testing.T) {
+	cmds := MapToolsToCommands([]string{"Memory", "Session", "Knowledge"})
+	set := toSet(cmds)
+	for _, want := range []string{
+		ContextToolMemoryRecall,
+		ContextToolSessionSearch, ContextToolSessionGet,
+		ContextToolKnowledgeSearch, ContextToolKnowledgeGet,
+	} {
+		if !set[want] {
+			t.Errorf("expected %q, got %v", want, cmds)
+		}
+	}
+}
+
+func TestMapPersonaTools_UnknownCollected(t *testing.T) {
+	m := mapPersonaTools([]string{"Read", "WebFetch", "Banana"})
+	if len(m.unknown) != 2 || m.unknown[0] != "WebFetch" || m.unknown[1] != "Banana" {
+		t.Errorf("unknown = %v, want [WebFetch Banana]", m.unknown)
+	}
+	if m.writable {
+		t.Error("read-only set must not be writable")
+	}
+}
+
+func TestIsReadOnlyToolSet_AliasesAndSpecifiers(t *testing.T) {
+	if isReadOnlyToolSet([]string{"bash"}) {
+		t.Error("lowercase bash must count as writable")
+	}
+	if isReadOnlyToolSet([]string{"Bash(go test:*)"}) {
+		t.Error("Bash with specifier must count as writable")
+	}
+	if isReadOnlyToolSet([]string{"MultiEdit"}) {
+		t.Error("MultiEdit must count as writable")
+	}
+	if !isReadOnlyToolSet([]string{"Memory", "Session", "Knowledge", "Read"}) {
+		t.Error("context tools are read-only")
+	}
+}
+
+func TestNewCustomAgent_DegradedFallbackTracked(t *testing.T) {
+	pa := &persona.Agent{Name: "helper", Tools: []string{"banana", "webfetch"}}
+	a := NewCustomAgent(pa, nil)
+	if !a.fellBackReadOnly {
+		t.Error("all-unknown tools list must mark fellBackReadOnly")
+	}
+	if len(a.unknownTools) != 2 {
+		t.Errorf("unknownTools = %v", a.unknownTools)
+	}
+	if !a.IsReadOnly() {
+		t.Error("fallback agent must be read-only")
+	}
+	set := toSet(a.AllowedCommands())
+	if !set["read"] || !set["search"] || !set["tree"] {
+		t.Errorf("fallback commands = %v", a.AllowedCommands())
+	}
+}
+
+func TestNewCustomAgent_LowercaseBashGrantsExec(t *testing.T) {
+	pa := &persona.Agent{Name: "builder", Tools: []string{"read", "bash"}}
+	a := NewCustomAgent(pa, nil)
+	if a.IsReadOnly() {
+		t.Error("bash grant must clear read-only")
+	}
+	if !toSet(a.AllowedCommands())["exec"] {
+		t.Errorf("expected exec, got %v", a.AllowedCommands())
+	}
+	if a.fellBackReadOnly || len(a.unknownTools) != 0 {
+		t.Errorf("unexpected degradation markers: fellBack=%v unknown=%v", a.fellBackReadOnly, a.unknownTools)
+	}
+}
+
+// --- policyCallSurface tests ---
+
+func TestPolicyCallSurface_NativeCanonicalized(t *testing.T) {
+	rtc := resolvedToolCall{
+		Name:       "run_command",
+		Subcmd:     "exec",
+		Native:     true,
+		NativeArgs: map[string]interface{}{"cmd": "go build ./..."},
+		RawArgs:    `{"cmd":"go build ./..."}`,
+	}
+	name, args := policyCallSurface(rtc)
+	if name != "@coder" {
+		t.Errorf("name = %q, want @coder", name)
+	}
+	if !strings.Contains(args, `"cmd":"exec"`) || !strings.Contains(args, "go build ./...") {
+		t.Errorf("args must carry the {cmd:exec,args:{...}} envelope, got %s", args)
+	}
+}
+
+func TestPolicyCallSurface_XMLPassthrough(t *testing.T) {
+	rtc := resolvedToolCall{
+		Name:    "@coder",
+		Subcmd:  "exec",
+		RawArgs: `{"cmd":"exec","args":{"cmd":"ls"}}`,
+	}
+	name, args := policyCallSurface(rtc)
+	if name != "@coder" || args != rtc.RawArgs {
+		t.Errorf("XML mode must pass through unchanged, got (%q, %s)", name, args)
+	}
+}
+
+func TestIsPolicyExemptSubcmd(t *testing.T) {
+	for _, sub := range []string{"mail", recallSubcmd, ContextToolMemoryRecall, ContextToolSessionGet} {
+		if !isPolicyExemptSubcmd(sub) {
+			t.Errorf("%q must be policy-exempt", sub)
+		}
+	}
+	for _, sub := range []string{"exec", "write", "read", "delegate"} {
+		if isPolicyExemptSubcmd(sub) {
+			t.Errorf("%q must NOT be policy-exempt", sub)
+		}
+	}
+}
+
+// --- recall tool tests ---
+
+func TestExecuteRecall_ExpandsMarkers(t *testing.T) {
+	RegisterCCRRecaller(func(key string) (string, bool) {
+		if key == "aaaabbbbccccdddd" {
+			return "ORIGINAL CONTENT", true
+		}
+		return "", false
+	})
+	defer RegisterCCRRecaller(nil)
+
+	v := validatedTC{rtc: resolvedToolCall{
+		Subcmd:     recallSubcmd,
+		Native:     true,
+		NativeArgs: map[string]interface{}{"keys": "please expand <<ccr:aaaabbbbccccdddd>>"},
+	}}
+	r := executeRecall(v)
+	if r.failed {
+		t.Fatalf("recall failed: %v", r.record.Error)
+	}
+	if !strings.Contains(r.output, "ORIGINAL CONTENT") {
+		t.Errorf("output = %q", r.output)
+	}
+}
+
+func TestExecuteRecall_UnknownKeyFails(t *testing.T) {
+	RegisterCCRRecaller(func(string) (string, bool) { return "", false })
+	defer RegisterCCRRecaller(nil)
+
+	v := validatedTC{rtc: resolvedToolCall{
+		Subcmd:     recallSubcmd,
+		Native:     true,
+		NativeArgs: map[string]interface{}{"keys": "<<ccr:aaaabbbbccccdddd>>"},
+	}}
+	r := executeRecall(v)
+	if !r.failed {
+		t.Error("all-miss recall must be reported as failed")
+	}
+}
+
+func TestExecuteRecall_NoRecallerRegistered(t *testing.T) {
+	RegisterCCRRecaller(nil)
+	v := validatedTC{rtc: resolvedToolCall{Subcmd: recallSubcmd, Native: true,
+		NativeArgs: map[string]interface{}{"keys": "<<ccr:aaaabbbbccccdddd>>"}}}
+	if r := executeRecall(v); !r.failed {
+		t.Error("recall without a recaller must fail cleanly")
+	}
+}
+
+// --- context tool defs/runner tests ---
+
+func TestContextToolDefinitions_RequiresRunner(t *testing.T) {
+	RegisterContextToolRunner(nil)
+	if defs := ContextToolDefinitions([]string{ContextToolMemoryRecall}); len(defs) != 0 {
+		t.Errorf("no runner registered → no defs, got %d", len(defs))
+	}
+
+	RegisterContextToolRunner(func(context.Context, string, map[string]interface{}) (string, error) {
+		return "", nil
+	})
+	defer RegisterContextToolRunner(nil)
+
+	defs := ContextToolDefinitions([]string{"read", ContextToolMemoryRecall, ContextToolKnowledgeSearch})
+	if len(defs) != 2 {
+		t.Fatalf("defs = %d, want 2", len(defs))
+	}
+}
+
+func TestExecuteContextTool_RoutesToRunner(t *testing.T) {
+	var gotTool string
+	RegisterContextToolRunner(func(_ context.Context, tool string, args map[string]interface{}) (string, error) {
+		gotTool = tool
+		if args["query"] != "auth" {
+			return "", errors.New("missing query")
+		}
+		return "HIT", nil
+	})
+	defer RegisterContextToolRunner(nil)
+
+	v := validatedTC{rtc: resolvedToolCall{
+		Subcmd:     ContextToolSessionSearch,
+		Native:     true,
+		NativeArgs: map[string]interface{}{"query": "auth"},
+	}}
+	r := executeContextTool(context.Background(), v)
+	if r.failed || !strings.Contains(r.output, "HIT") {
+		t.Fatalf("unexpected result: failed=%v output=%q err=%v", r.failed, r.output, r.record.Error)
+	}
+	if gotTool != ContextToolSessionSearch {
+		t.Errorf("tool = %q", gotTool)
+	}
+}
+
+func TestResolvedCallArgs_XMLEnvelope(t *testing.T) {
+	args := resolvedCallArgs(resolvedToolCall{
+		RawArgs: `{"cmd":"session-search","args":{"query":"x"}}`,
+	})
+	if args["query"] != "x" {
+		t.Errorf("args = %v", args)
+	}
+}
+
+// --- prompt preservation tests ---
+
+func TestNativeToolSystemPrompt_PreservesSpecialist(t *testing.T) {
+	cfg := WorkerReActConfig{SystemPrompt: "You are a specialized CODE REVIEWER agent.\nUse <tool_call> syntax."}
+	got := nativeToolSystemPrompt(cfg)
+	if !strings.Contains(got, "CODE REVIEWER") {
+		t.Error("specialist identity must be preserved in native mode")
+	}
+	if !strings.Contains(got, "NATIVE TOOL CALLING MODE") {
+		t.Error("native override section missing")
+	}
+	if !strings.Contains(got, "TRUNCATED & COMPRESSED OUTPUT") {
+		t.Error("context guidance missing")
+	}
+}
+
+func TestNativeToolSystemPrompt_GenericFallback(t *testing.T) {
+	got := nativeToolSystemPrompt(WorkerReActConfig{})
+	if !strings.Contains(got, "specialized coding agent") {
+		t.Error("generic charter missing for empty specialist prompt")
+	}
+	if !strings.Contains(got, "TRUNCATED & COMPRESSED OUTPUT") {
+		t.Error("context guidance missing")
+	}
+}
+
+func toSet(list []string) map[string]bool {
+	set := make(map[string]bool, len(list))
+	for _, s := range list {
+		set[s] = true
+	}
+	return set
+}

--- a/cli/agent/workers/context_tools_test.go
+++ b/cli/agent/workers/context_tools_test.go
@@ -289,3 +289,16 @@ func toSet(list []string) map[string]bool {
 	}
 	return set
 }
+
+func TestMapToolsToCommands_MultiEditGrantsMultipatch(t *testing.T) {
+	set := toSet(MapToolsToCommands([]string{"MultiEdit"}))
+	if !set["patch"] || !set["multipatch"] {
+		t.Errorf("MultiEdit must grant patch and multipatch, got %v", MapToolsToCommands([]string{"MultiEdit"}))
+	}
+}
+
+func TestIsWriteCommand_Multipatch(t *testing.T) {
+	if !isWriteCommand("multipatch") {
+		t.Error("multipatch modifies files and must be classified as a write command")
+	}
+}

--- a/cli/agent/workers/context_tools_test.go
+++ b/cli/agent/workers/context_tools_test.go
@@ -211,7 +211,7 @@ func TestContextToolDefinitions_RequiresRunner(t *testing.T) {
 		t.Errorf("no runner registered → no defs, got %d", len(defs))
 	}
 
-	RegisterContextToolRunner(func(context.Context, string, map[string]interface{}) (string, error) {
+	RegisterContextToolRunner(func(context.Context, string, string) (string, error) {
 		return "", nil
 	})
 	defer RegisterContextToolRunner(nil)
@@ -224,9 +224,9 @@ func TestContextToolDefinitions_RequiresRunner(t *testing.T) {
 
 func TestExecuteContextTool_RoutesToRunner(t *testing.T) {
 	var gotTool string
-	RegisterContextToolRunner(func(_ context.Context, tool string, args map[string]interface{}) (string, error) {
+	RegisterContextToolRunner(func(_ context.Context, tool string, argsJSON string) (string, error) {
 		gotTool = tool
-		if args["query"] != "auth" {
+		if !strings.Contains(argsJSON, `"query":"auth"`) {
 			return "", errors.New("missing query")
 		}
 		return "HIT", nil

--- a/cli/agent/workers/registry.go
+++ b/cli/agent/workers/registry.go
@@ -185,6 +185,23 @@ func LoadCustomAgents(registry *Registry, mgr *persona.Manager, logger *zap.Logg
 		registry.Register(customAgent)
 		loaded++
 
+		// Surface frontmatter tools: problems instead of silently degrading
+		// the agent — an unmatched "bash" (case/alias) used to strip exec
+		// with no trace beyond a read-only agent the user didn't ask for.
+		if len(customAgent.unknownTools) > 0 {
+			logger.Warn("Custom agent has unrecognized frontmatter tools (check spelling/case; known: Read, Grep, Glob, Bash, Write, Edit, Agent, Memory, Session, Knowledge)",
+				zap.String("agent", pa.Name),
+				zap.Strings("unknown_tools", customAgent.unknownTools),
+			)
+		}
+		if customAgent.fellBackReadOnly {
+			logger.Warn("Custom agent tools list matched nothing — agent degraded to the read-only default command set",
+				zap.String("agent", pa.Name),
+				zap.Strings("tools", pa.Tools),
+				zap.Strings("fallback_commands", customAgent.AllowedCommands()),
+			)
+		}
+
 		logger.Info("Registered custom persona agent as worker",
 			zap.String("agent", pa.Name),
 			zap.String("type", string(agentType)),

--- a/cli/agent/workers/subagent.go
+++ b/cli/agent/workers/subagent.go
@@ -341,6 +341,11 @@ func subagentSystemPrompt(preface string, readOnly bool, tools []string) string 
 	}
 	sb.WriteString(fmt.Sprintf("\nAllowed tools: %s\n", strings.Join(tools, ", ")))
 
+	// Same truncated/compressed-output navigation guidance every worker gets.
+	sb.WriteString("\n")
+	sb.WriteString(workerContextGuidance)
+	sb.WriteString("\n")
+
 	// Knowledge: point the subagent at the session scratch dir in case it
 	// needs to stage intermediate files.
 	if tmp := os.Getenv("CHATCLI_AGENT_TMPDIR"); tmp != "" {

--- a/cli/agent/workers/tool_definitions.go
+++ b/cli/agent/workers/tool_definitions.go
@@ -415,6 +415,12 @@ var nativeToolNameMap = map[string]string{
 	"clean_backups":     "clean",
 	"delegate_subagent": "delegate",
 	"send_mail":         "mail",
+	"recall_output":     recallSubcmd,
+	"memory_recall":     ContextToolMemoryRecall,
+	"session_search":    ContextToolSessionSearch,
+	"session_get":       ContextToolSessionGet,
+	"knowledge_search":  ContextToolKnowledgeSearch,
+	"knowledge_get":     ContextToolKnowledgeGet,
 }
 
 // MailToolDefinition is the native tool definition for squad mail. It is

--- a/cli/agent/workers/tool_result_storage.go
+++ b/cli/agent/workers/tool_result_storage.go
@@ -112,28 +112,44 @@ func TruncateToolResult(subcmd, result string) string {
 	if fn := currentToolOutputCompressor(); fn != nil {
 		result = fn(subcmd, result)
 	}
-	if len(result) <= MaxInlineResultBytes {
-		return result
+	return overflowToDisk(subcmd, result, InlinePreviewBytes)
+}
+
+// overflowToDisk persists content past MaxInlineResultBytes to a result_*.txt
+// file and returns a previewBytes-sized preview plus the file reference. It
+// never runs the CCR compressor — callers that want compression apply it
+// first (TruncateToolResult). Content within the inline limit is returned
+// unchanged; when the disk write fails the content is hard-truncated at the
+// preview size so the caller never ships an oversized result.
+func overflowToDisk(label, content string, previewBytes int) string {
+	if len(content) <= MaxInlineResultBytes {
+		return content
+	}
+	if previewBytes <= 0 {
+		previewBytes = InlinePreviewBytes
+	}
+	if previewBytes >= len(content) {
+		return content
 	}
 
-	// Save full result to disk
+	// Save full content to disk
 	n := atomic.AddUint64(&resultCounter, 1)
-	filename := fmt.Sprintf("result_%s_%d.txt", subcmd, n)
+	filename := fmt.Sprintf("result_%s_%d.txt", label, n)
 	fullPath := filepath.Join(getResultDir(), filename)
 
-	if err := os.WriteFile(fullPath, []byte(result), 0o600); err != nil {
+	if err := os.WriteFile(fullPath, []byte(content), 0o600); err != nil {
 		// If we can't save, just truncate hard
-		return result[:MaxInlineResultBytes] + "\n... [output truncated — write to disk failed]"
+		return content[:MaxInlineResultBytes] + "\n... [output truncated — write to disk failed]"
 	}
 
 	// Return preview + reference
-	preview := result[:InlinePreviewBytes]
+	preview := content[:previewBytes]
 	// Try to cut at a newline boundary for cleaner output
-	if lastNL := strings.LastIndex(preview, "\n"); lastNL > InlinePreviewBytes/2 {
+	if lastNL := strings.LastIndex(preview, "\n"); lastNL > previewBytes/2 {
 		preview = preview[:lastNL+1]
 	}
 
-	return preview + fmt.Sprintf(TruncatedResultSuffix, fullPath, len(result))
+	return preview + fmt.Sprintf(TruncatedResultSuffix, fullPath, len(content))
 }
 
 // CleanupResultFiles removes all temporary result files.

--- a/cli/agent/workers/tool_result_storage_test.go
+++ b/cli/agent/workers/tool_result_storage_test.go
@@ -43,3 +43,36 @@ func TestCleanupResultFiles(t *testing.T) {
 	// Just verify it doesn't panic
 	CleanupResultFiles()
 }
+
+func TestOverflowToDisk_LargePreviewPreserved(t *testing.T) {
+	SetResultDir(t.TempDir())
+	defer SetResultDir("")
+
+	content := strings.Repeat("worker output line\n", 3000) // ~57KB
+	out := overflowToDisk("worker", content, MaxWorkerOutputBytes-256)
+
+	if !strings.Contains(out, "full output saved to") {
+		t.Fatalf("expected overflow reference, got tail %q", out[len(out)-120:])
+	}
+	// Preview must be near the requested budget, not the 4KB default.
+	if len(out) < 20*1024 {
+		t.Errorf("preview too small (%d bytes) — requested budget was ~30KB", len(out))
+	}
+	if len(out) > MaxWorkerOutputBytes+256 {
+		t.Errorf("inline result exceeds the historical bound: %d bytes", len(out))
+	}
+}
+
+func TestOverflowToDisk_SmallContentUnchanged(t *testing.T) {
+	content := "small"
+	if got := overflowToDisk("worker", content, 1024); got != content {
+		t.Errorf("small content must pass through unchanged, got %q", got)
+	}
+}
+
+func TestOverflowToDisk_PreviewLargerThanContent(t *testing.T) {
+	content := strings.Repeat("x", MaxInlineResultBytes+10)
+	if got := overflowToDisk("worker", content, MaxInlineResultBytes+100); got != content {
+		t.Error("content below the preview budget must pass through unchanged")
+	}
+}

--- a/cli/agent/workers/worker_react.go
+++ b/cli/agent/workers/worker_react.go
@@ -89,15 +89,7 @@ func RunWorkerReAct(
 	// without a registered handle simply reports nothing.
 	liveRun := runs.FromContext(ctx)
 
-	maxTurns := config.MaxTurns
-	if maxTurns <= 0 {
-		maxTurns = DefaultWorkerMaxTurns
-		if envVal := os.Getenv("CHATCLI_AGENT_WORKER_MAX_TURNS"); envVal != "" {
-			if v, err := strconv.Atoi(envVal); err == nil && v > 0 {
-				maxTurns = v
-			}
-		}
-	}
+	maxTurns := resolveWorkerMaxTurns(config)
 
 	// Detect if we can use native function calling
 	toolAware, useNativeTools := client.AsToolAware(llmClient)
@@ -108,41 +100,13 @@ func RunWorkerReAct(
 	// Build tool definitions for native mode
 	var toolDefs []models.ToolDefinition
 	if useNativeTools {
-		toolDefs = CoderToolDefinitions(config.AllowedCommands)
-		// Read-only context tools (memory/session/knowledge) granted via the
-		// allowlist — CoderToolDefinitions only knows engine subcommands.
-		toolDefs = append(toolDefs, ContextToolDefinitions(config.AllowedCommands)...)
-		// Squad mail is a universal capability: every worker can message
-		// other agents regardless of its command allowlist.
-		toolDefs = append(toolDefs, MailToolDefinition())
-		// CCR recall is universal too: compressed/truncated results carry
-		// <<ccr:KEY>> markers every worker must be able to expand.
-		if currentCCRRecaller() != nil {
-			toolDefs = append(toolDefs, RecallToolDefinition())
-		}
+		toolDefs = buildWorkerToolDefs(config)
 		logger.Info("Using native function calling",
 			zap.Int("tools", len(toolDefs)),
 			zap.String("callID", callID))
 	}
 
-	// Adjust system prompt for native tool mode (no XML instructions needed)
-	systemPrompt := config.SystemPrompt
-	if useNativeTools {
-		systemPrompt = nativeToolSystemPrompt(config)
-	} else if strings.TrimSpace(systemPrompt) != "" {
-		// XML mode keeps the specialist prompt and gains the same
-		// context-navigation guidance native mode embeds.
-		systemPrompt += "\n\n" + workerContextGuidance
-	}
-
-	// Proactive recall: give the worker the same [MEMORY AUTO-RECALL] /
-	// [SESSION RECALL] surfaces the orchestrator gets, keyed off its task.
-	// Best-effort and bounded — "" when nothing matched or no provider.
-	if provider := currentWorkerContextProvider(); provider != nil {
-		if block := provider(task); strings.TrimSpace(block) != "" {
-			systemPrompt += "\n\n## SESSION CONTEXT (proactive recall)\n" + block
-		}
-	}
+	systemPrompt := buildWorkerSystemPrompt(config, useNativeTools, task)
 
 	history := []models.Message{
 		{Role: "system", Content: systemPrompt},
@@ -356,6 +320,63 @@ func RunWorkerReAct(
 		ToolCalls:     allToolCalls,
 		ParallelCalls: maxParallel,
 	}, nil
+}
+
+// resolveWorkerMaxTurns resolves the effective turn budget for a worker:
+// config wins, then CHATCLI_AGENT_WORKER_MAX_TURNS, then the default.
+func resolveWorkerMaxTurns(config WorkerReActConfig) int {
+	if config.MaxTurns > 0 {
+		return config.MaxTurns
+	}
+	if envVal := os.Getenv("CHATCLI_AGENT_WORKER_MAX_TURNS"); envVal != "" {
+		if v, err := strconv.Atoi(envVal); err == nil && v > 0 {
+			return v
+		}
+	}
+	return DefaultWorkerMaxTurns
+}
+
+// buildWorkerToolDefs assembles the native tool definitions for a worker:
+// its allowlisted engine subcommands, the read-only context tools granted
+// through the same allowlist, universal squad mail, and (when a recaller is
+// wired) universal CCR recall.
+func buildWorkerToolDefs(config WorkerReActConfig) []models.ToolDefinition {
+	toolDefs := CoderToolDefinitions(config.AllowedCommands)
+	// Read-only context tools (memory/session/knowledge) granted via the
+	// allowlist — CoderToolDefinitions only knows engine subcommands.
+	toolDefs = append(toolDefs, ContextToolDefinitions(config.AllowedCommands)...)
+	// Squad mail is a universal capability: every worker can message
+	// other agents regardless of its command allowlist.
+	toolDefs = append(toolDefs, MailToolDefinition())
+	// CCR recall is universal too: compressed/truncated results carry
+	// <<ccr:KEY>> markers every worker must be able to expand.
+	if currentCCRRecaller() != nil {
+		toolDefs = append(toolDefs, RecallToolDefinition())
+	}
+	return toolDefs
+}
+
+// buildWorkerSystemPrompt composes the worker's effective system prompt:
+// mode-appropriate charter + context-navigation guidance + the proactive
+// recall block for this task (best-effort, "" when nothing matched).
+func buildWorkerSystemPrompt(config WorkerReActConfig, useNativeTools bool, task string) string {
+	systemPrompt := config.SystemPrompt
+	if useNativeTools {
+		systemPrompt = nativeToolSystemPrompt(config)
+	} else if strings.TrimSpace(systemPrompt) != "" {
+		// XML mode keeps the specialist prompt and gains the same
+		// context-navigation guidance native mode embeds.
+		systemPrompt += "\n\n" + workerContextGuidance
+	}
+
+	// Proactive recall: give the worker the same [MEMORY AUTO-RECALL] /
+	// [SESSION RECALL] surfaces the orchestrator gets, keyed off its task.
+	if provider := currentWorkerContextProvider(); provider != nil {
+		if block := provider(task); strings.TrimSpace(block) != "" {
+			systemPrompt += "\n\n## SESSION CONTEXT (proactive recall)\n" + block
+		}
+	}
+	return systemPrompt
 }
 
 // callWorkerLLM performs one LLM round trip in either native function-calling

--- a/cli/agent/workers/worker_react.go
+++ b/cli/agent/workers/worker_react.go
@@ -1080,7 +1080,7 @@ If you cannot complete the task with your available tools, say so clearly — do
 // isWriteCommand returns true if the subcommand modifies files.
 func isWriteCommand(cmd string) bool {
 	switch cmd {
-	case "write", "patch", "exec", "test", "rollback", "clean":
+	case "write", "patch", "multipatch", "exec", "test", "rollback", "clean":
 		return true
 	}
 	return false

--- a/cli/agent/workers/worker_react.go
+++ b/cli/agent/workers/worker_react.go
@@ -109,9 +109,17 @@ func RunWorkerReAct(
 	var toolDefs []models.ToolDefinition
 	if useNativeTools {
 		toolDefs = CoderToolDefinitions(config.AllowedCommands)
+		// Read-only context tools (memory/session/knowledge) granted via the
+		// allowlist — CoderToolDefinitions only knows engine subcommands.
+		toolDefs = append(toolDefs, ContextToolDefinitions(config.AllowedCommands)...)
 		// Squad mail is a universal capability: every worker can message
 		// other agents regardless of its command allowlist.
 		toolDefs = append(toolDefs, MailToolDefinition())
+		// CCR recall is universal too: compressed/truncated results carry
+		// <<ccr:KEY>> markers every worker must be able to expand.
+		if currentCCRRecaller() != nil {
+			toolDefs = append(toolDefs, RecallToolDefinition())
+		}
 		logger.Info("Using native function calling",
 			zap.Int("tools", len(toolDefs)),
 			zap.String("callID", callID))
@@ -121,6 +129,19 @@ func RunWorkerReAct(
 	systemPrompt := config.SystemPrompt
 	if useNativeTools {
 		systemPrompt = nativeToolSystemPrompt(config)
+	} else if strings.TrimSpace(systemPrompt) != "" {
+		// XML mode keeps the specialist prompt and gains the same
+		// context-navigation guidance native mode embeds.
+		systemPrompt += "\n\n" + workerContextGuidance
+	}
+
+	// Proactive recall: give the worker the same [MEMORY AUTO-RECALL] /
+	// [SESSION RECALL] surfaces the orchestrator gets, keyed off its task.
+	// Best-effort and bounded — "" when nothing matched or no provider.
+	if provider := currentWorkerContextProvider(); provider != nil {
+		if block := provider(task); strings.TrimSpace(block) != "" {
+			systemPrompt += "\n\n## SESSION CONTEXT (proactive recall)\n" + block
+		}
 	}
 
 	history := []models.Message{
@@ -146,12 +167,23 @@ func RunWorkerReAct(
 	var finalOutput strings.Builder
 	maxParallel := 0
 
-	allowed := make(map[string]bool, len(config.AllowedCommands)+1)
+	allowed := make(map[string]bool, len(config.AllowedCommands)+2)
 	for _, cmd := range config.AllowedCommands {
 		allowed[cmd] = true
 	}
 	// Universal squad-mail capability (see MailToolDefinition).
 	allowed["mail"] = true
+	// Universal CCR recall (see RecallToolDefinition) — only when wired.
+	if currentCCRRecaller() != nil {
+		allowed[recallSubcmd] = true
+	}
+
+	// Worker-loop microcompact: long runs (up to maxTurns) accumulate tool
+	// results with no other reduction mechanism. Same engine and knobs as
+	// the orchestrator's, sharing the session CCR layer so every dropped
+	// byte stays recoverable via the recall tool.
+	mcCfg := agent.DefaultMicrocompactConfig()
+	mcCfg.CCR = currentSquadCompressionLayer()
 
 	// --- Failure tracking for reflection ---
 	consecutiveFailures := 0
@@ -182,6 +214,12 @@ func RunWorkerReAct(
 				history = appendInboxMessage(history, mail.FormatInbox(inbox))
 			}
 		}
+
+		// Progressively compact old tool results (turn boundary only, so a
+		// tool_use/tool_result pair is never split). CCR-backed when the
+		// session layer is registered — otherwise same legacy behavior the
+		// orchestrator had before CCR.
+		history, _ = agent.ApplyMicrocompact(history, turn, mcCfg, logger)
 
 		// --- Call LLM (native or text mode) ---
 		responseText, nativeToolCalls, newHistory, err := callWorkerLLM(ctx, useNativeTools, toolAware, llmClient, history, toolDefs)
@@ -303,7 +341,12 @@ func RunWorkerReAct(
 
 	output := finalOutput.String()
 	if len(output) > MaxWorkerOutputBytes {
-		output = output[:MaxWorkerOutputBytes] + "\n... [output truncated]"
+		// Persist the full output and keep (almost) the same inline budget as
+		// before — the tail is now recoverable via the referenced overflow
+		// file instead of silently lost. The margin keeps preview + reference
+		// suffix within the historical MaxWorkerOutputBytes bound.
+		const suffixMargin = 256
+		output = overflowToDisk("worker", output, MaxWorkerOutputBytes-suffixMargin)
 	}
 
 	return &AgentResult{
@@ -352,8 +395,13 @@ func executeToolCall(ctx context.Context, v validatedTC, lockMgr *FileLockManage
 		return execResult{index: v.index, output: v.msg + "\n", failed: true, toolID: v.rtc.ID}
 	}
 
-	if policyChecker != nil {
-		policyAllowed, msg := policyChecker.CheckAndPrompt(ctx, v.rtc.Name, v.rtc.RawArgs)
+	// In-process tools (squad mail, CCR recall, read-only context views) have
+	// no filesystem/shell/network side effects — the security policy exists
+	// to gate those, so these skip the check instead of tripping an "ask"
+	// prompt that no rule pattern can ever whitelist.
+	if policyChecker != nil && !isPolicyExemptSubcmd(v.rtc.Subcmd) {
+		policyName, policyArgs := policyCallSurface(v.rtc)
+		policyAllowed, msg := policyChecker.CheckAndPrompt(ctx, policyName, policyArgs)
 		if !policyAllowed {
 			blockedMsg := fmt.Sprintf("[BLOCKED BY POLICY] %s", msg)
 			record := ToolCallRecord{
@@ -376,6 +424,15 @@ func executeToolCall(ctx context.Context, v validatedTC, lockMgr *FileLockManage
 	// subcommand.
 	if v.rtc.Subcmd == "mail" {
 		return executeMailSend(ctx, v)
+	}
+
+	// Special-case: recall expands CCR markers via the registered session
+	// layer; context tools are served by the registered read-only runner.
+	if v.rtc.Subcmd == recallSubcmd {
+		return executeRecall(v)
+	}
+	if isContextToolSubcmd(v.rtc.Subcmd) {
+		return executeContextTool(ctx, v)
 	}
 
 	filePath := extractFilePathFromResolved(v.rtc)
@@ -651,7 +708,8 @@ func appendTurnFeedback(history []models.Message, useNativeTools bool, results [
 	// Text mode: append feedback as user message (legacy behavior)
 	feedback := turnOutput
 	if len(feedback) > MaxWorkerOutputBytes {
-		feedback = feedback[:MaxWorkerOutputBytes] + "\n... [feedback truncated]"
+		const suffixMargin = 256
+		feedback = overflowToDisk("feedback", feedback, MaxWorkerOutputBytes-suffixMargin)
 	}
 
 	// --- REFLECTION MECHANISM ---
@@ -662,10 +720,49 @@ func appendTurnFeedback(history []models.Message, useNativeTools bool, results [
 	return append(history, models.Message{Role: "user", Content: feedback})
 }
 
-// nativeToolSystemPrompt builds a cleaner system prompt for native tool calling mode.
-// No XML syntax instructions needed — the LLM calls tools via the API directly.
-func nativeToolSystemPrompt(config WorkerReActConfig) string {
-	return `You are a specialized coding agent in ChatCLI.
+// isPolicyExemptSubcmd reports whether a subcommand runs entirely in-process
+// with no filesystem/shell/network side effects, and therefore skips the
+// security policy check (there is nothing for a rule to gate, and the "ask"
+// fallback would block workers on prompts no pattern can whitelist).
+func isPolicyExemptSubcmd(subcmd string) bool {
+	return subcmd == "mail" || subcmd == recallSubcmd || isContextToolSubcmd(subcmd)
+}
+
+// policyCallSurface returns the (toolName, args) pair presented to the
+// security policy for a resolved tool call. Native calls are canonicalized
+// to the same "@coder" + {"cmd":subcmd,"args":{...}} envelope XML mode
+// produces — without this, PolicyManager.Check saw toolName "run_command"
+// and read the SHELL command out of args["cmd"] as if it were the
+// subcommand, so rules like "@coder exec" never matched and the read-only
+// exec auto-allow never fired (every worker exec degraded to "ask").
+func policyCallSurface(rtc resolvedToolCall) (string, string) {
+	if !rtc.Native {
+		return rtc.Name, rtc.RawArgs
+	}
+	envelope := map[string]interface{}{"cmd": rtc.Subcmd}
+	if len(rtc.NativeArgs) > 0 {
+		envelope["args"] = rtc.NativeArgs
+	}
+	data, err := json.Marshal(envelope)
+	if err != nil {
+		return rtc.Name, rtc.RawArgs
+	}
+	return "@coder", string(data)
+}
+
+// workerContextGuidance teaches every worker how to navigate truncated and
+// compressed context — the same affordances the orchestrator's prompt has.
+// Model-facing: English on purpose.
+const workerContextGuidance = `## TRUNCATED & COMPRESSED OUTPUT
+Large tool results are reduced before you see them; nothing is lost:
+- "[full output saved to /path/result_*.txt — N bytes total]": the COMPLETE output is in that file. Read it with the read tool (use start/end line ranges to page through big files).
+- "<<ccr:KEY>>" markers: the original content is archived. Expand markers with the recall tool (pass the marker(s) in "keys").
+- File reads truncated at a byte limit: re-read the same file with start/end (or head/tail) to get the remaining ranges.
+Prefer recalling/reading the stored original over guessing about content you cannot see.`
+
+// nativeToolCoreRules is the generic native-mode charter used when a worker
+// has no specialist system prompt of its own.
+const nativeToolCoreRules = `You are a specialized coding agent in ChatCLI.
 
 ## RULES
 1. ALWAYS read a file before modifying it — never edit blind.
@@ -681,6 +778,29 @@ func nativeToolSystemPrompt(config WorkerReActConfig) string {
 - Verify critical changes by reading the result
 
 Content is always plain text — no base64 encoding needed.`
+
+// nativeModeOverride supersedes any XML tool-call syntax instructions that a
+// specialist prompt (built-in agent or custom persona) carries — native
+// function calling replaces that surface entirely, but the specialist
+// identity, expertise, skills and review rules above it must be preserved.
+const nativeModeOverride = `## NATIVE TOOL CALLING MODE (overrides any syntax above)
+Native function calling is ACTIVE. Any earlier instructions describing <tool_call> XML syntax, <reasoning> tags, JSON envelopes or base64 content are OBSOLETE for this run:
+1. Call the provided tools directly through the function-calling API. Content is plain text — no base64.
+2. Do NOT narrate your actions between tool calls.
+3. Only output text AFTER all tool calls are done, for the final result or if blocked.
+Everything else above (your role, expertise, constraints, response structure) still applies.`
+
+// nativeToolSystemPrompt builds the system prompt for native tool calling
+// mode. The specialist prompt (built-in agent role or custom persona) is
+// PRESERVED — discarding it made every worker a generic coder — with a
+// trailing override that retires the XML syntax instructions it may carry.
+// Workers without a specialist prompt get the generic charter.
+func nativeToolSystemPrompt(config WorkerReActConfig) string {
+	specialist := strings.TrimSpace(config.SystemPrompt)
+	if specialist == "" {
+		return nativeToolCoreRules + "\n\n" + workerContextGuidance
+	}
+	return specialist + "\n\n" + nativeModeOverride + "\n\n" + workerContextGuidance
 }
 
 // buildReflectionPrompt constructs reflection guidance based on failure severity.

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -2933,9 +2933,16 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 						agent.ColorGray)
 				}
 
-				// Inject results as feedback for the orchestrator
+				// Inject results as feedback for the orchestrator. The
+				// AgentFeedback meta lets microcompact age this block like
+				// tool output — as a plain user message it was invisible to
+				// every reduction mechanism short of full compaction.
 				feedback := workers.FormatResults(agentResults)
-				a.cli.history = append(a.cli.history, models.Message{Role: "user", Content: feedback})
+				a.cli.history = append(a.cli.history, models.Message{
+					Role:    "user",
+					Content: feedback,
+					Meta:    &models.MessageMeta{AgentFeedback: true},
+				})
 
 				// If there are also tool_calls in the same response, skip them —
 				// the orchestrator should use agent_calls OR tool_calls, not both
@@ -3930,6 +3937,14 @@ func (a *AgentMode) initMultiAgent(ctx context.Context) bool {
 	// the user switched providers at runtime.
 	if a.agentRegistry != nil {
 		a.parallelMode = true
+		// Re-sync session-scoped policy state: unattended and automode may
+		// have changed since the registry was first built (this branch used
+		// to freeze the boot-time values for the whole process lifetime).
+		if a.policyAdapter != nil {
+			a.policyAdapter.unattended = a.cli.unattended
+			a.policyAdapter.autoApprove = a.askAutoApproved
+		}
+		workers.RegisterWorkerContextProvider(a.followUpRecallBlocks)
 		if a.agentDispatcher != nil {
 			provider := a.cli.Provider
 			if provider == "" {
@@ -4004,12 +4019,18 @@ func (a *AgentMode) initMultiAgent(ctx context.Context) bool {
 	// Attach policy enforcement so parallel workers respect security rules
 	if pa, err := newWorkerPolicyAdapter(a.logger); err == nil {
 		pa.unattended = a.cli.unattended // gateway: auto-approve "ask" instead of blocking on stdin
+		pa.autoApprove = a.askAutoApproved
 		a.policyAdapter = pa
 		a.agentDispatcher.SetPolicyChecker(pa)
 		a.logger.Info("Policy enforcement enabled for parallel workers")
 	} else {
 		a.logger.Warn("Failed to initialize policy checker for parallel workers", zap.Error(err))
 	}
+
+	// Proactive recall for workers: each dispatched task gets the same
+	// [MEMORY AUTO-RECALL] / [SESSION RECALL] surfaces the orchestrator's
+	// system prompt carries, keyed off the task text.
+	workers.RegisterWorkerContextProvider(a.followUpRecallBlocks)
 
 	// Attach the seven-pattern quality pipeline (Self-Refine, CoVe,
 	// Reflexion, …). Pipeline starts with the hooks selected by the

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -819,6 +819,14 @@ func NewChatCLI(ctx context.Context, manager manager.LLMManager, logger *zap.Log
 		out, _ := cli.compressionLayer.CompressToolOutput(toolName, output)
 		return out
 	})
+	// The reverse direction: workers get a recall tool over the same store,
+	// so compression is no longer a one-way door inside a worker's loop.
+	workers.RegisterCCRRecaller(cli.compressionLayer.Recall)
+	// Worker-loop microcompact archives dropped bytes into the same store.
+	workers.RegisterSquadCompressionLayer(cli.compressionLayer)
+	// Read-only memory/session/knowledge views for workers that opt in
+	// (persona frontmatter tools: Memory, Session, Knowledge).
+	workers.RegisterContextToolRunner(cli.runWorkerContextTool)
 
 	// Wire the @knowledge tool to this session's context manager so the agent
 	// can interrogate attached knowledge bases on demand.

--- a/cli/coder/policy_worker_envelope_test.go
+++ b/cli/coder/policy_worker_envelope_test.go
@@ -1,0 +1,48 @@
+package coder
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// Workers canonicalize native tool calls to the "@coder" +
+// {"cmd":subcmd,"args":{...}} envelope before the policy check (see
+// workers.policyCallSurface). These tests pin the contract: rules written
+// against "@coder <subcmd>" must match that surface.
+func TestCheck_WorkerCanonicalEnvelopeMatchesRules(t *testing.T) {
+	pm := &PolicyManager{
+		Rules: []Rule{
+			{Pattern: "@coder read", Action: ActionAllow},
+			{Pattern: "@coder exec", Action: ActionAsk},
+			{Pattern: "@coder write --file /etc", Action: ActionDeny},
+		},
+		configPath: t.TempDir() + "/policy.json",
+		logger:     zap.NewNop(),
+	}
+
+	if got := pm.Check("@coder", `{"cmd":"read","args":{"file":"main.go"}}`); got != ActionAllow {
+		t.Errorf("read envelope = %v, want allow", got)
+	}
+	if got := pm.Check("@coder", `{"cmd":"exec","args":{"cmd":"go build ./..."}}`); got != ActionAsk {
+		t.Errorf("exec envelope = %v, want ask (explicit rule)", got)
+	}
+	if got := pm.Check("@coder", `{"cmd":"write","args":{"file":"/etc/passwd","content":"x"}}`); got != ActionDeny {
+		t.Errorf("write /etc envelope = %v, want deny", got)
+	}
+}
+
+// The pre-fix surface — toolName "run_command" with the shell command in
+// args["cmd"] — never matched "@coder ..." rules; the worker adapter no
+// longer produces it, but the mismatch is pinned here as documentation of
+// why the canonicalization exists.
+func TestCheck_LegacyNativeSurfaceNeverMatchedCoderRules(t *testing.T) {
+	pm := &PolicyManager{
+		Rules:      []Rule{{Pattern: "@coder exec", Action: ActionAllow}},
+		configPath: t.TempDir() + "/policy.json",
+		logger:     zap.NewNop(),
+	}
+	if got := pm.Check("run_command", `{"cmd":"go build ./..."}`); got != ActionAsk {
+		t.Errorf("legacy surface = %v, want ask (rule cannot match)", got)
+	}
+}

--- a/cli/history_compactor.go
+++ b/cli/history_compactor.go
@@ -386,12 +386,23 @@ func (hc *HistoryCompactor) structuredSummarize(
 		return nil, fmt.Errorf("structured summarization LLM call failed: %w", err)
 	}
 
+	// Archive the FULL middle segment (untruncated, unlike the summarizer
+	// input above) before replacing it: level 1 (trim) and level 3
+	// (emergency) already preserve what they drop via CCR, and this was the
+	// pipeline's only irreversible cut. Best-effort — a disabled layer or an
+	// over-cap segment keeps the legacy lossy behavior.
+	recallNote := ""
+	if key, ok := hc.compress.Archive(renderMessagesForArchive(middleMessages)); ok {
+		recallNote = "\n\n[full transcript of the summarized segment recoverable via @recall " +
+			compress.FormatMarker(key) + "]"
+	}
+
 	// Reconstruct: system + summary message + recent messages
 	result := make([]models.Message, 0, systemEnd+1+cfg.MinKeepRecent)
 	result = append(result, history[:systemEnd]...)
 	result = append(result, models.Message{
 		Role:    "user",
-		Content: fmt.Sprintf("[STRUCTURED SUMMARY — covering %d earlier messages]\n\n%s", len(middleMessages), response),
+		Content: fmt.Sprintf("[STRUCTURED SUMMARY — covering %d earlier messages]\n\n%s%s", len(middleMessages), response, recallNote),
 		Meta: &models.MessageMeta{
 			IsSummary: true,
 			SummaryOf: len(middleMessages),
@@ -400,6 +411,20 @@ func (hc *HistoryCompactor) structuredSummarize(
 	result = append(result, history[recentStart:]...)
 
 	return result, nil
+}
+
+// renderMessagesForArchive renders a message segment for verbatim CCR
+// archival: role-tagged, full content, no truncation.
+func renderMessagesForArchive(msgs []models.Message) string {
+	var sb strings.Builder
+	for _, msg := range msgs {
+		sb.WriteString("[")
+		sb.WriteString(msg.Role)
+		sb.WriteString("]: ")
+		sb.WriteString(msg.Content)
+		sb.WriteString("\n\n")
+	}
+	return sb.String()
 }
 
 // snapToToolBlockBoundary moves a keep-recent cut point so it never splits an

--- a/cli/history_compactor_archive_test.go
+++ b/cli/history_compactor_archive_test.go
@@ -1,0 +1,96 @@
+/*
+ * ChatCLI - structuredSummarize CCR archival tests.
+ * Copyright (c) 2024 Edilson Freitas. License: Apache-2.0.
+ */
+
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/cli/compress"
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+// summarizerFake implements client.LLMClient and returns a canned summary.
+type summarizerFake struct{}
+
+func (summarizerFake) GetModelName() string { return "fake" }
+func (summarizerFake) SendPrompt(_ context.Context, _ string, _ []models.Message, _ int) (string, error) {
+	return "## Files Read\n- none", nil
+}
+
+func summarizeFixtureHistory(minKeepRecent int) []models.Message {
+	h := []models.Message{{Role: "system", Content: "charter"}}
+	// Middle block: 6 messages that will be summarized away.
+	for i := 0; i < 3; i++ {
+		h = append(h,
+			models.Message{Role: "user", Content: strings.Repeat("question detail ", 50)},
+			models.Message{Role: "assistant", Content: strings.Repeat("answer detail ", 50)},
+		)
+	}
+	for i := 0; i < minKeepRecent; i++ {
+		h = append(h, models.Message{Role: "user", Content: "recent"})
+	}
+	return h
+}
+
+func TestStructuredSummarize_ArchivesMiddleSegment(t *testing.T) {
+	layer := compress.NewLayer(compress.Config{Mode: compress.ModeLossyWithCCR, Store: compress.NewMemoryStore()})
+	hc := NewHistoryCompactor(zap.NewNop())
+	hc.SetCompressionLayer(layer)
+
+	cfg := CompactConfig{MinKeepRecent: 2}
+	history := summarizeFixtureHistory(cfg.MinKeepRecent)
+
+	got, err := hc.structuredSummarize(context.Background(), history, summarizerFake{}, cfg)
+	if err != nil {
+		t.Fatalf("structuredSummarize: %v", err)
+	}
+
+	var summary *models.Message
+	for i := range got {
+		if got[i].Meta != nil && got[i].Meta.IsSummary {
+			summary = &got[i]
+			break
+		}
+	}
+	if summary == nil {
+		t.Fatal("no summary message produced")
+	}
+
+	keys := compress.ExtractKeys(summary.Content)
+	if len(keys) != 1 {
+		t.Fatalf("summary must carry exactly one recall marker, got %d in %q", len(keys), summary.Content)
+	}
+	recovered, ok := layer.Recall(keys[0])
+	if !ok {
+		t.Fatal("archived segment not recoverable")
+	}
+	// The archive must carry the FULL middle segment, role-tagged.
+	if !strings.Contains(recovered, "question detail") || !strings.Contains(recovered, "[assistant]:") {
+		t.Errorf("archived segment incomplete: %q", recovered[:min(200, len(recovered))])
+	}
+}
+
+func TestStructuredSummarize_NoLayerKeepsLegacyBehavior(t *testing.T) {
+	hc := NewHistoryCompactor(zap.NewNop())
+	cfg := CompactConfig{MinKeepRecent: 2}
+
+	got, err := hc.structuredSummarize(context.Background(), summarizeFixtureHistory(cfg.MinKeepRecent), summarizerFake{}, cfg)
+	if err != nil {
+		t.Fatalf("structuredSummarize: %v", err)
+	}
+	for _, msg := range got {
+		if msg.Meta != nil && msg.Meta.IsSummary {
+			if compress.ExtractKeys(msg.Content) != nil {
+				t.Error("without a compression layer the summary must not carry markers")
+			}
+			return
+		}
+	}
+	t.Fatal("no summary message produced")
+}

--- a/cli/policy_adapter.go
+++ b/cli/policy_adapter.go
@@ -39,6 +39,13 @@ type workerPolicyAdapter struct {
 	// access is gated at the messaging edge). ActionDeny still blocks.
 	unattended bool
 
+	// autoApprove, when set, is consulted on an "ask" verdict before any
+	// interactive prompt: it reports whether the session's /policy automode
+	// admits this call (safety-immune operations excluded — see
+	// AgentMode.askAutoApproved). Without it, automode only reached the
+	// orchestrator's own tool calls and workers kept prompting on stdin.
+	autoApprove func(toolName, args string) bool
+
 	// restoreInput, when set, runs after each interactive prompt so the
 	// agent loop can re-arm its cbreak type-ahead TTY state (the prompt
 	// forces cooked mode to render/read cleanly).
@@ -125,6 +132,13 @@ func (a *workerPolicyAdapter) CheckAndPrompt(ctx context.Context, toolName, args
 			// Gateway: no human to answer; blocking on stdin would hang the
 			// worker silently. Auto-approve (see field doc).
 			a.logger.Info("Worker tool call auto-approved (unattended gateway)",
+				zap.String("tool", toolName))
+			return true, ""
+		}
+		if a.autoApprove != nil && a.autoApprove(toolName, args) {
+			// Session automode (/policy mode auto): same convenience the
+			// orchestrator's loop gets, with the same safety-immunity carve-out.
+			a.logger.Info("Worker tool call auto-approved (policy automode)",
 				zap.String("tool", toolName))
 			return true, ""
 		}

--- a/cli/worker_context_tools.go
+++ b/cli/worker_context_tools.go
@@ -20,7 +20,14 @@ import (
 // process-global), but exposes ONLY their read verbs: the envelope is built
 // here from a fixed cmd per tool, so a worker can never reach save/fork/
 // attach/remember/forget through this surface.
-func (cli *ChatCLI) runWorkerContextTool(ctx context.Context, tool string, args map[string]interface{}) (string, error) {
+func (cli *ChatCLI) runWorkerContextTool(ctx context.Context, tool string, argsJSON string) (string, error) {
+	var args map[string]interface{}
+	if argsJSON != "" {
+		// Lenient on purpose: a malformed args object degrades to the empty
+		// set and the plugin's own parser reports what is actually required.
+		_ = json.Unmarshal([]byte(argsJSON), &args)
+	}
+
 	envelope := func(cmd string, inner map[string]interface{}) (string, error) {
 		payload := map[string]interface{}{"cmd": cmd}
 		if len(inner) > 0 {

--- a/cli/worker_context_tools.go
+++ b/cli/worker_context_tools.go
@@ -1,0 +1,86 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/diillson/chatcli/cli/agent/workers"
+	"github.com/diillson/chatcli/cli/plugins"
+)
+
+// runWorkerContextTool executes one read-only context tool call on behalf of
+// a squad worker/subagent. It reuses the same builtin plugins the
+// orchestrator's @memory/@session/@knowledge tools run on (adapters are
+// process-global), but exposes ONLY their read verbs: the envelope is built
+// here from a fixed cmd per tool, so a worker can never reach save/fork/
+// attach/remember/forget through this surface.
+func (cli *ChatCLI) runWorkerContextTool(ctx context.Context, tool string, args map[string]interface{}) (string, error) {
+	envelope := func(cmd string, inner map[string]interface{}) (string, error) {
+		payload := map[string]interface{}{"cmd": cmd}
+		if len(inner) > 0 {
+			payload["args"] = inner
+		}
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return "", err
+		}
+		return string(data), nil
+	}
+
+	// pick copies only the whitelisted keys — lenient on missing/mistyped
+	// values (the plugin's own parser reports what is actually required).
+	pick := func(keys ...string) map[string]interface{} {
+		inner := make(map[string]interface{}, len(keys))
+		for _, k := range keys {
+			if v, ok := args[k]; ok && v != nil {
+				inner[k] = v
+			}
+		}
+		return inner
+	}
+
+	switch tool {
+	case workers.ContextToolMemoryRecall:
+		env, err := envelope("recall", pick("query"))
+		if err != nil {
+			return "", err
+		}
+		return plugins.NewBuiltinMemoryPlugin().Execute(ctx, []string{env})
+
+	case workers.ContextToolSessionSearch:
+		env, err := envelope("search", pick("query", "limit"))
+		if err != nil {
+			return "", err
+		}
+		return plugins.NewBuiltinSessionPlugin().Execute(ctx, []string{env})
+
+	case workers.ContextToolSessionGet:
+		env, err := envelope("get", pick("name", "offset", "limit", "query", "message"))
+		if err != nil {
+			return "", err
+		}
+		return plugins.NewBuiltinSessionPlugin().Execute(ctx, []string{env})
+
+	case workers.ContextToolKnowledgeSearch:
+		env, err := envelope("search", pick("query", "top_k", "kb"))
+		if err != nil {
+			return "", err
+		}
+		return plugins.NewBuiltinKnowledgePlugin().Execute(ctx, []string{env})
+
+	case workers.ContextToolKnowledgeGet:
+		env, err := envelope("get", pick("source", "offset", "kb"))
+		if err != nil {
+			return "", err
+		}
+		return plugins.NewBuiltinKnowledgePlugin().Execute(ctx, []string{env})
+	}
+
+	return "", fmt.Errorf("unknown worker context tool %q", tool)
+}

--- a/cli/workspace/memory/episodes_extraction_test.go
+++ b/cli/workspace/memory/episodes_extraction_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestProcessExtractionResult_Episodes(t *testing.T) {
 	m := NewManager(t.TempDir(), DefaultConfig(), zap.NewNop())
+	t.Cleanup(m.WaitGraphPersist)
 	m.SetWorkspaceDir("/home/u/chatcli")
 
 	sum := m.ProcessExtractionResult(`## DAILY
@@ -62,6 +63,7 @@ func TestProcessExtractionResult_Episodes(t *testing.T) {
 
 func TestProcessExtractionResult_EpisodesNothingNew(t *testing.T) {
 	m := NewManager(t.TempDir(), DefaultConfig(), zap.NewNop())
+	t.Cleanup(m.WaitGraphPersist)
 	sum := m.ProcessExtractionResult("## EPISODES\nNOTHING_NEW\n")
 	if sum.EpisodesAdded != 0 {
 		t.Errorf("NOTHING_NEW section must add nothing, got %d", sum.EpisodesAdded)
@@ -73,6 +75,7 @@ func TestProcessExtractionResult_EpisodesNothingNew(t *testing.T) {
 
 func TestGetMemoryIndex_IncludesEpisodes(t *testing.T) {
 	m := NewManager(t.TempDir(), DefaultConfig(), zap.NewNop())
+	t.Cleanup(m.WaitGraphPersist)
 	m.Episodes.Add(Episode{Date: time.Now(), Summary: "Shipped the exporter"})
 
 	idx := m.GetMemoryIndex(600)
@@ -83,6 +86,7 @@ func TestGetMemoryIndex_IncludesEpisodes(t *testing.T) {
 
 func TestRetriever_RecentEpisodesSection(t *testing.T) {
 	m := NewManager(t.TempDir(), DefaultConfig(), zap.NewNop())
+	t.Cleanup(m.WaitGraphPersist)
 	m.Episodes.Add(Episode{Date: time.Now().Add(-24 * time.Hour), Summary: "Hardened the parser", Outcome: "merged"})
 
 	out := m.GetMemoryContext()

--- a/cli/workspace/memory/graph_cache_test.go
+++ b/cli/workspace/memory/graph_cache_test.go
@@ -271,6 +271,7 @@ func TestGraphCache_StatsNeverBuilds(t *testing.T) {
 
 func TestDirtyTaps_ContentMutationsMark(t *testing.T) {
 	mgr := NewManager(t.TempDir(), DefaultConfig(), zap.NewNop())
+	t.Cleanup(mgr.WaitGraphPersist)
 	// Wire a counting builder so we can observe dirtiness through Snapshot.
 	var builds atomic.Int32
 	mgr.SetGraphSource(func() *knowledge.Graph {

--- a/cli/workspace/memory/index_test.go
+++ b/cli/workspace/memory/index_test.go
@@ -15,6 +15,7 @@ import (
 func seedManager(t *testing.T) *Manager {
 	t.Helper()
 	mgr := NewManager(t.TempDir(), DefaultConfig(), testLogger())
+	t.Cleanup(mgr.WaitGraphPersist)
 	mgr.ProcessExtraction(`## LONGTERM
 - ChatCLI uses Go with a plugin system
 - embed.FS needs '/' separators on Windows
@@ -74,6 +75,7 @@ func TestGetMemoryIndex_BudgetCap(t *testing.T) {
 
 func TestGetMemoryIndex_EmptyMemory(t *testing.T) {
 	mgr := NewManager(t.TempDir(), DefaultConfig(), testLogger())
+	t.Cleanup(mgr.WaitGraphPersist)
 	if idx := mgr.GetMemoryIndex(0); idx != "" {
 		t.Errorf("empty memory should yield empty index, got %q", idx)
 	}

--- a/cli/workspace/memory/removal_hooks_test.go
+++ b/cli/workspace/memory/removal_hooks_test.go
@@ -67,6 +67,7 @@ func TestSetOnRemovedLegacyDelegateStillWorks(t *testing.T) {
 
 func TestAttachVectorIndexNilPreservesGraphHook(t *testing.T) {
 	mgr := NewManager(t.TempDir(), DefaultConfig(), zap.NewNop())
+	t.Cleanup(mgr.WaitGraphPersist)
 	var graph int
 	mgr.Facts.SetRemovalHook("graph", func([]string) { graph++ })
 

--- a/cli/workspace/memory/retriever_graph_test.go
+++ b/cli/workspace/memory/retriever_graph_test.go
@@ -23,6 +23,7 @@ func (s staticGraphSource) Snapshot() *knowledge.Graph { return s.g }
 func graphFixture(t *testing.T) (*Manager, string, string) {
 	t.Helper()
 	mgr := NewManager(t.TempDir(), DefaultConfig(), zap.NewNop())
+	t.Cleanup(mgr.WaitGraphPersist)
 	mgr.Facts.AddFact("the gateway daemon auto-approves tool calls", "architecture", nil)
 	mgr.Facts.AddFact("bedrock payload cap is learned from rejections", "gotcha", nil)
 
@@ -58,6 +59,7 @@ func graphFixture(t *testing.T) (*Manager, string, string) {
 
 func TestRelatedGraphSection_NilGraphAbsent(t *testing.T) {
 	mgr := NewManager(t.TempDir(), DefaultConfig(), zap.NewNop())
+	t.Cleanup(mgr.WaitGraphPersist)
 	mgr.Facts.AddFact("some fact", "general", nil)
 	mgr.retriever.SetGraph(nil)
 	out := mgr.GetRelevantContext([]string{"some"})

--- a/cli/workspace/memory/rollup_episodes_test.go
+++ b/cli/workspace/memory/rollup_episodes_test.go
@@ -112,6 +112,7 @@ func TestRollup_NilEpisodesKeepsLegacyBehavior(t *testing.T) {
 
 func TestManager_RollupsWiredToEpisodes(t *testing.T) {
 	m := NewManager(t.TempDir(), DefaultConfig(), zap.NewNop())
+	t.Cleanup(m.WaitGraphPersist)
 	monday := pastMonday(5)
 	m.Episodes.Add(Episode{Date: monday, Summary: "Wired the rollup pipeline"})
 

--- a/models/models.go
+++ b/models/models.go
@@ -20,6 +20,14 @@ type MessageMeta struct {
 	// format. See cli.MessageTrimmer.trimMessage.
 	PreserveVerbatim bool `json:"preserve_verbatim,omitempty"`
 
+	// AgentFeedback marks a user-role message that carries aggregated squad
+	// worker results (workers.FormatResults). These are tool output in user
+	// clothing — up to MaxWorkers × 30KB in one message — and the flag lets
+	// agent.ApplyMicrocompact age them like regular tool results instead of
+	// treating them as untouchable user text. Structural on purpose: the
+	// flag survives compaction rewrites, park snapshots and session saves.
+	AgentFeedback bool `json:"agent_feedback,omitempty"`
+
 	// SkillNames marks a mid-loop skill injection block (agent/coder mode)
 	// and records which skills it carries, comma-separated. Identification
 	// is structural on purpose: compaction may rewrite the content, but

--- a/pkg/persona/types.go
+++ b/pkg/persona/types.go
@@ -61,7 +61,7 @@ type Agent struct {
 	Description string     `json:"description" yaml:"description"`
 	Skills      StringList `json:"skills" yaml:"skills"`   // Usando StringList para robustez
 	Plugins     StringList `json:"plugins" yaml:"plugins"` // Usando StringList para robustez
-	Tools       StringList `json:"tools" yaml:"tools"`     // Allowed tools for worker mode (Read, Grep, Glob, Bash, Write, Edit)
+	Tools       StringList `json:"tools" yaml:"tools"`     // Allowed tools for worker mode (Read, Grep, Glob, Bash, Write, Edit, Agent, Memory, Session, Knowledge; case-insensitive, aliases and Bash(...) specifiers accepted)
 
 	// Per-agent LLM preferences (Fase: multi-agent parity with skills).
 	// Model declares the ideal model id for when this agent runs as a


### PR DESCRIPTION
## Summary

Squad workers ran blind to every context surface the orchestrator (and the human) has: no recall over compressed output, irreversible 30 KB cuts, no memory/session/knowledge access, specialist prompts discarded in native mode, and a policy mismatch that degraded every worker exec to an interactive ask. This PR closes the gap end to end, in four phases.

### Phase 1 — unblock exec on custom personas
- Tolerant frontmatter tools parsing: case-insensitive, aliases (shell, patch, multiedit), Claude Code argument specifiers. Unknown tokens and silent read-only degradation now log explicit warnings at registration.
- Native worker tool calls are canonicalized to the coder policy envelope before the security check, so existing rules match again, safety immunity sees the real surface, and suggested patterns persist correctly.
- Policy automode now reaches workers (safety-immune operations still prompt); unattended and automode state re-sync when the registry is reused.

### Phase 2 — recall and loss-free truncation
- Universal recall tool over the shared CCR store; worker, subagent and persona prompts teach reading overflow files and expanding compression markers.
- Oversized worker final outputs and text-mode feedback are persisted to overflow files with a recoverable reference instead of being cut.
- Squad feedback messages carry a structural flag so microcompact ages them like tool results.

### Phase 3 — navigate like a human
- Native tool mode preserves the specialist system prompt (including custom personas), appending an override that retires only the XML syntax.
- Personas can opt into read-only memory, session and knowledge tools via frontmatter; each worker gets proactive memory/session recall blocks derived from its task; workers run microcompact in their own loop.

### Phase 4 — close the last irreversible cut
- Structured history compaction archives the summarized middle segment in the CCR store and links it from the summary.

### Follow-up fix
- multipatch was missing from the worker write-command classifier (a read-only worker granted it could write); MultiEdit now grants multipatch plus patch, matching the documented mapping.

## Intentional behavior changes
- In-process tools (squad mail, recall, read-only context tools) skip the policy check: they have no filesystem/shell/network side effects, and the ask fallback blocked them on prompts no rule pattern could whitelist.
- Worker security prompts now display the canonical @coder envelope (same as XML mode) instead of the raw native tool name.

## Testing
- Full suite green on both modules, including -race on the root module.
- New unit tests: frontmatter parsing tolerance, policy envelope contract, recall/context tool execution, overflow persistence, microcompact aging of squad feedback, compactor archival.
- Local quality floors: build/vet/gofmt/golangci-lint (diff) clean, patch coverage 66% (threshold 60), cyclo, apidiff, i18n parity, license headers and commit lint all passing.

Docs updated on the docs site (customizable-agents, multi-agent-orchestration, subagent-delegation — en and pt).