### PR TITLE
chore(deps): bump Go toolchain and builder images to 1.26.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # License: MIT
 
 # --- Build stage ---
-FROM golang:1.26.5-alpine AS builder
+FROM golang:1.26.6-alpine AS builder
 
 RUN apk add --no-cache git ca-certificates
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/diillson/chatcli
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.43.4

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -2,7 +2,7 @@
 # Must be built from the repo root: docker build -f operator/Dockerfile .
 # This is required because go.mod uses: replace github.com/diillson/chatcli => ../
 
-FROM golang:1.26.5 AS builder
+FROM golang:1.26.6 AS builder
 
 WORKDIR /workspace
 

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/diillson/chatcli/operator
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/diillson/chatcli v0.0.0


### PR DESCRIPTION
Go 1.26.6 ships the fixes for the stdlib advisories published this week — net/url (GO-2026-6218), html/template (GO-2026-6091), crypto/tls (GO-2026-6090), net/http (GO-2026-6089), encoding/xml (GO-2026-6088), encoding/asn1 (GO-2026-5972) — plus the x/net idna issue (GO-2026-5026 / CVE-2026-39821).

These are what currently fail the security-scan companion workflow (Go Vulnerability Check and both Trivy image gates) on any fresh run, including PR #1335 — the last green scheduled run on main predates the advisories (Aug 10).

Changes, moved together:
- go directive in both modules: 1.26.5 to 1.26.6 (go mod tidy run on both)
- builder images: golang:1.26.6-alpine (ChatCLI) and golang:1.26.6 (operator) — tags verified on Docker Hub
- grpc-health-probe is built from source with the same builder, so it picks up the fixed standard library too

Full test suites pass on both modules with the new toolchain.