### PR TITLE
feat(models): refresh provider catalogs and add Bedrock Mantle-to-runtime fallback

### DIFF
--- a/cli/cost_tracker.go
+++ b/cli/cost_tracker.go
@@ -500,13 +500,17 @@ func claudePricing(model string) (float64, float64, bool) {
 // ("gpt-4o").
 func openAIPricing(model string) (float64, float64, bool) {
 	switch {
-	// gpt-5.6 (Jul 2026): preços de lista da API por tier. O caso genérico
-	// "gpt-5.6" cobre o alias de família (que o catálogo resolve para Sol)
-	// e precisa vir depois dos tiers específicos.
+	// gpt-5.6 (Jul 2026): preços de lista da API por tier, já refletindo
+	// os cortes de 30/Jul/2026 (terra −20%, luna −80%; Sol inalterado —
+	// developers.openai.com/docs/pricing). O caso genérico "gpt-5.6"
+	// cobre o alias de família (que o catálogo resolve para Sol) e
+	// precisa vir depois dos tiers específicos. O surcharge de
+	// long-context (>272K input = 2×/1,5×) não é modelado — cost_tracker
+	// trabalha com um único tier por modelo.
 	case strings.Contains(model, "gpt-5.6-terra"):
-		return 2.50, 15.0, true
+		return 2.0, 12.0, true
 	case strings.Contains(model, "gpt-5.6-luna"):
-		return 1.0, 6.0, true
+		return 0.20, 1.20, true
 	case strings.Contains(model, "gpt-5.6"):
 		return 5.0, 30.0, true
 	case strings.Contains(model, "gpt-4o-mini"):
@@ -533,12 +537,35 @@ func openAIPricing(model string) (float64, float64, bool) {
 	return 0, 0, false
 }
 
+// googlePricing cobre as gerações Gemini 3.x/2.x/1.5 (ai.google.dev
+// pricing, Aug 2026). Ordering: tags específicas antes das genéricas —
+// "gemini-3" (Pro/preview) por último no bloco 3.x porque é substring de
+// todos os ids 3.x; "gemini-2.5-flash-lite" antes de "gemini-2.5-flash".
+// 3.7/3.6-flash usam o preço introdutório vigente ($0.75/$3.75 até
+// 31/Dez/2026; dobra a partir de Jan/2027 — revisar na virada).
 func googlePricing(model string) (float64, float64, bool) {
 	switch {
+	case strings.Contains(model, "gemini-3.7-flash"), strings.Contains(model, "gemini-3.6-flash"):
+		return 0.75, 3.75, true
+	case strings.Contains(model, "gemini-3.5-flash-lite"):
+		return 0.30, 2.50, true
+	case strings.Contains(model, "gemini-3.5-flash"):
+		return 1.50, 9.0, true
+	case strings.Contains(model, "gemini-3.1-pro"):
+		return 2.0, 12.0, true
+	case strings.Contains(model, "gemini-3.1-flash-lite"):
+		return 0.25, 1.50, true
+	case strings.Contains(model, "gemini-3-flash"):
+		return 0.50, 3.0, true
+	case strings.Contains(model, "gemini-3"):
+		// gemini-3 / gemini-3-pro(-preview) — mesmo tier do 3.1 Pro.
+		return 2.0, 12.0, true
 	case strings.Contains(model, "gemini-2.5-pro"):
 		return 1.25, 10.0, true
+	case strings.Contains(model, "gemini-2.5-flash-lite"):
+		return 0.10, 0.40, true
 	case strings.Contains(model, "gemini-2.5-flash"):
-		return 0.15, 0.60, true
+		return 0.30, 2.50, true
 	case strings.Contains(model, "gemini-2.0"):
 		return 0.075, 0.30, true
 	case strings.Contains(model, "gemini-1.5-pro"):
@@ -549,8 +576,19 @@ func googlePricing(model string) (float64, float64, bool) {
 	return 0, 0, false
 }
 
+// grokPricing cobre a geração 2026 (docs.x.ai/docs/pricing, Aug 2026).
+// A xAI cobra por tier de prompt (<200K / ≥200K); cost_tracker modela um
+// único tier, então usamos o tier base (<200K) — consistente com o
+// tratamento de long-context da OpenAI acima. Específicos antes do
+// genérico "grok".
 func grokPricing(model string) (float64, float64, bool) {
 	switch {
+	case strings.Contains(model, "grok-4.6"), strings.Contains(model, "grok-4.5"):
+		return 2.0, 6.0, true
+	case strings.Contains(model, "grok-4.3"), strings.Contains(model, "grok-4.20"):
+		return 1.25, 2.50, true
+	case strings.Contains(model, "grok-build"):
+		return 1.0, 2.0, true
 	case strings.Contains(model, "grok-3"):
 		return 3.0, 15.0, true
 	case strings.Contains(model, "grok-2"):
@@ -570,14 +608,27 @@ func zaiPricing(model string) (float64, float64, bool) {
 	switch {
 	case strings.Contains(model, "glm-5.2"), strings.Contains(model, "glm-5-2"):
 		return 1.40, 4.40, true
+	case strings.Contains(model, "glm-5.1"), strings.Contains(model, "glm-5-1"):
+		// GLM-5.1: mesmo tier da 5.2 no pricing oficial (docs.z.ai).
+		return 1.40, 4.40, true
+	case strings.Contains(model, "glm-5-turbo"), strings.Contains(model, "glm-5v-turbo"):
+		return 1.20, 4.00, true
 	case strings.Contains(model, "glm-5"):
 		return 1.00, 3.20, true
 	}
 	return 0, 0, false
 }
 
+// deepseekPricing — geração V4 (api-docs.deepseek.com, Aug 2026). A
+// DeepSeek cobra peak/off-peak (off-peak = metade); cost_tracker usa o
+// preço de pico para não sub-reportar. V4 específicos antes dos legados.
 func deepseekPricing(model string) (float64, float64, bool) {
 	switch {
+	case strings.Contains(model, "deepseek-v4-pro"):
+		return 1.32, 3.96, true
+	case strings.Contains(model, "deepseek-v4"):
+		// deepseek-v4-flash e futuros ids v4 sem tier próprio.
+		return 0.44, 1.32, true
 	case strings.Contains(model, "deepseek-r1"):
 		return 0.55, 2.19, true
 	case strings.Contains(model, "deepseek"):
@@ -607,7 +658,13 @@ func providerFallbackPricing(provider, model string) (float64, float64) {
 		return 0.50, 0.50
 	case strings.HasPrefix(model, "kimi-k3"):
 		return 3.00, 15.00
+	case strings.HasPrefix(model, "kimi-k2.7-code-highspeed"):
+		// K2.7 Code highspeed (platform.kimi.ai pricing, Aug 2026): 2× o
+		// tier padrão K2.x — specific beats generic, senão o match "kimi"
+		// abaixo cobraria a metade.
+		return 1.90, 8.00
 	case strings.Contains(provider, "moonshot"), strings.HasPrefix(model, "kimi"), strings.HasPrefix(model, "moonshot"):
+		// Cobre também kimi-k2.7-code ($0.95/$4.00 — mesmo tier do K2.6).
 		return 0.95, 4.00
 	case strings.Contains(provider, "copilot"):
 		return 2.50, 10.0

--- a/cli/cost_tracker_pricing_test.go
+++ b/cli/cost_tracker_pricing_test.go
@@ -33,11 +33,12 @@ func TestGetModelPricing(t *testing.T) {
 		{"claude haiku legacy", "CLAUDEAI", "claude-3-haiku", 0.25, 1.25},
 
 		// OpenAI — specific before generic.
-		// gpt-5.6 tiers (Jul 2026 list prices): the specific terra/luna
-		// tags must win before the bare gpt-5.6 case, which covers the
-		// family alias that the catalog resolves to Sol.
-		{"gpt-5.6-terra before gpt-5.6", "OPENAI", "gpt-5.6-terra", 2.50, 15.0},
-		{"gpt-5.6-luna before gpt-5.6", "OPENAI", "gpt-5.6-luna", 1.0, 6.0},
+		// gpt-5.6 tiers (list prices after the Jul 30 2026 cuts: terra
+		// −20%, luna −80%): the specific terra/luna tags must win before
+		// the bare gpt-5.6 case, which covers the family alias that the
+		// catalog resolves to Sol.
+		{"gpt-5.6-terra before gpt-5.6", "OPENAI", "gpt-5.6-terra", 2.0, 12.0},
+		{"gpt-5.6-luna before gpt-5.6", "OPENAI", "gpt-5.6-luna", 0.20, 1.20},
 		{"gpt-5.6 generic is sol", "OPENAI", "gpt-5.6-sol", 5.0, 30.0},
 		{"gpt-5.6 bare alias", "OPENAI", "gpt-5.6", 5.0, 30.0},
 		{"gpt-4o-mini before gpt-4o", "OPENAI", "gpt-4o-mini", 0.15, 0.60},
@@ -52,19 +53,40 @@ func TestGetModelPricing(t *testing.T) {
 		{"o1-mini before o1", "OPENAI", "o1-mini", 3.0, 12.0},
 		{"o1", "OPENAI", "o1", 15.0, 60.0},
 
-		// Google
+		// Google — Gemini 3.x (ai.google.dev pricing, Aug 2026). The
+		// generic "gemini-3" (Pro) case is a substring of every 3.x id,
+		// so the specific tags must win first; same for the flash-lite
+		// vs flash pairs.
+		{"gemini 3.7 flash", "GOOGLEAI", "gemini-3.7-flash", 0.75, 3.75},
+		{"gemini 3.6 flash", "GOOGLEAI", "gemini-3.6-flash", 0.75, 3.75},
+		{"gemini 3.5 flash-lite before flash", "GOOGLEAI", "gemini-3.5-flash-lite", 0.30, 2.50},
+		{"gemini 3.5 flash", "GOOGLEAI", "gemini-3.5-flash", 1.50, 9.0},
+		{"gemini 3.1 pro preview", "GOOGLEAI", "gemini-3.1-pro-preview", 2.0, 12.0},
+		{"gemini 3.1 flash-lite", "GOOGLEAI", "gemini-3.1-flash-lite", 0.25, 1.50},
+		{"gemini 3 flash preview", "GOOGLEAI", "gemini-3-flash-preview", 0.50, 3.0},
+		{"gemini 3 pro generic last", "GOOGLEAI", "gemini-3-pro-preview", 2.0, 12.0},
 		{"gemini 2.5 pro", "GOOGLEAI", "gemini-2.5-pro", 1.25, 10.0},
-		{"gemini 2.5 flash", "GOOGLEAI", "gemini-2.5-flash", 0.15, 0.60},
+		{"gemini 2.5 flash-lite before flash", "GOOGLEAI", "gemini-2.5-flash-lite", 0.10, 0.40},
+		{"gemini 2.5 flash", "GOOGLEAI", "gemini-2.5-flash", 0.30, 2.50},
 		{"gemini 2.0", "GOOGLEAI", "gemini-2.0-flash", 0.075, 0.30},
 		{"gemini 1.5 pro", "GOOGLEAI", "gemini-1.5-pro", 1.25, 5.0},
 		{"gemini 1.5 flash", "GOOGLEAI", "gemini-1.5-flash", 0.075, 0.30},
 
-		// xAI Grok
+		// xAI Grok — 2026 generation (docs.x.ai pricing, base <200K tier).
+		{"grok-4.6", "XAI", "grok-4.6", 2.0, 6.0},
+		{"grok-4.5", "XAI", "grok-4.5", 2.0, 6.0},
+		{"grok-4.3", "XAI", "grok-4.3", 1.25, 2.50},
+		{"grok-4.20 reasoning", "XAI", "grok-4.20-0309-reasoning", 1.25, 2.50},
+		{"grok-build", "XAI", "grok-build-0.1", 1.0, 2.0},
 		{"grok-3", "XAI", "grok-3", 3.0, 15.0},
 		{"grok-2", "XAI", "grok-2", 2.0, 10.0},
 		{"grok generic", "XAI", "grok-4", 5.0, 15.0},
 
-		// DeepSeek
+		// DeepSeek — V4 (Aug 2026) uses the peak-hour list price (the
+		// off-peak halves are not modeled); specific v4 tags before the
+		// legacy r1/generic cases.
+		{"deepseek-v4-pro", "OPENROUTER", "deepseek-v4-pro", 1.32, 3.96},
+		{"deepseek-v4-flash", "OPENROUTER", "deepseek-v4-flash", 0.44, 1.32},
 		{"deepseek-r1 before deepseek", "OPENROUTER", "deepseek-r1", 0.55, 2.19},
 		{"deepseek bare", "OPENROUTER", "deepseek-chat", 0.27, 1.10},
 
@@ -77,14 +99,21 @@ func TestGetModelPricing(t *testing.T) {
 		// GLM/ZAI ids keep the conservative flat fallback.
 		{"glm-5.2", "ZAI", "glm-5.2", 1.40, 4.40},
 		{"glm-5.2 via model on other provider", "OTHER", "glm-5.2", 1.40, 4.40},
+		{"glm-5.1 same tier as 5.2", "ZAI", "glm-5.1", 1.40, 4.40},
+		{"glm-5-turbo own tier", "ZAI", "glm-5-turbo", 1.20, 4.00},
+		{"glm-5v-turbo own tier", "ZAI", "glm-5v-turbo", 1.20, 4.00},
 		{"glm-5 via glm model", "OTHER", "glm-5", 1.00, 3.20},
 		{"zai via provider", "ZAI", "anything", 0.50, 0.50},
 		{"zai legacy glm model", "OTHER", "glm-4.5", 0.50, 0.50},
 
 		// Moonshot (Kimi) — K3 has its own list price (well above the K2
 		// line) and its specific case must win over the generic kimi match;
-		// everything else keeps the conservative K2.6 single tier.
+		// the K2.7 Code highspeed tier is 2× the K2.x standard and must
+		// also win before the generic match. Everything else keeps the
+		// conservative K2.6 single tier.
 		{"kimi-k3 own tier", "MOONSHOT", "kimi-k3", 3.00, 15.00},
+		{"kimi-k2.7-code-highspeed own tier", "MOONSHOT", "kimi-k2.7-code-highspeed", 1.90, 8.00},
+		{"kimi-k2.7-code standard tier", "MOONSHOT", "kimi-k2.7-code", 0.95, 4.00},
 		{"moonshot via provider", "MOONSHOT", "kimi-k2.6", 0.95, 4.00},
 		{"kimi-k2.5", "MOONSHOT", "kimi-k2.5", 0.95, 4.00},
 		{"moonshot-v1", "MOONSHOT", "moonshot-v1-128k", 0.95, 4.00},

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -86,7 +86,10 @@ const (
 	// Model ids seguem o formato Bedrock (ex.: "anthropic.claude-3-5-sonnet-20241022-v2:0").
 	// Para inference profiles regionais, use o prefixo apropriado (ex.: "us.anthropic.claude-sonnet-4-20250514-v1:0").
 	// Default usa inference profile global (exigido por modelos 3.7+ / 4.x+).
-	DefaultBedrockModel  = "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
+	// Sonnet 4.6 espelha o DefaultClaudeAIModel — mesmo tier de preço do
+	// 4.5 ($3/$15), caminho InvokeModel estável (sem dependência do
+	// endpoint Mantle).
+	DefaultBedrockModel  = "global.anthropic.claude-sonnet-4-6"
 	DefaultBedrockRegion = "us-east-1"
 
 	// Valores padrão para Ollama

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -1682,6 +1682,7 @@
   "llm.minimax.using_anthropic_compat": "MiniMax using Anthropic-compatible endpoint",
   "llm.info.fetched_models": "Fetched %s models",
   "llm.bedrock.profile_display": "%s (Bedrock profile)",
+  "llm.bedrock.mantle_fallback_invoke": "bedrock-mantle endpoint failed for %s; falling back to the runtime InvokeModel endpoint as %s (set BEDROCK_ANTHROPIC_ENDPOINT=mantle to disable the fallback)",
   "llm.bedrock.provider_override_conflict": "BEDROCK_PROVIDER=%s conflicts with model %s, which only speaks the Converse API; the override was ignored for this call",
   "llm.bedrock.app_profile_display": "%s (Bedrock application profile)",
   "llm.info.fetched_models_total": "Fetched %s models (total: %d, chat: %d)",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1682,6 +1682,7 @@
   "llm.minimax.using_anthropic_compat": "MiniMax using Anthropic-compatible endpoint",
   "llm.info.fetched_models": "Fetched %s models",
   "llm.bedrock.profile_display": "%s (Bedrock profile)",
+  "llm.bedrock.mantle_fallback_invoke": "bedrock-mantle endpoint failed for %s; falling back to the runtime InvokeModel endpoint as %s (set BEDROCK_ANTHROPIC_ENDPOINT=mantle to disable the fallback)",
   "llm.bedrock.provider_override_conflict": "BEDROCK_PROVIDER=%s conflicts with model %s, which only speaks the Converse API; the override was ignored for this call",
   "llm.bedrock.app_profile_display": "%s (Bedrock application profile)",
   "llm.info.fetched_models_total": "Fetched %s models (total: %d, chat: %d)",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -1682,6 +1682,7 @@
   "llm.minimax.using_anthropic_compat": "MiniMax usando endpoint compatível com Anthropic",
   "llm.info.fetched_models": "Fetched %s models",
   "llm.bedrock.profile_display": "%s (perfil Bedrock)",
+  "llm.bedrock.mantle_fallback_invoke": "endpoint bedrock-mantle falhou para %s; usando fallback pelo endpoint runtime InvokeModel como %s (defina BEDROCK_ANTHROPIC_ENDPOINT=mantle para desativar o fallback)",
   "llm.bedrock.provider_override_conflict": "BEDROCK_PROVIDER=%s conflita com o modelo %s, que só fala a Converse API; o override foi ignorado nesta chamada",
   "llm.bedrock.app_profile_display": "%s (perfil de aplicação Bedrock)",
   "llm.info.fetched_models_total": "Fetched %s models (total: %d, chat: %d)",

--- a/llm/bedrock/bedrock_client.go
+++ b/llm/bedrock/bedrock_client.go
@@ -388,7 +388,30 @@ func (c *BedrockClient) SendPrompt(ctx context.Context, prompt string, history [
 		return c.sendPromptConverse(ctx, prompt, history, maxTokens)
 	default:
 		if usesMantleEndpoint(c.model) {
-			return c.sendPromptAnthropicMantle(ctx, prompt, history, maxTokens)
+			resp, err := c.sendPromptAnthropicMantle(ctx, prompt, history, maxTokens)
+			if err == nil || resolveAnthropicEndpointMode() != endpointModeAuto || ctx.Err() != nil {
+				// Success, operator-pinned "mantle", or the caller is gone:
+				// nothing to fall back to.
+				return resp, err
+			}
+			// Auto mode: the Mantle surface failed after its own retries —
+			// re-route the same request through the legacy InvokeModel
+			// runtime under an inference-profile id. Same Messages payload,
+			// different endpoint; regional outages, VPC gaps and account-
+			// level Mantle restrictions recover here. Genuinely invalid
+			// requests fail again on the runtime side and surface that
+			// error (annotated with the original Mantle failure).
+			fallbackModel := invokeFallbackModelID(c.model)
+			c.logger.Warn(i18n.T("llm.bedrock.mantle_fallback_invoke", c.model, fallbackModel), zap.Error(err))
+			resp, invokeErr := c.sendPromptAnthropicModel(ctx, fallbackModel, prompt, history, maxTokens)
+			if invokeErr != nil {
+				// Both chains stay inspectable (%w twice): errors.As walks
+				// invokeErr first, so payload-recovery reads the InvokeModel
+				// request size, while the Mantle failure stays visible for
+				// WAF/proxy classification.
+				return "", fmt.Errorf("%w (bedrock-mantle previously failed: %w)", invokeErr, err)
+			}
+			return resp, nil
 		}
 		return c.sendPromptAnthropic(ctx, prompt, history, maxTokens)
 	}
@@ -396,6 +419,14 @@ func (c *BedrockClient) SendPrompt(ctx context.Context, prompt string, history [
 
 // sendPromptAnthropic uses the Anthropic Messages body schema on Bedrock.
 func (c *BedrockClient) sendPromptAnthropic(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {
+	return c.sendPromptAnthropicModel(ctx, c.model, prompt, history, maxTokens)
+}
+
+// sendPromptAnthropicModel is sendPromptAnthropic with an explicit wire
+// model id — the Mantle→InvokeModel fallback re-routes the configured
+// model under its inference-profile spelling without mutating c.model
+// (the next call still tries Mantle first; a healthy Mantle wins again).
+func (c *BedrockClient) sendPromptAnthropicModel(ctx context.Context, wireModel, prompt string, history []models.Message, maxTokens int) (string, error) {
 	effectiveMaxTokens := maxTokens
 	if effectiveMaxTokens <= 0 {
 		effectiveMaxTokens = c.getMaxTokens()
@@ -412,7 +443,7 @@ func (c *BedrockClient) sendPromptAnthropic(ctx context.Context, prompt string, 
 		reqBody["system"] = systemObj
 	}
 
-	applyAnthropicThinkingForEffort(reqBody, c.model, ctx)
+	applyAnthropicThinkingForEffort(reqBody, wireModel, ctx)
 
 	enforceCacheControlBudget(reqBody, anthropicMaxCacheBreakpoints)
 
@@ -422,7 +453,7 @@ func (c *BedrockClient) sendPromptAnthropic(ctx context.Context, prompt string, 
 	}
 
 	start := time.Now()
-	client.LogRequestStart(c.logger, "BEDROCK", c.model,
+	client.LogRequestStart(c.logger, "BEDROCK", wireModel,
 		zap.String("family", string(familyAnthropic)),
 		zap.String("region", c.region),
 		zap.String("endpoint", RuntimeEndpointURL(c.region)),
@@ -434,19 +465,19 @@ func (c *BedrockClient) sendPromptAnthropic(ctx context.Context, prompt string, 
 
 	responseText, err := utils.Retry(ctx, c.logger, c.maxAttempts, c.backoff, func(ctx context.Context) (string, error) {
 		out, err := c.runtime.InvokeModel(ctx, &bedrockruntime.InvokeModelInput{
-			ModelId:     stringPtr(c.model),
+			ModelId:     stringPtr(wireModel),
 			ContentType: stringPtr("application/json"),
 			Accept:      stringPtr("application/json"),
 			Body:        payload,
 		})
 		if err != nil {
-			return "", wrapBedrockInferenceProfileError(c.model, err)
+			return "", wrapBedrockInferenceProfileError(wireModel, err)
 		}
 		return parseAnthropicBody(out.Body)
 	})
 
 	if err != nil {
-		client.LogRequestFinish(c.logger, "BEDROCK", c.model, "error", time.Since(start),
+		client.LogRequestFinish(c.logger, "BEDROCK", wireModel, "error", time.Since(start),
 			zap.String("family", string(familyAnthropic)),
 		)
 		c.logger.Error(i18n.T("llm.error.get_response_after_retries", "Bedrock"), zap.Error(err))
@@ -454,7 +485,7 @@ func (c *BedrockClient) sendPromptAnthropic(ctx context.Context, prompt string, 
 		// learn the proxy/WAF cap from the exact size that was rejected.
 		return "", client.WithRequestSize(err, len(payload))
 	}
-	client.LogRequestFinish(c.logger, "BEDROCK", c.model, "success", time.Since(start),
+	client.LogRequestFinish(c.logger, "BEDROCK", wireModel, "success", time.Since(start),
 		zap.String("family", string(familyAnthropic)),
 		zap.Int("response_chars", len(responseText)),
 	)

--- a/llm/bedrock/mantle.go
+++ b/llm/bedrock/mantle.go
@@ -49,6 +49,38 @@ func mantleMessagesURL(region string) string {
 	return strings.TrimSuffix(base, "/") + "/anthropic/v1/messages"
 }
 
+// anthropicEndpointMode is the operator's routing choice for Anthropic
+// requests on Bedrock, read from BEDROCK_ANTHROPIC_ENDPOINT.
+type anthropicEndpointMode int
+
+const (
+	// endpointModeAuto (default / "auto"): catalog decides — models
+	// flagged bedrock_mantle_only go to Mantle with an automatic
+	// fallback to InvokeModel when the Mantle call fails; everything
+	// else stays on InvokeModel.
+	endpointModeAuto anthropicEndpointMode = iota
+	// endpointModeMantle ("mantle"): every Anthropic request pinned to
+	// the Mantle Messages endpoint — no fallback (the operator asked
+	// for this surface explicitly).
+	endpointModeMantle
+	// endpointModeInvoke ("invoke"/"invokemodel"/"legacy"): every
+	// Anthropic request pinned to InvokeModel.
+	endpointModeInvoke
+)
+
+// resolveAnthropicEndpointMode parses BEDROCK_ANTHROPIC_ENDPOINT.
+// Unknown values fall back to auto so a typo degrades to the default
+// routing instead of silently pinning a surface.
+func resolveAnthropicEndpointMode() anthropicEndpointMode {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("BEDROCK_ANTHROPIC_ENDPOINT"))) {
+	case "mantle":
+		return endpointModeMantle
+	case "invoke", "invokemodel", "legacy":
+		return endpointModeInvoke
+	}
+	return endpointModeAuto
+}
+
 // usesMantleEndpoint decides whether an Anthropic-family request must go
 // through the Mantle Messages endpoint instead of legacy InvokeModel.
 //
@@ -63,12 +95,13 @@ func mantleMessagesURL(region string) string {
 // picked from ListInferenceProfiles routes the same as the canonical id.
 // BEDROCK_ANTHROPIC_ENDPOINT overrides for operators: "mantle" forces
 // every Anthropic request onto the Messages endpoint, "invoke"/"legacy"
-// pins them all to InvokeModel.
+// pins them all to InvokeModel. In the default "auto" mode, a Mantle
+// failure additionally falls back to InvokeModel (see SendPrompt).
 func usesMantleEndpoint(model string) bool {
-	switch strings.ToLower(strings.TrimSpace(os.Getenv("BEDROCK_ANTHROPIC_ENDPOINT"))) {
-	case "mantle":
+	switch resolveAnthropicEndpointMode() {
+	case endpointModeMantle:
 		return true
-	case "invoke", "invokemodel", "legacy":
+	case endpointModeInvoke:
 		return false
 	}
 	return catalog.HasCapability(catalog.ProviderBedrock, model, "bedrock_mantle_only")
@@ -116,6 +149,27 @@ func mantleModelID(model string) string {
 		return id
 	}
 	return model
+}
+
+// invokeFallbackModelID maps the model id the Mantle path was serving
+// onto an id the legacy InvokeModel surface accepts on-demand. Recent
+// Claude generations have no bare-ID on-demand surface — InvokeModel
+// requires an inference-profile id — so a canonical "anthropic.claude-*"
+// id gets the global. profile prefix (the profile AWS publishes for every
+// family-5 model). Ids that already carry a profile prefix, application-
+// profile ARNs and non-Claude ids pass through unchanged.
+func invokeFallbackModelID(model string) string {
+	trimmed := strings.TrimSpace(model)
+	m := strings.ToLower(trimmed)
+	for _, p := range mantleProfilePrefixes {
+		if strings.HasPrefix(m, p) && strings.HasPrefix(m[len(p):], "anthropic.") {
+			return trimmed
+		}
+	}
+	if strings.HasPrefix(m, "anthropic.") {
+		return "global." + trimmed
+	}
+	return trimmed
 }
 
 // sendPromptAnthropicMantle sends a Messages API request to the

--- a/llm/bedrock/mantle_test.go
+++ b/llm/bedrock/mantle_test.go
@@ -379,3 +379,122 @@ func TestSendPromptAnthropicMantleAPIError(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid_request_error")
 	assert.Contains(t, err.Error(), "boom")
 }
+
+// The Mantle→InvokeModel fallback re-routes the configured model under an
+// inference-profile spelling InvokeModel accepts on-demand. Canonical
+// "anthropic." ids gain the global. profile; ids already carrying a
+// profile prefix, application-profile ARNs and non-Claude ids pass
+// through unchanged.
+func TestInvokeFallbackModelID(t *testing.T) {
+	assert.Equal(t, "global.anthropic.claude-sonnet-5", invokeFallbackModelID("anthropic.claude-sonnet-5"))
+	assert.Equal(t, "global.anthropic.claude-fable-5", invokeFallbackModelID("anthropic.claude-fable-5"))
+	assert.Equal(t, "global.anthropic.claude-opus-5", invokeFallbackModelID("anthropic.claude-opus-5"))
+	// Profile spellings stay as configured.
+	assert.Equal(t, "us.anthropic.claude-sonnet-5", invokeFallbackModelID("us.anthropic.claude-sonnet-5"))
+	assert.Equal(t, "global.anthropic.claude-opus-4-8", invokeFallbackModelID("global.anthropic.claude-opus-4-8"))
+	// ARNs and non-Claude ids pass through untouched.
+	arn := "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abcdef"
+	assert.Equal(t, arn, invokeFallbackModelID(arn))
+	assert.Equal(t, "openai.gpt-oss-120b-1:0", invokeFallbackModelID("openai.gpt-oss-120b-1:0"))
+}
+
+// BEDROCK_ANTHROPIC_ENDPOINT parsing: unset/"auto"/typos → auto (catalog
+// decides, with fallback); "mantle" and "invoke"/"legacy" pin a surface.
+func TestResolveAnthropicEndpointMode(t *testing.T) {
+	setEnvForTest(t, "BEDROCK_ANTHROPIC_ENDPOINT", "")
+	assert.Equal(t, endpointModeAuto, resolveAnthropicEndpointMode())
+
+	setEnvForTest(t, "BEDROCK_ANTHROPIC_ENDPOINT", "auto")
+	assert.Equal(t, endpointModeAuto, resolveAnthropicEndpointMode())
+
+	setEnvForTest(t, "BEDROCK_ANTHROPIC_ENDPOINT", "MANTLE")
+	assert.Equal(t, endpointModeMantle, resolveAnthropicEndpointMode())
+
+	setEnvForTest(t, "BEDROCK_ANTHROPIC_ENDPOINT", "invoke")
+	assert.Equal(t, endpointModeInvoke, resolveAnthropicEndpointMode())
+	setEnvForTest(t, "BEDROCK_ANTHROPIC_ENDPOINT", "invokemodel")
+	assert.Equal(t, endpointModeInvoke, resolveAnthropicEndpointMode())
+	setEnvForTest(t, "BEDROCK_ANTHROPIC_ENDPOINT", "legacy")
+	assert.Equal(t, endpointModeInvoke, resolveAnthropicEndpointMode())
+
+	// A typo degrades to auto instead of silently pinning a surface.
+	setEnvForTest(t, "BEDROCK_ANTHROPIC_ENDPOINT", "mantel")
+	assert.Equal(t, endpointModeAuto, resolveAnthropicEndpointMode())
+}
+
+// End-to-end: the Mantle endpoint fails after its retries, and SendPrompt
+// re-routes the same request through the runtime InvokeModel endpoint
+// under the global. inference-profile spelling.
+func TestSendPromptMantleFallsBackToInvoke(t *testing.T) {
+	mantleCalls := 0
+	mantleSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mantleCalls++
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"overloaded_error","message":"mantle indisponível"}}`))
+	}))
+	defer mantleSrv.Close()
+
+	var invokePath string
+	runtimeSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		invokePath = r.URL.Path
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"via-invoke"}]}`))
+	}))
+	defer runtimeSrv.Close()
+
+	setEnvForTest(t, "BEDROCK_ANTHROPIC_ENDPOINT", "")
+	setEnvForTest(t, "BEDROCK_MANTLE_BASE_URL", mantleSrv.URL)
+	setEnvForTest(t, "BEDROCK_BASE_URL", runtimeSrv.URL)
+	// SigV4 on both surfaces: the runtime SDK refuses bearer tokens over
+	// plain HTTP, and httptest serves HTTP — static env creds sign fine.
+	setEnvForTest(t, "AWS_BEARER_TOKEN_BEDROCK", "")
+	setEnvForTest(t, "AWS_REGION", "us-east-1")
+	setEnvForTest(t, "AWS_ACCESS_KEY_ID", "test-access-key")
+	setEnvForTest(t, "AWS_SECRET_ACCESS_KEY", "test-secret-key")
+	setEnvForTest(t, "AWS_SESSION_TOKEN", "")
+	setEnvForTest(t, "AWS_PROFILE", "")
+
+	c := NewBedrockClient("anthropic.claude-sonnet-5", "us-east-1", "", zap.NewNop(), 1, 0)
+	out, err := c.SendPrompt(t.Context(), "ping", nil, 128)
+	require.NoError(t, err)
+	assert.Equal(t, "via-invoke", out)
+	assert.Positive(t, mantleCalls, "the Mantle surface must be tried first")
+	assert.Contains(t, invokePath, "global.anthropic.claude-sonnet-5",
+		"the fallback must invoke under the inference-profile spelling")
+}
+
+// Operator-pinned "mantle" means no fallback: the Mantle error surfaces
+// and the runtime endpoint is never touched.
+func TestSendPromptMantlePinnedDoesNotFallBack(t *testing.T) {
+	mantleSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"overloaded_error","message":"mantle indisponível"}}`))
+	}))
+	defer mantleSrv.Close()
+
+	runtimeCalls := 0
+	runtimeSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		runtimeCalls++
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"via-invoke"}]}`))
+	}))
+	defer runtimeSrv.Close()
+
+	setEnvForTest(t, "BEDROCK_ANTHROPIC_ENDPOINT", "mantle")
+	setEnvForTest(t, "BEDROCK_MANTLE_BASE_URL", mantleSrv.URL)
+	setEnvForTest(t, "BEDROCK_BASE_URL", runtimeSrv.URL)
+	// SigV4 on both surfaces: the runtime SDK refuses bearer tokens over
+	// plain HTTP, and httptest serves HTTP — static env creds sign fine.
+	setEnvForTest(t, "AWS_BEARER_TOKEN_BEDROCK", "")
+	setEnvForTest(t, "AWS_REGION", "us-east-1")
+	setEnvForTest(t, "AWS_ACCESS_KEY_ID", "test-access-key")
+	setEnvForTest(t, "AWS_SECRET_ACCESS_KEY", "test-secret-key")
+
+	c := NewBedrockClient("anthropic.claude-sonnet-5", "us-east-1", "", zap.NewNop(), 1, 0)
+	_, err := c.SendPrompt(t.Context(), "ping", nil, 128)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "overloaded_error")
+	assert.Zero(t, runtimeCalls, "pinned mantle must never touch InvokeModel")
+}

--- a/llm/catalog/catalog.go
+++ b/llm/catalog/catalog.go
@@ -604,12 +604,22 @@ var registry = []ModelMeta{
 	// is physically impossible — the API rejects requests with output
 	// over the per-model cap.
 	//
-	// Gemini 3.x generation (verified per-model on ai.google.dev, Jul
-	// 2026): 3.6-flash (stable, current default workhorse, Jul 21 2026),
+	// Gemini 3.x generation (verified per-model on ai.google.dev, Aug
+	// 2026): 3.7-flash (GA Aug 13 2026), 3.6-flash (Jul 21 2026),
 	// 3.5-flash, 3.5-flash-lite and 3.1-flash-lite stable; 3.1-pro-preview
 	// and 3-flash-preview in preview. The whole generation shares the
 	// uniform 1,048,576 / 65,536 profile. Newest first so generic alias
 	// prefixes ("gemini-3") don't shadow the more specific ids.
+	{
+		ID:              "gemini-3.7-flash",
+		Aliases:         []string{"gemini-3.7-flash", "gemini-3.7-flash-latest"},
+		DisplayName:     "Gemini 3.7 Flash",
+		Provider:        ProviderGoogleAI,
+		ContextWindow:   1048576,
+		MaxOutputTokens: 65536,
+		PreferredAPI:    "gemini_api",
+		Capabilities:    []string{"vision", "tools", "json_mode", "code_execution"},
+	},
 	{
 		ID:              "gemini-3.6-flash",
 		Aliases:         []string{"gemini-3.6-flash", "gemini-3.6-flash-latest"},
@@ -868,13 +878,25 @@ var registry = []ModelMeta{
 	// previously written as a single comma-joined string instead of
 	// separate entries — Resolve() never matched them. Fixed here.
 	//
-	// 2026 generation (context windows per docs.x.ai/docs/models, Jul
-	// 2026): grok-4.5 500K, grok-4.3 1M (flagship, Apr 30 2026), the
-	// grok-4.20 family 1M, grok-build 256K. xAI still documents no
-	// separate output cap — the 16K ceiling below follows the same
-	// convention as the older entries. Newest first; the entry carrying
-	// the generic "grok-4.20" alias sits after the more specific 4.20
-	// variants so it cannot shadow them.
+	// 2026 generation (context windows per docs.x.ai/developers/models,
+	// Aug 2026): grok-4.6 500K (flagship, Aug 12 2026), grok-4.5 500K,
+	// grok-4.3 1M, the grok-4.20 family 1M, grok-build 256K. xAI still
+	// documents no separate output cap — the 16K ceiling below follows
+	// the same convention as the older entries. Newest first; the entry
+	// carrying the generic "grok-4.20" alias sits after the more specific
+	// 4.20 variants so it cannot shadow them. The announced "fast"
+	// variant of 4.6 has no published model id yet — do not add it until
+	// docs.x.ai lists one.
+	{
+		ID:              "grok-4.6",
+		Aliases:         []string{"grok-4.6", "grok-4.6-latest"},
+		DisplayName:     "Grok-4.6",
+		Provider:        ProviderXAI,
+		ContextWindow:   500000,
+		MaxOutputTokens: 16384,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"vision", "tools", "json_mode"},
+	},
 	{
 		ID:              "grok-4.5",
 		Aliases:         []string{"grok-4.5", "grok-4.5-latest"},
@@ -1177,10 +1199,18 @@ var registry = []ModelMeta{
 	// (released Jul 2026): 2.8T total / 104B active params, 1M context via
 	// Kimi Delta Attention, text+image+video input. Output stays at the
 	// K2.x 128K cap — aggregator listings that show output = context are an
-	// unbounded-listing artifact, not a real per-request cap. K2.6 (Apr
-	// 2026, 1T/32B, 256K) remains supported, K2.5 is the prior generation,
-	// moonshot-v1-* are the classic chat models split by context.
-	// Ordering: newest IDs first so generic aliases don't shadow specific tags.
+	// unbounded-listing artifact, not a real per-request cap. The
+	// kimi-k2.7-code line (Jun 2026) is the coding-tuned K2.x: 256K
+	// context, 32,768 default output per platform.kimi.ai/docs/pricing.
+	// K2.6 (Apr 2026, 1T/32B, 256K) remains supported. Sunsets announced
+	// on platform.kimi.ai/docs/models (Aug 2026): kimi-k2.5 and the
+	// moonshot-v1-* series retire 2026-08-31, kimi-latest deprecated since
+	// 2026-01-28 — entries stay until the dates pass so pinned configs
+	// keep resolving.
+	// Ordering: newest IDs first so generic aliases don't shadow specific
+	// tags — "kimi-k2.7-code-highspeed" MUST precede "kimi-k2.7-code",
+	// whose alias set would otherwise swallow it (Resolve matches aliases
+	// by prefix/contains in registry order).
 	{
 		ID:              "kimi-k3",
 		Aliases:         []string{"kimi-k3", "kimi-k-3", "k3", "k-3"},
@@ -1190,6 +1220,26 @@ var registry = []ModelMeta{
 		MaxOutputTokens: 131072,
 		PreferredAPI:    APIChatCompletions,
 		Capabilities:    []string{"tools", "vision", "thinking", "json_mode"},
+	},
+	{
+		ID:              "kimi-k2.7-code-highspeed",
+		Aliases:         []string{"kimi-k2.7-code-highspeed", "kimi-k2-7-code-highspeed"},
+		DisplayName:     "Kimi K2.7 Code (highspeed)",
+		Provider:        ProviderMoonshot,
+		ContextWindow:   262144,
+		MaxOutputTokens: 32768,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"tools", "thinking", "json_mode"},
+	},
+	{
+		ID:              "kimi-k2.7-code",
+		Aliases:         []string{"kimi-k2.7-code", "kimi-k2-7-code", "kimi-k2.7", "kimi-k2-7", "k2.7", "k2-7"},
+		DisplayName:     "Kimi K2.7 Code",
+		Provider:        ProviderMoonshot,
+		ContextWindow:   262144,
+		MaxOutputTokens: 32768,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"tools", "thinking", "json_mode"},
 	},
 	{
 		ID:              "kimi-k2.6",
@@ -1433,7 +1483,7 @@ var registry = []ModelMeta{
 	// same as Sonnet 5.
 	{
 		ID:              "anthropic.claude-fable-5",
-		Aliases:         []string{"bedrock-fable-5", "global.anthropic.claude-fable-5", "claude-fable-5", "fable-5"},
+		Aliases:         []string{"bedrock-fable-5", "global.anthropic.claude-fable-5", "us.anthropic.claude-fable-5", "claude-fable-5", "fable-5"},
 		DisplayName:     "Claude Fable 5 (Bedrock, 1M ctx)",
 		Provider:        ProviderBedrock,
 		ContextWindow:   1000000,
@@ -1448,7 +1498,7 @@ var registry = []ModelMeta{
 	// path instead of InvokeModel.
 	{
 		ID:              "anthropic.claude-opus-5",
-		Aliases:         []string{"bedrock-opus-5", "global.anthropic.claude-opus-5", "claude-opus-5", "opus-5"},
+		Aliases:         []string{"bedrock-opus-5", "global.anthropic.claude-opus-5", "us.anthropic.claude-opus-5", "eu.anthropic.claude-opus-5", "au.anthropic.claude-opus-5", "claude-opus-5", "opus-5"},
 		DisplayName:     "Claude Opus 5 (Bedrock, 1M ctx)",
 		Provider:        ProviderBedrock,
 		ContextWindow:   1000000,
@@ -1463,7 +1513,7 @@ var registry = []ModelMeta{
 	// this id to InvokeModel would return a ValidationException.
 	{
 		ID:              "anthropic.claude-sonnet-5",
-		Aliases:         []string{"bedrock-sonnet-5", "global.anthropic.claude-sonnet-5", "claude-sonnet-5", "sonnet-5"},
+		Aliases:         []string{"bedrock-sonnet-5", "global.anthropic.claude-sonnet-5", "us.anthropic.claude-sonnet-5", "eu.anthropic.claude-sonnet-5", "au.anthropic.claude-sonnet-5", "claude-sonnet-5", "sonnet-5"},
 		DisplayName:     "Claude Sonnet 5 (Bedrock, 1M ctx)",
 		Provider:        ProviderBedrock,
 		ContextWindow:   1000000,

--- a/llm/catalog/catalog_test.go
+++ b/llm/catalog/catalog_test.go
@@ -147,6 +147,27 @@ func TestMoonshotCatalogEntries(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, "kimi-k3", short.ID)
 
+	// Kimi K2.7 Code line (Jun 2026): 256K context, 32,768 default output
+	// per platform.kimi.ai/docs/pricing. The highspeed entry sits BEFORE
+	// the plain -code entry in the registry — Resolve matches aliases by
+	// prefix/contains in registry order, so the plain entry's aliases
+	// would otherwise swallow the highspeed id.
+	hs, ok := Resolve(ProviderMoonshot, "kimi-k2.7-code-highspeed")
+	assert.True(t, ok, "kimi-k2.7-code-highspeed must resolve")
+	assert.Equal(t, "kimi-k2.7-code-highspeed", hs.ID, "highspeed must not be shadowed by kimi-k2.7-code")
+	assert.Equal(t, 262144, hs.ContextWindow)
+	assert.Equal(t, 32768, hs.MaxOutputTokens)
+
+	code, ok := Resolve(ProviderMoonshot, "kimi-k2.7-code")
+	assert.True(t, ok, "kimi-k2.7-code must resolve")
+	assert.Equal(t, "kimi-k2.7-code", code.ID)
+	assert.Equal(t, 262144, code.ContextWindow)
+	assert.Equal(t, 32768, code.MaxOutputTokens)
+	// The bare k2.7 spellings ride the -code entry via aliases.
+	bare, ok := Resolve(ProviderMoonshot, "kimi-k2.7")
+	assert.True(t, ok)
+	assert.Equal(t, "kimi-k2.7-code", bare.ID)
+
 	// Pin the public specs of the Kimi K2.6/K2.5 entries so silent drift on
 	// the model card (e.g. catalog edits during a refactor) shows up here
 	// instead of at runtime.
@@ -578,6 +599,7 @@ func TestBedrockProviderFallbacks(t *testing.T) {
 // GoogleAI provider fallback and undersize the context window.
 func TestGemini3FamilyEntries(t *testing.T) {
 	for _, id := range []string{
+		"gemini-3.7-flash",
 		"gemini-3.6-flash",
 		"gemini-3.5-flash",
 		"gemini-3.5-flash-lite",
@@ -605,6 +627,7 @@ func TestGemini3FamilyEntries(t *testing.T) {
 // ceiling convention).
 func TestGrok2026Entries(t *testing.T) {
 	cases := map[string]int{
+		"grok-4.6":                     500000,
 		"grok-4.5":                     500000,
 		"grok-4.3":                     1000000,
 		"grok-4.20-0309-reasoning":     1000000,
@@ -677,5 +700,32 @@ func TestBedrockNovaEntries(t *testing.T) {
 		assert.Equal(t, ProviderBedrock, meta.Provider, "%s provider", model)
 		assert.Equal(t, wantCtx, meta.ContextWindow, "%s context window", model)
 		assert.Equal(t, wantCtx, GetContextWindow(ProviderBedrock, model), "%s GetContextWindow", model)
+	}
+}
+
+// TestBedrockFamily5ProfileAliases pins the geo/global inference-profile
+// spellings AWS publishes for the family-5 models (model cards, Aug 2026):
+// every profile id must resolve back to the canonical Mantle-servable
+// entry so routing (bedrock_mantle_only) and specs stay consistent
+// whatever spelling the operator configured.
+func TestBedrockFamily5ProfileAliases(t *testing.T) {
+	cases := map[string]string{
+		"us.anthropic.claude-fable-5":      "anthropic.claude-fable-5",
+		"global.anthropic.claude-fable-5":  "anthropic.claude-fable-5",
+		"us.anthropic.claude-opus-5":       "anthropic.claude-opus-5",
+		"eu.anthropic.claude-opus-5":       "anthropic.claude-opus-5",
+		"au.anthropic.claude-opus-5":       "anthropic.claude-opus-5",
+		"us.anthropic.claude-sonnet-5":     "anthropic.claude-sonnet-5",
+		"eu.anthropic.claude-sonnet-5":     "anthropic.claude-sonnet-5",
+		"au.anthropic.claude-sonnet-5":     "anthropic.claude-sonnet-5",
+		"global.anthropic.claude-sonnet-5": "anthropic.claude-sonnet-5",
+	}
+	for id, want := range cases {
+		meta, ok := Resolve(ProviderBedrock, id)
+		if !assert.True(t, ok, "profile id %s must resolve", id) {
+			continue
+		}
+		assert.Equal(t, want, meta.ID, "profile id %s", id)
+		assert.Contains(t, meta.Capabilities, "bedrock_mantle_only", "profile id %s keeps Mantle routing", id)
 	}
 }

--- a/llm/manager/llm_manager_test.go
+++ b/llm/manager/llm_manager_test.go
@@ -155,7 +155,7 @@ func TestLLMManager_GetClient(t *testing.T) {
 
 		client, err := mgr.GetClient("BEDROCK", "")
 		assert.NoError(t, err)
-		assert.Contains(t, client.GetModelName(), "Sonnet 4.5")
+		assert.Contains(t, client.GetModelName(), "Sonnet 4.6")
 	})
 
 	t.Run("Unsupported Provider", func(t *testing.T) {

--- a/operator/README.md
+++ b/operator/README.md
@@ -252,7 +252,7 @@ spec:
   provider: BEDROCK
   # Modern Claude on Bedrock requires an inference profile id
   # (prefix global./us./eu./apac.). For Claude 3/3.5 the base id also works.
-  model: global.anthropic.claude-sonnet-4-5-20250929-v1:0
+  model: global.anthropic.claude-sonnet-4-6
   replicas: 1
   apiKeys:
     name: chatcli-bedrock-keys

--- a/operator/config/samples/platform_v1alpha1_instance_bedrock.yaml
+++ b/operator/config/samples/platform_v1alpha1_instance_bedrock.yaml
@@ -46,7 +46,7 @@ spec:
   # Default model already uses a global inference profile required for modern Claude.
   # For older models (3, 3.5) the base id works; for 3.7+/4.x/4.5/4.6 you MUST use
   # a prefix like "global.", "us.", "eu.", or "apac.".
-  model: global.anthropic.claude-sonnet-4-5-20250929-v1:0
+  model: global.anthropic.claude-sonnet-4-6
   image:
     repository: ghcr.io/diillson/chatcli
     tag: latest


### PR DESCRIPTION
## Summary

August 2026 multi-provider model catalog refresh plus a new resilience feature on Bedrock: automatic fallback from the `bedrock-mantle` Messages endpoint to the legacy InvokeModel runtime.

### Catalog additions (verified against official vendor docs)

- **Google**: `gemini-3.7-flash` (GA Aug 13, 1,048,576 / 65,536)
- **xAI**: `grok-4.6` (flagship Aug 12, 500K ctx)
- **Moonshot**: `kimi-k2.7-code` + `kimi-k2.7-code-highspeed` (256K ctx, 32,768 default output) — highspeed registered before the plain entry so alias prefix/contains matching cannot shadow it
- **Bedrock**: `us./eu./au.` inference-profile aliases for the Claude family-5 entries, per the AWS model cards

Deliberately **not** added: GLM-5.3 (announced, API still "coming soon" — no official id), the Grok 4.6 fast variant (no published id), and anything unconfirmed (GPT-5.7/Grok 5/Kimi K4 do not exist).

### Pricing refresh (`cli/cost_tracker.go`)

- Gemini 3.x full block + 2.5 correction (2.5-flash was $0.15/$0.60; official is $0.30/$2.50, flash-lite $0.10/$0.40)
- Grok 4.6/4.5/4.3/4.20/build (base <200K tier)
- DeepSeek V4 pro/flash (peak-hour list price, conservative)
- GLM-5.1 and glm-5-turbo/5v-turbo tiers
- Kimi K2.7 Code highspeed tier (2× standard)
- gpt-5.6-terra/luna July 30 price cuts ($2/$12 and $0.20/$1.20)

### Bedrock: Mantle→runtime fallback (the feature)

`BEDROCK_ANTHROPIC_ENDPOINT` unset/`auto` (default) now means: catalog-flagged models (`bedrock_mantle_only` — Fable 5, Opus 5, Sonnet 5) try the Mantle Messages endpoint first; if the call fails after its retries, the same request is re-sent through InvokeModel under the `global.` inference-profile spelling (ids already carrying a profile prefix or ARNs pass through unchanged). Recovers regional outages, VPCs without a Mantle interface endpoint, and account-level Mantle restrictions — previously the operator had to flip `BEDROCK_ANTHROPIC_ENDPOINT=invoke` by hand.

- Operator pins keep their exact semantics: `mantle` = no fallback, `invoke` = runtime only
- The fallback never mutates the configured model — the next call tries Mantle first again
- Both error chains stay inspectable (double `%w`) so agent-mode payload recovery reads the InvokeModel request size while the Mantle failure remains visible for WAF classification
- New i18n key `llm.bedrock.mantle_fallback_invoke` in en / en-US / pt-BR

### Breaking change (label applied)

`config.DefaultBedrockModel` moves from the Sonnet 4.5 dated profile to `global.anthropic.claude-sonnet-4-6` — mirrors `DefaultClaudeAIModel` at the same $3/$15 tier, stable InvokeModel path. Operator README/sample synced. This is what Floor 13 (apidiff) flags: an exported const value change, acknowledged via the `breaking-change` label.

## Test plan

- New e2e tests: Mantle 503 → InvokeModel serves the request under the `global.` id; pinned `mantle` never touches the runtime
- Unit tests: endpoint-mode parsing (typos degrade to auto), fallback id mapping (canonical/profile/ARN/non-Claude)
- Catalog spec tests: gemini-3.7-flash, grok-4.6, K2.7 Code ordering/shadowing, family-5 profile alias resolution
- Pricing table pins updated and extended
- `go build ./...`, full `go test ./...` (102 packages), golangci-lint clean, local QG floors green (i18n parity, cyclo, ai-smells, patch coverage)
