### PR TITLE
feat(models): refresh image and embedding catalogs for Aug 2026

### DIFF
--- a/cli/config_env_defaults.go
+++ b/cli/config_env_defaults.go
@@ -166,8 +166,8 @@ var envDefaults = map[string]envDefault{
 	// the model/dimensions defaults so /config can show what each provider
 	// would use if selected.
 	"CHATCLI_EMBED_PROVIDER":   {Value: "(off)", Source: "llm/embedding/factory.go (empty == null)"},
-	"CHATCLI_EMBED_MODEL":      {Value: "(provider-specific)", Source: "voyage-4 / text-embedding-3-small / amazon.titan-embed-text-v2:0"},
-	"CHATCLI_EMBED_DIMENSIONS": {Value: "(provider-default)", Source: "openai 1536, titan-v2 1024 (256/512/1024), titan-v1 1536, cohere-v3 1024, cohere-v4 1536, nova-mme 3072 (256/384/1024/3072)"},
+	"CHATCLI_EMBED_MODEL":      {Value: "(provider-specific)", Source: "voyage-4 / text-embedding-3-small / gemini-embedding-2 / amazon.titan-embed-text-v2:0"},
+	"CHATCLI_EMBED_DIMENSIONS": {Value: "(provider-default)", Source: "openai 1536, google 3072 (128-3072), titan-v2 1024 (256/512/1024), titan-v1 1536, cohere-v3 1024, cohere-v4 1536, nova-mme 3072 (256/384/1024/3072)"},
 
 	// ─── Cost / budget ───────────────────────────────────────────
 	"CHATCLI_SESSION_BUDGET_USD": {Value: "(no budget)", Source: "cost_tracker.go"},

--- a/cli/config_env_defaults.go
+++ b/cli/config_env_defaults.go
@@ -166,8 +166,8 @@ var envDefaults = map[string]envDefault{
 	// the model/dimensions defaults so /config can show what each provider
 	// would use if selected.
 	"CHATCLI_EMBED_PROVIDER":   {Value: "(off)", Source: "llm/embedding/factory.go (empty == null)"},
-	"CHATCLI_EMBED_MODEL":      {Value: "(provider-specific)", Source: "voyage-3 / text-embedding-3-small / amazon.titan-embed-text-v2:0"},
-	"CHATCLI_EMBED_DIMENSIONS": {Value: "(provider-default)", Source: "openai 1536, titan-v2 1024 (256/512/1024), titan-v1 1536, cohere-v3 1024"},
+	"CHATCLI_EMBED_MODEL":      {Value: "(provider-specific)", Source: "voyage-4 / text-embedding-3-small / amazon.titan-embed-text-v2:0"},
+	"CHATCLI_EMBED_DIMENSIONS": {Value: "(provider-default)", Source: "openai 1536, titan-v2 1024 (256/512/1024), titan-v1 1536, cohere-v3 1024, cohere-v4 1536, nova-mme 3072 (256/384/1024/3072)"},
 
 	// ─── Cost / budget ───────────────────────────────────────────
 	"CHATCLI_SESSION_BUDGET_USD": {Value: "(no budget)", Source: "cost_tracker.go"},
@@ -203,7 +203,7 @@ var envDefaults = map[string]envDefault{
 	"CHATCLI_IMAGE_PROVIDER":      {Value: "auto", Source: "imagegen.NewFromEnv"},
 	"CHATCLI_IMAGE_API":           {Value: "images", Source: "imagegen (images|responses)"},
 	"CHATCLI_IMAGE_URL":           {Value: "(none)", Source: "imagegen self-hosted endpoint"},
-	"CHATCLI_IMAGE_MODEL":         {Value: "gpt-image-1", Source: "imagegen.defaultImageModel"},
+	"CHATCLI_IMAGE_MODEL":         {Value: "gpt-image-2", Source: "imagegen.defaultImageModel"},
 	"CHATCLI_IMAGE_EDIT_PROVIDER": {Value: "(inherit)", Source: "imagegen edit fallback when active provider can't edit"},
 	"CHATCLI_IMAGE_EDIT_MODEL":    {Value: "(default)", Source: "imagegen edit fallback model"},
 

--- a/cli/hyde_setup.go
+++ b/cli/hyde_setup.go
@@ -135,7 +135,7 @@ func (cli *ChatCLI) ensureHyDEVectors(qcfg quality.Config) {
 	provider := cli.hydeProviderForSession()
 	if embedding.IsNull(provider) {
 		cli.logger.Info("HyDE vectors requested but no embedding provider configured; using keyword-only retrieval",
-			zap.String("hint", "set CHATCLI_EMBED_PROVIDER=voyage|openai|bedrock"))
+			zap.String("hint", "set CHATCLI_EMBED_PROVIDER=voyage|openai|google|bedrock"))
 		return
 	}
 	memDir := ""

--- a/cli/plugins/builtin_image.go
+++ b/cli/plugins/builtin_image.go
@@ -224,7 +224,7 @@ func (p *BuiltinImagePlugin) ExecuteWithStream(ctx context.Context, args []strin
 		// edit-capable fallback — reported below so the switch is explicit.
 		editor, used, fellBack, ok := imagegen.ResolveEditor(ctx, provider, nil)
 		if !ok {
-			return "", fmt.Errorf("@image: backend %q does not support image editing and no edit-capable fallback is configured. Editing backends: sdwebui (img2img, keyless), openai (gpt-image-1), google (Gemini image), bedrock (Stability/Nova). Set CHATCLI_IMAGE_EDIT_PROVIDER or switch the image provider. Generation-only: xai, zai, minimax", provider.Name())
+			return "", fmt.Errorf("@image: backend %q does not support image editing and no edit-capable fallback is configured. Editing backends: sdwebui (img2img, keyless), openai (gpt-image-2), google (Gemini image), bedrock (Stability/Nova). Set CHATCLI_IMAGE_EDIT_PROVIDER or switch the image provider. Generation-only: xai, zai, minimax", provider.Name())
 		}
 		inputs, err := loadInputImages(paths)
 		if err != nil {

--- a/llm/embedding/bedrock.go
+++ b/llm/embedding/bedrock.go
@@ -10,11 +10,17 @@
  *
  *   - Titan v1 / v2 (amazon.titan-embed-text-*): single text per call,
  *     dimension knob on v2 (256 / 512 / 1024).
- *   - Cohere v3 (cohere.embed-*): batch-native, 1024-dim fixed.
+ *   - Cohere v3 (cohere.embed-*-v3): batch-native, 1024-dim fixed.
+ *   - Cohere v4 (cohere.embed-v4:0, optionally us./eu./global. profile):
+ *     batch-native, embeddings come back keyed by type ({"float": [...]}),
+ *     1536-dim default.
+ *   - Nova Multimodal Embeddings (amazon.nova-2-multimodal-embeddings-*):
+ *     single text per call (SINGLE_EMBEDDING task), dimension knob
+ *     (256 / 384 / 1024 / 3072).
  *
- * For Titan, batches are parallelized with a small worker pool to
- * stay within Bedrock's per-account InvokeModel concurrency budget
- * without serializing IO.
+ * For the single-text families, batches are parallelized with a small
+ * worker pool to stay within Bedrock's per-account InvokeModel
+ * concurrency budget without serializing IO.
  */
 package embedding
 
@@ -42,12 +48,15 @@ const (
 	titanV2DefaultDim = 1024
 	titanV1Dim        = 1536
 	cohereV3Dim       = 1024
-	// bedrockTitanBatchConcurrency caps how many parallel InvokeModel
-	// calls the provider issues for Titan when the caller hands in a
-	// batch. 8 is a defensive default that lands well under typical
-	// Bedrock account quotas while still hiding most of the per-call
-	// latency behind concurrency.
-	bedrockTitanBatchConcurrency = 8
+	cohereV4Dim       = 1536
+	novaMMEDefaultDim = 3072
+	// bedrockSingleBatchConcurrency caps how many parallel InvokeModel
+	// calls the provider issues for the single-text-per-call families
+	// (Titan, Nova MME) when the caller hands in a batch. 8 is a
+	// defensive default that lands well under typical Bedrock account
+	// quotas while still hiding most of the per-call latency behind
+	// concurrency.
+	bedrockSingleBatchConcurrency = 8
 )
 
 // embedFamily identifies the body schema for a Bedrock embedding model.
@@ -56,6 +65,7 @@ type embedFamily string
 const (
 	embedFamilyTitan  embedFamily = "titan"
 	embedFamilyCohere embedFamily = "cohere"
+	embedFamilyNova   embedFamily = "nova"
 )
 
 // Bedrock is the AWS Bedrock embeddings provider.
@@ -88,7 +98,8 @@ type Bedrock struct {
 // NewBedrock constructs the provider. region/profile follow the same
 // precedence as the chat client (caller resolves env vars). When dim
 // is 0, the family default is used (Titan v2: 1024, Titan v1: 1536,
-// Cohere v3: 1024). A nil logger is replaced with zap.NewNop().
+// Cohere v3: 1024, Cohere v4: 1536, Nova MME: 3072). A nil logger is
+// replaced with zap.NewNop().
 func NewBedrock(model, region, profile string, dim int, logger *zap.Logger) (*Bedrock, error) {
 	if logger == nil {
 		logger = zap.NewNop()
@@ -102,6 +113,9 @@ func NewBedrock(model, region, profile string, dim int, logger *zap.Logger) (*Be
 	}
 	if family == embedFamilyTitan && !isValidTitanDim(model, dim) {
 		return nil, fmt.Errorf("bedrock embeddings: invalid dimension %d for %s (Titan v2 supports 256/512/1024; v1 fixed at 1536)", dim, model)
+	}
+	if family == embedFamilyNova && !isValidNovaDim(dim) {
+		return nil, fmt.Errorf("bedrock embeddings: invalid dimension %d for %s (Nova Multimodal Embeddings supports 256/384/1024/3072)", dim, model)
 	}
 	return &Bedrock{
 		model:   model,
@@ -119,9 +133,9 @@ func (b *Bedrock) Name() string { return "bedrock:" + b.model }
 // Dimension returns the vector dimensionality.
 func (b *Bedrock) Dimension() int { return b.dim }
 
-// Embed converts the batch to vectors. Titan models loop with bounded
-// parallelism (one InvokeModel per text); Cohere ships the whole batch
-// in a single call.
+// Embed converts the batch to vectors. Titan and Nova MME models loop
+// with bounded parallelism (one InvokeModel per text); Cohere ships the
+// whole batch in a single call.
 func (b *Bedrock) Embed(ctx context.Context, texts []string) ([][]float32, error) {
 	if len(texts) == 0 {
 		return nil, nil
@@ -148,8 +162,10 @@ func (b *Bedrock) Embed(ctx context.Context, texts []string) ([][]float32, error
 	switch b.family {
 	case embedFamilyCohere:
 		out, err = b.embedCohere(ctx, texts)
+	case embedFamilyNova:
+		out, err = b.embedPerText(ctx, texts, "nova", b.invokeNova)
 	default:
-		out, err = b.embedTitan(ctx, texts)
+		out, err = b.embedPerText(ctx, texts, "titan", b.invokeTitan)
 	}
 	if err != nil {
 		return nil, b.classifyCredError(err)
@@ -242,24 +258,15 @@ func (b *Bedrock) ensureRuntime(ctx context.Context) error {
 	return b.initErr
 }
 
-// ── Titan family ────────────────────────────────────────────────────
+// ── Single-text families (Titan, Nova MME) ──────────────────────────
 
-type titanRequest struct {
-	InputText  string `json:"inputText"`
-	Dimensions int    `json:"dimensions,omitempty"`
-	Normalize  bool   `json:"normalize,omitempty"`
-}
-
-type titanResponse struct {
-	Embedding           []float32 `json:"embedding"`
-	InputTextTokenCount int       `json:"inputTextTokenCount"`
-}
-
-func (b *Bedrock) embedTitan(ctx context.Context, texts []string) ([][]float32, error) {
+// embedPerText fans the batch out over invoke with bounded parallelism
+// for the families whose API takes one text per InvokeModel call.
+func (b *Bedrock) embedPerText(ctx context.Context, texts []string, label string, invoke func(context.Context, string) ([]float32, error)) ([][]float32, error) {
 	out := make([][]float32, len(texts))
 	errs := make([]error, len(texts))
 
-	concurrency := bedrockTitanBatchConcurrency
+	concurrency := bedrockSingleBatchConcurrency
 	if concurrency > len(texts) {
 		concurrency = len(texts)
 	}
@@ -271,7 +278,7 @@ func (b *Bedrock) embedTitan(ctx context.Context, texts []string) ([][]float32, 
 		go func(idx int, in string) {
 			defer wg.Done()
 			defer func() { <-sem }()
-			vec, err := b.invokeTitan(ctx, in)
+			vec, err := invoke(ctx, in)
 			if err != nil {
 				errs[idx] = err
 				return
@@ -282,10 +289,23 @@ func (b *Bedrock) embedTitan(ctx context.Context, texts []string) ([][]float32, 
 	wg.Wait()
 	for i, err := range errs {
 		if err != nil {
-			return nil, fmt.Errorf("bedrock titan: index %d: %w", i, err)
+			return nil, fmt.Errorf("bedrock %s: index %d: %w", label, i, err)
 		}
 	}
 	return out, nil
+}
+
+// ── Titan family ────────────────────────────────────────────────────
+
+type titanRequest struct {
+	InputText  string `json:"inputText"`
+	Dimensions int    `json:"dimensions,omitempty"`
+	Normalize  bool   `json:"normalize,omitempty"`
+}
+
+type titanResponse struct {
+	Embedding           []float32 `json:"embedding"`
+	InputTextTokenCount int       `json:"inputTextTokenCount"`
 }
 
 func (b *Bedrock) invokeTitan(ctx context.Context, text string) ([]float32, error) {
@@ -316,16 +336,98 @@ func (b *Bedrock) invokeTitan(ctx context.Context, text string) ([]float32, erro
 	return parsed.Embedding, nil
 }
 
+// ── Nova Multimodal Embeddings family ───────────────────────────────
+
+// novaRequest is the SINGLE_EMBEDDING task shape of Nova Multimodal
+// Embeddings (amazon.nova-2-multimodal-embeddings). Only the text
+// modality is used here; segmentation and audio/video need the async
+// API and are out of scope for retrieval embeddings.
+type novaRequest struct {
+	TaskType              string              `json:"taskType"`
+	SingleEmbeddingParams novaEmbeddingParams `json:"singleEmbeddingParams"`
+}
+
+type novaEmbeddingParams struct {
+	EmbeddingPurpose   string       `json:"embeddingPurpose"`
+	EmbeddingDimension int          `json:"embeddingDimension"`
+	Text               novaTextSpec `json:"text"`
+}
+
+type novaTextSpec struct {
+	TruncationMode string `json:"truncationMode"`
+	Value          string `json:"value"`
+}
+
+type novaResponse struct {
+	Embeddings []struct {
+		EmbeddingType string    `json:"embeddingType"`
+		Embedding     []float32 `json:"embedding"`
+	} `json:"embeddings"`
+}
+
+func (b *Bedrock) invokeNova(ctx context.Context, text string) ([]float32, error) {
+	body := novaRequest{
+		TaskType: "SINGLE_EMBEDDING",
+		SingleEmbeddingParams: novaEmbeddingParams{
+			EmbeddingPurpose:   "GENERIC_INDEX",
+			EmbeddingDimension: b.dim,
+			Text:               novaTextSpec{TruncationMode: "END", Value: text},
+		},
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("nova marshal: %w", err)
+	}
+	out, err := b.runtime.InvokeModel(ctx, &bedrockruntime.InvokeModelInput{
+		ModelId:     aws.String(b.model),
+		ContentType: aws.String("application/json"),
+		Accept:      aws.String("application/json"),
+		Body:        payload,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var parsed novaResponse
+	if err := json.Unmarshal(out.Body, &parsed); err != nil {
+		return nil, fmt.Errorf("nova decode: %w", err)
+	}
+	if len(parsed.Embeddings) == 0 || len(parsed.Embeddings[0].Embedding) == 0 {
+		return nil, fmt.Errorf("nova: empty embedding in response")
+	}
+	return parsed.Embeddings[0].Embedding, nil
+}
+
 // ── Cohere family ───────────────────────────────────────────────────
 
 type cohereRequest struct {
 	Texts     []string `json:"texts"`
 	InputType string   `json:"input_type"`
 	Truncate  string   `json:"truncate,omitempty"`
+	// EmbeddingTypes is required by Embed v4 (whose response keys the
+	// vectors by type); v3 works without it and keeps its flat response,
+	// so it is only sent for v4.
+	EmbeddingTypes []string `json:"embedding_types,omitempty"`
 }
 
+// cohereResponse tolerates both Cohere response generations: v3 returns
+// "embeddings" as a plain array of vectors, v4 (embedding_types) keys
+// them by type ({"embeddings": {"float": [...]}}).
 type cohereResponse struct {
-	Embeddings [][]float32 `json:"embeddings"`
+	Embeddings json.RawMessage `json:"embeddings"`
+}
+
+func (r *cohereResponse) vectors() ([][]float32, error) {
+	var flat [][]float32
+	if err := json.Unmarshal(r.Embeddings, &flat); err == nil {
+		return flat, nil
+	}
+	var keyed struct {
+		Float [][]float32 `json:"float"`
+	}
+	if err := json.Unmarshal(r.Embeddings, &keyed); err != nil {
+		return nil, err
+	}
+	return keyed.Float, nil
 }
 
 func (b *Bedrock) embedCohere(ctx context.Context, texts []string) ([][]float32, error) {
@@ -333,6 +435,9 @@ func (b *Bedrock) embedCohere(ctx context.Context, texts []string) ([][]float32,
 		Texts:     texts,
 		InputType: "search_document",
 		Truncate:  "END",
+	}
+	if isCohereV4ID(b.model) {
+		body.EmbeddingTypes = []string{"float"}
 	}
 	payload, err := json.Marshal(body)
 	if err != nil {
@@ -351,10 +456,14 @@ func (b *Bedrock) embedCohere(ctx context.Context, texts []string) ([][]float32,
 	if err := json.Unmarshal(out.Body, &parsed); err != nil {
 		return nil, fmt.Errorf("cohere decode: %w", err)
 	}
-	if len(parsed.Embeddings) != len(texts) {
-		return nil, fmt.Errorf("cohere returned %d vectors for %d inputs", len(parsed.Embeddings), len(texts))
+	vecs, err := parsed.vectors()
+	if err != nil {
+		return nil, fmt.Errorf("cohere decode embeddings: %w", err)
 	}
-	return parsed.Embeddings, nil
+	if len(vecs) != len(texts) {
+		return nil, fmt.Errorf("cohere returned %d vectors for %d inputs", len(vecs), len(texts))
+	}
+	return vecs, nil
 }
 
 // ── Family + dim helpers ────────────────────────────────────────────
@@ -364,18 +473,43 @@ func resolveEmbedFamily(model string) embedFamily {
 	if strings.Contains(m, "cohere.embed") || strings.Contains(m, "cohere-embed") {
 		return embedFamilyCohere
 	}
+	// amazon.nova-2-multimodal-embeddings-v1:0, optionally behind an
+	// inference-profile prefix (us./eu./global.).
+	if strings.Contains(m, "nova") && strings.Contains(m, "embed") {
+		return embedFamilyNova
+	}
 	return embedFamilyTitan
 }
 
 func defaultDim(model string, family embedFamily) int {
 	switch family {
 	case embedFamilyCohere:
+		if isCohereV4ID(model) {
+			return cohereV4Dim
+		}
 		return cohereV3Dim
+	case embedFamilyNova:
+		return novaMMEDefaultDim
 	}
 	if isTitanV1ID(model) {
 		return titanV1Dim
 	}
 	return titanV2DefaultDim
+}
+
+// isCohereV4ID reports whether the model is Cohere Embed v4
+// (cohere.embed-v4:0, possibly profile-prefixed) as opposed to the v3
+// pair (cohere.embed-english-v3 / cohere.embed-multilingual-v3).
+func isCohereV4ID(model string) bool {
+	return strings.Contains(strings.ToLower(model), "embed-v4")
+}
+
+func isValidNovaDim(dim int) bool {
+	switch dim {
+	case 256, 384, 1024, 3072:
+		return true
+	}
+	return false
 }
 
 func (b *Bedrock) isTitanV2() bool {

--- a/llm/embedding/bedrock_test.go
+++ b/llm/embedding/bedrock_test.go
@@ -24,8 +24,12 @@ func TestResolveEmbedFamily(t *testing.T) {
 		"amazon.titan-embed-image-v1":   embedFamilyTitan,
 		"cohere.embed-english-v3":       embedFamilyCohere,
 		"cohere.embed-multilingual-v3":  embedFamilyCohere,
+		"cohere.embed-v4:0":             embedFamilyCohere,
+		"global.cohere.embed-v4:0":      embedFamilyCohere,
 		"us.amazon.titan-embed-text-v2": embedFamilyTitan,
-		"":                              embedFamilyTitan, // default safety
+		"amazon.nova-2-multimodal-embeddings-v1:0":    embedFamilyNova,
+		"us.amazon.nova-2-multimodal-embeddings-v1:0": embedFamilyNova,
+		"": embedFamilyTitan, // default safety
 	}
 	for id, want := range cases {
 		if got := resolveEmbedFamily(id); got != want {
@@ -42,6 +46,8 @@ func TestDefaultDim(t *testing.T) {
 		{"amazon.titan-embed-text-v2:0", titanV2DefaultDim},
 		{"amazon.titan-embed-text-v1", titanV1Dim},
 		{"cohere.embed-english-v3", cohereV3Dim},
+		{"cohere.embed-v4:0", cohereV4Dim},
+		{"amazon.nova-2-multimodal-embeddings-v1:0", novaMMEDefaultDim},
 	}
 	for _, tc := range cases {
 		family := resolveEmbedFamily(tc.model)
@@ -94,6 +100,25 @@ func TestNewBedrock_DefaultsAndOverrides(t *testing.T) {
 func TestNewBedrock_RejectsInvalidTitanDim(t *testing.T) {
 	if _, err := NewBedrock("amazon.titan-embed-text-v2:0", "us-east-1", "", 999, nil); err == nil {
 		t.Fatal("expected error for invalid Titan v2 dimension")
+	}
+}
+
+func TestNewBedrock_NovaDims(t *testing.T) {
+	p, err := NewBedrock("amazon.nova-2-multimodal-embeddings-v1:0", "us-east-1", "", 0, nil)
+	if err != nil {
+		t.Fatalf("nova constructor: %v", err)
+	}
+	if p.family != embedFamilyNova {
+		t.Errorf("expected nova family; got %q", p.family)
+	}
+	if p.Dimension() != novaMMEDefaultDim {
+		t.Errorf("nova dim = %d, want %d", p.Dimension(), novaMMEDefaultDim)
+	}
+	if _, err := NewBedrock("amazon.nova-2-multimodal-embeddings-v1:0", "us-east-1", "", 384, nil); err != nil {
+		t.Errorf("384 must be a valid Nova dimension: %v", err)
+	}
+	if _, err := NewBedrock("amazon.nova-2-multimodal-embeddings-v1:0", "us-east-1", "", 512, nil); err == nil {
+		t.Error("expected error for invalid Nova dimension 512")
 	}
 }
 
@@ -154,6 +179,58 @@ func TestCohereRequestShape(t *testing.T) {
 	if got["input_type"] != "search_document" {
 		t.Errorf("input_type missing or wrong: %v", got["input_type"])
 	}
+	// v3 requests must NOT carry embedding_types (only v4 gets it).
+	if _, present := got["embedding_types"]; present {
+		t.Errorf("embedding_types must be omitted when unset: %v", got)
+	}
+}
+
+// TestNovaRequestShape pins the SINGLE_EMBEDDING body of Nova Multimodal
+// Embeddings — taskType + singleEmbeddingParams with purpose, dimension
+// and the text spec. AWS rejects malformed bodies, so shape drift would
+// break embeddings without us noticing.
+func TestNovaRequestShape(t *testing.T) {
+	body := novaRequest{
+		TaskType: "SINGLE_EMBEDDING",
+		SingleEmbeddingParams: novaEmbeddingParams{
+			EmbeddingPurpose:   "GENERIC_INDEX",
+			EmbeddingDimension: 3072,
+			Text:               novaTextSpec{TruncationMode: "END", Value: "hello"},
+		},
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["taskType"] != "SINGLE_EMBEDDING" {
+		t.Errorf("taskType missing or wrong: %v", got["taskType"])
+	}
+	params, ok := got["singleEmbeddingParams"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("singleEmbeddingParams missing: %v", got)
+	}
+	if params["embeddingPurpose"] != "GENERIC_INDEX" || params["embeddingDimension"].(float64) != 3072 {
+		t.Errorf("params wrong: %v", params)
+	}
+	text, ok := params["text"].(map[string]interface{})
+	if !ok || text["value"] != "hello" || text["truncationMode"] != "END" {
+		t.Errorf("text spec wrong: %v", params["text"])
+	}
+}
+
+func TestNovaResponseDecode(t *testing.T) {
+	raw := []byte(`{"embeddings":[{"embeddingType":"TEXT","embedding":[0.1,0.2,0.3]}]}`)
+	var parsed novaResponse
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(parsed.Embeddings) != 1 || len(parsed.Embeddings[0].Embedding) != 3 {
+		t.Errorf("nova response wrong: %+v", parsed)
+	}
 }
 
 // TestTitanResponseDecode pins the parser against the canonical Titan v2
@@ -173,13 +250,32 @@ func TestTitanResponseDecode(t *testing.T) {
 }
 
 func TestCohereResponseDecode(t *testing.T) {
+	// v3 shape: embeddings is a plain array of vectors.
 	raw := []byte(`{"embeddings":[[0.1,0.2],[0.3,0.4]]}`)
 	var parsed cohereResponse
 	if err := json.Unmarshal(raw, &parsed); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if len(parsed.Embeddings) != 2 {
-		t.Errorf("expected 2 vectors; got %d", len(parsed.Embeddings))
+	vecs, err := parsed.vectors()
+	if err != nil {
+		t.Fatalf("vectors: %v", err)
+	}
+	if len(vecs) != 2 {
+		t.Errorf("expected 2 vectors; got %d", len(vecs))
+	}
+
+	// v4 shape (embedding_types): vectors keyed by type.
+	raw = []byte(`{"embeddings":{"float":[[0.1,0.2],[0.3,0.4],[0.5,0.6]]}}`)
+	parsed = cohereResponse{}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("decode v4: %v", err)
+	}
+	vecs, err = parsed.vectors()
+	if err != nil {
+		t.Fatalf("vectors v4: %v", err)
+	}
+	if len(vecs) != 3 || vecs[2][1] != 0.6 {
+		t.Errorf("v4 vectors wrong: %v", vecs)
 	}
 }
 

--- a/llm/embedding/bedrock_test.go
+++ b/llm/embedding/bedrock_test.go
@@ -13,20 +13,25 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 	"time"
 )
 
 func TestResolveEmbedFamily(t *testing.T) {
 	cases := map[string]embedFamily{
-		"amazon.titan-embed-text-v2:0":  embedFamilyTitan,
-		"amazon.titan-embed-text-v1":    embedFamilyTitan,
-		"amazon.titan-embed-image-v1":   embedFamilyTitan,
-		"cohere.embed-english-v3":       embedFamilyCohere,
-		"cohere.embed-multilingual-v3":  embedFamilyCohere,
-		"cohere.embed-v4:0":             embedFamilyCohere,
-		"global.cohere.embed-v4:0":      embedFamilyCohere,
-		"us.amazon.titan-embed-text-v2": embedFamilyTitan,
+		"amazon.titan-embed-text-v2:0":                embedFamilyTitan,
+		"amazon.titan-embed-text-v1":                  embedFamilyTitan,
+		"amazon.titan-embed-image-v1":                 embedFamilyTitan,
+		"cohere.embed-english-v3":                     embedFamilyCohere,
+		"cohere.embed-multilingual-v3":                embedFamilyCohere,
+		"cohere.embed-v4:0":                           embedFamilyCohere,
+		"global.cohere.embed-v4:0":                    embedFamilyCohere,
+		"us.amazon.titan-embed-text-v2":               embedFamilyTitan,
 		"amazon.nova-2-multimodal-embeddings-v1:0":    embedFamilyNova,
 		"us.amazon.nova-2-multimodal-embeddings-v1:0": embedFamilyNova,
 		"": embedFamilyTitan, // default safety
@@ -230,6 +235,93 @@ func TestNovaResponseDecode(t *testing.T) {
 	}
 	if len(parsed.Embeddings) != 1 || len(parsed.Embeddings[0].Embedding) != 3 {
 		t.Errorf("nova response wrong: %+v", parsed)
+	}
+}
+
+// TestEmbed_EndToEnd exercises the real InvokeModel path of every
+// family against a local httptest server via BEDROCK_BASE_URL. Static
+// SigV4 env creds are used because the runtime SDK refuses bearer
+// tokens over plain HTTP (httptest serves HTTP).
+func TestEmbed_EndToEnd(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		path, _ := url.PathUnescape(r.URL.Path)
+		w.Header().Set("content-type", "application/json")
+		switch {
+		case strings.Contains(path, "titan-embed"):
+			if !strings.Contains(string(body), "inputText") {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			_, _ = w.Write([]byte(`{"embedding":[0.1,0.2],"inputTextTokenCount":2}`))
+		case strings.Contains(path, "nova-2-multimodal"):
+			if !strings.Contains(string(body), "SINGLE_EMBEDDING") {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			_, _ = w.Write([]byte(`{"embeddings":[{"embeddingType":"TEXT","embedding":[0.5,0.6]}]}`))
+		case strings.Contains(path, "embed-v4"):
+			// v4 must request typed embeddings and gets the keyed shape.
+			if !strings.Contains(string(body), "embedding_types") {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			_, _ = w.Write([]byte(`{"embeddings":{"float":[[0.1],[0.2]]}}`))
+		case strings.Contains(path, "embed-english-v3"):
+			// v3 must NOT send embedding_types and gets the flat shape.
+			if strings.Contains(string(body), "embedding_types") {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			_, _ = w.Write([]byte(`{"embeddings":[[0.1],[0.2]]}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("BEDROCK_BASE_URL", srv.URL)
+	t.Setenv("AWS_BEARER_TOKEN_BEDROCK", "")
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("AWS_ACCESS_KEY_ID", "test-access-key")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test-secret-key")
+	t.Setenv("AWS_SESSION_TOKEN", "")
+	t.Setenv("AWS_PROFILE", "")
+
+	cases := []struct {
+		name    string
+		model   string
+		n       int
+		wantDim int
+	}{
+		{"titan", "amazon.titan-embed-text-v2:0", 3, 2},
+		{"nova", "amazon.nova-2-multimodal-embeddings-v1:0", 2, 2},
+		{"cohere-v3", "cohere.embed-english-v3", 2, 1},
+		{"cohere-v4", "cohere.embed-v4:0", 2, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := NewBedrock(tc.model, "us-east-1", "", 0, nil)
+			if err != nil {
+				t.Fatalf("constructor: %v", err)
+			}
+			texts := make([]string, tc.n)
+			for i := range texts {
+				texts[i] = fmt.Sprintf("text %d", i)
+			}
+			vecs, err := p.Embed(context.Background(), texts)
+			if err != nil {
+				t.Fatalf("embed: %v", err)
+			}
+			if len(vecs) != tc.n {
+				t.Fatalf("got %d vectors for %d inputs", len(vecs), tc.n)
+			}
+			for i, v := range vecs {
+				if len(v) != tc.wantDim {
+					t.Errorf("vector %d has dim %d, want %d", i, len(v), tc.wantDim)
+				}
+			}
+		})
 	}
 }
 

--- a/llm/embedding/embedding.go
+++ b/llm/embedding/embedding.go
@@ -9,8 +9,10 @@
  * Providers wired in this package:
  *   - voyage  : Voyage AI (Anthropic-recommended, best quality/$)
  *   - openai  : OpenAI text-embedding-3-small (256/512/1024/1536 dim)
- *   - bedrock : AWS Bedrock — Titan v1/v2 (single-text) and Cohere v3
- *               (batch); reuses the chat client's AWS credential chain.
+ *   - google  : Gemini API gemini-embedding-2 (128–3072 dim, Matryoshka)
+ *   - bedrock : AWS Bedrock — Titan v1/v2 and Nova MME (single-text),
+ *               Cohere v3/v4 (batch); reuses the chat client's AWS
+ *               credential chain.
  *   - null    : default no-op (returned when no provider is configured)
  */
 package embedding

--- a/llm/embedding/factory.go
+++ b/llm/embedding/factory.go
@@ -20,13 +20,14 @@ import (
 // ErrUnknownProvider.
 //
 // Required env vars per provider:
-//   - voyage: VOYAGE_API_KEY (model: CHATCLI_EMBED_MODEL or "voyage-3")
+//   - voyage: VOYAGE_API_KEY (model: CHATCLI_EMBED_MODEL or "voyage-4")
 //   - openai: OPENAI_API_KEY (model: CHATCLI_EMBED_MODEL or
 //     "text-embedding-3-small"; dim: CHATCLI_EMBED_DIMENSIONS)
 //   - bedrock: AWS credential chain (AWS_PROFILE / AWS_ACCESS_KEY_ID /
 //     IAM role); model: CHATCLI_EMBED_MODEL or "amazon.titan-embed-text-v2:0";
-//     dim: CHATCLI_EMBED_DIMENSIONS (Titan v2: 256/512/1024); region:
-//     BEDROCK_REGION or AWS_REGION; profile: AWS_PROFILE.
+//     dim: CHATCLI_EMBED_DIMENSIONS (Titan v2: 256/512/1024; Nova MME:
+//     256/384/1024/3072); region: BEDROCK_REGION or AWS_REGION;
+//     profile: AWS_PROFILE.
 func NewByName(name string) (Provider, error) {
 	switch NormalizeName(name) {
 	case "", "null", "off":

--- a/llm/embedding/factory.go
+++ b/llm/embedding/factory.go
@@ -16,13 +16,16 @@ import (
 )
 
 // NewByName returns a provider by short name. Supported names: "voyage",
-// "openai", "bedrock", "null", "" (== "null"). Unknown names return
-// ErrUnknownProvider.
+// "openai", "google", "bedrock", "null", "" (== "null"). Unknown names
+// return ErrUnknownProvider.
 //
 // Required env vars per provider:
 //   - voyage: VOYAGE_API_KEY (model: CHATCLI_EMBED_MODEL or "voyage-4")
 //   - openai: OPENAI_API_KEY (model: CHATCLI_EMBED_MODEL or
 //     "text-embedding-3-small"; dim: CHATCLI_EMBED_DIMENSIONS)
+//   - google: GEMINI_API_KEY / GOOGLEAI_API_KEY / GOOGLE_API_KEY (model:
+//     CHATCLI_EMBED_MODEL or "gemini-embedding-2"; dim:
+//     CHATCLI_EMBED_DIMENSIONS, 128–3072 via Matryoshka, default 3072)
 //   - bedrock: AWS credential chain (AWS_PROFILE / AWS_ACCESS_KEY_ID /
 //     IAM role); model: CHATCLI_EMBED_MODEL or "amazon.titan-embed-text-v2:0";
 //     dim: CHATCLI_EMBED_DIMENSIONS (Titan v2: 256/512/1024; Nova MME:
@@ -42,6 +45,15 @@ func NewByName(name string) (Provider, error) {
 			}
 		}
 		return NewOpenAI(os.Getenv("OPENAI_API_KEY"), os.Getenv("CHATCLI_EMBED_MODEL"), dim)
+	case "google", "gemini":
+		dim := 0
+		if v := os.Getenv("CHATCLI_EMBED_DIMENSIONS"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil {
+				dim = n
+			}
+		}
+		key := firstNonEmpty(os.Getenv("GEMINI_API_KEY"), os.Getenv("GOOGLEAI_API_KEY"), os.Getenv("GOOGLE_API_KEY"))
+		return NewGoogle(key, os.Getenv("CHATCLI_EMBED_MODEL"), dim)
 	case "bedrock":
 		dim := 0
 		if v := os.Getenv("CHATCLI_EMBED_DIMENSIONS"); v != "" {

--- a/llm/embedding/google.go
+++ b/llm/embedding/google.go
@@ -1,0 +1,187 @@
+/*
+ * ChatCLI - Google Gemini embeddings provider.
+ *
+ * Defaults to gemini-embedding-2 (3072 dim, multimodal-ready, GA as of
+ * Aug 2026 — gemini-embedding-001 is superseded and shuts down
+ * 2028-05-14). Batches ride the :batchEmbedContents endpoint. The
+ * output_dimensionality knob (CHATCLI_EMBED_DIMENSIONS, 128–3072 via
+ * MRL/Matryoshka) trades quality for storage; truncated vectors are
+ * L2-normalized locally because gemini-embedding-001 returns them
+ * unnormalized (gemini-embedding-2 auto-normalizes — renormalizing is
+ * a no-op there).
+ */
+package embedding
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	googleDefaultModel = "gemini-embedding-2"
+	googleDefaultDim   = 3072
+	googleEndpointBase = "https://generativelanguage.googleapis.com/v1beta"
+	// googleBatchMax is the request cap of :batchEmbedContents — larger
+	// batches are chunked into sequential calls.
+	googleBatchMax = 100
+)
+
+// Google is the Gemini API embeddings provider.
+type Google struct {
+	apiKey   string
+	model    string
+	endpoint string
+	dim      int
+	batchMax int
+	client   *http.Client
+}
+
+// NewGoogle constructs the provider. apiKey is required. When dim <= 0
+// the model's native dimension (3072) is used and no truncation is
+// requested from the API.
+func NewGoogle(apiKey, model string, dim int) (*Google, error) {
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return nil, fmt.Errorf("google embeddings: API key is required (set GEMINI_API_KEY or GOOGLEAI_API_KEY)")
+	}
+	if strings.TrimSpace(model) == "" {
+		model = googleDefaultModel
+	}
+	if dim <= 0 {
+		dim = googleDefaultDim
+	}
+	return &Google{
+		apiKey:   apiKey,
+		model:    model,
+		endpoint: googleEndpointBase,
+		dim:      dim,
+		batchMax: googleBatchMax,
+		client:   &http.Client{Timeout: 30 * time.Second},
+	}, nil
+}
+
+// Name identifies the provider in /config quality output.
+func (g *Google) Name() string { return "google:" + g.model }
+
+// Dimension returns the vector dimensionality.
+func (g *Google) Dimension() int { return g.dim }
+
+type googleEmbedPart struct {
+	Text string `json:"text"`
+}
+
+type googleEmbedContent struct {
+	Parts []googleEmbedPart `json:"parts"`
+}
+
+type googleEmbedRequest struct {
+	Model                string             `json:"model"`
+	Content              googleEmbedContent `json:"content"`
+	OutputDimensionality int                `json:"outputDimensionality,omitempty"`
+}
+
+type googleBatchRequest struct {
+	Requests []googleEmbedRequest `json:"requests"`
+}
+
+type googleBatchResponse struct {
+	Embeddings []struct {
+		Values []float32 `json:"values"`
+	} `json:"embeddings"`
+}
+
+// Embed sends the batch through :batchEmbedContents (chunked at the
+// API's request cap) and returns the vectors in input order.
+func (g *Google) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+	out := make([][]float32, 0, len(texts))
+	for start := 0; start < len(texts); start += g.batchMax {
+		end := start + g.batchMax
+		if end > len(texts) {
+			end = len(texts)
+		}
+		vecs, err := g.embedChunk(ctx, texts[start:end])
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, vecs...)
+	}
+	return out, nil
+}
+
+func (g *Google) embedChunk(ctx context.Context, texts []string) ([][]float32, error) {
+	reqs := make([]googleEmbedRequest, len(texts))
+	for i, text := range texts {
+		reqs[i] = googleEmbedRequest{
+			Model:   "models/" + g.model,
+			Content: googleEmbedContent{Parts: []googleEmbedPart{{Text: text}}},
+		}
+		if g.dim != googleDefaultDim {
+			reqs[i].OutputDimensionality = g.dim
+		}
+	}
+	payload, err := json.Marshal(googleBatchRequest{Requests: reqs})
+	if err != nil {
+		return nil, fmt.Errorf("google embeddings marshal: %w", err)
+	}
+	endpoint := fmt.Sprintf("%s/models/%s:batchEmbedContents", strings.TrimRight(g.endpoint, "/"), g.model)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-goog-api-key", g.apiKey)
+
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("google embeddings request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("google embeddings HTTP %d: %s", resp.StatusCode, truncateBytes(body, 200))
+	}
+	var parsed googleBatchResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("google embeddings decode: %w", err)
+	}
+	if len(parsed.Embeddings) != len(texts) {
+		return nil, fmt.Errorf("google embeddings returned %d vectors for %d inputs", len(parsed.Embeddings), len(texts))
+	}
+	out := make([][]float32, len(texts))
+	for i, e := range parsed.Embeddings {
+		if len(e.Values) == 0 {
+			return nil, fmt.Errorf("google embeddings: empty vector at index %d", i)
+		}
+		out[i] = l2Normalize(e.Values)
+	}
+	return out, nil
+}
+
+// l2Normalize scales v to unit length in place and returns it. Cosine
+// similarity is scale-invariant, so normalizing an already-normalized
+// vector is a no-op — this only matters for truncated dims on
+// gemini-embedding-001, which the API returns unnormalized.
+func l2Normalize(v []float32) []float32 {
+	var sum float64
+	for _, x := range v {
+		sum += float64(x) * float64(x)
+	}
+	if sum == 0 {
+		return v
+	}
+	norm := math.Sqrt(sum)
+	for i := range v {
+		v[i] = float32(float64(v[i]) / norm)
+	}
+	return v
+}

--- a/llm/embedding/google.go
+++ b/llm/embedding/google.go
@@ -1,5 +1,7 @@
 /*
  * ChatCLI - Google Gemini embeddings provider.
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
  *
  * Defaults to gemini-embedding-2 (3072 dim, multimodal-ready, GA as of
  * Aug 2026 — gemini-embedding-001 is superseded and shuts down

--- a/llm/embedding/google_test.go
+++ b/llm/embedding/google_test.go
@@ -1,5 +1,7 @@
 /*
  * ChatCLI - Google Gemini embeddings tests.
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
  *
  * Network-free: a local httptest server plays the :batchEmbedContents
  * endpoint, pinning the request shape (models/ prefix, parts, the

--- a/llm/embedding/google_test.go
+++ b/llm/embedding/google_test.go
@@ -1,0 +1,168 @@
+/*
+ * ChatCLI - Google Gemini embeddings tests.
+ *
+ * Network-free: a local httptest server plays the :batchEmbedContents
+ * endpoint, pinning the request shape (models/ prefix, parts, the
+ * outputDimensionality knob) and the chunking + normalization behavior.
+ */
+package embedding
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNewGoogle_Defaults(t *testing.T) {
+	if _, err := NewGoogle("", "", 0); err == nil {
+		t.Fatal("expected error for empty API key")
+	}
+	p, err := NewGoogle("k", "", 0)
+	if err != nil {
+		t.Fatalf("constructor: %v", err)
+	}
+	if p.model != googleDefaultModel {
+		t.Errorf("default model = %q, want %q", p.model, googleDefaultModel)
+	}
+	if p.Dimension() != googleDefaultDim {
+		t.Errorf("default dim = %d, want %d", p.Dimension(), googleDefaultDim)
+	}
+	if p.Name() != "google:"+googleDefaultModel {
+		t.Errorf("name = %q", p.Name())
+	}
+}
+
+func TestGoogleEmbed_BatchShapeAndChunking(t *testing.T) {
+	var calls int
+	var lastPath, lastKey string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		lastPath = r.URL.Path
+		lastKey = r.Header.Get("x-goog-api-key")
+		var body googleBatchRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		for _, req := range body.Requests {
+			if !strings.HasPrefix(req.Model, "models/") || len(req.Content.Parts) != 1 {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			// Native dim requested — the truncation knob must be absent.
+			if req.OutputDimensionality != 0 {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+		}
+		var resp googleBatchResponse
+		resp.Embeddings = make([]struct {
+			Values []float32 `json:"values"`
+		}, len(body.Requests))
+		for i := range resp.Embeddings {
+			resp.Embeddings[i].Values = []float32{1, 0}
+		}
+		w.Header().Set("content-type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	p, err := NewGoogle("test-key", "", 0)
+	if err != nil {
+		t.Fatalf("constructor: %v", err)
+	}
+	p.endpoint = srv.URL
+	p.batchMax = 2 // force chunking with a small batch
+
+	texts := []string{"a", "b", "c", "d", "e"}
+	vecs, err := p.Embed(context.Background(), texts)
+	if err != nil {
+		t.Fatalf("embed: %v", err)
+	}
+	if len(vecs) != len(texts) {
+		t.Fatalf("got %d vectors for %d inputs", len(vecs), len(texts))
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 chunked calls for 5 texts at batchMax=2; got %d", calls)
+	}
+	if !strings.Contains(lastPath, googleDefaultModel+":batchEmbedContents") {
+		t.Errorf("unexpected path %q", lastPath)
+	}
+	if lastKey != "test-key" {
+		t.Errorf("API key header missing; got %q", lastKey)
+	}
+}
+
+func TestGoogleEmbed_TruncatedDimNormalizes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body googleBatchRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if len(body.Requests) != 1 || body.Requests[0].OutputDimensionality != 2 {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		// Unnormalized on purpose — the provider must L2-normalize.
+		_, _ = fmt.Fprint(w, `{"embeddings":[{"values":[3,4]}]}`)
+	}))
+	defer srv.Close()
+
+	p, err := NewGoogle("k", "gemini-embedding-001", 2)
+	if err != nil {
+		t.Fatalf("constructor: %v", err)
+	}
+	p.endpoint = srv.URL
+	vecs, err := p.Embed(context.Background(), []string{"x"})
+	if err != nil {
+		t.Fatalf("embed: %v", err)
+	}
+	norm := math.Sqrt(float64(vecs[0][0])*float64(vecs[0][0]) + float64(vecs[0][1])*float64(vecs[0][1]))
+	if math.Abs(norm-1) > 1e-6 {
+		t.Errorf("vector not unit-length after normalization: %v (norm %f)", vecs[0], norm)
+	}
+}
+
+func TestGoogleEmbed_ErrorSurface(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = fmt.Fprint(w, `{"error":{"message":"key invalid"}}`)
+	}))
+	defer srv.Close()
+	p, err := NewGoogle("bad", "", 0)
+	if err != nil {
+		t.Fatalf("constructor: %v", err)
+	}
+	p.endpoint = srv.URL
+	if _, err := p.Embed(context.Background(), []string{"x"}); err == nil || !strings.Contains(err.Error(), "403") {
+		t.Errorf("expected HTTP 403 error; got %v", err)
+	}
+}
+
+func TestNewByName_Google(t *testing.T) {
+	t.Setenv("GEMINI_API_KEY", "gk")
+	t.Setenv("GOOGLEAI_API_KEY", "")
+	t.Setenv("GOOGLE_API_KEY", "")
+	t.Setenv("CHATCLI_EMBED_MODEL", "")
+	t.Setenv("CHATCLI_EMBED_DIMENSIONS", "1536")
+	p, err := NewByName("google")
+	if err != nil {
+		t.Fatalf("google factory: %v", err)
+	}
+	gp, ok := p.(*Google)
+	if !ok {
+		t.Fatalf("expected *Google; got %T", p)
+	}
+	if gp.model != googleDefaultModel || gp.Dimension() != 1536 {
+		t.Errorf("model=%q dim=%d; want %q/1536", gp.model, gp.Dimension(), googleDefaultModel)
+	}
+	if _, err := NewByName("gemini"); err != nil {
+		t.Errorf("gemini alias must resolve: %v", err)
+	}
+}

--- a/llm/embedding/voyage.go
+++ b/llm/embedding/voyage.go
@@ -2,8 +2,11 @@
  * ChatCLI - Voyage AI embeddings provider (Anthropic-recommended).
  *
  * Voyage offers strong quality/$ for retrieval. Default model is
- * `voyage-3` (1024 dim) which is the recommended general-purpose model
- * as of 2026; override via CHATCLI_EMBED_MODEL.
+ * `voyage-4` (1024 dim), the general-purpose tier of the voyage-4
+ * family (Jan 2026; same price as voyage-3, strictly better, and the
+ * whole family shares one embedding space). Override via
+ * CHATCLI_EMBED_MODEL — e.g. voyage-4-large (quality flagship),
+ * voyage-4-lite (cheapest) or voyage-code-4 (code retrieval).
  */
 package embedding
 
@@ -19,7 +22,7 @@ import (
 )
 
 const (
-	voyageDefaultModel = "voyage-3"
+	voyageDefaultModel = "voyage-4"
 	voyageDefaultDim   = 1024
 	voyageEndpoint     = "https://api.voyageai.com/v1/embeddings"
 )

--- a/llm/imagegen/catalog.go
+++ b/llm/imagegen/catalog.go
@@ -36,27 +36,33 @@ type ModelInfo struct {
 func KnownModels() []ModelInfo {
 	return []ModelInfo{
 		// OpenAI Images API (gpt-image family). May require org verification.
-		// DALL-E 2/3 were retired (dall-e-3 on 2026-03-04; both shut down
-		// 2026-05-12) — removed, they only error now. Use the gpt-image family.
-		{Name: "gpt-image-2", Provider: "openai", API: "images", Note: "Newest OpenAI image model — adds reasoning (Images API)."},
-		{Name: "gpt-image-1.5", Provider: "openai", API: "images", Note: "OpenAI Images API."},
-		{Name: "gpt-image-1", Provider: "openai", API: "images", Note: "OpenAI Images API (broadly available; default)."},
-		{Name: "gpt-image-1-mini", Provider: "openai", API: "images", Note: "Smaller/cheaper OpenAI image model."},
-		// OpenAI Responses API (a chat model generates via the image_generation tool).
+		// DALL-E 2/3 were retired (shut down 2026-05-12) — removed, they only
+		// error now. The rest of the gpt-image family is deprecated in favor of
+		// gpt-image-2: gpt-image-1 shuts down 2026-10-23; gpt-image-1.5,
+		// gpt-image-1-mini and chatgpt-image-latest shut down 2026-12-01.
+		{Name: "gpt-image-2", Provider: "openai", API: "images", Note: "Newest OpenAI image model — adds reasoning (Images API; default)."},
+		{Name: "gpt-image-1.5", Provider: "openai", API: "images", Note: "OpenAI Images API (deprecated; shuts down 2026-12-01)."},
+		{Name: "gpt-image-1", Provider: "openai", API: "images", Note: "OpenAI Images API (deprecated; shuts down 2026-10-23)."},
+		{Name: "gpt-image-1-mini", Provider: "openai", API: "images", Note: "Smaller/cheaper OpenAI image model (deprecated; shuts down 2026-12-01)."},
+		// OpenAI Responses API (a chat model generates via the image_generation
+		// tool). gpt-5 base models are deprecated (shutdown 2026-12-11) —
+		// replaced by the gpt-5.6 family (sol/terra/luna), all image-capable.
+		{Name: "gpt-5.6-sol", Provider: "openai", API: "responses", Note: "OpenAI flagship w/ image_generation tool (Responses API; default)."},
+		{Name: "gpt-5.6-terra", Provider: "openai", API: "responses", Note: "Mid-tier gpt-5.6 w/ image_generation tool (Responses API)."},
+		{Name: "gpt-5.6-luna", Provider: "openai", API: "responses", Note: "Cheapest gpt-5.6 w/ image_generation tool (Responses API)."},
 		{Name: "gpt-5.5", Provider: "openai", API: "responses", Note: "Chat model w/ image_generation tool (Responses API)."},
-		{Name: "gpt-5", Provider: "openai", API: "responses", Note: "gpt-5 and newer support the image_generation tool."},
-		// Google Imagen (:predict, generation-only). Imagen 3 was retired from the
-		// Gemini API (only 404s now) — Imagen 4 is the current family.
-		{Name: "imagen-4.0-generate-001", Provider: "google", API: "native", Note: "Google Imagen 4 (predict; default)."},
-		{Name: "imagen-4.0-ultra-generate-001", Provider: "google", API: "native", Note: "Google Imagen 4 Ultra (predict; highest quality)."},
-		{Name: "imagen-4.0-fast-generate-001", Provider: "google", API: "native", Note: "Google Imagen 4 Fast (predict; cheapest/fast)."},
-		// Google Gemini image models (:generateContent — text-to-image AND editing).
-		{Name: "gemini-2.5-flash-image", Provider: "google", API: "gemini", Note: "Gemini 2.5 Flash Image (gen + edit; default editor)."},
-		{Name: "gemini-3-pro-image", Provider: "google", API: "gemini", Note: "Gemini 3 Pro Image (gen + edit; highest quality)."},
-		{Name: "gemini-3.1-flash-image", Provider: "google", API: "gemini", Note: "Gemini 3.1 Flash Image (gen + edit; fast)."},
+		// Google Gemini image models (:generateContent — text-to-image AND
+		// editing, "Nano Banana"). The whole Imagen :predict family was shut
+		// down on 2026-08-17 (Google's stated replacement is
+		// gemini-3.1-flash-image) — Imagen entries removed, they only 404 now.
+		{Name: "gemini-3.1-flash-image", Provider: "google", API: "gemini", Note: "Gemini 3.1 Flash Image / Nano Banana 2 (gen + edit; default)."},
+		{Name: "gemini-3.1-flash-lite-image", Provider: "google", API: "gemini", Note: "Gemini 3.1 Flash-Lite Image (gen + edit; fastest/cheapest)."},
+		{Name: "gemini-3-pro-image", Provider: "google", API: "gemini", Note: "Gemini 3 Pro Image (gen + edit; studio-quality 4K)."},
+		{Name: "gemini-2.5-flash-image", Provider: "google", API: "gemini", Note: "Gemini 2.5 Flash Image (deprecated; shuts down 2026-10-02)."},
 		// xAI. grok-2-image was retired and grok-imagine-image-quality is async
 		// (it resets the connection on /images/generations → EOF) — removed.
-		{Name: "grok-imagine-image", Provider: "xai", API: "native", Note: "xAI Grok Imagine (OpenAI-shaped /images/generations, no size; URL response)."},
+		{Name: "grok-imagine-image-2.0", Provider: "xai", API: "native", Note: "xAI Grok Imagine 2.0 (newest; OpenAI-shaped /images/generations, no size; URL response; default)."},
+		{Name: "grok-imagine-image", Provider: "xai", API: "native", Note: "xAI Grok Imagine (cheaper; OpenAI-shaped /images/generations, no size; URL response)."},
 		// Z.AI (Zhipu) — OpenAI-shaped /images/generations, returns image URLs.
 		// cogview-3-flash is China-only (open.bigmodel.cn) and not on api.z.ai — omitted.
 		{Name: "glm-image", Provider: "zai", API: "images", Note: "Z.AI GLM-Image (newest; bilingual text-in-image; default)."},
@@ -64,13 +70,13 @@ func KnownModels() []ModelInfo {
 		// MiniMax (Hailuo) — custom /v1/image_generation endpoint, base64 response.
 		{Name: "image-01", Provider: "minimax", API: "native", Note: "MiniMax Image-01 (text-to-image, up to 9 images)."},
 		// AWS Bedrock (InvokeModel). Current Stability models use the text-to-image
-		// shape; the Amazon TEXT_IMAGE models are legacy (AWS recommends migrating
-		// to Stability Core/Ultra/SD3.5 — Nova Canvas EOL 2026-09-30).
+		// shape; the Amazon TEXT_IMAGE models are legacy with no first-party
+		// successor (the Nova 2 family has no image-gen model). Titan Image v2
+		// hit EOL 2026-06-30 (requests fail) — removed.
 		{Name: "stability.stable-image-core-v1:1", Provider: "bedrock", API: "stability", Note: "Bedrock Stability Stable Image Core (current; cheapest, fast; default)."},
 		{Name: "stability.stable-image-ultra-v1:1", Provider: "bedrock", API: "stability", Note: "Bedrock Stability Stable Image Ultra (current; highest quality)."},
 		{Name: "stability.sd3-5-large-v1:0", Provider: "bedrock", API: "stability", Note: "Bedrock Stability SD3.5 Large (current; flagship)."},
 		{Name: "amazon.nova-canvas-v1:0", Provider: "bedrock", API: "native", Note: "Bedrock Nova Canvas (TEXT_IMAGE; LEGACY, EOL 2026-09-30)."},
-		{Name: "amazon.titan-image-generator-v2:0", Provider: "bedrock", API: "native", Note: "Bedrock Titan Image v2 (TEXT_IMAGE; LEGACY, EOL 2026-06-30)."},
 	}
 }
 

--- a/llm/imagegen/factory.go
+++ b/llm/imagegen/factory.go
@@ -15,7 +15,7 @@
  *   2. CHATCLI_IMAGE_URL              → an OpenAI-compatible /images/generations
  *      endpoint. Keyless (unless CHATCLI_IMAGE_KEY is set).
  *   3. OPENAI_API_KEY                 → OpenAI images (paid).
- *   4. GOOGLEAI_API_KEY/GEMINI_API_KEY → native Google Imagen.
+ *   4. GOOGLEAI_API_KEY/GEMINI_API_KEY → native Google Gemini image models.
  *   5. XAI_API_KEY                    → native xAI grok-image.
  *   6. ZAI_API_KEY                    → Z.AI CogView-4 / GLM-Image.
  *   7. MINIMAX_API_KEY               → MiniMax Image-01.
@@ -41,9 +41,10 @@ const (
 	openAIBaseURL = "https://api.openai.com/v1"
 	xaiBaseURL    = "https://api.x.ai/v1"
 	// defaultXAIModel is xAI's current image model. grok-2-image was retired
-	// (404s now); grok-imagine-image is the current Grok Imagine generator
-	// (OpenAI-shaped /images/generations, returns an image URL).
-	defaultXAIModel = "grok-imagine-image"
+	// (404s now); grok-imagine-image-2.0 is the newest Grok Imagine generator
+	// and the one xAI's docs recommend (OpenAI-shaped /images/generations,
+	// returns an image URL). grok-imagine-image remains as the cheaper tier.
+	defaultXAIModel = "grok-imagine-image-2.0"
 
 	// Z.AI (Zhipu) CogView / GLM-Image: OpenAI-shaped /images/generations, but
 	// the response carries image URLs and the "n" field is rejected.
@@ -74,8 +75,8 @@ func NewFromEnvContext(ctx context.Context, logger *zap.Logger) Provider {
 		return selfHostedOrNull(url, model, logger)
 	case "openai":
 		// CHATCLI_IMAGE_API=responses routes OpenAI through the Responses API
-		// (a chat model like gpt-5.5 generates the image) instead of the
-		// Images API (gpt-image-1).
+		// (a chat model like gpt-5.6-sol generates the image) instead of the
+		// Images API (gpt-image-2).
 		if openAIWantsResponses() {
 			return responsesOrNull(model, logger, "CHATCLI_IMAGE_PROVIDER=openai + API=responses but OPENAI_API_KEY is empty")
 		}
@@ -129,7 +130,7 @@ func NewFromEnvContext(ctx context.Context, logger *zap.Logger) Provider {
 		return bedrockOrNull(ctx, model, logger)
 	}
 	// Cloud fallbacks: any provider whose key is present. OpenAI first for
-	// back-compat, then Google (native Imagen) — so @image is not limited to a
+	// back-compat, then Google (Gemini image) — so @image is not limited to a
 	// single provider.
 	if key := strings.TrimSpace(os.Getenv("OPENAI_API_KEY")); key != "" {
 		if openAIWantsResponses() {
@@ -155,7 +156,7 @@ func NewFromEnvContext(ctx context.Context, logger *zap.Logger) Provider {
 // ResolveEditor returns an edit-capable provider for image editing. It first
 // honors the CONFIGURED backend (the one /model-image / CHATCLI_IMAGE_* selects)
 // so a single model choice serves both generation and editing. Only when that
-// backend cannot edit (xAI, Z.AI, MiniMax, Imagen-predict) does it route to an
+// backend cannot edit (xAI, Z.AI, MiniMax) does it route to an
 // edit-capable fallback, reporting the backend actually used so the caller can
 // tell the user a switch happened. Returns ok=false when no editor is reachable.
 func ResolveEditor(ctx context.Context, primary Provider, logger *zap.Logger) (ed Editor, used string, fellBack bool, ok bool) {

--- a/llm/imagegen/google.go
+++ b/llm/imagegen/google.go
@@ -4,10 +4,12 @@
  * License: Apache-2.0
  *
  * Google's image API does NOT speak the OpenAI shape, so it needs its own
- * backend: POST {base}/v1beta/models/{model}:predict?key=KEY with
- * {instances:[{prompt}], parameters:{sampleCount}} returning
- * {predictions:[{bytesBase64Encoded, mimeType}]}. This is what lets @image use
- * Gemini/Imagen instead of being limited to OpenAI-shaped backends.
+ * backend. Gemini image models ("Nano Banana", the current family) generate
+ * and edit via :generateContent with an IMAGE response modality; the legacy
+ * Imagen :predict path ({instances:[{prompt}]} → {predictions:[...]}) is kept
+ * only for pinned imagen-* ids — Google shut the Imagen family down on
+ * 2026-08-17. This is what lets @image use Gemini instead of being limited to
+ * OpenAI-shaped backends.
  */
 package imagegen
 
@@ -28,14 +30,12 @@ import (
 
 const (
 	googleImageBase = "https://generativelanguage.googleapis.com"
-	// defaultImagenModel is the current Imagen generation model. Imagen 3
-	// (imagen-3.0-generate-002) was retired from the Gemini API and only 404s
-	// now; Imagen 4 is the current family.
-	defaultImagenModel = "imagen-4.0-generate-001"
-	// defaultGeminiImageModel is a Gemini image model ("Nano Banana") that
-	// edits via :generateContent with an inline input image. Imagen's :predict
-	// endpoint is generation-only, so editing routes through this model.
-	defaultGeminiImageModel = "gemini-2.5-flash-image"
+	// defaultGeminiImageModel is the current Gemini image model ("Nano Banana
+	// 2"), generating AND editing via :generateContent. It is the default for
+	// both because the whole Imagen :predict family was shut down on
+	// 2026-08-17 (Google's stated replacement is this model); pinned imagen-*
+	// ids still route to :predict and surface Google's own error.
+	defaultGeminiImageModel = "gemini-3.1-flash-image"
 )
 
 // Google generates images via the Imagen predict endpoint.
@@ -52,7 +52,7 @@ func NewGoogle(apiKey, model string, logger *zap.Logger) (*Google, error) {
 		return nil, fmt.Errorf("imagegen: Google API key is required")
 	}
 	if strings.TrimSpace(model) == "" {
-		model = defaultImagenModel
+		model = defaultGeminiImageModel
 	}
 	if logger == nil {
 		logger = zap.NewNop()

--- a/llm/imagegen/imagegen_more_test.go
+++ b/llm/imagegen/imagegen_more_test.go
@@ -161,7 +161,7 @@ func TestAspectRatio(t *testing.T) {
 }
 
 func TestKnownModels_NewIDs(t *testing.T) {
-	want := map[string]bool{"gpt-image-2": false, "gpt-image-1-mini": false, "grok-imagine-image": false, "imagen-4.0-generate-001": false, "gemini-2.5-flash-image": false, "amazon.nova-canvas-v1:0": false, "stability.sd3-5-large-v1:0": false}
+	want := map[string]bool{"gpt-image-2": false, "gpt-image-1-mini": false, "gpt-5.6-sol": false, "grok-imagine-image-2.0": false, "grok-imagine-image": false, "gemini-3.1-flash-image": false, "gemini-3.1-flash-lite-image": false, "gemini-2.5-flash-image": false, "amazon.nova-canvas-v1:0": false, "stability.sd3-5-large-v1:0": false}
 	for _, m := range KnownModels() {
 		if _, ok := want[m.Name]; ok {
 			want[m.Name] = true

--- a/llm/imagegen/openai_compatible.go
+++ b/llm/imagegen/openai_compatible.go
@@ -27,10 +27,11 @@ import (
 )
 
 const (
-	// defaultImageModel is OpenAI's current image model. dall-e-3 is legacy and
-	// not available on newer accounts; gpt-image-1 is the current default and
-	// returns b64_json (no response_format needed).
-	defaultImageModel = "gpt-image-1"
+	// defaultImageModel is OpenAI's current image model. dall-e was retired and
+	// the rest of the gpt-image family is deprecated (gpt-image-1 shuts down
+	// 2026-10-23; 1.5/1-mini 2026-12-01) — gpt-image-2 is the replacement for
+	// all of them and returns b64_json (no response_format needed).
+	defaultImageModel = "gpt-image-2"
 	imageGenTimeout   = 180 * time.Second
 	imagesPath        = "/images/generations"
 	imagesEditPath    = "/images/edits"

--- a/llm/imagegen/openai_responses.go
+++ b/llm/imagegen/openai_responses.go
@@ -4,11 +4,11 @@
  * License: Apache-2.0
  *
  * Unlike the Images API (/images/generations, used by the dedicated image
- * models like gpt-image-1), the Responses API lets a general chat/reasoning
- * model (e.g. gpt-5.5) generate images via the built-in image_generation tool:
+ * models like gpt-image-2), the Responses API lets a general chat/reasoning
+ * model (e.g. gpt-5.6-sol) generate images via the built-in image_generation tool:
  *
  *   POST {base}/responses
- *   { "model": "gpt-5.5", "input": "<prompt>", "tools": [{"type":"image_generation"}] }
+ *   { "model": "gpt-5.6-sol", "input": "<prompt>", "tools": [{"type":"image_generation"}] }
  *
  * The response's output array contains an "image_generation_call" item whose
  * "result" is a base64 PNG. This backend covers that path so users can pick
@@ -55,7 +55,7 @@ func NewOpenAIResponses(baseURL, apiKey, model string, logger *zap.Logger) (*Ope
 		return nil, fmt.Errorf("imagegen: API key is required for the Responses API")
 	}
 	if strings.TrimSpace(model) == "" {
-		model = "gpt-5.5"
+		model = "gpt-5.6-sol"
 	}
 	if logger == nil {
 		logger = zap.NewNop()


### PR DESCRIPTION
## Summary

Refresh of the image-generation and embedding model catalogs against each provider's official docs (verified 2026-08-18), plus a new Google embedding provider.

### Image generation
- **OpenAI**: default is now `gpt-image-2` — `gpt-image-1` shuts down 2026-10-23 and `gpt-image-1.5`/`1-mini`/`chatgpt-image-latest` shut down 2026-12-01 (kept in the catalog with deprecation notes while they still work). Responses API default moves to `gpt-5.6-sol`; catalog lists the gpt-5.6 sol/terra/luna family (gpt-5 base is deprecated, shutdown 2026-12-11).
- **Google**: the entire Imagen `:predict` family was **shut down by Google on 2026-08-17** — entries removed and the provider default (generation and editing) is now `gemini-3.1-flash-image` (Nano Banana 2, Google's stated replacement). Added the new `gemini-3.1-flash-lite-image`; `gemini-2.5-flash-image` marked deprecated (shutdown 2026-10-02).
- **xAI**: new default `grok-imagine-image-2.0` (the model xAI's docs recommend); `grok-imagine-image` kept as the cheaper tier.
- **Bedrock**: removed `amazon.titan-image-generator-v2:0` (EOL 2026-06-30 already passed — requests fail); Nova Canvas kept with its EOL 2026-09-30 note (no Amazon first-party successor exists). Stability lineup confirmed current.
- **Z.AI / MiniMax**: verified unchanged (`glm-image`, `cogview-4-250304`, `image-01`).

### Embeddings
- **Voyage**: default moves `voyage-3` → `voyage-4` (Jan 2026 family; same $0.06/1M price, strictly better, shared embedding space; `voyage-code-4` released Aug 2026). Dim auto-detection makes the switch safe.
- **OpenAI**: verified — `text-embedding-3-small/large` remain the newest; no change.
- **NEW — Google provider** (`CHATCLI_EMBED_PROVIDER=google`): `gemini-embedding-2` (GA, 3072-dim native, free tier), Matryoshka dims 128–3072 via `CHATCLI_EMBED_DIMENSIONS`, batching via `:batchEmbedContents` (chunked at the API's 100-request cap), truncated vectors L2-normalized locally (gemini-embedding-001 returns them unnormalized). Reads `GEMINI_API_KEY`/`GOOGLEAI_API_KEY`/`GOOGLE_API_KEY`.
- **Bedrock**: added support for **Cohere Embed v4** (`cohere.embed-v4:0`, incl. `us.`/`eu.`/`global.` profiles; sends `embedding_types`, parses the type-keyed response, 1536-dim default) and **Nova Multimodal Embeddings** (`amazon.nova-2-multimodal-embeddings-v1:0`, SINGLE_EMBEDDING task, dims 256/384/1024/3072, per-text worker pool like Titan). Titan Text Embeddings v2 remains the default (still active, no EOL).

### Also
- `/config` env tables, HyDE hint and the `@image` edit-error message updated.
- Docs site (~/chatcli.ai) synced EN+pt + corpus regenerated (pushed directly to its main per the usual flow).
- Dated follow-up issues: #1364 (Oct 2026 image-model removals), #1365 (Dec 2026 removals).

## Test plan
- `go build ./...` and full `go test ./...` green; golangci-lint clean; Floor 3 patch-coverage gate green locally against origin/main.
- New unit tests: Cohere v3 flat vs v4 type-keyed decode, v3 omits `embedding_types`, Nova request/response shapes and dim validation, family resolution for profile-prefixed ids, refreshed catalog IDs.
- New e2e tests: Bedrock InvokeModel path for Titan / Nova MME / Cohere v3 / Cohere v4 against httptest via `BEDROCK_BASE_URL` with static SigV4 creds; Google `:batchEmbedContents` shape, chunking, truncated-dim normalization, error surface and factory dispatch.