### PR TITLE
chore(deps): ignore Go pre-release docker tags in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,11 @@ updates:
     labels:
       - "docker"
       - "dependencies"
+    ignore:
+      # Never bump build images to Go pre-release tags (rc/beta/alpha);
+      # stable releases are picked up automatically.
+      - dependency-name: "golang"
+        versions: ["*rc*", "*beta*", "*alpha*"]
 
   # Go module dependencies (operator — separate go.mod)
   - package-ecosystem: "gomod"
@@ -54,3 +59,8 @@ updates:
     labels:
       - "docker"
       - "dependencies"
+    ignore:
+      # Never bump build images to Go pre-release tags (rc/beta/alpha);
+      # stable releases are picked up automatically.
+      - dependency-name: "golang"
+        versions: ["*rc*", "*beta*", "*alpha*"]


### PR DESCRIPTION
## Summary

Dependabot opened #1340 and #1341 bumping the builder images to golang 1.27rc2 — a release candidate. We do not build production images on pre-release toolchains (we just stabilized on Go 1.26.6 in #1336 for the stdlib CVE), so both PRs were closed.

This PR adds an ignore rule to both docker update entries in dependabot.yml so rc, beta and alpha tags of the golang image are never proposed. Stable version bumps keep flowing normally, including the eventual Go 1.27.0.

## Changes
- .github/dependabot.yml: ignore golang docker tags matching rc, beta and alpha wildcards in the root and operator entries.