### PR TITLE
ci(dependabot): replace invalid docker ignore globs with a pre-release tag guard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,11 +32,14 @@ updates:
     labels:
       - "docker"
       - "dependencies"
-    ignore:
-      # Never bump build images to Go pre-release tags (rc/beta/alpha);
-      # stable releases are picked up automatically.
-      - dependency-name: "golang"
-        versions: ["*rc*", "*beta*", "*alpha*"]
+    # NOTE: no `ignore.versions` for Go pre-release tags here. The docker
+    # ecosystem parses `versions` as Bundler requirements (globs like
+    # "*rc*" are a config error that breaks parsing repo-wide), and
+    # requirement matching compares the tag's release part — 1.27rc2 and
+    # the stable 1.27.0 evaluate identically, so an rc-only ignore is
+    # inexpressible. The guard lives in
+    # .github/workflows/dependabot-guard.yml instead: any PR that puts an
+    # rc/beta/alpha golang base-image tag in a Dockerfile fails visibly.
 
   # Go module dependencies (operator — separate go.mod)
   - package-ecosystem: "gomod"
@@ -59,8 +62,11 @@ updates:
     labels:
       - "docker"
       - "dependencies"
-    ignore:
-      # Never bump build images to Go pre-release tags (rc/beta/alpha);
-      # stable releases are picked up automatically.
-      - dependency-name: "golang"
-        versions: ["*rc*", "*beta*", "*alpha*"]
+    # NOTE: no `ignore.versions` for Go pre-release tags here. The docker
+    # ecosystem parses `versions` as Bundler requirements (globs like
+    # "*rc*" are a config error that breaks parsing repo-wide), and
+    # requirement matching compares the tag's release part — 1.27rc2 and
+    # the stable 1.27.0 evaluate identically, so an rc-only ignore is
+    # inexpressible. The guard lives in
+    # .github/workflows/dependabot-guard.yml instead: any PR that puts an
+    # rc/beta/alpha golang base-image tag in a Dockerfile fails visibly.

--- a/.github/workflows/dependabot-guard.yml
+++ b/.github/workflows/dependabot-guard.yml
@@ -1,0 +1,39 @@
+# Dependabot Guard — blocks Go pre-release base-image tags.
+#
+# Why a workflow and not dependabot.yml `ignore.versions`: the docker
+# ecosystem parses `versions` as Bundler requirements — globs ("*rc*")
+# are a parse error that invalidates the whole config, and requirement
+# matching strips the pre-release part of a tag (1.27rc2 evaluates as
+# 1.27, equal to the stable 1.27.0), so "ignore rc but allow stable" is
+# inexpressible there. Dependabot's own pre-release filter also misses
+# golang's dotless rc form (it proposed 1.26.6 → 1.27rc2 in the past).
+# This check is the enforcement point: an rc/beta/alpha golang tag in a
+# Dockerfile fails the PR visibly instead of sailing through a green CI.
+name: Dependabot Guard
+
+on:
+  pull_request:
+    paths:
+      - "**/Dockerfile*"
+
+permissions:
+  contents: read
+
+jobs:
+  block-go-prerelease-tags:
+    name: Block Go pre-release image tags
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Fail on golang rc/beta/alpha base-image tags
+        run: |
+          set -euo pipefail
+          matches=$(grep -RInE '^[[:space:]]*FROM[[:space:]]+[^[:space:]]*golang:[^[:space:]]*(rc|beta|alpha)[0-9]*' \
+            --include='Dockerfile*' . || true)
+          if [ -n "$matches" ]; then
+            echo "::error::Go pre-release base-image tag detected — rc/beta/alpha tags are never merged (they pass CI but are not production Go releases):"
+            echo "$matches"
+            exit 1
+          fi
+          echo "No Go pre-release base-image tags found."


### PR DESCRIPTION
## Summary

The `.github/dependabot.yml` check is failing on every PR — including the pending release PR #1346 — with:

```
The property '#/updates/2/ignore/0/versions' includes invalid version requirements for a docker ignore condition
The property '#/updates/4/ignore/0/versions' includes invalid version requirements for a docker ignore condition
```

The globs (`*rc*`, `*beta*`, `*alpha*`) added in #1342 are not valid for the **docker** ecosystem: `ignore.versions` is parsed as Bundler version requirements, so the whole config is rejected.

Worse, the intent is *inexpressible* through `ignore.versions` for docker: `Dependabot::Docker::Requirement#satisfied_by?` compares against the tag's **release part**, under which `1.27rc2` and the stable `1.27.0` evaluate identically — any requirement that blocks the rc also blocks the stable release. Dependabot's built-in pre-release filter misses golang's dotless rc form too, which is exactly how #1340/#1341 (`1.26.6 → 1.27rc2`) got proposed.

## Fix

- **`.github/dependabot.yml`**: remove the two invalid `ignore` blocks (main + operator docker updates), with a comment explaining why the mechanism cannot work.
- **`.github/workflows/dependabot-guard.yml`** (new): runs on any PR touching a `Dockerfile*`; fails with a visible error when a `golang` base-image tag contains `rc`/`beta`/`alpha`. This turns the previous silent-green-CI hazard into a red check, so an rc bump can never be merged by accident.

## Test plan

- `yq` parses both files; 5 update blocks preserved
- Guard regex: zero matches on the current tree (stable `1.26.6` tags); matches `FROM golang:1.27rc2-alpine` and not `FROM golang:1.26.6` in a synthetic Dockerfile
- After merge, release-please updates #1346 and the fresh head gets a clean dependabot parse