### PR TITLE
feat(coder): post-edit LSP diagnostics injected into the tool result

### DIFF
--- a/cli/config_sections.go
+++ b/cli/config_sections.go
@@ -687,6 +687,7 @@ func (cli *ChatCLI) showConfigAgent() {
 	kv(p, "CHATCLI_AGENT_TMPDIR", envOr("CHATCLI_AGENT_TMPDIR"))
 	kv(p, "CHATCLI_AGENT_KEEP_TMPDIR", envBool("CHATCLI_AGENT_KEEP_TMPDIR"))
 	kv(p, "CHATCLI_MAX_COMMAND_OUTPUT", envOr("CHATCLI_MAX_COMMAND_OUTPUT"))
+	kv(p, "CHATCLI_CODER_AUTODIAG", envBool("CHATCLI_CODER_AUTODIAG"))
 
 	fmt.Println(p)
 	subheader(p, "cfg.sub.agent.coder_denial")

--- a/cli/lsp_tool_adapter.go
+++ b/cli/lsp_tool_adapter.go
@@ -107,8 +107,14 @@ func (a *lspToolAdapter) Diagnostics(file string) (string, error) {
 	if len(diags) == 0 {
 		return fmt.Sprintf("%s: no diagnostics — the file is clean.", relPath(sess.Root, "file://"+abs)), nil
 	}
+	return renderDiagnosticsList(sess.Root, abs, diags), nil
+}
+
+// renderDiagnosticsList formats a non-empty diagnostics slice as bounded,
+// model-facing text. Shared by Diagnostics and QuickDiagnostics.
+func renderDiagnosticsList(root, abs string, diags []lsp.Diagnostic) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "%d diagnostic(s) in %s:\n", len(diags), relPath(sess.Root, "file://"+abs))
+	fmt.Fprintf(&b, "%d diagnostic(s) in %s:\n", len(diags), relPath(root, "file://"+abs))
 	for _, d := range diags {
 		src := d.Source
 		if src != "" {
@@ -117,7 +123,23 @@ func (a *lspToolAdapter) Diagnostics(file string) (string, error) {
 		fmt.Fprintf(&b, "- L%d:%d [%s] %s%s\n",
 			d.Range.Start.Line+1, d.Range.Start.Character+1, d.SeverityLabel(), d.Message, src)
 	}
-	return strings.TrimRight(b.String(), "\n"), nil
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// QuickDiagnostics implements plugins.LSPQuickDiagnoser: same findings as
+// Diagnostics, plus an explicit hasIssues flag so the post-edit auto-check
+// can stay silent on clean (or inconclusive) files instead of spending
+// tokens announcing cleanliness.
+func (a *lspToolAdapter) QuickDiagnostics(file string) (string, bool, error) {
+	sess, abs, err := a.acquire(file)
+	if err != nil {
+		return "", false, err
+	}
+	diags, ok := sess.Client.Diagnostics(sess.URI, lspDiagnosticsWait)
+	if !ok || len(diags) == 0 {
+		return "", false, nil
+	}
+	return renderDiagnosticsList(sess.Root, abs, diags), true, nil
 }
 
 // Definition implements plugins.LSPAdapter. line/column are 1-based.

--- a/cli/plugins/builtin_coder.go
+++ b/cli/plugins/builtin_coder.go
@@ -82,5 +82,10 @@ func (p *BuiltinCoderPlugin) ExecuteWithStream(ctx context.Context, args []strin
 	if err != nil {
 		return output, fmt.Errorf("plugin execution failed: %w", err)
 	}
+	// Post-edit diagnostics: a successful mutation immediately reports any
+	// language-server findings on the touched files (see coder_autodiag.go).
+	// This is the single chokepoint every surface funnels through — agent
+	// loop, squad workers, MCP/ACP tool passthrough and `chatcli tool`.
+	output = appendAutoDiagnostics(subcmd, subArgs, output)
 	return output, nil
 }

--- a/cli/plugins/coder_autodiag.go
+++ b/cli/plugins/coder_autodiag.go
@@ -1,0 +1,162 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+/*
+ * coder_autodiag.go — post-edit diagnostics for @coder.
+ *
+ * Every mutating @coder subcommand (write, patch, multipatch) leaves a window
+ * where the model believes the edit is fine but the file no longer compiles —
+ * the error only surfaces turns later, when a test or exec fails. This hook
+ * closes that window: right after a successful mutation, the touched files
+ * are checked through the same session-scoped LSP pool the @lsp tool uses,
+ * and any findings are appended to the tool result as a compact
+ * [DIAGNOSTICS] block the model sees IMMEDIATELY.
+ *
+ * Degrades to a no-op when: the env kill switch is set, no LSP adapter is
+ * wired (one-shot surfaces without a pool), the adapter lacks the quick
+ * capability, or the language has no server. A clean file appends nothing —
+ * silence means clean, keeping the happy path at zero token cost.
+ */
+package plugins
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// coderAutoDiagEnv is the kill switch for post-edit diagnostics. Unset or
+// any value other than the off-forms keeps the feature on — the block is
+// advisory, capped, and free when the file is clean.
+const coderAutoDiagEnv = "CHATCLI_CODER_AUTODIAG"
+
+// coderAutoDiagEnabled honors CHATCLI_CODER_AUTODIAG=0|false|off|no.
+func coderAutoDiagEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(coderAutoDiagEnv))) {
+	case "0", "false", "off", "no":
+		return false
+	}
+	return true
+}
+
+// LSPQuickDiagnoser is an OPTIONAL capability of the wired LSPAdapter:
+// diagnostics that report whether anything was actually found, so callers
+// can stay silent on clean files. A separate interface (not a new LSPAdapter
+// method) because LSPAdapter is exported API — extending it would break
+// existing implementers.
+type LSPQuickDiagnoser interface {
+	// QuickDiagnostics returns the rendered findings for file and whether
+	// any finding exists. hasIssues=false means clean or inconclusive —
+	// either way there is nothing worth injecting.
+	QuickDiagnostics(file string) (text string, hasIssues bool, err error)
+}
+
+const (
+	// maxAutoDiagFiles bounds how many touched files are checked per call —
+	// a runaway multipatch must not turn one edit into a diagnostics storm.
+	maxAutoDiagFiles = 5
+	// maxAutoDiagBytes caps the appended block so a pathological file (a
+	// thousand parse errors) cannot flood the tool result.
+	maxAutoDiagBytes = 3000
+)
+
+// mutatingCoderSubcommands are the @coder subcommands whose success means
+// file content changed on disk.
+var mutatingCoderSubcommands = map[string]bool{
+	"write":      true,
+	"patch":      true,
+	"multipatch": true,
+}
+
+// autoDiagTargets extracts the file paths a mutating subcommand touched from
+// its argv: the --file flag for write/patch, the edits JSON for multipatch.
+// Lenient by design — a shape it does not recognize yields no targets, never
+// an error (the edit itself already succeeded).
+func autoDiagTargets(subcmd string, args []string) []string {
+	switch subcmd {
+	case "write", "patch":
+		if f := flagValue(args, "--file"); f != "" {
+			return []string{f}
+		}
+	case "multipatch":
+		raw := flagValue(args, "--edits")
+		if raw == "" {
+			return nil
+		}
+		var edits []struct {
+			File string `json:"file"`
+		}
+		if err := json.Unmarshal([]byte(raw), &edits); err != nil {
+			return nil
+		}
+		seen := make(map[string]bool, len(edits))
+		out := make([]string, 0, len(edits))
+		for _, e := range edits {
+			f := strings.TrimSpace(e.File)
+			if f == "" || seen[f] {
+				continue
+			}
+			seen[f] = true
+			out = append(out, f)
+		}
+		return out
+	}
+	return nil
+}
+
+// flagValue returns the value of a --flag in argv, supporting both the
+// two-token form (--flag value) and the inline form (--flag=value).
+func flagValue(args []string, flag string) string {
+	for i, a := range args {
+		if a == flag && i+1 < len(args) {
+			return strings.TrimSpace(args[i+1])
+		}
+		if v, ok := strings.CutPrefix(a, flag+"="); ok {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+// appendAutoDiagnostics runs post-edit diagnostics for a successful mutating
+// subcommand and returns output with the findings block appended. Model-facing
+// English, like every other injected block.
+func appendAutoDiagnostics(subcmd string, args []string, output string) string {
+	if !mutatingCoderSubcommands[subcmd] || !coderAutoDiagEnabled() {
+		return output
+	}
+	qd, ok := currentLSPAdapter().(LSPQuickDiagnoser)
+	if !ok {
+		return output
+	}
+	targets := autoDiagTargets(subcmd, args)
+	if len(targets) == 0 {
+		return output
+	}
+	if len(targets) > maxAutoDiagFiles {
+		targets = targets[:maxAutoDiagFiles]
+	}
+
+	var b strings.Builder
+	for _, file := range targets {
+		text, hasIssues, err := qd.QuickDiagnostics(file)
+		if err != nil || !hasIssues || strings.TrimSpace(text) == "" {
+			continue
+		}
+		if b.Len()+len(text) > maxAutoDiagBytes {
+			b.WriteString(fmt.Sprintf("- %s: findings omitted (diagnostics budget) — run @lsp diagnostics on it.\n", file))
+			continue
+		}
+		b.WriteString(text)
+		b.WriteString("\n")
+	}
+	if b.Len() == 0 {
+		return output
+	}
+	return output + "\n[DIAGNOSTICS] The edit succeeded but the language server reports issues in the touched file(s). " +
+		"Fix them before moving on:\n" + strings.TrimRight(b.String(), "\n")
+}

--- a/cli/plugins/coder_autodiag_test.go
+++ b/cli/plugins/coder_autodiag_test.go
@@ -1,0 +1,172 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+/*
+ * coder_autodiag_test.go
+ *
+ * Post-edit diagnostics: a successful @coder mutation must surface language-
+ * server findings immediately, stay silent on clean files, respect the env
+ * kill switch, and degrade to a no-op when no capable adapter is wired.
+ */
+package plugins
+
+import (
+	"strings"
+	"testing"
+)
+
+// fakeDiagAdapter implements LSPAdapter plus the LSPQuickDiagnoser capability.
+type fakeDiagAdapter struct {
+	findings map[string]string // file -> rendered findings ("" = clean)
+	calls    []string
+}
+
+func (f *fakeDiagAdapter) Diagnostics(file string) (string, error) { return f.findings[file], nil }
+func (f *fakeDiagAdapter) Definition(string, int, int) (string, error) {
+	return "", nil
+}
+func (f *fakeDiagAdapter) References(string, int, int, bool, int) (string, error) {
+	return "", nil
+}
+func (f *fakeDiagAdapter) Symbols(string) (string, error)         { return "", nil }
+func (f *fakeDiagAdapter) Hover(string, int, int) (string, error) { return "", nil }
+
+func (f *fakeDiagAdapter) QuickDiagnostics(file string) (string, bool, error) {
+	f.calls = append(f.calls, file)
+	text := f.findings[file]
+	return text, text != "", nil
+}
+
+func withLSPAdapter(t *testing.T, a LSPAdapter) {
+	t.Helper()
+	SetLSPAdapter(a)
+	t.Cleanup(func() { SetLSPAdapter(nil) })
+}
+
+func TestAutoDiagTargets(t *testing.T) {
+	cases := []struct {
+		name   string
+		subcmd string
+		args   []string
+		want   []string
+	}{
+		{"write two-token", "write", []string{"--file", "main.go", "--content", "x"}, []string{"main.go"}},
+		{"patch inline form", "patch", []string{"--file=pkg/a/b.go", "--search", "x", "--replace", "y"}, []string{"pkg/a/b.go"}},
+		{"multipatch json dedup", "multipatch", []string{"--edits", `[{"file":"a.go"},{"file":"b.go"},{"file":"a.go"}]`}, []string{"a.go", "b.go"}},
+		{"multipatch bad json", "multipatch", []string{"--edits", "not json"}, nil},
+		{"read is not mutating", "read", []string{"--file", "main.go"}, nil},
+		{"write without file", "write", []string{"--content", "x"}, nil},
+	}
+	for _, tc := range cases {
+		got := autoDiagTargets(tc.subcmd, tc.args)
+		if len(got) != len(tc.want) {
+			t.Fatalf("%s: expected %v, got %v", tc.name, tc.want, got)
+		}
+		for i := range tc.want {
+			if got[i] != tc.want[i] {
+				t.Fatalf("%s: expected %v, got %v", tc.name, tc.want, got)
+			}
+		}
+	}
+}
+
+func TestAppendAutoDiagnostics_InjectsFindings(t *testing.T) {
+	fake := &fakeDiagAdapter{findings: map[string]string{
+		"main.go": "1 diagnostic(s) in main.go:\n- L3:1 [error] undefined: foo (compiler)",
+	}}
+	withLSPAdapter(t, fake)
+
+	out := appendAutoDiagnostics("write", []string{"--file", "main.go"}, "File written.")
+	if !strings.Contains(out, "[DIAGNOSTICS]") || !strings.Contains(out, "undefined: foo") {
+		t.Fatalf("expected findings appended, got:\n%s", out)
+	}
+	if !strings.HasPrefix(out, "File written.") {
+		t.Fatalf("original output must be preserved, got:\n%s", out)
+	}
+}
+
+func TestAppendAutoDiagnostics_SilentOnCleanFile(t *testing.T) {
+	fake := &fakeDiagAdapter{findings: map[string]string{}}
+	withLSPAdapter(t, fake)
+
+	out := appendAutoDiagnostics("write", []string{"--file", "clean.go"}, "File written.")
+	if out != "File written." {
+		t.Fatalf("clean file must append nothing, got:\n%s", out)
+	}
+	if len(fake.calls) != 1 || fake.calls[0] != "clean.go" {
+		t.Fatalf("expected exactly one diagnostics call, got %v", fake.calls)
+	}
+}
+
+func TestAppendAutoDiagnostics_KillSwitch(t *testing.T) {
+	fake := &fakeDiagAdapter{findings: map[string]string{"main.go": "boom"}}
+	withLSPAdapter(t, fake)
+	t.Setenv(coderAutoDiagEnv, "off")
+
+	out := appendAutoDiagnostics("write", []string{"--file", "main.go"}, "File written.")
+	if out != "File written." {
+		t.Fatalf("kill switch must disable the hook, got:\n%s", out)
+	}
+	if len(fake.calls) != 0 {
+		t.Fatalf("no diagnostics call expected with the kill switch on, got %v", fake.calls)
+	}
+}
+
+func TestAppendAutoDiagnostics_NoAdapterOrCapability(t *testing.T) {
+	// No adapter wired at all.
+	SetLSPAdapter(nil)
+	if out := appendAutoDiagnostics("write", []string{"--file", "x.go"}, "ok"); out != "ok" {
+		t.Fatalf("nil adapter must no-op, got:\n%s", out)
+	}
+	// Adapter without the quick capability: the interface holds a
+	// *fakeDiagAdapter inner value only — pass the plain LSPAdapter subset.
+	var subset LSPAdapter = &lspAdapterOnly{}
+	withLSPAdapter(t, subset)
+	if out := appendAutoDiagnostics("write", []string{"--file", "x.go"}, "ok"); out != "ok" {
+		t.Fatalf("adapter without capability must no-op, got:\n%s", out)
+	}
+}
+
+// lspAdapterOnly implements LSPAdapter and deliberately NOT LSPQuickDiagnoser.
+type lspAdapterOnly struct{}
+
+func (*lspAdapterOnly) Diagnostics(string) (string, error)                     { return "", nil }
+func (*lspAdapterOnly) Definition(string, int, int) (string, error)            { return "", nil }
+func (*lspAdapterOnly) References(string, int, int, bool, int) (string, error) { return "", nil }
+func (*lspAdapterOnly) Symbols(string) (string, error)                         { return "", nil }
+func (*lspAdapterOnly) Hover(string, int, int) (string, error)                 { return "", nil }
+
+func TestAppendAutoDiagnostics_BudgetCap(t *testing.T) {
+	big := strings.Repeat("x", maxAutoDiagBytes)
+	fake := &fakeDiagAdapter{findings: map[string]string{
+		"a.go": big,
+		"b.go": "1 diagnostic(s) in b.go:\n- L1:1 [error] boom",
+	}}
+	withLSPAdapter(t, fake)
+
+	out := appendAutoDiagnostics("multipatch",
+		[]string{"--edits", `[{"file":"a.go"},{"file":"b.go"}]`}, "done")
+	if !strings.Contains(out, big) {
+		t.Fatal("first file findings should fit the budget")
+	}
+	if strings.Contains(out, "boom") {
+		t.Fatal("second file must be elided once the budget is spent")
+	}
+	if !strings.Contains(out, "findings omitted (diagnostics budget)") {
+		t.Fatalf("elision must be explicit, got:\n%s", out)
+	}
+}
+
+func TestAppendAutoDiagnostics_FileCap(t *testing.T) {
+	fake := &fakeDiagAdapter{findings: map[string]string{}}
+	withLSPAdapter(t, fake)
+
+	edits := `[{"file":"a.go"},{"file":"b.go"},{"file":"c.go"},{"file":"d.go"},{"file":"e.go"},{"file":"f.go"},{"file":"g.go"}]`
+	appendAutoDiagnostics("multipatch", []string{"--edits", edits}, "done")
+	if len(fake.calls) != maxAutoDiagFiles {
+		t.Fatalf("expected at most %d diagnostics calls, got %d", maxAutoDiagFiles, len(fake.calls))
+	}
+}


### PR DESCRIPTION
## O que muda

Depois de um write/patch/multipatch bem-sucedido do @coder, os arquivos tocados são checados via pool LSP da sessão (o mesmo do @lsp) e os findings entram no resultado da tool como bloco [DIAGNOSTICS] — o modelo vê o arquivo quebrado imediatamente, em vez de descobrir turnos depois num teste.

- Silencioso em arquivo limpo (custo zero de tokens no caminho feliz)
- Cap de 5 arquivos e 3000 bytes por bloco, com elisão explícita
- Kill switch: CHATCLI_CODER_AUTODIAG=off (exposto no /config)
- Degrada a no-op sem language server, sem adapter (superfícies sem pool) ou sem a capability
- Capability opcional LSPQuickDiagnoser (interface separada — LSPAdapter é API exportada, método novo seria breaking)
- Hook no chokepoint do plugin @coder: agent loop, squad workers, MCP/ACP passthrough e chatcli tool herdam

## Testes
- targets (write/patch/multipatch, formas --file e --file=, dedup, JSON inválido)
- injeção, silêncio em arquivo limpo, kill switch, no-adapter/no-capability, caps de budget e de arquivos
- go build ./... e suíte cli/plugins + cli verdes