### PR TITLE
feat(skills): activation and memory parity across every surface + parser describe-leak fix

### DIFF
--- a/cli/agent/toolcall_parser.go
+++ b/cli/agent/toolcall_parser.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html"
+	"regexp"
 	"strings"
 )
 
@@ -25,11 +26,25 @@ type ToolCall struct {
 //   - Args containing '>' characters (JSON, HTML entities, etc.)
 //   - JSON tool calls:  {"tool_call":"@coder","args":{...}}
 //   - Multiple tool calls in a single response
+//
+// Quoted-context rule: tool-call syntax inside inline code spans (`...`) is
+// always illustrative and never parsed. Fenced code blocks are illustrative by
+// default too — a model DESCRIBING a tool (e.g. echoing @tools describe usage
+// examples) must not trigger an execution — with one recovery exception: when
+// the response contains no call outside a fence, fences whose info string is
+// empty/xml/json are re-scanned, because some models wrap their one real call
+// in such a fence. Fenced calls whose args are documentation placeholders
+// ("...") are still rejected there.
 func ParseToolCalls(text string) ([]ToolCall, error) {
 	var calls []ToolCall
 
+	// Split quoted contexts out first: fenced blocks are collected for the
+	// recovery pass below, and the scannable copy has fenced lines and
+	// inline code spans blanked so the primary parsers never see them.
+	fences, scannable := maskQuotedSegments(text)
+
 	// Try XML-style parsing first (primary format)
-	xmlCalls, xmlErr := parseXMLToolCalls(text)
+	xmlCalls, xmlErr := parseXMLToolCalls(scannable)
 	if xmlErr == nil && len(xmlCalls) > 0 {
 		calls = append(calls, xmlCalls...)
 	}
@@ -39,17 +54,18 @@ func ParseToolCalls(text string) ([]ToolCall, error) {
 	// The JSON scanner can pick up JSON embedded inside XML args attributes
 	// (e.g. the {"cmd":"read",...} inside args='{"cmd":"read",...}'), which
 	// would cause the same tool call to appear twice in the batch.
-	jsonCalls := parseJSONToolCalls(text)
+	jsonCalls := parseJSONToolCalls(scannable)
 	for _, jc := range jsonCalls {
 		if !isDuplicateToolCall(calls, jc) {
 			calls = append(calls, jc)
 		}
 	}
 
-	// Try extracting from markdown code blocks (```xml or ```json)
+	// Recovery pass: no call found outside a fence — re-scan executable
+	// fences (```xml / ```json / bare ```), where some models wrap their
+	// actual call. Documentation fences (```bash, ```text, …) never execute.
 	if len(calls) == 0 {
-		mdCalls := parseMarkdownCodeBlockToolCalls(text)
-		calls = append(calls, mdCalls...)
+		calls = append(calls, parseFencedToolCalls(fences)...)
 	}
 
 	// Last-resort fallback: "[tool: @name {args}]" shorthand. Some models
@@ -57,8 +73,14 @@ func ParseToolCalls(text string) ([]ToolCall, error) {
 	// canonical tag. Gated on zero calls so prose that merely mentions the
 	// bracket syntax alongside a real <tool_call> never duplicates a batch.
 	if len(calls) == 0 {
-		calls = append(calls, parseBracketToolCalls(text)...)
+		calls = append(calls, parseBracketToolCalls(scannable)...)
 	}
+
+	// Drop documentation examples that leaked through: a call whose args are
+	// a bare placeholder ("...", "{...}") is usage-syntax being described,
+	// never an executable request. Applied to every stage so an unfenced
+	// prose echo of a usage line is rejected the same way a fenced one is.
+	calls = rejectUsageExamples(calls)
 
 	// Apply JSON recovery/normalization to ALL parsed calls (XML, JSON, markdown).
 	// This fixes single quotes, unquoted keys, and other malformations.
@@ -550,47 +572,239 @@ func skipSpacesTabs(text string, pos int) int {
 	return pos
 }
 
-// parseMarkdownCodeBlockToolCalls extracts tool calls from markdown code blocks.
-// LLMs sometimes wrap tool calls in ```xml or ```json blocks.
-func parseMarkdownCodeBlockToolCalls(text string) []ToolCall {
-	var calls []ToolCall
+// fencedBlock is one markdown code fence collected by maskQuotedSegments:
+// its info string (the word after the opening backticks) and raw content.
+type fencedBlock struct {
+	info    string
+	content string
+}
 
-	// Find ```xml ... ``` or ```json ... ``` blocks
-	searchFrom := 0
-	for searchFrom < len(text) {
-		startIdx := strings.Index(text[searchFrom:], "```")
-		if startIdx < 0 {
-			break
+// maskQuotedSegments walks text line by line collecting fenced code blocks
+// and producing a "scannable" copy where fenced lines and inline code spans
+// are blanked out (byte-for-byte, so no offset shifts). The primary parsers
+// run on the scannable copy — syntax the model merely QUOTES (a usage example
+// in a fence, a tag in `inline code`) is invisible to them — while the
+// collected fences feed the executable-fence recovery pass.
+func maskQuotedSegments(text string) ([]fencedBlock, string) {
+	var blocks []fencedBlock
+	var masked strings.Builder
+	masked.Grow(len(text))
+
+	inFence := false
+	var fenceMarker byte
+	var fenceLen int
+	var info string
+	var content strings.Builder
+
+	rest := text
+	for len(rest) > 0 {
+		line := rest
+		if nl := strings.IndexByte(rest, '\n'); nl >= 0 {
+			line = rest[:nl+1]
+			rest = rest[nl+1:]
+		} else {
+			rest = ""
 		}
-		startIdx += searchFrom
+		trimmed := strings.TrimLeft(line, " \t")
 
-		// Find the end of the opening fence line
-		lineEnd := strings.Index(text[startIdx+3:], "\n")
-		if lineEnd < 0 {
-			break
+		if inFence {
+			if fenceCloses(trimmed, fenceMarker, fenceLen) {
+				inFence = false
+				blocks = append(blocks, fencedBlock{info: info, content: content.String()})
+			} else {
+				content.WriteString(line)
+			}
+			masked.WriteString(blankPreservingNewlines(line))
+			continue
 		}
-		lineEnd += startIdx + 3
 
-		// Find closing ```
-		closeIdx := strings.Index(text[lineEnd:], "```")
-		if closeIdx < 0 {
-			break
+		if marker, mlen, rem, ok := fenceOpens(trimmed); ok {
+			inFence = true
+			fenceMarker, fenceLen = marker, mlen
+			info = strings.TrimSpace(rem)
+			content.Reset()
+			masked.WriteString(blankPreservingNewlines(line))
+			continue
 		}
-		closeIdx += lineEnd
 
-		blockContent := text[lineEnd:closeIdx]
-
-		// Try parsing the block content as tool calls
-		xmlCalls, _ := parseXMLToolCalls(blockContent)
-		calls = append(calls, xmlCalls...)
-
-		jsonCalls := parseJSONToolCalls(blockContent)
-		calls = append(calls, jsonCalls...)
-
-		searchFrom = closeIdx + 3
+		masked.WriteString(maskInlineCodeSpans(line))
 	}
+	if inFence {
+		// Unterminated fence (truncated response): still counts as fenced.
+		blocks = append(blocks, fencedBlock{info: info, content: content.String()})
+	}
+	return blocks, masked.String()
+}
 
+// fenceOpens reports whether a (left-trimmed) line opens a code fence: a run
+// of three or more '`' or '~'. Returns the marker, run length and the info
+// string remainder.
+func fenceOpens(trimmed string) (byte, int, string, bool) {
+	if len(trimmed) < 3 {
+		return 0, 0, "", false
+	}
+	marker := trimmed[0]
+	if marker != '`' && marker != '~' {
+		return 0, 0, "", false
+	}
+	n := 0
+	for n < len(trimmed) && trimmed[n] == marker {
+		n++
+	}
+	if n < 3 {
+		return 0, 0, "", false
+	}
+	return marker, n, strings.TrimRight(trimmed[n:], "\r\n"), true
+}
+
+// fenceCloses reports whether a (left-trimmed) line closes the open fence:
+// a run of at least fenceLen of the same marker with nothing else after it.
+func fenceCloses(trimmed string, marker byte, fenceLen int) bool {
+	n := 0
+	for n < len(trimmed) && trimmed[n] == marker {
+		n++
+	}
+	if n < fenceLen {
+		return false
+	}
+	return strings.TrimSpace(trimmed[n:]) == ""
+}
+
+// blankPreservingNewlines replaces every byte of s with a space except CR/LF,
+// keeping the masked copy byte-aligned with the original.
+func blankPreservingNewlines(s string) string {
+	b := []byte(s)
+	for i, ch := range b {
+		if ch != '\n' && ch != '\r' {
+			b[i] = ' '
+		}
+	}
+	return string(b)
+}
+
+// maskInlineCodeSpans blanks `inline code` spans within a single line. A span
+// is a backtick run and the next run of the same length; unmatched backticks
+// are left untouched.
+func maskInlineCodeSpans(line string) string {
+	if !strings.Contains(line, "`") {
+		return line
+	}
+	b := []byte(line)
+	i := 0
+	for i < len(b) {
+		if b[i] != '`' {
+			i++
+			continue
+		}
+		runLen := 0
+		for i+runLen < len(b) && b[i+runLen] == '`' {
+			runLen++
+		}
+		delim := strings.Repeat("`", runLen)
+		closeIdx := indexDelimiterRun(string(b[i+runLen:]), delim)
+		if closeIdx < 0 {
+			i += runLen
+			continue
+		}
+		for j := i; j < i+runLen+closeIdx+runLen; j++ {
+			if b[j] != '\n' && b[j] != '\r' {
+				b[j] = ' '
+			}
+		}
+		i += runLen + closeIdx + runLen
+	}
+	return string(b)
+}
+
+// indexDelimiterRun finds delim in s where the match is not part of a longer
+// backtick run (CommonMark: a 1-backtick span cannot close on a 2-backtick
+// run). Returns the index or -1.
+func indexDelimiterRun(s, delim string) int {
+	from := 0
+	for {
+		idx := strings.Index(s[from:], delim)
+		if idx < 0 {
+			return -1
+		}
+		pos := from + idx
+		end := pos + len(delim)
+		if end < len(s) && s[end] == '`' {
+			// Longer run — skip past it entirely.
+			for end < len(s) && s[end] == '`' {
+				end++
+			}
+			from = end
+			continue
+		}
+		return pos
+	}
+}
+
+// executableFenceInfo reports whether a fence's info string marks content the
+// recovery pass may treat as a real call. Only the shapes models actually use
+// to WRAP a call qualify; anything else (```bash, ```text, ```markdown, a
+// natural-language label…) is documentation and never executes.
+func executableFenceInfo(info string) bool {
+	switch strings.ToLower(strings.TrimSpace(info)) {
+	case "", "xml", "json", "tool", "tool_call", "toolcall":
+		return true
+	}
+	return false
+}
+
+// parseFencedToolCalls extracts tool calls from collected fenced blocks. Runs
+// only when nothing was found outside a fence (see ParseToolCalls), and only
+// over executable fences.
+func parseFencedToolCalls(fences []fencedBlock) []ToolCall {
+	var calls []ToolCall
+	for _, f := range fences {
+		if !executableFenceInfo(f.info) {
+			continue
+		}
+		xmlCalls, _ := parseXMLToolCalls(f.content)
+		calls = append(calls, xmlCalls...)
+		// Same dedup rule as the top-level flow: the JSON scanner re-finds
+		// the object embedded in an XML args attribute.
+		for _, jc := range parseJSONToolCalls(f.content) {
+			if !isDuplicateToolCall(calls, jc) {
+				calls = append(calls, jc)
+			}
+		}
+	}
 	return calls
+}
+
+// usageExamplePlaceholderRe matches an args value that is entirely an
+// ellipsis placeholder, e.g. "query": "..." — the shape documentation and
+// @tools describe output use for "fill this in".
+var usageExamplePlaceholderRe = regexp.MustCompile(`:\s*['"](?:\.\.\.|…)['"]`)
+
+// isUsageExampleArgs reports whether args reads as documentation placeholder
+// syntax rather than an executable request.
+func isUsageExampleArgs(args string) bool {
+	t := strings.TrimSpace(args)
+	switch t {
+	case "...", "…", "{...}", "{…}":
+		return true
+	}
+	if strings.Contains(t, "<...>") {
+		return true
+	}
+	return usageExamplePlaceholderRe.MatchString(t)
+}
+
+// rejectUsageExamples filters out calls whose args are documentation
+// placeholders. A described call ("use it like <tool_call name=… args='…'/>")
+// must never reach the execution gate.
+func rejectUsageExamples(calls []ToolCall) []ToolCall {
+	out := calls[:0]
+	for _, c := range calls {
+		if isUsageExampleArgs(c.Args) {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out
 }
 
 // extractJSONObject attempts to extract a balanced JSON object starting at pos.

--- a/cli/agent/toolcall_parser_quoted_test.go
+++ b/cli/agent/toolcall_parser_quoted_test.go
@@ -1,0 +1,142 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+/*
+ * toolcall_parser_quoted_test.go
+ *
+ * Quoted-context rules: tool-call syntax the model merely DESCRIBES — inside
+ * inline code spans, documentation fences or with placeholder args — must
+ * never parse as an executable call, while the historical recovery paths
+ * (real call wrapped in a ```xml/```json fence) keep working.
+ */
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseToolCalls_InlineCodeSpanIsIllustrative(t *testing.T) {
+	text := "Você pode usar `<tool_call name=\"@websearch\" args='{\"query\":\"golang\"}' />` para pesquisar."
+	calls, err := ParseToolCalls(text)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("inline-code example must not execute, got %d call(s): %+v", len(calls), calls)
+	}
+}
+
+func TestParseToolCalls_DocumentationFenceIsIllustrative(t *testing.T) {
+	for _, lang := range []string{"bash", "text", "markdown", "exemplo"} {
+		text := "A ferramenta funciona assim:\n\n```" + lang + "\n" +
+			`<tool_call name="@coder" args='{"cmd":"exec","args":{"command":"rm -rf build"}}' />` +
+			"\n```\n\nÉ só isso."
+		calls, err := ParseToolCalls(text)
+		if err != nil {
+			t.Fatalf("[%s] unexpected error: %v", lang, err)
+		}
+		if len(calls) != 0 {
+			t.Fatalf("[%s] documentation fence must not execute, got %+v", lang, calls)
+		}
+	}
+}
+
+func TestParseToolCalls_ExecutableFenceStillRecovers(t *testing.T) {
+	for _, lang := range []string{"", "xml", "json"} {
+		text := "Vou ler o arquivo agora.\n\n```" + lang + "\n" +
+			`<tool_call name="@coder" args='{"cmd":"read","args":{"file":"main.go"}}' />` +
+			"\n```\n"
+		calls, err := ParseToolCalls(text)
+		if err != nil {
+			t.Fatalf("[%q] unexpected error: %v", lang, err)
+		}
+		if len(calls) != 1 || calls[0].Name != "@coder" {
+			t.Fatalf("[%q] expected the fenced real call to recover, got %+v", lang, calls)
+		}
+	}
+}
+
+func TestParseToolCalls_UnfencedCallWinsOverFencedExample(t *testing.T) {
+	text := `<tool_call name="@coder" args='{"cmd":"read","args":{"file":"go.mod"}}' />` + "\n\n" +
+		"Depois disso você poderia rodar:\n\n```xml\n" +
+		`<tool_call name="@coder" args='{"cmd":"exec","args":{"command":"go test ./..."}}' />` +
+		"\n```\n"
+	calls, err := ParseToolCalls(text)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected only the unfenced call, got %d: %+v", len(calls), calls)
+	}
+	if !strings.Contains(calls[0].Args, `"read"`) {
+		t.Fatalf("wrong call survived: %+v", calls[0])
+	}
+}
+
+func TestParseToolCalls_PlaceholderArgsRejected(t *testing.T) {
+	cases := []string{
+		`<tool_call name="@websearch" args="..." />`,
+		`<tool_call name="@tools" args='{"cmd":"describe","args":{"name":"..."}}' />`,
+		`Use [tool: @websearch {...}] para pesquisar.`,
+	}
+	for _, text := range cases {
+		calls, err := ParseToolCalls(text)
+		if err != nil {
+			t.Fatalf("%q: unexpected error: %v", text, err)
+		}
+		if len(calls) != 0 {
+			t.Fatalf("%q: placeholder example must not execute, got %+v", text, calls)
+		}
+	}
+}
+
+func TestParseToolCalls_RealCallsStillParseEverywhere(t *testing.T) {
+	// Plain unfenced call with prose around it — the bread-and-butter shape.
+	text := "Vou pesquisar.\n" +
+		`<tool_call name="@websearch" args='{"query":"golang generics"}' />` + "\nAguarde."
+	calls, err := ParseToolCalls(text)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(calls) != 1 || calls[0].Name != "@websearch" {
+		t.Fatalf("expected the real call to parse, got %+v", calls)
+	}
+}
+
+func TestParseToolCalls_ToolsDescribeEchoDoesNotExecute(t *testing.T) {
+	// The exact leak the field reported: the model echoes @tools describe
+	// output (usage examples) back to the user inside a documentation fence
+	// and in inline code, and the parser used to capture it as a run request.
+	text := "O @coder aceita estes comandos. Exemplo de uso:\n\n" +
+		"```bash\n" +
+		`<tool_call name="@coder" args='{"cmd":"exec","args":{"command":"ls -la"}}' />` + "\n" +
+		"```\n\n" +
+		"Também dá para chamar via `[tool: @coder exec ls -la]` no formato curto.\n"
+	calls, err := ParseToolCalls(text)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("describe echo must not reach the execution gate, got %+v", calls)
+	}
+}
+
+func TestMaskQuotedSegments_TildeFenceAndUnterminated(t *testing.T) {
+	fences, masked := maskQuotedSegments("~~~python\nprint('<tool_call name=\"@x\" args=\"1\"/>')\n~~~\nfora\n```json\n{\"tool_call\":\"@coder\",\"args\":{\"cmd\":\"read\"}}")
+	if len(fences) != 2 {
+		t.Fatalf("expected 2 fences (one unterminated), got %d", len(fences))
+	}
+	if fences[0].info != "python" || fences[1].info != "json" {
+		t.Fatalf("unexpected infos: %+v", fences)
+	}
+	if strings.Contains(masked, "tool_call") {
+		t.Fatalf("fenced content leaked into masked text: %q", masked)
+	}
+	if !strings.Contains(masked, "fora") {
+		t.Fatalf("unfenced text must survive masking: %q", masked)
+	}
+}

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -2491,8 +2491,11 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 		// Helm chart for this") — or whose path glob matches a file the agent
 		// just started touching — is injected at the next turn boundary, in
 		// time to improve the remaining work. Deduped per Run, so a skill the
-		// user's query already activated never re-fires here.
-		if block, names := a.rescanSkillsMidLoop(aiResponse, turn); block != "" {
+		// user's query already activated never re-fires here. Native tool
+		// calls carry their args OUTSIDE the response text, so they are
+		// appended to the scanned surface explicitly — otherwise path-glob
+		// skills would only ever fire on the XML fallback.
+		if block, names := a.rescanSkillsMidLoop(rescanSurface(aiResponse, nativeToolCalls), turn); block != "" {
 			pendingSkill.content, pendingSkill.names = block, names
 			notifySkillActivation(names)
 		}

--- a/cli/cli_config_reload_test.go
+++ b/cli/cli_config_reload_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -43,6 +44,11 @@ func TestReloadableEnvVarsCoverCriticalProviderVars(t *testing.T) {
 // TestRouteConfigReloadAlias garante que /config --reload (e a forma sem
 // hífens) despacha para o mesmo reloadConfiguration do /reload.
 func TestRouteConfigReloadAlias(t *testing.T) {
+	// Hermeticidade: reloadConfiguration carrega CHATCLI_DOTENV (ou ./.env)
+	// via godotenv.Overload — apontado para o .env REAL do dev, ele injetava
+	// as variáveis pessoais (ex.: ZAI_USE_CODING_PLAN=true) no processo de
+	// teste e quebrava os testes de pricing que rodam depois.
+	t.Setenv("CHATCLI_DOTENV", filepath.Join(t.TempDir(), ".env"))
 	c := minimalCLI(t)
 	config.InitGlobal(c.logger)
 	for _, alias := range []string{"--reload", "reload"} {

--- a/cli/memory_worker.go
+++ b/cli/memory_worker.go
@@ -111,6 +111,19 @@ func (mw *memoryWorker) nudge(ctx context.Context) {
 	go mw.maybeExtract(detached)
 }
 
+// queueSegmentForNextSession persists a conversation segment to the pending
+// WAL WITHOUT triggering an extraction pass. The one-shot surface exits
+// right after its turn, so an async extraction could never finish — it only
+// enqueues, and the next session's worker drains the backlog.
+func (mw *memoryWorker) queueSegmentForNextSession(segment []models.Message) {
+	if mw.cli.memoryStore == nil || len(segment) == 0 {
+		return
+	}
+	if _, err := mw.persistPending(segment); err != nil {
+		mw.logger.Warn("Memory worker: could not queue one-shot segment", zap.Error(err))
+	}
+}
+
 // nudgeSegment queues an externally-owned conversation segment (a headless
 // MCP/RPC turn whose live history is swapped back right after the call) and
 // triggers an extraction pass over the queue. nudge() cannot serve this path:

--- a/cli/oneshot_mode.go
+++ b/cli/oneshot_mode.go
@@ -92,6 +92,7 @@ func (cli *ChatCLI) HandleOneShotOrFatal(ctx context.Context, opts *Options) boo
 			fmt.Fprintln(os.Stderr, i18n.T("oneshot.error.coder_failed")+"\n\n"+i18n.T("oneshot.details_label")+":\n```\n"+err.Error()+"\n```")
 			cli.logger.Fatal("Erro no modo coder one-shot", zap.Error(err))
 		}
+		cli.queueOneShotMemory()
 		return true
 	}
 
@@ -113,7 +114,28 @@ func (cli *ChatCLI) HandleOneShotOrFatal(ctx context.Context, opts *Options) boo
 		}
 	}
 
+	cli.queueOneShotMemory()
 	return true
+}
+
+// queueOneShotMemory persists the one-shot conversation (chat turn or full
+// agent/coder transcript) to the memory worker's pending WAL. One-shot exits
+// immediately, so no extraction pass runs here — the NEXT session's worker
+// drains the backlog, giving `-p` invocations the same long-term memory and
+// self-evolve treatment every other surface gets. System messages are prompt
+// scaffolding and are skipped.
+func (cli *ChatCLI) queueOneShotMemory() {
+	if cli.memWorker == nil || len(cli.history) == 0 {
+		return
+	}
+	seg := make([]models.Message, 0, len(cli.history))
+	for _, m := range cli.history {
+		if m.Role == "system" {
+			continue
+		}
+		seg = append(seg, m)
+	}
+	cli.memWorker.queueSegmentForNextSession(seg)
 }
 
 // resolveOneShotCommand expands a slash-command input for the -p surface
@@ -177,13 +199,34 @@ func (cli *ChatCLI) RunOnce(ctx context.Context, input string, disableAnimation 
 	images, visionDesc := cli.gateImagesForModel(ctx, images)
 	additionalContext += visionDesc
 
+	// Skill parity with the interactive chat turn: pinned skills and
+	// trigger/path auto-activation fire on the one-shot prompt exactly like
+	// they would in the REPL (`-p "/coder …"` already had them through the
+	// agent engine; plain `-p` chat was the one surface without any).
+	pinned, autoSkills, filePaths := cli.resolveSkillsForTurn(userInput, additionalContext)
+	modelHint, skillEffort := cli.pickSkillHints(pinned, autoSkills, filePaths)
+
 	// One-shot used to send the bare user prompt with NO system message at
 	// all — no mode hint, no language directive, no memory. A user with
 	// months of persisted facts got a model with total amnesia ("each
 	// session starts fresh"). Inject the chat-mode baseline plus memory.
 	if sys := cli.oneShotSystemMessage(ctx, userInput); sys != "" {
+		if sb := concatSkillBlocks(pinned, autoSkills); sb != "" {
+			sys += "\n\n" + sb
+		}
 		cli.history = append(cli.history, models.Message{Role: "system", Content: sys})
 	}
+
+	// Skill model/effort routing, same precedence as the interactive turn
+	// and the MCP/ACP chat turn (explicit CLI flags already resolved
+	// cli.Client, and a hint failure degrades to the session client).
+	activeClient := cli.Client
+	if modelHint != "" {
+		if c, _, _, err := cli.resolveRPCChatClient(modelHint, RPCChatOpts{}); err == nil && c != nil {
+			activeClient = c
+		}
+	}
+	ctx = cli.applyChatEffortHint(ctx, routeEffortForPrompt(userInput, skillEffort))
 
 	cli.history = append(cli.history, models.Message{
 		Role:    "user",
@@ -199,21 +242,21 @@ func (cli *ChatCLI) RunOnce(ctx context.Context, input string, disableAnimation 
 		cli.historyCompactor.SetStatusCallback(func(stage CompactStage, msg string) {
 			fmt.Fprintf(os.Stderr, "  %s\n", msg)
 		})
-		if compacted, compactErr := cli.historyCompactor.Compact(ctx, cli.history, cli.Client, cfg); compactErr == nil {
+		if compacted, compactErr := cli.historyCompactor.Compact(ctx, cli.history, activeClient, cfg); compactErr == nil {
 			cli.history = compacted
 		}
 		cli.historyCompactor.SetStatusCallback(nil)
 	}
 
 	if !disableAnimation {
-		cli.animation.ShowThinkingAnimation(cli.Client.GetModelName())
+		cli.animation.ShowThinkingAnimation(activeClient.GetModelName())
 	}
 
 	effectiveMaxTokens := cli.getMaxTokensForCurrentLLM()
-	aiResponse, err := cli.Client.SendPrompt(ctx, userInput+additionalContext, cli.history, effectiveMaxTokens)
+	aiResponse, err := activeClient.SendPrompt(ctx, userInput+additionalContext, cli.history, effectiveMaxTokens)
 	// Auto-retry on OAuth token expiration (401)
 	if cli.refreshClientOnAuthError(err) {
-		aiResponse, err = cli.Client.SendPrompt(ctx, userInput+additionalContext, cli.history, effectiveMaxTokens)
+		aiResponse, err = activeClient.SendPrompt(ctx, userInput+additionalContext, cli.history, effectiveMaxTokens)
 	}
 
 	if !disableAnimation {
@@ -226,9 +269,13 @@ func (cli *ChatCLI) RunOnce(ctx context.Context, input string, disableAnimation 
 
 	// Track cost for one-shot mode — prefer real API usage
 	if cli.costTracker != nil {
-		usage := client.GetUsageOrEstimate(cli.Client, len(userInput+additionalContext), len(aiResponse))
+		usage := client.GetUsageOrEstimate(activeClient, len(userInput+additionalContext), len(aiResponse))
 		cli.costTracker.RecordRealUsage(cli.Provider, cli.Model, usage)
 	}
+
+	// Keep the assistant reply in the (process-local) history so the
+	// dispatcher can queue the complete turn for memory extraction.
+	cli.history = append(cli.history, models.Message{Role: "assistant", Content: aiResponse})
 
 	if rawOutput {
 		fmt.Println(aiResponse) // Imprime texto limpo

--- a/cli/rpc_history_delta_test.go
+++ b/cli/rpc_history_delta_test.go
@@ -1,0 +1,70 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+/*
+ * rpc_history_delta_test.go
+ *
+ * historyTailDelta feeds session-swapped MCP/ACP coder/agent runs into the
+ * memory worker (nudgeSegment): the delta must capture the run's new
+ * messages, skip system scaffolding, and stay safe under mid-run compaction
+ * that rewrites part of the prefix.
+ */
+package cli
+
+import (
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+)
+
+func TestHistoryTailDelta_AppendedMessages(t *testing.T) {
+	before := []models.Message{
+		{Role: "user", Content: "old question"},
+		{Role: "assistant", Content: "old answer"},
+	}
+	after := append(append([]models.Message(nil), before...),
+		models.Message{Role: "system", Content: "scaffold"},
+		models.Message{Role: "user", Content: "new task"},
+		models.Message{Role: "assistant", Content: "done"},
+	)
+	delta := historyTailDelta(before, after)
+	if len(delta) != 2 {
+		t.Fatalf("expected 2 messages (system skipped), got %d: %+v", len(delta), delta)
+	}
+	if delta[0].Content != "new task" || delta[1].Content != "done" {
+		t.Fatalf("unexpected delta: %+v", delta)
+	}
+}
+
+func TestHistoryTailDelta_NoNewMessages(t *testing.T) {
+	h := []models.Message{{Role: "user", Content: "q"}, {Role: "assistant", Content: "a"}}
+	if delta := historyTailDelta(h, h); len(delta) != 0 {
+		t.Fatalf("identical histories must yield empty delta, got %+v", delta)
+	}
+}
+
+func TestHistoryTailDelta_CompactedPrefixOverIncludes(t *testing.T) {
+	before := []models.Message{
+		{Role: "user", Content: "q1"},
+		{Role: "assistant", Content: "a1"},
+		{Role: "user", Content: "q2"},
+	}
+	// Compaction rewrote everything past the first message into a summary,
+	// then the run appended a new exchange.
+	after := []models.Message{
+		{Role: "user", Content: "q1"},
+		{Role: "assistant", Content: "[summary of a1/q2]"},
+		{Role: "user", Content: "new task"},
+		{Role: "assistant", Content: "done"},
+	}
+	delta := historyTailDelta(before, after)
+	if len(delta) != 3 {
+		t.Fatalf("rewritten tail must count as new (over-include, never drop), got %+v", delta)
+	}
+	if delta[len(delta)-1].Content != "done" {
+		t.Fatalf("run messages missing from delta: %+v", delta)
+	}
+}

--- a/cli/rpc_support_full.go
+++ b/cli/rpc_support_full.go
@@ -455,6 +455,16 @@ func (cli *ChatCLI) runLoopRPC(ctx context.Context, o RPCRunOpts, fn func(contex
 	if err != nil {
 		return out, err
 	}
+	// Session-swapped runs are invisible to the memory worker's live-delta
+	// gate (the history is restored before its goroutine ever looks), so —
+	// mirroring runChatTurnSerialized — the run's new messages are queued
+	// explicitly. Without this, coder/agent sessions driven over MCP/ACP
+	// never feed memory extraction nor self-evolve skill authoring.
+	if o.HistoryOut != nil && cli.memWorker != nil {
+		if delta := historyTailDelta(o.History, *o.HistoryOut); len(delta) > 0 {
+			cli.memWorker.nudgeSegment(ctx, delta)
+		}
+	}
 	// Structured runs return the clean final answer when the loop captured
 	// one; the discarded transcript is only a fallback for edge turns that
 	// produced no prose.
@@ -465,6 +475,28 @@ func (cli *ChatCLI) runLoopRPC(ctx context.Context, o RPCRunOpts, fn func(contex
 		out = "(no textual output)"
 	}
 	return out, nil
+}
+
+// historyTailDelta returns the messages of `after` that were produced on top
+// of `before`: everything past the longest common prefix, minus system-role
+// entries (prompt scaffolding, not conversation). Comparing role+content —
+// not just lengths — keeps the delta correct when mid-run compaction
+// rewrote part of the prefix: the rewritten tail then counts as new, which
+// over-includes (extraction dedups) rather than silently dropping the run.
+func historyTailDelta(before, after []models.Message) []models.Message {
+	lcp := 0
+	for lcp < len(before) && lcp < len(after) &&
+		before[lcp].Role == after[lcp].Role && before[lcp].Content == after[lcp].Content {
+		lcp++
+	}
+	var delta []models.Message
+	for _, m := range after[lcp:] {
+		if m.Role == "system" {
+			continue
+		}
+		delta = append(delta, m)
+	}
+	return delta
 }
 
 // applyRPCOverrides mutates provider/model and quality env for one run and

--- a/cli/rpc_support_full.go
+++ b/cli/rpc_support_full.go
@@ -489,7 +489,7 @@ func historyTailDelta(before, after []models.Message) []models.Message {
 		before[lcp].Role == after[lcp].Role && before[lcp].Content == after[lcp].Content {
 		lcp++
 	}
-	var delta []models.Message
+	delta := make([]models.Message, 0, len(after)-lcp)
 	for _, m := range after[lcp:] {
 		if m.Role == "system" {
 			continue

--- a/cli/skill_activation.go
+++ b/cli/skill_activation.go
@@ -49,18 +49,6 @@ func skillInjectBudget() int {
 	return n
 }
 
-// filePathTokenRe matches bare file-like tokens inside a user message.
-//
-// It is intentionally stricter than pathMentionRe: here we do not require a
-// leading "@" because the intent is to detect casual mentions like
-// "run go test on pkg/foo/bar_test.go" or "look at src/index.ts". To avoid
-// false positives on prose, a token must contain either:
-//   - a slash (so we're clearly looking at a path), OR
-//   - a recognized extension (.go, .ts, .py, .md, etc.) with no whitespace
-//
-// We match a superset and filter in code for extension validity.
-var filePathTokenRe = regexp.MustCompile(`(?:\./|~/|/)?[A-Za-z0-9_.\-]+(?:/[A-Za-z0-9_.\-]+)+|[A-Za-z0-9_.\-]+\.(?:go|ts|tsx|js|jsx|py|rs|java|kt|rb|php|cs|cpp|cc|c|h|hpp|md|mdx|json|ya?ml|toml|sh|bash|zsh|sql|proto|tf|dockerfile|lock|mod|sum|css|scss|html?)`)
-
 // extractFilePaths returns a deduplicated, forward-slash-normalized list of
 // file-path tokens present in the input. It looks at three sources:
 //
@@ -112,8 +100,9 @@ func extractFilePaths(input string) []string {
 		}
 	}
 
-	// 3. Bare tokens with a slash or known extension.
-	for _, tok := range filePathTokenRe.FindAllString(input, -1) {
+	// 3. Bare tokens with a slash or known extension — shared with the
+	//    flat-prompt surfaces (gRPC server/operator) via pkg/persona.
+	for _, tok := range persona.ExtractPathTokens(input) {
 		add(tok)
 	}
 

--- a/cli/skill_rescan.go
+++ b/cli/skill_rescan.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/diillson/chatcli/cli/agent"
 	llmclient "github.com/diillson/chatcli/llm/client"
+	"github.com/diillson/chatcli/models"
 	"github.com/diillson/chatcli/pkg/persona"
 	"go.uber.org/zap"
 )
@@ -95,6 +96,27 @@ func rescanNewSkills(mgr *persona.Manager, injected map[string]bool, cooldown ma
 		out = append(out, s)
 	}
 	return out
+}
+
+// rescanSurface composes the text scanned by the mid-loop skill re-activation
+// for one assistant turn: the response text plus the JSON arguments of every
+// NATIVE tool call. XML-fallback calls are already embedded in the response
+// text; native calls arrive in a separate struct, so without this append a
+// `paths:`-glob skill would never see the files the agent is touching when
+// the provider uses native tool calling.
+func rescanSurface(aiResponse string, nativeToolCalls []models.ToolCall) string {
+	if len(nativeToolCalls) == 0 {
+		return aiResponse
+	}
+	var b strings.Builder
+	b.WriteString(aiResponse)
+	for _, tc := range nativeToolCalls {
+		b.WriteString("\n")
+		b.WriteString(tc.Name)
+		b.WriteString(" ")
+		b.WriteString(tc.ArgumentsJSON())
+	}
+	return b.String()
 }
 
 // skillRunBudget is the cumulative per-Run cap on skill characters injected

--- a/cli/skill_rescan_test.go
+++ b/cli/skill_rescan_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	llmclient "github.com/diillson/chatcli/llm/client"
+	"github.com/diillson/chatcli/models"
 	"github.com/diillson/chatcli/pkg/persona"
 	"go.uber.org/zap"
 )
@@ -242,5 +243,35 @@ func TestRescanSkillsMidLoop_RunBudgetDegradesToPointer(t *testing.T) {
 	}
 	if !strings.Contains(block, "guidance for writing Helm charts") {
 		t.Fatalf("description must always be visible:\n%s", block)
+	}
+}
+
+func TestRescanSurface_AppendsNativeToolCallArgs(t *testing.T) {
+	calls := []models.ToolCall{
+		{Name: "write_file", Arguments: map[string]interface{}{"file": "deploy/chart/values.yaml"}},
+		{Name: "read_file", Arguments: map[string]interface{}{"file": "main.go"}},
+	}
+	surface := rescanSurface("I'll update the chart values now.", calls)
+	for _, want := range []string{"I'll update the chart values now.", "deploy/chart/values.yaml", "main.go", "write_file"} {
+		if !strings.Contains(surface, want) {
+			t.Fatalf("surface missing %q:\n%s", want, surface)
+		}
+	}
+	// Path tokens inside native args must reach the path-glob matcher.
+	paths := extractFilePaths(surface)
+	found := false
+	for _, p := range paths {
+		if p == "deploy/chart/values.yaml" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("native tool arg path not extracted, got %v", paths)
+	}
+}
+
+func TestRescanSurface_NoNativeCallsIsIdentity(t *testing.T) {
+	if got := rescanSurface("plain response", nil); got != "plain response" {
+		t.Fatalf("identity expected, got %q", got)
 	}
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -149,6 +149,11 @@ func RunServer(args []string, llmMgr manager.LLMManager, logger *zap.Logger) err
 		)
 	}
 
+	// Skill auto-activation for server-side prompts: remote SendPrompt/
+	// StreamPrompt/InteractiveSession turns and the operator's analysis RPCs
+	// get the same trigger/path skill matching the interactive surfaces have.
+	srv.SetPersonaManager(persona.NewManager(logger))
+
 	// Initialize fallback chain if configured.
 	initFallbackChain(opts, llmMgr, srv, logger)
 

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -1850,6 +1850,7 @@
   "server.stopped": "ChatCLI gRPC server stopped",
   "server.handler.client_config": "Using client-provided config",
   "server.handler.client_api_key": "Using client-provided API key",
+  "server.handler.skills_activated": "Server: skills auto-activated for prompt",
   "server.handler.user_question_prefix": "\n\nUser Question: ",
   "server.analysis.issue_name_required": "issue_name is required",
   "server.analysis.llm_client_failed": "Failed to get LLM client for analysis",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1850,6 +1850,7 @@
   "server.stopped": "ChatCLI gRPC server stopped",
   "server.handler.client_config": "Using client-provided config",
   "server.handler.client_api_key": "Using client-provided API key",
+  "server.handler.skills_activated": "Server: skills auto-activated for prompt",
   "server.handler.user_question_prefix": "\n\nUser Question: ",
   "server.analysis.issue_name_required": "issue_name is required",
   "server.analysis.llm_client_failed": "Failed to get LLM client for analysis",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -1850,6 +1850,7 @@
   "server.stopped": "Servidor gRPC ChatCLI parado",
   "server.handler.client_config": "Usando configuração fornecida pelo cliente",
   "server.handler.client_api_key": "Usando chave API fornecida pelo cliente",
+  "server.handler.skills_activated": "Servidor: skills auto-ativadas para o prompt",
   "server.handler.user_question_prefix": "\n\nUser Question: ",
   "server.analysis.issue_name_required": "issue_name is required",
   "server.analysis.llm_client_failed": "Falha ao obter cliente LLM para análise",

--- a/pkg/persona/activation_text.go
+++ b/pkg/persona/activation_text.go
@@ -41,9 +41,10 @@ func ExtractPathTokens(text string) []string {
 	if text == "" {
 		return nil
 	}
-	seen := make(map[string]bool)
-	var out []string
-	for _, tok := range pathTokenRe.FindAllString(text, -1) {
+	matches := pathTokenRe.FindAllString(text, -1)
+	seen := make(map[string]bool, len(matches))
+	out := make([]string, 0, len(matches))
+	for _, tok := range matches {
 		tok = strings.ReplaceAll(strings.TrimSpace(tok), "\\", "/")
 		tok = strings.Trim(tok, ".,;:()[]{}\"'`")
 		if tok == "" || seen[tok] {

--- a/pkg/persona/activation_text.go
+++ b/pkg/persona/activation_text.go
@@ -1,0 +1,99 @@
+/*
+ * ChatCLI - Persona System
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+/*
+ * activation_text.go — flat-prompt skill activation helpers.
+ *
+ * The interactive surfaces (REPL, one-shot, MCP/ACP) compose skills into
+ * structured system-prompt blocks inside the cli package. Surfaces that only
+ * have a flat prompt string to work with — the gRPC server serving remote
+ * clients and the Kubernetes operator's analysis requests — need the same
+ * auto-activation without importing cli. This file hosts the shared pieces:
+ * bare file-path token extraction (feeds `paths:` glob matching) and a
+ * prompt-preamble renderer for activated skills.
+ */
+package persona
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// DefaultActivationBudget caps the total characters of skill BODIES inlined
+// in one activation block. Skills past the budget keep their header and
+// description; the body degrades to a read-on-demand pointer.
+const DefaultActivationBudget = 24_000
+
+// pathTokenRe matches bare file-like tokens inside free text. A token must
+// contain either a slash (clearly a path) or a recognized source/config
+// extension, so prose almost never false-positives.
+var pathTokenRe = regexp.MustCompile(`(?:\./|~/|/)?[A-Za-z0-9_.\-]+(?:/[A-Za-z0-9_.\-]+)+|[A-Za-z0-9_.\-]+\.(?:go|ts|tsx|js|jsx|py|rs|java|kt|rb|php|cs|cpp|cc|c|h|hpp|md|mdx|json|ya?ml|toml|sh|bash|zsh|sql|proto|tf|dockerfile|lock|mod|sum|css|scss|html?)`)
+
+// ExtractPathTokens returns a deduplicated, forward-slash-normalized list of
+// bare file-path tokens present in text. The result feeds
+// Manager.FindPathMatchedSkills — it is never used to read files, so
+// non-existent paths are kept (a skill may match paths being planned).
+func ExtractPathTokens(text string) []string {
+	if text == "" {
+		return nil
+	}
+	seen := make(map[string]bool)
+	var out []string
+	for _, tok := range pathTokenRe.FindAllString(text, -1) {
+		tok = strings.ReplaceAll(strings.TrimSpace(tok), "\\", "/")
+		tok = strings.Trim(tok, ".,;:()[]{}\"'`")
+		if tok == "" || seen[tok] {
+			continue
+		}
+		seen[tok] = true
+		out = append(out, tok)
+	}
+	return out
+}
+
+// BuildActivationPromptBlock renders auto-activated skills as a prompt
+// preamble for flat-prompt surfaces. Bodies are inlined until budget is
+// spent (0 disables the cap); overflowing skills keep name + description
+// plus a pointer to their source file. Model-facing English by design.
+func BuildActivationPromptBlock(skills []*Skill, budget int) string {
+	if len(skills) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("# Auto-loaded Skills\n\n")
+	b.WriteString("The following skills were automatically activated by the request ")
+	b.WriteString("content (matched via `triggers:` keywords or `paths:` globs in the ")
+	b.WriteString("skill frontmatter). Follow their guidance when relevant.\n\n")
+	spent := 0
+	for _, s := range skills {
+		fmt.Fprintf(&b, "## Skill: %s", s.Name)
+		if s.Version != "" {
+			fmt.Fprintf(&b, " (v%s)", s.Version)
+		}
+		b.WriteString("\n\n")
+		if s.Description != "" {
+			b.WriteString(s.Description)
+			b.WriteString("\n\n")
+		}
+		body := strings.TrimSpace(s.Content)
+		if body == "" {
+			continue
+		}
+		if budget > 0 && spent+len(body) > budget {
+			if s.Path != "" {
+				fmt.Fprintf(&b, "_Body not inlined (skill budget). Full instructions at: %s_\n\n", s.Path)
+			} else {
+				b.WriteString("_Body not inlined (skill budget) and no source file is available. Rely on the description above; do not invent instructions._\n\n")
+			}
+			continue
+		}
+		b.WriteString(body)
+		b.WriteString("\n\n")
+		spent += len(body)
+	}
+	return b.String()
+}

--- a/pkg/persona/activation_text_test.go
+++ b/pkg/persona/activation_text_test.go
@@ -1,0 +1,74 @@
+/*
+ * ChatCLI - Persona System Tests (flat-prompt activation helpers)
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package persona
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExtractPathTokens(t *testing.T) {
+	got := ExtractPathTokens("olha o pkg/foo/bar_test.go e o main.go (e o deploy/chart/values.yaml).")
+	want := []string{"pkg/foo/bar_test.go", "main.go", "deploy/chart/values.yaml"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}
+
+func TestExtractPathTokens_EmptyAndProse(t *testing.T) {
+	if got := ExtractPathTokens(""); got != nil {
+		t.Fatalf("empty text must yield nil, got %v", got)
+	}
+	if got := ExtractPathTokens("nenhum caminho aqui, só prosa comum."); len(got) != 0 {
+		t.Fatalf("prose must yield nothing, got %v", got)
+	}
+}
+
+func TestExtractPathTokens_Dedup(t *testing.T) {
+	got := ExtractPathTokens("main.go e de novo main.go")
+	if len(got) != 1 || got[0] != "main.go" {
+		t.Fatalf("expected single deduped token, got %v", got)
+	}
+}
+
+func TestBuildActivationPromptBlock(t *testing.T) {
+	skills := []*Skill{
+		{Name: "helm-deploy", Version: "1.0", Description: "How we deploy Helm charts.", Content: "Step one. Step two."},
+		{Name: "empty-body", Description: "Header-only skill."},
+	}
+	block := BuildActivationPromptBlock(skills, DefaultActivationBudget)
+	for _, want := range []string{"# Auto-loaded Skills", "## Skill: helm-deploy (v1.0)", "Step one. Step two.", "## Skill: empty-body"} {
+		if !strings.Contains(block, want) {
+			t.Fatalf("block missing %q:\n%s", want, block)
+		}
+	}
+	if BuildActivationPromptBlock(nil, DefaultActivationBudget) != "" {
+		t.Fatal("no skills must render empty")
+	}
+}
+
+func TestBuildActivationPromptBlock_BudgetOverflowDegradesToPointer(t *testing.T) {
+	big := strings.Repeat("x", 100)
+	skills := []*Skill{
+		{Name: "first", Content: big, Path: "/tmp/first/SKILL.md"},
+		{Name: "second", Content: big, Path: "/tmp/second/SKILL.md"},
+	}
+	block := BuildActivationPromptBlock(skills, 150)
+	if !strings.Contains(block, big) {
+		t.Fatal("first skill body should inline within budget")
+	}
+	if strings.Count(block, big) != 1 {
+		t.Fatal("second skill body must NOT inline past the budget")
+	}
+	if !strings.Contains(block, "/tmp/second/SKILL.md") {
+		t.Fatal("overflowing skill must keep a source pointer")
+	}
+}

--- a/pkg/persona/manager.go
+++ b/pkg/persona/manager.go
@@ -27,6 +27,9 @@ type Manager struct {
 
 	// usage records which skills get auto-activated, for analytics.
 	usage *usage.Store
+	// usageWG tracks the in-flight asynchronous usage writes so callers
+	// (tests above all) can wait for them — see WaitUsageFlush.
+	usageWG sync.WaitGroup
 }
 
 // NewManager creates a new persona manager
@@ -302,14 +305,27 @@ func (m *Manager) FindAutoActivatedSkills(text string, filePaths []string) []*Sk
 		}
 	}
 	// Record activations asynchronously so analytics never slow a turn.
+	// Tracked by usageWG: an untracked goroutine writing under the user's
+	// home races test TempDir cleanup (and process exit on one-shot).
 	if m.usage != nil && len(out) > 0 {
 		names := make([]string, 0, len(out))
 		for _, s := range out {
 			names = append(names, s.Name)
 		}
-		go m.usage.Record(names...)
+		m.usageWG.Add(1)
+		go func() {
+			defer m.usageWG.Done()
+			m.usage.Record(names...)
+		}()
 	}
 	return out
+}
+
+// WaitUsageFlush blocks until every in-flight asynchronous usage-analytics
+// write has finished. Callers that redirect HOME to a temporary directory
+// (tests) must invoke it before the directory is removed.
+func (m *Manager) WaitUsageFlush() {
+	m.usageWG.Wait()
 }
 
 // UsageRanking returns skill activation analytics, most-used first.

--- a/server/handler.go
+++ b/server/handler.go
@@ -60,6 +60,10 @@ type Handler struct {
 	pluginManager *plugins.Manager
 	personaLoader *persona.Loader
 
+	// Skill auto-activation for server-side prompts (optional, nil when not
+	// configured). Set via SetPersonaManager.
+	personaManager *persona.Manager
+
 	// Provider fallback chain (optional, nil when not configured)
 	fallbackChain *fallback.Chain
 
@@ -138,16 +142,44 @@ func (h *Handler) SetWatcher(cfg WatcherConfig) {
 	h.watcherNamespace = cfg.Namespace
 }
 
-// enrichPrompt prepends K8s watcher context to the prompt if available.
+// enrichPrompt prepends auto-activated skills and K8s watcher context to the
+// prompt if available.
 func (h *Handler) enrichPrompt(prompt string) string {
+	enriched := h.applySkills(prompt)
 	if h.watcherContextFunc == nil {
-		return prompt
+		return enriched
 	}
 	ctx := h.watcherContextFunc()
 	if ctx == "" {
+		return enriched
+	}
+	return ctx + i18n.T("server.handler.user_question_prefix") + enriched
+}
+
+// applySkills matches the request text against the skill catalog (trigger
+// keywords + path globs) and, when skills fire, prepends their guidance block
+// — the same auto-activation contract every interactive surface has. No-op
+// when no persona manager is configured or nothing matches. Exposed to the
+// analysis path too, which deliberately skips enrichPrompt (the operator
+// sends its own watcher context) but must not skip skills.
+func (h *Handler) applySkills(prompt string) string {
+	if h.personaManager == nil || strings.TrimSpace(prompt) == "" {
 		return prompt
 	}
-	return ctx + i18n.T("server.handler.user_question_prefix") + prompt
+	skills := h.personaManager.FindAutoActivatedSkills(prompt, persona.ExtractPathTokens(prompt))
+	if len(skills) == 0 {
+		return prompt
+	}
+	block := persona.BuildActivationPromptBlock(skills, persona.DefaultActivationBudget)
+	if block == "" {
+		return prompt
+	}
+	names := make([]string, 0, len(skills))
+	for _, s := range skills {
+		names = append(names, s.Name)
+	}
+	h.logger.Info(i18n.T("server.handler.skills_activated"), zap.Strings("skills", names))
+	return block + "\n" + i18n.T("server.handler.user_question_prefix") + prompt
 }
 
 // getClient resolves the LLM client to use, optionally overriding provider/model.
@@ -308,6 +340,12 @@ func protoSessionDataToModels(psd *pb.SessionDataV2) *models.SessionData {
 
 func (h *Handler) SetPluginManager(pm *plugins.Manager) {
 	h.pluginManager = pm
+}
+
+// SetPersonaManager enables skill auto-activation on server-side prompts
+// (SendPrompt/StreamPrompt/InteractiveSession and the operator analysis RPCs).
+func (h *Handler) SetPersonaManager(pm *persona.Manager) {
+	h.personaManager = pm
 }
 
 // SetPersonaLoader sets the persona loader for remote agent/skill discovery.

--- a/server/handler_analysis.go
+++ b/server/handler_analysis.go
@@ -64,8 +64,10 @@ func (h *Handler) AnalyzeIssue(ctx context.Context, req *pb.AnalyzeIssueRequest)
 	// NOTE: Do NOT call enrichPrompt() here. The operator sends its own enriched
 	// kubernetes_context (up to 30KB with logs, metrics, GitOps, source code, cascade
 	// analysis) in the RPC request. enrichPrompt() is for interactive CLI sessions only
-	// and would duplicate/conflict with the operator's context.
-	response, err := llmClient.SendPrompt(ctx, prompt, nil, 0)
+	// and would duplicate/conflict with the operator's context. Skills are a
+	// different matter: server-side skill guidance (runbooks, conventions)
+	// must reach operator analyses too, so only applySkills runs.
+	response, err := llmClient.SendPrompt(ctx, h.applySkills(prompt), nil, 0)
 	if err != nil {
 		h.logger.Error(i18n.T("server.analysis.llm_failed"), zap.Error(err), zap.String("issue", req.IssueName))
 		return nil, status.Errorf(codes.Internal, "%s", i18n.T("server.analysis.llm_error", err))
@@ -549,7 +551,9 @@ func (h *Handler) AgenticStep(ctx context.Context, req *pb.AgenticStepRequest) (
 	}
 
 	prompt := buildAgenticStepPrompt(req)
-	response, err := llmClient.SendPrompt(ctx, prompt, nil, 0)
+	// Same contract as AnalyzeIssue: no enrichPrompt (operator owns the k8s
+	// context), but server-side skills still activate on the step prompt.
+	response, err := llmClient.SendPrompt(ctx, h.applySkills(prompt), nil, 0)
 	if err != nil {
 		h.logger.Error(i18n.T("server.agentic.llm_failed"), zap.Error(err), zap.String("issue", req.IssueName), zap.Int32("step", req.CurrentStep))
 		return nil, status.Errorf(codes.Internal, "%s", i18n.T("server.agentic.llm_error", err))

--- a/server/handler_analysis.go
+++ b/server/handler_analysis.go
@@ -66,7 +66,7 @@ func (h *Handler) AnalyzeIssue(ctx context.Context, req *pb.AnalyzeIssueRequest)
 	// analysis) in the RPC request. enrichPrompt() is for interactive CLI sessions only
 	// and would duplicate/conflict with the operator's context. Skills are a
 	// different matter: server-side skill guidance (runbooks, conventions)
-	// must reach operator analyses too, so only applySkills runs.
+	// must reach operator analysis prompts too, so only applySkills runs.
 	response, err := llmClient.SendPrompt(ctx, h.applySkills(prompt), nil, 0)
 	if err != nil {
 		h.logger.Error(i18n.T("server.analysis.llm_failed"), zap.Error(err), zap.String("issue", req.IssueName))

--- a/server/handler_skills_test.go
+++ b/server/handler_skills_test.go
@@ -1,0 +1,96 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+/*
+ * handler_skills_test.go
+ *
+ * Server-side skill auto-activation: prompts served by the gRPC surface
+ * (remote clients and the operator's analysis RPCs) must match the skill
+ * catalog the same way interactive surfaces do.
+ */
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/i18n"
+	"github.com/diillson/chatcli/pkg/persona"
+	"go.uber.org/zap"
+)
+
+// writeServerTestSkill seeds one skill under a fake HOME so persona.NewManager
+// (which resolves ~/.chatcli/skills) picks it up.
+func writeServerTestSkill(t *testing.T, home, name, triggers, body string) {
+	t.Helper()
+	dir := filepath.Join(home, ".chatcli", "skills", name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "---\nname: " + name + "\ndescription: test skill for " + name + "\ntriggers: " + triggers + "\n---\n" + body + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func newSkillTestHandler(t *testing.T) *Handler {
+	t.Helper()
+	i18n.Init()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // windows UserHomeDir
+	writeServerTestSkill(t, home, "helm-runbook", "helm, crashloopbackoff", "Always check values.yaml first.")
+
+	h := NewHandler(nil, nil, zap.NewNop(), "OPENAI", "gpt-test")
+	h.SetPersonaManager(persona.NewManager(zap.NewNop()))
+	return h
+}
+
+func TestApplySkills_TriggerMatchInjectsBlock(t *testing.T) {
+	h := newSkillTestHandler(t)
+	prompt := "o pod está em CrashLoopBackOff depois do deploy com helm"
+	out := h.applySkills(prompt)
+	if !strings.Contains(out, "## Skill: helm-runbook") {
+		t.Fatalf("expected skill block injected, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Always check values.yaml first.") {
+		t.Fatalf("expected skill body inlined, got:\n%s", out)
+	}
+	if !strings.Contains(out, prompt) {
+		t.Fatalf("original prompt must be preserved, got:\n%s", out)
+	}
+}
+
+func TestApplySkills_NoMatchIsPassthrough(t *testing.T) {
+	h := newSkillTestHandler(t)
+	prompt := "resuma este texto sem nenhum gatilho"
+	if out := h.applySkills(prompt); out != prompt {
+		t.Fatalf("no-match must be a passthrough, got:\n%s", out)
+	}
+}
+
+func TestApplySkills_NilManagerIsPassthrough(t *testing.T) {
+	i18n.Init()
+	h := NewHandler(nil, nil, zap.NewNop(), "OPENAI", "gpt-test")
+	prompt := "helm crashloopbackoff"
+	if out := h.applySkills(prompt); out != prompt {
+		t.Fatalf("nil manager must be a passthrough, got:\n%s", out)
+	}
+}
+
+func TestEnrichPrompt_ComposesSkillsAndWatcherContext(t *testing.T) {
+	h := newSkillTestHandler(t)
+	h.SetWatcherContext(func() string { return "K8S CONTEXT" })
+	out := h.enrichPrompt("problema de helm no cluster")
+	if !strings.Contains(out, "K8S CONTEXT") {
+		t.Fatalf("watcher context missing:\n%s", out)
+	}
+	if !strings.Contains(out, "## Skill: helm-runbook") {
+		t.Fatalf("skill block missing:\n%s", out)
+	}
+}

--- a/server/handler_skills_test.go
+++ b/server/handler_skills_test.go
@@ -47,7 +47,12 @@ func newSkillTestHandler(t *testing.T) *Handler {
 	writeServerTestSkill(t, home, "helm-runbook", "helm, crashloopbackoff", "Always check values.yaml first.")
 
 	h := NewHandler(nil, nil, zap.NewNop(), "OPENAI", "gpt-test")
-	h.SetPersonaManager(persona.NewManager(zap.NewNop()))
+	pm := persona.NewManager(zap.NewNop())
+	// Usage analytics are written asynchronously under HOME; wait for the
+	// flush before t.TempDir removes the fake home, or cleanup flakes with
+	// "directory not empty".
+	t.Cleanup(pm.WaitUsageFlush)
+	h.SetPersonaManager(pm)
 	return h
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -322,6 +322,11 @@ func (s *Server) SetPersonaLoader(pl *persona.Loader) {
 	s.handler.SetPersonaLoader(pl)
 }
 
+// SetPersonaManager enables skill auto-activation on server-side prompts.
+func (s *Server) SetPersonaManager(pm *persona.Manager) {
+	s.handler.SetPersonaManager(pm)
+}
+
 // SetFallbackChain configures the provider fallback chain for automatic failover.
 func (s *Server) SetFallbackChain(chain *fallback.Chain) {
 	s.handler.SetFallbackChain(chain)


### PR DESCRIPTION
## O que muda

### 1. Parser de tool calls: describe nunca vira execução
O parser capturava sintaxe de tool call em QUALQUER lugar do texto — inclusive exemplos que o modelo ecoa ao descrever uma ferramenta (saída do @tools describe, fences de documentação, inline code). Isso vazava para o gate de segurança como uma tentativa de execução real.

Agora:
- fences de código e inline code são ilustrativos por padrão (parsing primário roda numa cópia mascarada)
- fences só executam como recovery quando nenhuma call fora de fence existe E o info string é executável (xml, json ou vazio) — fences bash/text/markdown nunca executam
- args placeholder (reticências de documentação) são sempre rejeitados
- dedup no recovery de fence (o JSON embutido no atributo args era capturado 2x)

### 2. Paridade de auto-ativação de skills
| Superfície | Antes | Depois |
|---|---|---|
| One-shot chat (-p) | nenhuma skill | pinned + auto + hints de modelo/effort |
| Rescan mid-loop (coder/agent) | só texto da resposta | + args de tool calls nativas (paths de arquivos) |
| Server gRPC (SendPrompt/Stream/Interactive) | nenhuma | ativação por trigger/path |
| Operator (AnalyzeIssue/AgenticStep) | nenhuma | ativação por trigger/path |

### 3. Paridade de memória/self-evolve
- Runs coder/agent via MCP/ACP (histórico session-swapped) agora alimentam o memory worker via delta — antes nunca geravam memórias nem skill candidates
- One-shot enfileira a conversa no WAL pendente; a próxima sessão extrai

### 4. Fix de flake local pré-existente
TestRouteConfigReloadAlias carregava o .env real do dev no processo de teste e quebrava os testes de pricing ZAI que rodam depois.

## Testes
- go build ./... e go test ./... verdes nos dois módulos (chatcli e operator)
- novos testes: parser quoted-context, persona activation/path-tokens, server applySkills, rescanSurface, historyTailDelta