### PR TITLE
fix(agents): stop the loose-code guard from swallowing valid agent_call dispatches

### DIFF
--- a/cli/agent/workers/parser_test.go
+++ b/cli/agent/workers/parser_test.go
@@ -1,6 +1,7 @@
 package workers
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -163,5 +164,64 @@ func TestParseAgentCalls_UniqueIDs(t *testing.T) {
 			t.Fatalf("duplicate ID: %s", c.ID)
 		}
 		ids[c.ID] = true
+	}
+}
+
+// TestParseAgentCalls_MultilineCodePayload reproduces the field failure
+// shape: several self-closing agent_call tags whose task attributes embed
+// multiline source code — Python comparison operators (< / >), arrow
+// returns, hash-comment lines at column zero, f-strings and single quotes.
+// All calls must parse with their tasks intact.
+func TestParseAgentCalls_MultilineCodePayload(t *testing.T) {
+	text := `<agent_call agent="coder" task="Crie os arquivos em /tmp/api.
+
+ARQUIVO app/database.py - conteudo:
+async def get_db() -> AsyncSession:
+    async with AsyncSessionLocal() as session:
+        yield session
+
+ARQUIVO app/models/user.py - conteudo:
+class User(Base):
+    email: Mapped[str] = mapped_column(String(255), unique=True)" />
+
+<agent_call agent="coder" task="Crie os arquivos em /tmp/api.
+
+ARQUIVO app/core/init.py - conteudo:
+
+# core
+ARQUIVO app/routers/products.py - conteudo:
+if product.stock < data.quantity:
+    raise HTTPException(status_code=400)
+filters.append(Product.price >= min_price)
+filters.append(Product.name.ilike(f'%{search}%'))" />
+
+<agent_call agent="coder" task="ARQUIVO pytest.ini - conteudo:
+[pytest]
+asyncio_mode = auto
+python_functions = test_*" />`
+
+	calls, err := ParseAgentCalls(text)
+	if err != nil {
+		t.Fatalf("ParseAgentCalls: %v", err)
+	}
+	if len(calls) != 3 {
+		t.Fatalf("parsed %d calls, want 3", len(calls))
+	}
+	if got := CountAgentCallTags(text); got != 3 {
+		t.Fatalf("CountAgentCallTags = %d, want 3", got)
+	}
+	for i, c := range calls {
+		if c.Agent != "coder" {
+			t.Errorf("call %d agent = %q", i, c.Agent)
+		}
+	}
+	if !strings.Contains(calls[0].Task, "-> AsyncSession") {
+		t.Errorf("call 0 task lost the arrow-return content: %q", calls[0].Task)
+	}
+	if !strings.Contains(calls[1].Task, "# core") || !strings.Contains(calls[1].Task, "stock < data.quantity") {
+		t.Errorf("call 1 task lost hash-comment or comparison content")
+	}
+	if !strings.Contains(calls[2].Task, "python_functions = test_*") {
+		t.Errorf("call 2 task truncated: %q", calls[2].Task)
 	}
 }

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -2737,7 +2737,7 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 
 			// Prohibit loose code blocks in coder mode
 			if len(toolCalls) == 0 {
-				if strings.Contains(aiResponse, "```") || strings.Contains(aiResponse, "```execute:") || regexp.MustCompile(`(?m)^[$#]\s+`).MatchString(aiResponse) {
+				if looksLikeLooseCode(aiResponse) {
 					a.cli.history = append(a.cli.history, models.Message{
 						Role: "user",
 						Content: "FORMAT ERROR: Code blocks and shell commands are NOT allowed in /coder mode. " +

--- a/cli/coder_format_guard.go
+++ b/cli/coder_format_guard.go
@@ -1,0 +1,37 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/diillson/chatcli/cli/agent/workers"
+)
+
+// shellPromptLineRe matches a line that starts with a shell prompt marker
+// ("$ cmd" / "# cmd") — the signature of the model dumping raw shell
+// commands instead of emitting tool calls.
+var shellPromptLineRe = regexp.MustCompile(`(?m)^[$#]\s+`)
+
+// looksLikeLooseCode reports whether a coder-mode response that carried no
+// tool calls is dumping raw code blocks or shell commands instead of using
+// the tool-call protocol.
+//
+// Responses carrying <agent_call> tags are exempt: their task attributes
+// legitimately embed code — Python comments start lines with "# ", markdown
+// fences appear in instructions — and the squad dispatch block is the
+// intended consumer of that text. Flagging them here used to reject the
+// whole response with a FORMAT ERROR before the dispatch ever ran, silently
+// dropping valid dispatches and steering the model away from the squad flow
+// (the corrective message says "use <tool_call>"). Malformed agent_call tags
+// remain covered by the dispatch block's own CountAgentCallTags feedback.
+func looksLikeLooseCode(aiResponse string) bool {
+	if workers.CountAgentCallTags(aiResponse) > 0 {
+		return false
+	}
+	return strings.Contains(aiResponse, "```") || shellPromptLineRe.MatchString(aiResponse)
+}

--- a/cli/coder_format_guard_test.go
+++ b/cli/coder_format_guard_test.go
@@ -1,0 +1,53 @@
+/*
+ * ChatCLI - coder format guard tests.
+ * Copyright (c) 2024 Edilson Freitas. License: Apache-2.0.
+ */
+
+package cli
+
+import "testing"
+
+func TestLooksLikeLooseCode_AgentCallWithHashLinesExempt(t *testing.T) {
+	// Real-world shape: squad dispatch whose task embeds Python file contents,
+	// including comment lines starting with "# " at column zero. The old
+	// inline guard matched ^[$#]\s+ against the whole response and rejected
+	// the dispatch with a FORMAT ERROR before it was ever parsed.
+	resp := `<agent_call agent="coder" task="Crie os arquivos abaixo.
+
+ARQUIVO app/core/init.py - conteudo:
+
+# core
+ARQUIVO app/services/init.py - conteudo:
+
+# services" />`
+	if looksLikeLooseCode(resp) {
+		t.Fatal("agent_call payload with hash-comment lines must not be flagged as loose code")
+	}
+}
+
+func TestLooksLikeLooseCode_AgentCallWithFenceExempt(t *testing.T) {
+	resp := "<agent_call agent=\"coder\" task=\"Documente com:\n```go\nfunc main() {}\n```\" />"
+	if looksLikeLooseCode(resp) {
+		t.Fatal("agent_call payload with a markdown fence must not be flagged as loose code")
+	}
+}
+
+func TestLooksLikeLooseCode_PlainFenceFlagged(t *testing.T) {
+	resp := "Here is the file:\n```go\npackage main\n```"
+	if !looksLikeLooseCode(resp) {
+		t.Fatal("bare markdown fence without tool or agent calls must be flagged")
+	}
+}
+
+func TestLooksLikeLooseCode_ShellPromptFlagged(t *testing.T) {
+	resp := "Run this:\n$ go build ./...\nthen check the output"
+	if !looksLikeLooseCode(resp) {
+		t.Fatal("shell-prompt line without tool or agent calls must be flagged")
+	}
+}
+
+func TestLooksLikeLooseCode_PlainProseClean(t *testing.T) {
+	if looksLikeLooseCode("All files created successfully. The API is ready.") {
+		t.Fatal("plain prose must not be flagged")
+	}
+}

--- a/cli/config_sections_test.go
+++ b/cli/config_sections_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"path/filepath"
+
 	"github.com/diillson/chatcli/i18n"
 	"go.uber.org/zap"
 )
@@ -17,8 +19,25 @@ import (
 func TestMain(m *testing.M) {
 	// Force English for stable, locale-independent test assertions.
 	_ = os.Setenv("CHATCLI_LANG", "en")
+
+	// Hermetic work board: surfaces like the knowledge graph and the memory
+	// bootstrap card read the process-wide board store, whose Default()
+	// latches its path (the developer's real ~/.chatcli/board.json) on first
+	// use. Without this redirect, tests asserting on graph/board contents
+	// pass or fail depending on whatever cards the developer's live board
+	// happens to hold. Must run before any test touches the store — the
+	// latch is a sync.Once.
+	boardDir, boardDirErr := os.MkdirTemp("", "chatcli-test-board-*")
+	if boardDirErr == nil {
+		_ = os.Setenv("CHATCLI_BOARD_PATH", filepath.Join(boardDir, "board.json"))
+	}
+
 	i18n.Init()
-	os.Exit(m.Run())
+	code := m.Run()
+	if boardDirErr == nil {
+		_ = os.RemoveAll(boardDir)
+	}
+	os.Exit(code)
 }
 
 // captureStdout swaps os.Stdout for a pipe, runs fn, and returns the


### PR DESCRIPTION
## Symptom

In coder mode with the squad enabled, the orchestrator emits valid <agent_call> tags but they are never captured or dispatched — the response is silently discarded and the model drifts into doing the work itself.

## Root cause

The coder-mode loose-code guard runs BEFORE the agent_call dispatch block (which is labeled priority 0 but executes second). With no tool calls in the response, any markdown fence or any line starting with a hash/dollar marker rejects the whole response with a FORMAT ERROR and skips the turn. Agent_call task attributes legitimately embed source code — Python comment lines start with a hash at column zero, instructions can carry fences — so a pure-dispatch response was dropped before parsing, and the corrective FORMAT ERROR message actively steered the model away from the squad flow by demanding tool_call syntax.

The agent_call parser itself is innocent: a regression test in this PR feeds it multiline code-bearing task attributes (comparison operators, arrow returns, hash comments, f-strings) and all tags parse with content intact.

## Fix

- The guard moves to looksLikeLooseCode (precompiled pattern instead of a per-turn regexp compile) and exempts responses carrying agent_call tags; malformed tags remain covered by the dispatch block's CountAgentCallTags feedback loop.
- Parser regression test pinning the multiline code payload shape end to end.

## Also in this PR

Hermetic cli test binary: TestKnowledgeGraphEmptyWithoutStores failed on any machine whose real ~/.chatcli/board.json holds cards, because the knowledge-graph and bootstrap surfaces read the process-wide board store, which latches the real path on first use. TestMain now redirects CHATCLI_BOARD_PATH to a temp file before any test runs, so assertions no longer depend on the developer's live board.

## Testing

- New guard tests (agent_call with hash lines / fences exempt; bare fences and shell-prompt lines still flagged; plain prose clean) — the exempt cases fail against the old inline condition.
- Parser regression test with the field payload shape.
- Full cli and models suites green; golangci-lint diff clean.