### PR TITLE
feat(update): one-shot chatcli update subcommand for scripts and automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ updates silently in the background — the next start opens on the new version.
 Docker images and source builds are never touched; they get instructions
 instead. See `/config update` for the current policy and detected channel.
 
+For scripts and automation there is a one-shot surface: `chatcli update`
+applies the same flow without entering the REPL, and `chatcli update check`
+only reports. Exit codes: `0` updated or already current, `1` check/apply
+failure or a manual channel with a pending update, `2` invalid usage.
+
 <details>
 <summary><strong>Build from source</strong></summary>
 

--- a/README_PT.md
+++ b/README_PT.md
@@ -82,6 +82,18 @@ go install github.com/diillson/chatcli@latest
 # https://github.com/diillson/chatcli/releases
 ```
 
+Uma vez instalado, o ChatCLI se mantém atualizado: `/update` atualiza pelo
+mesmo canal da instalação (Homebrew, `go install` ou self-replace verificado
+do binário de release), e `CHATCLI_AUTO_UPDATE=auto` prepara updates em
+silêncio no background — o próximo start já abre na versão nova. Imagens
+Docker e builds locais nunca são tocados; recebem instruções. Veja
+`/config update` para a política atual e o canal detectado.
+
+Para scripts e automação existe a superfície one-shot: `chatcli update`
+aplica o mesmo fluxo sem entrar no REPL, e `chatcli update check` só
+reporta. Exit codes: `0` atualizado ou já na última versão, `1` falha de
+checagem/aplicação ou canal manual com update pendente, `2` uso inválido.
+
 <details>
 <summary><strong>Compilação a partir do código-fonte</strong></summary>
 

--- a/cli/update_command.go
+++ b/cli/update_command.go
@@ -19,11 +19,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/diillson/chatcli/config"
 	"github.com/diillson/chatcli/i18n"
 	"github.com/diillson/chatcli/ui/kit"
 	"github.com/diillson/chatcli/ui/theme"
 	"github.com/diillson/chatcli/update"
+	"github.com/diillson/chatcli/utils"
 	"github.com/diillson/chatcli/version"
+	"github.com/joho/godotenv"
 	"go.uber.org/zap"
 )
 
@@ -41,7 +44,75 @@ var (
 func (cli *ChatCLI) handleUpdateCommand(ctx context.Context, userInput string) {
 	args := strings.Fields(userInput)
 	checkOnly := len(args) > 1 && (args[1] == "check" || args[1] == "--check")
+	_ = runUpdateFlow(ctx, cli.logger, checkOnly)
+}
 
+// RunUpdateOneShot é a superfície one-shot do /update (`chatcli update`),
+// para scripts e automação: mesmo fluxo, mesma saída, sem boot do REPL. O
+// erro devolvido vira exit code no main — nil cobre "atualizado" e "já na
+// última versão"; falha de checagem, canal manual com update pendente e
+// falha de aplicação retornam o erro já impresso.
+func RunUpdateOneShot(ctx context.Context, logger *zap.Logger, checkOnly bool) error {
+	return runUpdateFlow(ctx, logger, checkOnly)
+}
+
+// UpdateSubcommandMain é o entrypoint completo do subcomando `chatcli update`:
+// boot mínimo (dotenv+i18n+tema+logger+config — sem LLM manager) seguido do
+// contrato de exit code de RunUpdateSubcommand. Vive no pacote cli para boot
+// e contrato ficarem sob teste — no main resta apenas o os.Exit.
+func UpdateSubcommandMain(args []string) int {
+	envFilePath := os.Getenv("CHATCLI_DOTENV")
+	if envFilePath == "" {
+		envFilePath = ".env"
+	} else if expanded, err := utils.ExpandPath(envFilePath); err == nil {
+		envFilePath = expanded
+	}
+	_ = godotenv.Load(envFilePath)
+	i18n.Init()
+	theme.InitFromEnv()
+
+	logger, err := utils.InitializeLogger()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to initialize logger: %v\n", err)
+		return 1
+	}
+	// Sync roda no return da função (diferente de um defer atrás de os.Exit,
+	// que nunca executaria); falha de sync em stdout é ruído conhecido do zap.
+	defer func() { _ = logger.Sync() }()
+
+	config.InitGlobal(logger)
+	config.Global.Load()
+	utils.ApplyGlobalTLSTrust(logger)
+
+	return RunUpdateSubcommand(context.Background(), logger, args)
+}
+
+// RunUpdateSubcommand é o corpo do subcomando `chatcli update [check]`:
+// parseia os args e mapeia o desfecho no exit code do processo — 0 atualizado
+// ou já na última versão (check incluso), 1 falha de checagem/aplicação ou
+// canal manual com update pendente, 2 uso inválido. Vive no pacote cli (e não
+// no main) para o contrato ficar sob teste; o main só faz o boot e repassa.
+func RunUpdateSubcommand(ctx context.Context, logger *zap.Logger, args []string) int {
+	checkOnly := false
+	for _, a := range args {
+		switch a {
+		case "check", "--check", "-check":
+			checkOnly = true
+		default:
+			fmt.Fprintln(os.Stderr, i18n.T("update.oneshot.usage"))
+			return 2
+		}
+	}
+	if err := RunUpdateOneShot(ctx, logger, checkOnly); err != nil {
+		return 1
+	}
+	return 0
+}
+
+// runUpdateFlow é o núcleo compartilhado entre o /update interativo e o
+// subcomando one-shot: checa a release, compara com o binário atual e aplica
+// pelo canal detectado, imprimindo cada passo.
+func runUpdateFlow(ctx context.Context, logger *zap.Logger, checkOnly bool) error {
 	info := detectInstallFn()
 	anchor := screenWidth()
 	fmt.Println()
@@ -52,14 +123,14 @@ func (cli *ChatCLI) handleUpdateCommand(ctx context.Context, userInput string) {
 	rep := version.GetReport(ctx)
 	if rep.CheckErr != nil {
 		fmt.Println(colorize("  ❌ "+i18n.T("update.err.check", rep.CheckErr.Error()), ColorYellow))
-		return
+		return rep.CheckErr
 	}
 	// Latest vazio sem erro = checagem desabilitada por política
 	// (CHATCLI_DISABLE_VERSION_CHECK); sem release para comparar, não há
 	// o que aplicar — informa em vez de exibir uma comparação vazia.
 	if rep.Latest == "" {
 		fmt.Println("  " + colorize(i18n.T("update.check_disabled"), ColorYellow))
-		return
+		return errors.New(i18n.T("update.check_disabled"))
 	}
 
 	fmt.Println("  " + colorize(i18n.T("update.method_label", methodLabel(info.Method)), ColorGray))
@@ -68,7 +139,7 @@ func (cli *ChatCLI) handleUpdateCommand(ctx context.Context, userInput string) {
 
 	if !rep.NeedsUpdate {
 		fmt.Println("  " + colorize("✓ "+i18n.T("update.uptodate"), ColorGreen))
-		return
+		return nil
 	}
 	// O usuário está prestes a atualizar (ou decidir se atualiza): mostra o
 	// que a versão nova traz antes de qualquer ação.
@@ -78,19 +149,19 @@ func (cli *ChatCLI) handleUpdateCommand(ctx context.Context, userInput string) {
 	}
 	if checkOnly {
 		fmt.Println("  " + colorize("⬆ "+i18n.T("update.available_hint"), ColorYellow))
-		return
+		return nil
 	}
 
 	switch info.Method {
 	case update.MethodDocker:
 		fmt.Println("  " + colorize(i18n.T("update.manual.docker"), ColorYellow))
-		return
+		return update.ErrManualMethod
 	case update.MethodSourceBuild:
 		fmt.Println("  " + colorize(i18n.T("update.manual.source"), ColorYellow))
-		return
+		return update.ErrManualMethod
 	case update.MethodUnknown:
 		fmt.Println("  " + colorize(i18n.T("update.manual.unknown"), ColorYellow))
-		return
+		return update.ErrManualMethod
 	}
 
 	if argv := update.CommandForVersion(info.Method, rep.Latest); argv != nil {
@@ -106,15 +177,16 @@ func (cli *ChatCLI) handleUpdateCommand(ctx context.Context, userInput string) {
 		}
 	})}
 	if err := applyUpdateFn(ctx, info, rep.Latest, opts); err != nil {
-		cli.printUpdateError(err, info, rep.Latest)
-		return
+		printUpdateError(logger, err, info, rep.Latest)
+		return err
 	}
 	fmt.Println("  " + colorize(i18n.T("update.success_restart", rep.Latest), ColorGreen))
+	return nil
 }
 
 // printUpdateError converte os erros tipados do pacote update em mensagens
 // acionáveis — cada modo de falha diz exatamente o que fazer em seguida.
-func (cli *ChatCLI) printUpdateError(err error, info update.Info, latest string) {
+func printUpdateError(logger *zap.Logger, err error, info update.Info, latest string) {
 	var notWritable *update.NotWritableError
 	var missingTool *update.MissingToolError
 	var unsupported *update.UnsupportedPlatformError
@@ -139,7 +211,7 @@ func (cli *ChatCLI) printUpdateError(err error, info update.Info, latest string)
 			"https://github.com/diillson/chatcli/releases/latest"))
 	case errors.As(err, &mismatch):
 		warn(i18n.T("update.err.mismatch"))
-		cli.logger.Warn("self-update: checksum mismatch",
+		logger.Warn("self-update: checksum mismatch",
 			zap.String("asset", mismatch.Asset),
 			zap.String("expected", mismatch.Expected),
 			zap.String("actual", mismatch.Actual))

--- a/cli/update_command_test.go
+++ b/cli/update_command_test.go
@@ -170,9 +170,160 @@ func TestHandleUpdateCommandWithVersionCheckDisabled(t *testing.T) {
 	}
 }
 
+// RunUpdateOneShot é a superfície de `chatcli update`: o erro devolvido é o
+// contrato de exit code para scripts — nil em "atualizado"/"já na última"/
+// check, erro em falha de checagem, canal manual pendente e falha de apply.
+func TestRunUpdateOneShotExitContract(t *testing.T) {
+	logger := minimalCLI(t).logger
+
+	t.Run("applies and returns nil", func(t *testing.T) {
+		applied := withUpdateSeams(t, update.MethodGoInstall, "1.5.0", "1.6.0", nil)
+		var err error
+		captureStdout(t, func() { err = RunUpdateOneShot(context.Background(), logger, false) })
+		if err != nil || applied.Load() != 1 {
+			t.Fatalf("esperado apply com sucesso, err=%v applied=%d", err, applied.Load())
+		}
+	})
+
+	t.Run("up to date returns nil", func(t *testing.T) {
+		applied := withUpdateSeams(t, update.MethodHomebrew, "1.5.0", "1.5.0", nil)
+		var err error
+		captureStdout(t, func() { err = RunUpdateOneShot(context.Background(), logger, false) })
+		if err != nil || applied.Load() != 0 {
+			t.Fatalf("já atualizado deve ser sucesso sem apply, err=%v applied=%d", err, applied.Load())
+		}
+	})
+
+	t.Run("check only never applies and returns nil", func(t *testing.T) {
+		applied := withUpdateSeams(t, update.MethodGoInstall, "1.5.0", "1.6.0", nil)
+		var err error
+		captureStdout(t, func() { err = RunUpdateOneShot(context.Background(), logger, true) })
+		if err != nil || applied.Load() != 0 {
+			t.Fatalf("check não aplica e é sucesso, err=%v applied=%d", err, applied.Load())
+		}
+	})
+
+	t.Run("manual channel with pending update returns ErrManualMethod", func(t *testing.T) {
+		applied := withUpdateSeams(t, update.MethodDocker, "1.5.0", "1.6.0", nil)
+		var err error
+		captureStdout(t, func() { err = RunUpdateOneShot(context.Background(), logger, false) })
+		if !errors.Is(err, update.ErrManualMethod) || applied.Load() != 0 {
+			t.Fatalf("canal manual pendente deve retornar ErrManualMethod, err=%v applied=%d", err, applied.Load())
+		}
+	})
+
+	t.Run("apply failure bubbles up", func(t *testing.T) {
+		wantErr := errors.New("boom")
+		withUpdateSeams(t, update.MethodGoInstall, "1.5.0", "1.6.0", wantErr)
+		var err error
+		captureStdout(t, func() { err = RunUpdateOneShot(context.Background(), logger, false) })
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("falha do apply deve subir, err=%v", err)
+		}
+	})
+
+	t.Run("disabled version check returns error", func(t *testing.T) {
+		withUpdateSeams(t, update.MethodGoInstall, "1.5.0", "1.6.0", nil)
+		t.Setenv("CHATCLI_DISABLE_VERSION_CHECK", "true")
+		var err error
+		captureStdout(t, func() { err = RunUpdateOneShot(context.Background(), logger, false) })
+		if err == nil {
+			t.Fatal("checagem desabilitada não tem release para aplicar — deve retornar erro")
+		}
+	})
+}
+
+// RunUpdateSubcommand é o corpo de `chatcli update`: parsing de args e o
+// mapeamento erro→exit code (0 ok, 1 falha, 2 uso inválido).
+func TestRunUpdateSubcommandExitCodes(t *testing.T) {
+	logger := minimalCLI(t).logger
+
+	t.Run("no args applies and exits 0", func(t *testing.T) {
+		applied := withUpdateSeams(t, update.MethodGoInstall, "1.5.0", "1.6.0", nil)
+		var code int
+		captureStdout(t, func() { code = RunUpdateSubcommand(context.Background(), logger, nil) })
+		if code != 0 || applied.Load() != 1 {
+			t.Fatalf("esperado exit 0 com apply, code=%d applied=%d", code, applied.Load())
+		}
+	})
+
+	t.Run("check variants never apply and exit 0", func(t *testing.T) {
+		for _, arg := range []string{"check", "--check", "-check"} {
+			applied := withUpdateSeams(t, update.MethodGoInstall, "1.5.0", "1.6.0", nil)
+			var code int
+			captureStdout(t, func() { code = RunUpdateSubcommand(context.Background(), logger, []string{arg}) })
+			if code != 0 || applied.Load() != 0 {
+				t.Fatalf("%s: esperado exit 0 sem apply, code=%d applied=%d", arg, code, applied.Load())
+			}
+		}
+	})
+
+	t.Run("apply failure exits 1", func(t *testing.T) {
+		withUpdateSeams(t, update.MethodGoInstall, "1.5.0", "1.6.0", errors.New("boom"))
+		var code int
+		captureStdout(t, func() { code = RunUpdateSubcommand(context.Background(), logger, nil) })
+		if code != 1 {
+			t.Fatalf("falha do apply deve sair 1, code=%d", code)
+		}
+	})
+
+	t.Run("invalid arg exits 2 without touching the network", func(t *testing.T) {
+		applied := withUpdateSeams(t, update.MethodGoInstall, "1.5.0", "1.6.0", nil)
+		code := RunUpdateSubcommand(context.Background(), logger, []string{"bogus"})
+		if code != 2 || applied.Load() != 0 {
+			t.Fatalf("arg inválido deve sair 2 sem fluxo, code=%d applied=%d", code, applied.Load())
+		}
+	})
+}
+
+// UpdateSubcommandMain cobre o boot completo do subcomando (dotenv, i18n,
+// tema, logger, config) e delega ao contrato de exit code — o main só chama
+// os.Exit no retorno.
+func TestUpdateSubcommandMainBootsAndDelegates(t *testing.T) {
+	t.Run("check exits 0 without applying", func(t *testing.T) {
+		applied := withUpdateSeams(t, update.MethodGoInstall, "1.5.0", "1.6.0", nil)
+		var code int
+		captureStdout(t, func() { code = UpdateSubcommandMain([]string{"check"}) })
+		if code != 0 || applied.Load() != 0 {
+			t.Fatalf("check deve sair 0 sem apply, code=%d applied=%d", code, applied.Load())
+		}
+	})
+
+	t.Run("invalid arg exits 2", func(t *testing.T) {
+		withUpdateSeams(t, update.MethodGoInstall, "1.5.0", "1.6.0", nil)
+		if code := UpdateSubcommandMain([]string{"bogus"}); code != 2 {
+			t.Fatalf("arg inválido deve sair 2, code=%d", code)
+		}
+	})
+
+	t.Run("CHATCLI_DOTENV path is expanded and loaded", func(t *testing.T) {
+		applied := withUpdateSeams(t, update.MethodGoInstall, "1.5.0", "1.6.0", nil)
+		dir := t.TempDir()
+		envFile := filepath.Join(dir, "custom.env")
+		if err := os.WriteFile(envFile, []byte("CHATCLI_TEST_SENTINEL=loaded\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("CHATCLI_DOTENV", envFile)
+		// godotenv.Load não sobrescreve env presente (mesmo vazia): o t.Setenv
+		// registra o restore e o Unsetenv garante a sentinela ausente de fato.
+		t.Setenv("CHATCLI_TEST_SENTINEL", "")
+		_ = os.Unsetenv("CHATCLI_TEST_SENTINEL")
+
+		var code int
+		captureStdout(t, func() { code = UpdateSubcommandMain([]string{"check"}) })
+		if code != 0 || applied.Load() != 0 {
+			t.Fatalf("check com dotenv custom deve sair 0, code=%d applied=%d", code, applied.Load())
+		}
+		if os.Getenv("CHATCLI_TEST_SENTINEL") != "loaded" {
+			t.Fatal("dotenv apontado por CHATCLI_DOTENV deve ser carregado no boot")
+		}
+	})
+}
+
 func TestPrintUpdateErrorMapsTypedErrors(t *testing.T) {
 	cli := minimalCLI(t)
 	info := update.Info{Method: update.MethodReleaseBinary, ExecPath: "/usr/local/bin/chatcli"}
+	logger := cli.logger
 
 	cases := []struct {
 		name   string
@@ -188,7 +339,7 @@ func TestPrintUpdateErrorMapsTypedErrors(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			out := captureStdout(t, func() { cli.printUpdateError(tc.err, info, "1.6.0") })
+			out := captureStdout(t, func() { printUpdateError(logger, tc.err, info, "1.6.0") })
 			if !strings.Contains(out, tc.expect) {
 				t.Fatalf("erro %s deve mencionar %q, saída: %q", tc.name, tc.expect, out)
 			}

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -226,6 +226,7 @@
   "update.running": "Running: %s",
   "update.downloading": "Downloading v%s (%s)...",
   "update.goinstall_fallback": "go install rejected this version (replace/exclude directives in its go.mod) — downloading the official release binary instead.",
+  "update.oneshot.usage": "Usage: chatcli update [check]",
   "update.success_restart": "Updated to v%s — restart chatcli to start using the new version.",
   "version.card.title": "ChatCLI · Version",
   "version.card.installed": "Installed",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -226,6 +226,7 @@
   "update.running": "Running: %s",
   "update.downloading": "Downloading v%s (%s)...",
   "update.goinstall_fallback": "go install rejected this version (replace/exclude directives in its go.mod) — downloading the official release binary instead.",
+  "update.oneshot.usage": "Usage: chatcli update [check]",
   "update.success_restart": "Updated to v%s — restart chatcli to start using the new version.",
   "version.card.title": "ChatCLI · Version",
   "version.card.installed": "Installed",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -226,6 +226,7 @@
   "update.running": "Executando: %s",
   "update.downloading": "Baixando v%s (%s)...",
   "update.goinstall_fallback": "go install recusou esta versão (diretivas replace/exclude no go.mod dela) — baixando o binário oficial da release no lugar.",
+  "update.oneshot.usage": "Uso: chatcli update [check]",
   "update.success_restart": "Atualizado para v%s — reinicie o chatcli para usar a nova versão.",
   "version.card.title": "ChatCLI · Versão",
   "version.card.installed": "Instalada",

--- a/main.go
+++ b/main.go
@@ -42,6 +42,9 @@ func dispatchSubcommand() bool {
 	case "daemon":
 		runDaemonSubcommand(os.Args[2:])
 		return true
+	case "update":
+		runUpdateSubcommand(os.Args[2:])
+		return true
 	case "mcp":
 		// Config-file management only (add/list/get/remove) — no LLM
 		// manager, no full ChatCLI boot; mirrors `claude mcp add`.
@@ -331,6 +334,15 @@ func runSubcommand(subcmd string, args []string) {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
+	}
+}
+
+// runUpdateSubcommand handles `chatcli update [check]` — a superfície
+// one-shot do /update para scripts e automação. Boot e contrato de exit code
+// vivem em cli.UpdateSubcommandMain (testável); aqui resta só o os.Exit.
+func runUpdateSubcommand(args []string) {
+	if code := cli.UpdateSubcommandMain(args); code != 0 {
+		os.Exit(code)
 	}
 }
 


### PR DESCRIPTION
## Summary

`/update` only existed inside the interactive REPL (the `-p` one-shot surface expands custom slash-command templates and routes `/agent`/`/run`/`/coder`, but never builtin REPL commands, and `CHATCLI_AUTO_UPDATE=auto` staging is background-only). This adds the script/automation surface:

- **`chatcli update`** applies the same flow as `/update` without entering the REPL; **`chatcli update check`** only reports. Dispatched standalone like the `daemon` subcommand — no LLM manager, no full boot.
- **Exit-code contract**: `0` updated or already current (`check` included), `1` check/apply failure or a manual channel (Docker, source build) with a pending update, `2` invalid usage.
- The interactive `/update` and the new surface share a single flow: the handler body moved to a package-level `runUpdateFlow` that now returns the outcome (`handleUpdateCommand` keeps ignoring it), and `printUpdateError` takes the logger explicitly. No exported symbol changed shape — `RunUpdateOneShot` is new.
- READMEs (en/pt) document the one-shot surface; the pt README also gains the previously missing self-update paragraph. The docs site auto-update page (en/pt) is synced separately.

## Test plan

- 6 exit-contract tests over the seams (applies, up-to-date, check-only never applies, manual channel returns `ErrManualMethod`, apply failure bubbles, disabled version check errors), plus the existing `/update` suite unchanged and green.
- Real-binary smoke: `chatcli update check` renders the update card and exits 0; `chatcli update foo` prints usage and exits 2.
- `go build ./...`, full `go test ./...` and the i18n parity gate green; `update.oneshot.usage` added to en, en-US and pt-BR.