### PR TITLE
feat(coder): outline e map — orientação estrutural sem ler arquivos inteiros

### DIFF
--- a/cli/plugins/builtin_coder_caps.go
+++ b/cli/plugins/builtin_coder_caps.go
@@ -17,13 +17,13 @@ import (
 // clean.
 
 // IsReadOnly reports whether the @coder subcommand is read-only for
-// the given args. Only `read`, `search`, `tree`, `list`, `stat` are
-// pure reads — every other subcommand (`exec`, `write`, `patch`,
-// `test`) mutates state.
+// the given args. Only `read`, `search`, `tree`, `list`, `stat`,
+// `outline` and `map` are pure reads — every other subcommand (`exec`,
+// `write`, `patch`, `test`) mutates state.
 func (p *BuiltinCoderPlugin) IsReadOnly(args []string) bool {
 	sub := coderSubcommand(args)
 	switch sub {
-	case "read", "search", "tree", "list", "stat":
+	case "read", "search", "tree", "list", "stat", "outline", "map":
 		return true
 	}
 	return false

--- a/pkg/coder/engine/commands_outline.go
+++ b/pkg/coder/engine/commands_outline.go
@@ -237,7 +237,7 @@ func fieldListText(fl *ast.FieldList) string {
 	if fl == nil {
 		return ""
 	}
-	var parts []string
+	parts := make([]string, 0, len(fl.List))
 	for _, f := range fl.List {
 		t := typeText(f.Type)
 		if n := len(f.Names); n > 1 {

--- a/pkg/coder/engine/commands_outline.go
+++ b/pkg/coder/engine/commands_outline.go
@@ -1,0 +1,308 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+/*
+ * commands_outline.go — code-structure orientation for the coder engine.
+ *
+ * `outline` renders one file's symbol skeleton (declarations + line numbers)
+ * and `map` renders a token-budgeted structural map of a whole tree — the
+ * "repo map" every large-codebase agent needs to orient itself without
+ * reading whole files. Go files are parsed natively with go/ast (exact
+ * signatures, zero dependencies); other languages get a pattern-based
+ * outline covering the common declaration forms.
+ */
+package engine
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// DefaultMapBudget bounds the map output in characters: enough structure to
+// orient, small enough to not flood a turn.
+const DefaultMapBudget = 8000
+
+// maxOutlineEntries bounds a single-file outline.
+const maxOutlineEntries = 300
+
+// handleOutline renders the symbol skeleton of one file.
+func (e *Engine) handleOutline(args []string) error {
+	fs := flag.NewFlagSet("outline", flag.ContinueOnError)
+	file := fs.String("file", "", "")
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*file) == "" {
+		return fmt.Errorf("--file requerido")
+	}
+	path := expandPath(*file)
+	entries, lang, err := outlineFile(path)
+	if err != nil {
+		return err
+	}
+	if len(entries) == 0 {
+		e.printf("%s: no declarations recognized (%s outline)\n", *file, lang)
+		return nil
+	}
+	e.printf("Outline of %s (%s, %d declaration(s)):\n", *file, lang, len(entries))
+	for i, en := range entries {
+		if i >= maxOutlineEntries {
+			e.printf("… and %d more.\n", len(entries)-i)
+			break
+		}
+		e.printf("%s\n", en)
+	}
+	return nil
+}
+
+// handleMap renders a budgeted structural map of a directory tree: files
+// ranked by how much structure they export, each with its declaration
+// skeleton, until the character budget is spent.
+func (e *Engine) handleMap(args []string) error {
+	fs := flag.NewFlagSet("map", flag.ContinueOnError)
+	dir := fs.String("dir", ".", "")
+	budget := fs.Int("budget", DefaultMapBudget, "")
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	root := expandPath(*dir)
+
+	type fileMap struct {
+		rel     string
+		entries []string
+		weight  int
+	}
+	var files []fileMap
+	ignore := map[string]bool{".git": true, "node_modules": true, "vendor": true, "dist": true, "build": true}
+
+	walkErr := filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		name := info.Name()
+		if info.IsDir() {
+			if (strings.HasPrefix(name, ".") && p != root) || ignore[name] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !isMappableSource(name) || info.Size() > 1<<20 {
+			return nil
+		}
+		entries, _, err := outlineFile(p)
+		if err != nil || len(entries) == 0 {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, p)
+		if relErr != nil {
+			rel = p
+		}
+		files = append(files, fileMap{rel: filepath.ToSlash(rel), entries: entries, weight: len(entries)})
+		return nil
+	})
+	if walkErr != nil {
+		return walkErr
+	}
+	if len(files) == 0 {
+		e.printf("No source files with recognizable structure under %s\n", *dir)
+		return nil
+	}
+
+	// Most structure first; path as the deterministic tiebreak.
+	sort.Slice(files, func(i, j int) bool {
+		if files[i].weight != files[j].weight {
+			return files[i].weight > files[j].weight
+		}
+		return files[i].rel < files[j].rel
+	})
+
+	if *budget <= 0 {
+		*budget = DefaultMapBudget
+	}
+	spent := 0
+	rendered := 0
+	e.printf("Repo map of %s (%d file(s) with structure, budget %d chars):\n", *dir, len(files), *budget)
+	for _, f := range files {
+		block := "\n" + f.rel + ":\n  " + strings.Join(f.entries, "\n  ") + "\n"
+		if spent+len(block) > *budget {
+			break
+		}
+		e.printf("%s", block)
+		spent += len(block)
+		rendered++
+	}
+	if rendered < len(files) {
+		e.printf("\n… %d more file(s) beyond the budget — run outline on specific files, or raise --budget.\n", len(files)-rendered)
+	}
+	return nil
+}
+
+// isMappableSource reports whether a filename is worth outlining for the map.
+func isMappableSource(name string) bool {
+	if strings.HasSuffix(name, "_test.go") {
+		return false
+	}
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".go", ".py", ".js", ".jsx", ".ts", ".tsx", ".java", ".rb", ".rs", ".kt", ".cs", ".php":
+		return true
+	}
+	return false
+}
+
+// outlineFile dispatches per language: exact go/ast outlines for Go, pattern
+// outlines for the rest. Returns the rendered entries and the parser used.
+func outlineFile(path string) ([]string, string, error) {
+	if strings.EqualFold(filepath.Ext(path), ".go") {
+		entries, err := outlineGo(path)
+		return entries, "go/ast", err
+	}
+	entries, err := outlineGeneric(path)
+	return entries, "pattern", err
+}
+
+// outlineGo renders a Go file's declarations with exact signatures.
+func outlineGo(path string) ([]string, error) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	var out []string
+	add := func(pos token.Pos, text string) {
+		out = append(out, fmt.Sprintf("L%d %s", fset.Position(pos).Line, text))
+	}
+	for _, decl := range f.Decls {
+		switch d := decl.(type) {
+		case *ast.FuncDecl:
+			recv := ""
+			if d.Recv != nil && len(d.Recv.List) > 0 {
+				recv = "(" + typeText(d.Recv.List[0].Type) + ") "
+			}
+			add(d.Pos(), "func "+recv+d.Name.Name+funcSignature(d.Type))
+		case *ast.GenDecl:
+			for _, spec := range d.Specs {
+				switch s := spec.(type) {
+				case *ast.TypeSpec:
+					kind := "type"
+					switch s.Type.(type) {
+					case *ast.StructType:
+						kind = "struct"
+					case *ast.InterfaceType:
+						kind = "interface"
+					}
+					add(s.Pos(), kind+" "+s.Name.Name)
+				case *ast.ValueSpec:
+					if d.Tok == token.CONST || d.Tok == token.VAR {
+						for _, n := range s.Names {
+							if n.Name == "_" {
+								continue
+							}
+							add(n.Pos(), strings.ToLower(d.Tok.String())+" "+n.Name)
+						}
+					}
+				}
+			}
+		}
+	}
+	return out, nil
+}
+
+// funcSignature renders a compact parameter/result signature.
+func funcSignature(t *ast.FuncType) string {
+	params := fieldListText(t.Params)
+	results := fieldListText(t.Results)
+	sig := "(" + params + ")"
+	if results != "" {
+		if strings.Contains(results, ",") {
+			sig += " (" + results + ")"
+		} else {
+			sig += " " + results
+		}
+	}
+	return sig
+}
+
+func fieldListText(fl *ast.FieldList) string {
+	if fl == nil {
+		return ""
+	}
+	var parts []string
+	for _, f := range fl.List {
+		t := typeText(f.Type)
+		if n := len(f.Names); n > 1 {
+			t = fmt.Sprintf("%s ×%d", t, n)
+		}
+		parts = append(parts, t)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// typeText renders a type expression compactly (best effort — enough for a
+// map, not a pretty-printer).
+func typeText(expr ast.Expr) string {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.StarExpr:
+		return "*" + typeText(t.X)
+	case *ast.SelectorExpr:
+		return typeText(t.X) + "." + t.Sel.Name
+	case *ast.ArrayType:
+		return "[]" + typeText(t.Elt)
+	case *ast.MapType:
+		return "map[" + typeText(t.Key) + "]" + typeText(t.Value)
+	case *ast.FuncType:
+		return "func(" + fieldListText(t.Params) + ")"
+	case *ast.InterfaceType:
+		return "interface{}"
+	case *ast.StructType:
+		return "struct{}"
+	case *ast.Ellipsis:
+		return "..." + typeText(t.Elt)
+	case *ast.ChanType:
+		return "chan " + typeText(t.Value)
+	case *ast.IndexExpr:
+		return typeText(t.X) + "[" + typeText(t.Index) + "]"
+	default:
+		return "?"
+	}
+}
+
+// genericDeclRe matches the common top-level declaration forms across the
+// mainstream languages the map supports (def/class/function/interface/etc.).
+var genericDeclRe = regexp.MustCompile(`^\s*(?:export\s+)?(?:public\s+|private\s+|protected\s+|static\s+|abstract\s+|final\s+|async\s+)*` +
+	`(def |class |function |interface |enum |struct |trait |impl |module |fn |const |type |var |let )`)
+
+// outlineGeneric renders a pattern-based outline for non-Go sources: any
+// line opening a recognizable declaration, with its line number.
+func outlineGeneric(path string) ([]string, error) {
+	data, err := os.ReadFile(path) // #nosec G304 -- path expanded by the engine helper, workspace-relative
+	if err != nil {
+		return nil, err
+	}
+	var out []string
+	for i, line := range strings.Split(string(data), "\n") {
+		if len(out) >= maxOutlineEntries {
+			break
+		}
+		if genericDeclRe.MatchString(line) {
+			trimmed := strings.TrimSpace(line)
+			if len(trimmed) > 120 {
+				trimmed = trimmed[:120] + "…"
+			}
+			out = append(out, fmt.Sprintf("L%d %s", i+1, trimmed))
+		}
+	}
+	return out, nil
+}

--- a/pkg/coder/engine/commands_outline_test.go
+++ b/pkg/coder/engine/commands_outline_test.go
@@ -1,0 +1,155 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+/*
+ * commands_outline_test.go
+ *
+ * outline: exact go/ast skeletons for Go, pattern skeletons for other
+ * languages. map: budgeted, deterministically ranked repo structure.
+ */
+package engine
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const outlineGoFixture = `package sample
+
+import "fmt"
+
+const answer = 42
+
+var Verbose bool
+
+type Greeter struct{ Name string }
+
+type Speaker interface{ Speak() string }
+
+func Hello(name string, times int) (string, error) {
+	return fmt.Sprintf("hi %s", name), nil
+}
+
+func (g *Greeter) Speak() string { return g.Name }
+`
+
+func newOutlineEngine(t *testing.T) (*Engine, *bytes.Buffer, string) {
+	t.Helper()
+	dir := t.TempDir()
+	var out bytes.Buffer
+	e := NewEngine(&out, &out, dir)
+	return e, &out, dir
+}
+
+func TestOutlineGoFile(t *testing.T) {
+	e, out, dir := newOutlineEngine(t)
+	path := filepath.Join(dir, "sample.go")
+	if err := os.WriteFile(path, []byte(outlineGoFixture), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := e.Execute(context.Background(), "outline", []string{"--file", path}); err != nil {
+		t.Fatal(err)
+	}
+	text := out.String()
+	for _, want := range []string{
+		"go/ast", "const answer", "var Verbose", "struct Greeter",
+		"interface Speaker", "func Hello(string, int) (string, error)",
+		"func (*Greeter) Speak() string",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("outline missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestOutlineGenericFile(t *testing.T) {
+	e, out, dir := newOutlineEngine(t)
+	path := filepath.Join(dir, "app.py")
+	py := "import os\n\nclass Server:\n    def start(self):\n        pass\n\ndef main():\n    pass\n"
+	if err := os.WriteFile(path, []byte(py), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := e.Execute(context.Background(), "outline", []string{"--file", path}); err != nil {
+		t.Fatal(err)
+	}
+	text := out.String()
+	for _, want := range []string{"pattern", "class Server", "def main"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("generic outline missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestOutlineRequiresFile(t *testing.T) {
+	e, _, _ := newOutlineEngine(t)
+	if err := e.Execute(context.Background(), "outline", nil); err == nil {
+		t.Fatal("outline without --file must error")
+	}
+}
+
+func TestMapRanksAndBudgets(t *testing.T) {
+	e, out, dir := newOutlineEngine(t)
+	// big.go carries more declarations than small.go and must render first.
+	big := "package a\n"
+	for i := 0; i < 12; i++ {
+		big += "func F" + string(rune('A'+i)) + "() {}\n"
+	}
+	if err := os.WriteFile(filepath.Join(dir, "big.go"), []byte(big), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "small.go"), []byte("package a\nfunc One() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Ignored dirs and tests must not appear.
+	if err := os.MkdirAll(filepath.Join(dir, "node_modules"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "node_modules", "x.js"), []byte("function hidden() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "big_test.go"), []byte("package a\nfunc TestX(t *T) {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := e.Execute(context.Background(), "map", []string{"--dir", dir}); err != nil {
+		t.Fatal(err)
+	}
+	text := out.String()
+	if !strings.Contains(text, "big.go") || !strings.Contains(text, "small.go") {
+		t.Fatalf("map missing files:\n%s", text)
+	}
+	if strings.Index(text, "big.go") > strings.Index(text, "small.go") {
+		t.Fatalf("ranking broken — most structure must come first:\n%s", text)
+	}
+	if strings.Contains(text, "hidden") || strings.Contains(text, "TestX") {
+		t.Fatalf("ignored/test files leaked into the map:\n%s", text)
+	}
+
+	// Tight budget: elision must be explicit.
+	out.Reset()
+	if err := e.Execute(context.Background(), "map", []string{"--dir", dir, "--budget", "120"}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "beyond the budget") {
+		t.Fatalf("budget elision must be explicit:\n%s", out.String())
+	}
+}
+
+func TestMapEmptyDir(t *testing.T) {
+	e, out, dir := newOutlineEngine(t)
+	if err := e.Execute(context.Background(), "map", []string{"--dir", dir}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "No source files") {
+		t.Fatalf("empty dir message missing:\n%s", out.String())
+	}
+}

--- a/pkg/coder/engine/engine.go
+++ b/pkg/coder/engine/engine.go
@@ -208,6 +208,10 @@ func (e *Engine) Execute(ctx context.Context, cmd string, args []string) error {
 		return e.handleMultipatch(args)
 	case "tree":
 		return e.handleTree(args)
+	case "outline":
+		return e.handleOutline(args)
+	case "map":
+		return e.handleMap(args)
 	case "search":
 		return e.handleSearch(ctx, args)
 	case "exec":

--- a/pkg/coder/engine/metadata.go
+++ b/pkg/coder/engine/metadata.go
@@ -43,7 +43,7 @@ func GetMetadata() Metadata {
 	return Metadata{
 		Name:        "@coder",
 		Description: "Suite de engenharia completa (IO, Search, Exec, Git, Test, Backup, Rollback, Patch).",
-		Usage:       `@coder <read|write|patch|tree|search|exec|git-status|git-diff|git-log|git-changed|git-branch|test|rollback|clean> [flags]`,
+		Usage:       `@coder <read|write|patch|tree|search|outline|map|exec|git-status|git-diff|git-log|git-changed|git-branch|test|rollback|clean> [flags]`,
 		Version:     Version,
 	}
 }
@@ -78,6 +78,27 @@ func GetSchema() string {
 				},
 				Examples: []string{
 					"read --file main.go --start 1 --end 120",
+				},
+			},
+			{
+				Name:        "outline",
+				Description: "Esqueleto de símbolos de um arquivo (declarações + linhas): go/ast para Go, padrões para outras linguagens.",
+				Flags: []FlagDefinition{
+					{Name: "--file", Type: "string", Description: "Caminho do arquivo.", Required: true},
+				},
+				Examples: []string{
+					"outline --file cli/cli.go",
+				},
+			},
+			{
+				Name:        "map",
+				Description: "Mapa estrutural do repositório dentro de um budget de caracteres: arquivos ranqueados por estrutura, cada um com seu esqueleto de declarações. Use para se orientar em codebases grandes sem ler arquivos inteiros.",
+				Flags: []FlagDefinition{
+					{Name: "--dir", Type: "string", Default: ".", Description: "Diretório raiz."},
+					{Name: "--budget", Type: "int", Default: strconv.Itoa(DefaultMapBudget), Description: "Limite de caracteres do mapa."},
+				},
+				Examples: []string{
+					"map --dir . --budget 8000",
 				},
 			},
 			{


### PR DESCRIPTION
## O que muda

Dois subcomandos read-only no @coder fecham o gap de orientação em codebases grandes (o repo map do Aider, o view_file_outline do Antigravity):

- **outline --file X** — esqueleto de símbolos de um arquivo com números de linha: assinaturas exatas via go/ast para Go (funcs, methods com receiver, structs, interfaces, consts, vars); padrão de declarações para Python, JS/TS/JSX, Java, Ruby, Rust, Kotlin, C#, PHP
- **map [--dir D] [--budget N]** — mapa estrutural do repositório dentro de um budget de caracteres (default 8000): arquivos ranqueados por quantidade de estrutura, cada um com seu esqueleto; elisão explícita quando o budget acaba; ignora .git/node_modules/vendor/dist/build, ocultos e _test.go

### Integração
- Dispatch no engine + catálogo de metadata (schema com flags e exemplos) + Usage
- Caps: ambos read-only e concurrency-safe (rodam no batch paralelo, sem prompt de segurança)
- Zero dependências novas (go/ast da stdlib; genérico por regex)

## Testes
- Outline Go (todas as formas de decl, assinaturas), genérico (Python), validação de flags
- Map: ranking determinístico, budget com elisão explícita, exclusão de ignorados/tests, dir vazio
- go build ./... e suítes engine + plugins verdes