### PR TITLE
fix(commands): resolve slash token when piped stdin follows the invocation

### DIFF
--- a/cli/commands_autoroute_test.go
+++ b/cli/commands_autoroute_test.go
@@ -159,6 +159,17 @@ func TestResolveOneShotCommand_CoderRoute(t *testing.T) {
 	if expanded != "deploy prod now" {
 		t.Errorf("expansion mismatch: %q", expanded)
 	}
+
+	// `git diff | chatcli -p "/deploy"`: piped stdin is appended after a
+	// newline before resolution — the bare command must still route and
+	// take the body as $ARGUMENTS.
+	expanded, coderRoute = cli.resolveOneShotCommand(context.Background(), "/deploy\ndiff --git a/x b/x")
+	if !coderRoute {
+		t.Fatal("bare mode:coder command with piped body must still route")
+	}
+	if expanded != "deploy diff --git a/x b/x now" {
+		t.Errorf("piped-body expansion mismatch: %q", expanded)
+	}
 }
 
 func TestResolveOneShotCommand_ChatRouteAndPassthrough(t *testing.T) {

--- a/cli/commands_integration.go
+++ b/cli/commands_integration.go
@@ -31,6 +31,7 @@ import (
 	"runtime"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/diillson/chatcli/cli/coder"
 	"github.com/diillson/chatcli/cli/commands"
@@ -125,20 +126,23 @@ func (cli *ChatCLI) slashCommandCatalog() *commands.Catalog {
 }
 
 // splitSlashInvocation splits "/token args" → (token, args, true) when the
-// input is shaped like a slash invocation.
+// input is shaped like a slash invocation. The token ends at the first
+// whitespace of any kind — piped stdin arrives appended after a newline
+// (`git diff | chatcli -p "/review"`), so a space-only split would fold the
+// pipe's first line into the token and miss the catalog.
 func splitSlashInvocation(input string) (string, string, bool) {
 	if !strings.HasPrefix(input, "/") || len(input) < 2 {
 		return "", "", false
 	}
 	trimmed := strings.TrimPrefix(input, "/")
-	parts := strings.SplitN(trimmed, " ", 2)
-	token := strings.TrimSpace(parts[0])
+	token := trimmed
+	args := ""
+	if cut := strings.IndexFunc(trimmed, unicode.IsSpace); cut >= 0 {
+		token = trimmed[:cut]
+		args = strings.TrimSpace(trimmed[cut:])
+	}
 	if token == "" {
 		return "", "", false
-	}
-	args := ""
-	if len(parts) > 1 {
-		args = strings.TrimSpace(parts[1])
 	}
 	return token, args, true
 }

--- a/cli/commands_integration_test.go
+++ b/cli/commands_integration_test.go
@@ -211,3 +211,20 @@ func TestOneShotExpansion_GoldenPath(t *testing.T) {
 		t.Errorf("one-shot expansion mismatch: %q ok=%v", expanded, ok)
 	}
 }
+
+func TestOneShotExpansion_PipedStdinBody(t *testing.T) {
+	cli, project := newCommandsTestCLI(t)
+	writeCommandFile(t, project, "review.md", "Review this change:\n$ARGUMENTS")
+
+	// runOneShotIfRequested appends piped stdin to the prompt after a
+	// newline; the bare command must still resolve and take the body as
+	// $ARGUMENTS.
+	input := "/review\ndiff --git a/x b/x\n+foo"
+	expanded, ok := cli.expandSlashCommandInput(context.Background(), input, false)
+	if !ok {
+		t.Fatal("bare command with piped body must expand")
+	}
+	if !strings.Contains(expanded, "diff --git a/x b/x\n+foo") {
+		t.Errorf("piped body must interpolate into $ARGUMENTS: %q", expanded)
+	}
+}

--- a/cli/commands_surfaces_test.go
+++ b/cli/commands_surfaces_test.go
@@ -124,7 +124,16 @@ func TestSplitSlashInvocation(t *testing.T) {
 	if tok, args, ok := splitSlashInvocation("/review-pr 1 2"); !ok || tok != "review-pr" || args != "1 2" {
 		t.Errorf("split mismatch: %q %q %v", tok, args, ok)
 	}
-	for _, bad := range []string{"", "/", "no-slash", "/ "} {
+	// The token ends at ANY whitespace: piped stdin arrives appended after
+	// a newline (`git diff | chatcli -p "/review"`), and the pipe body
+	// becomes args.
+	if tok, args, ok := splitSlashInvocation("/review\ndiff --git a/x b/x\n+foo"); !ok || tok != "review" || args != "diff --git a/x b/x\n+foo" {
+		t.Errorf("newline split mismatch: %q %q %v", tok, args, ok)
+	}
+	if tok, args, ok := splitSlashInvocation("/review\targs"); !ok || tok != "review" || args != "args" {
+		t.Errorf("tab split mismatch: %q %q %v", tok, args, ok)
+	}
+	for _, bad := range []string{"", "/", "no-slash", "/ ", "/\nbody"} {
 		if _, _, ok := splitSlashInvocation(bad); ok {
 			t.Errorf("%q must not parse as an invocation", bad)
 		}


### PR DESCRIPTION
## Problem

The one-shot surface appends piped stdin to the prompt after a newline before slash-command resolution, but `splitSlashInvocation` only cut the token at the first **space**. A bare invocation fed by a pipe:

```bash
git diff | chatcli -p "/review"
```

produced the token `review\ndiff`, missed the catalog, and the template never expanded — the raw text went to the model as plain chat. Passing any argument masked the bug, which is why existing tests never caught it.

## Fix

The token now ends at the first whitespace of **any** kind (`strings.IndexFunc` + `unicode.IsSpace`) and the whole piped body becomes `$ARGUMENTS`. Both catalog consumers (`peekSlashCommand`, `expandSlashCommandInput`) share the splitter, so every surface inherits the fix — including the coder auto-route: a bare `mode: coder` command driven by a pipe now routes to the coder engine with the pipe body as its input.

## Tests

- `TestSplitSlashInvocation`: newline/tab-separated body, empty-token-with-body rejection
- `TestOneShotExpansion_PipedStdinBody`: bare command + multiline body interpolates into `$ARGUMENTS`
- `TestResolveOneShotCommand_CoderRoute`: piped body keeps the coder route with correct expansion

`go build ./...`, full `go test ./cli` and `golangci-lint run ./cli/...` clean.