### PR TITLE
feat(agent): doom-loop guard — chamada idêntica repetida sem mudança de estado

### DIFF
--- a/cli/agent/toolguard/toolguard.go
+++ b/cli/agent/toolguard/toolguard.go
@@ -41,6 +41,11 @@ type Config struct {
 	// once an identical tool+args has failed this many times. 0 disables
 	// hard halt (advisory only). Default 0.
 	HaltAfterSameSig int
+	// WarnAfterRepeatSuccess is the number of SUCCESSFUL executions of the
+	// exact same tool+args — with no state change in between (see
+	// NoteStateChange) — before doom-loop guidance is emitted: the result
+	// cannot differ, so re-running it only burns turns. Default 3.
+	WarnAfterRepeatSuccess int
 }
 
 func (c Config) withDefaults() Config {
@@ -49,6 +54,9 @@ func (c Config) withDefaults() Config {
 	}
 	if c.WarnAfterSameSig <= 0 {
 		c.WarnAfterSameSig = 2
+	}
+	if c.WarnAfterRepeatSuccess <= 0 {
+		c.WarnAfterRepeatSuccess = 3
 	}
 	return c
 }
@@ -72,6 +80,8 @@ type Guard struct {
 	sigFails  map[string]int    // tool+args signature -> consecutive failures
 	lastErr   map[string]string // tool name -> last error message
 	warnedSig map[string]bool   // signature -> already warned (avoid spam)
+	sigOK     map[string]int    // signature -> successes since last state change
+	warnedOK  map[string]bool   // signature -> repeat-success already warned
 }
 
 // New returns a Guard with the given config (defaults applied).
@@ -82,7 +92,20 @@ func New(cfg Config) *Guard {
 		sigFails:  map[string]int{},
 		lastErr:   map[string]string{},
 		warnedSig: map[string]bool{},
+		sigOK:     map[string]int{},
+		warnedOK:  map[string]bool{},
 	}
+}
+
+// NoteStateChange resets the repeat-success tracking. Callers invoke it after
+// any tool with side effects runs (a write, a patch, an exec): once the world
+// changed, re-running a read legitimately yields new data, so earlier repeats
+// stop counting.
+func (g *Guard) NoteStateChange() {
+	g.mu.Lock()
+	g.sigOK = map[string]int{}
+	g.warnedOK = map[string]bool{}
+	g.mu.Unlock()
 }
 
 // Signature builds a stable identity for a tool call: name plus
@@ -111,6 +134,15 @@ func (g *Guard) Observe(tool, args, errMsg string, failed bool) Decision {
 				delete(g.sigFails, s)
 				delete(g.warnedSig, s)
 			}
+		}
+		// Doom-loop detection: the exact same successful call repeated with
+		// no state change in between cannot yield anything new. Interleaved
+		// repeats (read A, read B, read A, …) count too — the counter is
+		// per signature, reset only by NoteStateChange.
+		g.sigOK[sig]++
+		if g.sigOK[sig] >= g.cfg.WarnAfterRepeatSuccess && !g.warnedOK[sig] {
+			g.warnedOK[sig] = true
+			return Decision{Guidance: g.repeatSuccessMessage(tool, g.sigOK[sig])}
 		}
 		return Decision{}
 	}
@@ -176,6 +208,13 @@ func (g *Guard) toolDriftMessage(tool string, n int) string {
 		b.WriteString(e)
 	}
 	return b.String()
+}
+
+func (g *Guard) repeatSuccessMessage(tool string, n int) string {
+	return "[tool-loop] you have executed EXACTLY this " + tool + " call " +
+		plural(n, "time") + " with no state change in between — the result " +
+		"cannot differ. Reuse the earlier output instead of calling it again; " +
+		"if you need different data, change the arguments or the approach."
 }
 
 func (g *Guard) haltMessage(tool string, n int) string {

--- a/cli/agent/toolguard/toolguard_test.go
+++ b/cli/agent/toolguard/toolguard_test.go
@@ -77,3 +77,62 @@ func TestSignatureNormalizesWhitespace(t *testing.T) {
 		t.Error("signature should collapse whitespace")
 	}
 }
+
+func TestRepeatSuccessDoomLoop(t *testing.T) {
+	g := New(Config{})
+
+	// Two identical successful reads: silent.
+	for i := 0; i < 2; i++ {
+		if d := g.Observe("@coder", `{"cmd":"read","args":{"file":"main.go"}}`, "", false); d.Guidance != "" {
+			t.Fatalf("run %d must be silent, got %q", i+1, d.Guidance)
+		}
+	}
+	// Third identical success: doom-loop guidance, once.
+	d := g.Observe("@coder", `{"cmd":"read","args":{"file":"main.go"}}`, "", false)
+	if d.Guidance == "" || !strings.Contains(d.Guidance, "cannot differ") {
+		t.Fatalf("expected doom-loop guidance on 3rd repeat, got %q", d.Guidance)
+	}
+	if d := g.Observe("@coder", `{"cmd":"read","args":{"file":"main.go"}}`, "", false); d.Guidance != "" {
+		t.Fatalf("must warn only once per signature, got %q", d.Guidance)
+	}
+}
+
+func TestRepeatSuccessInterleavedCounts(t *testing.T) {
+	g := New(Config{})
+	for i := 0; i < 2; i++ {
+		g.Observe("@coder", `read A`, "", false)
+		g.Observe("@coder", `read B`, "", false)
+	}
+	// Third A, interleaved with B: still detected.
+	if d := g.Observe("@coder", `read A`, "", false); !strings.Contains(d.Guidance, "cannot differ") {
+		t.Fatalf("interleaved repeats must be detected, got %q", d.Guidance)
+	}
+}
+
+func TestNoteStateChangeResetsRepeatTracking(t *testing.T) {
+	g := New(Config{})
+	g.Observe("@coder", `read X`, "", false)
+	g.Observe("@coder", `read X`, "", false)
+	// A write happened: re-reading X is legitimate again.
+	g.NoteStateChange()
+	if d := g.Observe("@coder", `read X`, "", false); d.Guidance != "" {
+		t.Fatalf("state change must reset repeat tracking, got %q", d.Guidance)
+	}
+	g.Observe("@coder", `read X`, "", false)
+	if d := g.Observe("@coder", `read X`, "", false); d.Guidance == "" {
+		t.Fatal("repeats after the reset must be counted fresh")
+	}
+}
+
+func TestRepeatSuccessDoesNotAffectFailureTracking(t *testing.T) {
+	g := New(Config{})
+	g.Observe("@coder", `read Y`, "", false)
+	g.Observe("@coder", `read Y`, "", false)
+	// Failures on the same signature still follow the failure path.
+	if d := g.Observe("@coder", `read Y`, "boom", true); d.Guidance != "" {
+		t.Fatalf("first failure must be silent, got %q", d.Guidance)
+	}
+	if d := g.Observe("@coder", `read Y`, "boom", true); !strings.Contains(d.Guidance, "same arguments") {
+		t.Fatalf("expected same-sig failure guidance, got %q", d.Guidance)
+	}
+}

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -3618,6 +3618,19 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 				// Feed the per-tool failure guard. Guidance (if any) is
 				// injected into history after the batch results below.
 				if toolGuard != nil {
+					// A successful tool WITH side effects resets the
+					// repeat-success (doom-loop) tracking: the world changed,
+					// so re-running a read may legitimately differ now.
+					// plugins.IsReadOnly fails closed (unknown = mutating).
+					if execErr == nil {
+						if p, ok := a.cli.pluginManager.GetPlugin(tc.Name); ok {
+							if !plugins.IsReadOnly(p, []string{normalizedArgsStr}) {
+								toolGuard.NoteStateChange()
+							}
+						} else {
+							toolGuard.NoteStateChange()
+						}
+					}
 					errMsg := ""
 					if execErr != nil {
 						errMsg = execErr.Error()


### PR DESCRIPTION
## O que muda

O toolguard detectava só FALHAS repetidas; o padrão de agente travado que faltava era a mesma chamada BEM-SUCEDIDA repetida (re-ler o mesmo arquivo, re-rodar a mesma busca) — intercalada ou não — sem nenhuma mudança de estado no meio: o resultado não pode mudar e cada repetição queima turnos e tokens.

- No 3º sucesso idêntico (por assinatura tool+args), injeta orientação advisory no histórico: reusar o resultado anterior ou mudar abordagem — uma vez por assinatura
- NoteStateChange reseta o tracking quando qualquer tool COM efeitos colaterais roda (via capability read-only dos plugins, fail-closed) — re-ler depois de editar nunca dispara
- Repetições intercaladas (A, B, A, B, A) são detectadas — o contador é por assinatura, não por adjacência
- Zero mudança de fluxo: advisory append-only, mesmo canal do guard de falhas

## Testes
- 3º repeat dispara, warn único por assinatura, intercalado detectado, reset por state change, interplay com o tracking de falhas preservado
- go build ./... e suítes toolguard + cli verdes