### PR TITLE
feat(proc): sessões PTY interativas — REPLs, debuggers e ssh dirigíveis pelo agente

### DIFF
--- a/cli/agent/proc/pty_unix.go
+++ b/cli/agent/proc/pty_unix.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package proc
+
+import (
+	"os"
+	"os/exec"
+
+	"github.com/creack/pty"
+)
+
+// ptySupported reports PTY availability on this platform.
+const ptySupported = true
+
+// startWithPTY starts cmd attached to a fresh pseudo-terminal and returns
+// the master side. pty.Start gives the child its own session (Setsid) with
+// the slave as controlling terminal, so the process group id equals the pid
+// and the group-signal helpers keep working.
+func startWithPTY(cmd *exec.Cmd) (*os.File, error) {
+	return pty.Start(cmd)
+}

--- a/cli/agent/proc/pty_windows.go
+++ b/cli/agent/proc/pty_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package proc
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+)
+
+// ptySupported reports PTY availability on this platform. ConPTY support is
+// deliberately deferred — the Windows terminal stack has bitten before, so
+// interactive sessions ship Unix-first with an explicit error here.
+const ptySupported = false
+
+// startWithPTY is unavailable on Windows.
+func startWithPTY(_ *exec.Cmd) (*os.File, error) {
+	return nil, errors.New("interactive PTY sessions are not supported on Windows yet — use @proc start without pty")
+}

--- a/cli/agent/proc/supervisor.go
+++ b/cli/agent/proc/supervisor.go
@@ -22,6 +22,7 @@ package proc
 import (
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"sort"
 	"strings"
@@ -70,6 +71,7 @@ type Info struct {
 	ExitCode int // valid when State == StateExited
 	Started  time.Time
 	Ended    time.Time // zero while running
+	PTY      bool      // started on a pseudo-terminal (accepts Stdin)
 }
 
 // Validator vets a command before it runs — injected so @proc shares the
@@ -93,6 +95,11 @@ type managedProcess struct {
 
 	outMu sync.Mutex
 	out   []byte // ring-ish buffer, trimmed from the front at cap
+
+	// ptmx is the pseudo-terminal master for PTY-started processes (nil
+	// otherwise): the write side of Stdin and the read side of the ring.
+	ptmx   *os.File
+	ptmxMu sync.Mutex
 
 	done chan struct{}
 }
@@ -169,6 +176,124 @@ func (s *Supervisor) Start(command, dir string) (Info, error) {
 
 	s.logger.Info("proc: started", zap.String("id", id), zap.Int("pid", mp.info.PID), zap.String("cmd", command))
 	return mp.info, nil
+}
+
+// StartPTY launches command on a pseudo-terminal, so programs that demand a
+// TTY (REPLs, debuggers, ssh, prompts) run for real and Stdin can drive
+// them. Same vetting, limits and lifecycle as Start; Unix only.
+func (s *Supervisor) StartPTY(command, dir string) (Info, error) {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return Info{}, fmt.Errorf("empty command")
+	}
+	if !ptySupported {
+		_, err := startWithPTY(nil)
+		return Info{}, err
+	}
+	if s.validate != nil {
+		if err := s.validate(command); err != nil {
+			return Info{}, err
+		}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return Info{}, fmt.Errorf("supervisor closed")
+	}
+	if running := s.runningLocked(); running >= maxRunning {
+		return Info{}, fmt.Errorf("%d processes already running (limit %d) — stop one first (@proc stop)", running, maxRunning)
+	}
+
+	cmd := shellCommand(command)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	// No setProcessGroup here: the PTY start gives the child its own
+	// session (Setsid + controlling terminal), which also makes pgid == pid
+	// — the group-signal helpers in Stop keep working unchanged.
+
+	ptmx, err := startWithPTY(cmd)
+	if err != nil {
+		return Info{}, fmt.Errorf("start pty: %w", err)
+	}
+
+	s.seq++
+	id := fmt.Sprintf("p%d", s.seq)
+	mp := &managedProcess{
+		info: Info{ID: id, Command: command, Dir: dir, State: StateRunning, Started: time.Now(), PTY: true},
+		cmd:  cmd,
+		ptmx: ptmx,
+		done: make(chan struct{}),
+	}
+	mp.info.PID = cmd.Process.Pid
+
+	s.evictOldestExitedLocked()
+	s.procs[id] = mp
+
+	// The master side is the only reader of the terminal's output.
+	go func() {
+		buf := make([]byte, 4096)
+		w := ringWriter{mp}
+		for {
+			n, rerr := ptmx.Read(buf)
+			if n > 0 {
+				_, _ = w.Write(buf[:n])
+			}
+			if rerr != nil {
+				return
+			}
+		}
+	}()
+	go func() {
+		err := cmd.Wait()
+		s.mu.Lock()
+		mp.info.State = StateExited
+		mp.info.Ended = time.Now()
+		mp.info.ExitCode = exitCodeOf(err)
+		s.mu.Unlock()
+		mp.ptmxMu.Lock()
+		_ = ptmx.Close()
+		mp.ptmxMu.Unlock()
+		close(mp.done)
+	}()
+
+	s.logger.Info("proc: started (pty)", zap.String("id", id), zap.Int("pid", mp.info.PID), zap.String("cmd", command))
+	return mp.info, nil
+}
+
+// Stdin writes text to a PTY-started process's terminal; pressEnter appends
+// carriage return (what a terminal's Enter key sends).
+func (s *Supervisor) Stdin(id, text string, pressEnter bool) (Info, error) {
+	s.mu.Lock()
+	mp, ok := s.procs[id]
+	if !ok {
+		s.mu.Unlock()
+		return Info{}, fmt.Errorf("unknown process id %q (see list)", id)
+	}
+	info := mp.info
+	s.mu.Unlock()
+
+	if !info.PTY {
+		return info, fmt.Errorf("%s was not started with a pty — restart it via start with pty:true to drive its stdin", id)
+	}
+	if info.State != StateRunning {
+		return info, fmt.Errorf("%s already exited (code %d)", id, info.ExitCode)
+	}
+
+	payload := text
+	if pressEnter {
+		payload += "\r"
+	}
+	mp.ptmxMu.Lock()
+	defer mp.ptmxMu.Unlock()
+	if mp.ptmx == nil {
+		return info, fmt.Errorf("%s: terminal already closed", id)
+	}
+	if _, err := mp.ptmx.WriteString(payload); err != nil {
+		return info, fmt.Errorf("write to %s: %w", id, err)
+	}
+	return info, nil
 }
 
 // Status returns the snapshot for one process.

--- a/cli/agent/proc/supervisor_test.go
+++ b/cli/agent/proc/supervisor_test.go
@@ -215,3 +215,61 @@ func TestSupervisorRemoveAndUnknownID(t *testing.T) {
 		t.Fatalf("unknown-id error must list tracked ids, got %v", err)
 	}
 }
+
+func TestStartPTYAndStdin(t *testing.T) {
+	if !ptySupported {
+		t.Skip("pty not supported on this platform")
+	}
+	s := NewSupervisor(nil, nil)
+	t.Cleanup(s.CloseAll)
+
+	info, err := s.StartPTY("cat", "")
+	if err != nil {
+		t.Fatalf("StartPTY: %v", err)
+	}
+	if !info.PTY || info.PID == 0 {
+		t.Fatalf("unexpected info: %+v", info)
+	}
+
+	if _, err := s.Stdin(info.ID, "hello-pty", true); err != nil {
+		t.Fatalf("Stdin: %v", err)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		logs, _, err := s.Logs(info.ID, 50)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(logs, "hello-pty") {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("pty echo never captured, logs:\n%s", logs)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	if _, err := s.Stop(info.ID); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if _, err := s.Stdin(info.ID, "late", true); err == nil {
+		t.Fatal("Stdin after exit must error")
+	}
+}
+
+func TestStdinRejectsNonPTYAndUnknown(t *testing.T) {
+	s := NewSupervisor(nil, nil)
+	t.Cleanup(s.CloseAll)
+
+	info, err := s.Start("sleep 5", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Stdin(info.ID, "x", true); err == nil || !strings.Contains(err.Error(), "pty") {
+		t.Fatalf("non-pty process must reject stdin, got %v", err)
+	}
+	if _, err := s.Stdin("p999", "x", true); err == nil {
+		t.Fatal("unknown id must error")
+	}
+	_, _ = s.Stop(info.ID)
+}

--- a/cli/plugins/builtin_proc.go
+++ b/cli/plugins/builtin_proc.go
@@ -33,6 +33,19 @@ type ProcAdapter interface {
 	List() (string, error)
 }
 
+// ProcInteractive is an OPTIONAL capability of the wired ProcAdapter:
+// interactive pseudo-terminal sessions. A separate interface (not new
+// ProcAdapter methods) because ProcAdapter is exported API — extending it
+// would break existing implementers.
+type ProcInteractive interface {
+	// StartPTY launches the command attached to a pseudo-terminal, so
+	// TTY-demanding programs (REPLs, debuggers, ssh) run for real.
+	StartPTY(command, dir string) (string, error)
+	// Stdin writes text into a PTY process's terminal; pressEnter appends
+	// the terminal's Enter key.
+	Stdin(id, text string, pressEnter bool) (string, error)
+}
+
 type procAdapterHolder struct{ a ProcAdapter }
 
 var procAdapterAtom atomic.Value // procAdapterHolder
@@ -71,7 +84,11 @@ func (*BuiltinProcPlugin) Usage() string {
 	return `<tool_call name="@proc" args='{"cmd":"start","args":{"command":"npm run dev","dir":"./web"}}' />
 
 Subcommands (cmd + args):
-  start  {command, dir?}      launch a background process, returns its id
+  start  {command, dir?, pty?}  launch a background process, returns its id;
+                                pty:true attaches a real pseudo-terminal so
+                                REPLs/debuggers/ssh run for real (Unix)
+  stdin  {id, text, no_enter?}  type into a pty process's terminal (Enter is
+                                pressed unless no_enter:true)
   status {id}                 running/exited, pid, uptime, exit code
   logs   {id, tail?:1-1000}   last lines of combined stdout+stderr
   stop   {id}                 terminate the process tree (TERM → grace → KILL)
@@ -79,8 +96,10 @@ Subcommands (cmd + args):
   list   {}                   every tracked process
 
 Workflow: start the server, poll logs until it is ready, exercise it (e.g.
-@coder exec curl), read logs again, stop it when done. Everything still
-running dies with the session.`
+@coder exec curl), read logs again, stop it when done. Interactive flow:
+start {"command":"python3","pty":true} → stdin {"id":"p1","text":"1+1"} →
+logs to read the REPL's answer. Everything still running dies with the
+session.`
 }
 
 // Version is semver; bumped when the surface changes.
@@ -101,8 +120,18 @@ func (*BuiltinProcPlugin) Schema() string {
 				"flags": []map[string]interface{}{
 					{"name": "command", "description": "shell command to run", "type": "string", "required": true},
 					{"name": "dir", "description": "working directory (default: current)", "type": "string"},
+					{"name": "pty", "description": "attach a pseudo-terminal so interactive programs (REPLs, debuggers, ssh) run for real; drive them with stdin (Unix only)", "type": "bool"},
 				},
-				"examples": []string{`{"cmd":"start","args":{"command":"go run ./cmd/server","dir":"."}}`},
+				"examples": []string{`{"cmd":"start","args":{"command":"go run ./cmd/server","dir":"."}}`, `{"cmd":"start","args":{"command":"python3","pty":true}}`},
+			},
+			{
+				"name":        "stdin",
+				"description": "type into a pty process's terminal (presses Enter unless no_enter)",
+				"flags": []map[string]interface{}{idFlag,
+					{"name": "text", "description": "text to type", "type": "string", "required": true},
+					{"name": "no_enter", "description": "do not press Enter after the text", "type": "bool"},
+				},
+				"examples": []string{`{"cmd":"stdin","args":{"id":"p1","text":"import os"}}`},
 			},
 			{
 				"name":        "status",
@@ -166,6 +195,9 @@ func (p *BuiltinProcPlugin) ExecuteWithStream(_ context.Context, args []string, 
 		Dir     string `json:"dir"`
 		ID      string `json:"id"`
 		Tail    int    `json:"tail"`
+		PTY     bool   `json:"pty"`
+		Text    string `json:"text"`
+		NoEnter bool   `json:"no_enter"`
 	}
 	_ = json.Unmarshal([]byte(inner), &in)
 
@@ -174,7 +206,23 @@ func (p *BuiltinProcPlugin) ExecuteWithStream(_ context.Context, args []string, 
 		if strings.TrimSpace(in.Command) == "" {
 			return "", errors.New(`@proc start: "command" is required`)
 		}
+		if in.PTY {
+			ia, ok := adapter.(ProcInteractive)
+			if !ok {
+				return "", errors.New("@proc start: pty sessions are not available in this session")
+			}
+			return ia.StartPTY(in.Command, in.Dir)
+		}
 		return adapter.Start(in.Command, in.Dir)
+	case "stdin":
+		if err := requireProcID(in.ID); err != nil {
+			return "", err
+		}
+		ia, ok := adapter.(ProcInteractive)
+		if !ok {
+			return "", errors.New("@proc stdin: pty sessions are not available in this session")
+		}
+		return ia.Stdin(in.ID, in.Text, !in.NoEnter)
 	case "status":
 		if err := requireProcID(in.ID); err != nil {
 			return "", err
@@ -198,7 +246,7 @@ func (p *BuiltinProcPlugin) ExecuteWithStream(_ context.Context, args []string, 
 	case "list":
 		return adapter.List()
 	default:
-		return "", fmt.Errorf("@proc: unknown cmd %q (valid: start|status|logs|stop|remove|list)", cmd)
+		return "", fmt.Errorf("@proc: unknown cmd %q (valid: start|stdin|status|logs|stop|remove|list)", cmd)
 	}
 }
 
@@ -294,6 +342,8 @@ func canonicalProcCmd(cmd string) string {
 	switch strings.ToLower(strings.TrimSpace(cmd)) {
 	case "start", "run", "spawn", "launch":
 		return "start"
+	case "stdin", "input", "send", "type":
+		return "stdin"
 	case "status", "stat", "info":
 		return "status"
 	case "logs", "log", "tail", "output":

--- a/cli/plugins/builtin_proc_caps.go
+++ b/cli/plugins/builtin_proc_caps.go
@@ -44,6 +44,8 @@ func (p *BuiltinProcPlugin) DescribeCall(args []string) string {
 	switch cmd {
 	case "start":
 		return i18n.T("plugins.proc.describe_start", describeTrim(in.Command))
+	case "stdin":
+		return i18n.T("plugins.proc.describe_stdin", in.ID)
 	case "status":
 		return i18n.T("plugins.proc.describe_status", in.ID)
 	case "logs":

--- a/cli/plugins/builtin_proc_test.go
+++ b/cli/plugins/builtin_proc_test.go
@@ -153,3 +153,85 @@ func TestProcCapsPerSubcommand(t *testing.T) {
 		t.Fatal("@proc must advertise concurrency-safe")
 	}
 }
+
+// fakeInteractiveProcAdapter adds the ProcInteractive capability.
+type fakeInteractiveProcAdapter struct {
+	fakeProcAdapter
+	ptyCommand string
+	stdinID    string
+	stdinText  string
+	enter      bool
+}
+
+func (f *fakeInteractiveProcAdapter) StartPTY(command, dir string) (string, error) {
+	f.lastCall, f.ptyCommand, f.dir = "startpty", command, dir
+	return "started p1 on a pty", nil
+}
+
+func (f *fakeInteractiveProcAdapter) Stdin(id, text string, pressEnter bool) (string, error) {
+	f.lastCall, f.stdinID, f.stdinText, f.enter = "stdin", id, text, pressEnter
+	return "sent to " + id, nil
+}
+
+func TestProcPTYStartAndStdinDispatch(t *testing.T) {
+	fake := &fakeInteractiveProcAdapter{}
+	SetProcAdapter(fake)
+	t.Cleanup(func() { SetProcAdapter(nil) })
+	p := NewBuiltinProcPlugin()
+
+	out, err := p.Execute(context.Background(), []string{`{"cmd":"start","args":{"command":"python3","pty":true}}`})
+	if err != nil || !strings.Contains(out, "pty") {
+		t.Fatalf("pty start: out=%q err=%v", out, err)
+	}
+	if fake.lastCall != "startpty" || fake.ptyCommand != "python3" {
+		t.Fatalf("pty start not routed: %+v", fake)
+	}
+
+	// Plain start still uses the base path.
+	if _, err := p.Execute(context.Background(), []string{`{"cmd":"start","args":{"command":"srv"}}`}); err != nil {
+		t.Fatal(err)
+	}
+	if fake.lastCall != "start" {
+		t.Fatalf("plain start must not use pty path: %+v", fake)
+	}
+
+	out, err = p.Execute(context.Background(), []string{`{"cmd":"stdin","args":{"id":"p1","text":"1+1"}}`})
+	if err != nil || !strings.Contains(out, "sent to p1") {
+		t.Fatalf("stdin: out=%q err=%v", out, err)
+	}
+	if fake.stdinText != "1+1" || !fake.enter {
+		t.Fatalf("stdin args wrong: %+v", fake)
+	}
+	if _, err := p.Execute(context.Background(), []string{`{"cmd":"stdin","args":{"id":"p1","text":"x","no_enter":true}}`}); err != nil {
+		t.Fatal(err)
+	}
+	if fake.enter {
+		t.Fatal("no_enter must suppress Enter")
+	}
+	if _, err := p.Execute(context.Background(), []string{`{"cmd":"stdin","args":{"text":"x"}}`}); err == nil {
+		t.Fatal("stdin without id must error")
+	}
+}
+
+func TestProcPTYWithoutCapabilityErrors(t *testing.T) {
+	SetProcAdapter(&fakeProcAdapter{})
+	t.Cleanup(func() { SetProcAdapter(nil) })
+	p := NewBuiltinProcPlugin()
+
+	if _, err := p.Execute(context.Background(), []string{`{"cmd":"start","args":{"command":"python3","pty":true}}`}); err == nil {
+		t.Fatal("pty start without capability must error")
+	}
+	if _, err := p.Execute(context.Background(), []string{`{"cmd":"stdin","args":{"id":"p1","text":"x"}}`}); err == nil {
+		t.Fatal("stdin without capability must error")
+	}
+}
+
+func TestProcStdinCapsNotReadOnly(t *testing.T) {
+	p := NewBuiltinProcPlugin()
+	if p.IsReadOnly([]string{`{"cmd":"stdin","args":{"id":"p1","text":"x"}}`}) {
+		t.Fatal("stdin drives a process — never read-only")
+	}
+	if strings.TrimSpace(p.DescribeCall([]string{`{"cmd":"stdin","args":{"id":"p1","text":"x"}}`})) == "" {
+		t.Fatal("DescribeCall(stdin) empty")
+	}
+}

--- a/cli/proc_tool_adapter.go
+++ b/cli/proc_tool_adapter.go
@@ -50,6 +50,30 @@ func (a *procToolAdapter) Start(command, dir string) (string, error) {
 		info.ID, info.PID, info.Command, info.ID), nil
 }
 
+// StartPTY implements plugins.ProcInteractive: same lifecycle as Start, on a
+// real pseudo-terminal.
+func (a *procToolAdapter) StartPTY(command, dir string) (string, error) {
+	if dir != "" {
+		if expanded, err := utils.ExpandPath(dir); err == nil {
+			dir = expanded
+		}
+	}
+	info, err := a.supervisor().StartPTY(command, dir)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("started %s on a pty (pid %d): %s\nDrive it with @proc stdin {\"id\":%q,\"text\":\"…\"} and read the terminal with @proc logs.",
+		info.ID, info.PID, info.Command, info.ID), nil
+}
+
+// Stdin implements plugins.ProcInteractive.
+func (a *procToolAdapter) Stdin(id, text string, pressEnter bool) (string, error) {
+	if _, err := a.supervisor().Stdin(id, text, pressEnter); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("sent to %s. Read the terminal's reaction with @proc logs {\"id\":%q}.", id, id), nil
+}
+
 // Status implements plugins.ProcAdapter.
 func (a *procToolAdapter) Status(id string) (string, error) {
 	info, err := a.supervisor().Status(id)

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc
 	github.com/charmbracelet/glamour v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
+	github.com/creack/pty v1.1.24
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-rod/rod v0.116.2
 	github.com/goccy/go-graphviz v0.2.10

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJ
 github.com/corona10/goimagehash v1.1.0 h1:teNMX/1e+Wn/AYSbLHX8mj+mF9r60R1kBeqE9MkoYwI=
 github.com/corona10/goimagehash v1.1.0/go.mod h1:VkvE0mLn84L4aF8vCb6mafVajEb6QYMHl2ZJLn0mOGI=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -1464,6 +1464,7 @@
   "plugins.tools.describe_list": "Listing available tools",
   "plugins.tools.describe_describe": "Loading tool definition: %s",
   "plugins.proc.describe_generic": "Managing background processes",
+  "plugins.proc.describe_stdin": "Process: typing into %s",
   "plugins.proc.describe_start": "Starting background process: %s",
   "plugins.proc.describe_status": "Checking process %s",
   "plugins.proc.describe_logs": "Reading logs of %s",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1464,6 +1464,7 @@
   "plugins.tools.describe_list": "Listing available tools",
   "plugins.tools.describe_describe": "Loading tool definition: %s",
   "plugins.proc.describe_generic": "Managing background processes",
+  "plugins.proc.describe_stdin": "Process: typing into %s",
   "plugins.proc.describe_start": "Starting background process: %s",
   "plugins.proc.describe_status": "Checking process %s",
   "plugins.proc.describe_logs": "Reading logs of %s",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -1464,6 +1464,7 @@
   "plugins.tools.describe_list": "Listando tools disponíveis",
   "plugins.tools.describe_describe": "Carregando definição da tool: %s",
   "plugins.proc.describe_generic": "Gerenciando processos em background",
+  "plugins.proc.describe_stdin": "Processo: digitando em %s",
   "plugins.proc.describe_start": "Iniciando processo em background: %s",
   "plugins.proc.describe_status": "Verificando processo %s",
   "plugins.proc.describe_logs": "Lendo logs de %s",


### PR DESCRIPTION
## O que muda

O @proc ganha terminal interativo de verdade (o exec_command + write_stdin do Codex):

- **start {command, pty:true}** — processo roda anexado a um pseudo-terminal real: REPLs (python3, node), debuggers (dlv, pdb), ssh e prompts funcionam em vez de travar o agente
- **stdin {id, text, no_enter?}** — digita no terminal do processo (Enter incluso por padrão); a reação é lida pelo logs existente (o ring bounded captura o echo e a saída do terminal)
- Mesmo vetting (validator do exec do agente), mesmos limites e ciclo de vida; Stop/CloseAll fecham o ptmx
- Capability opcional ProcInteractive — a interface exportada ProcAdapter fica intacta (Floor 13)
- **Unix-first deliberado**: Windows retorna erro explícito (histórico do ConPTY); pty.Start dá sessão própria ao filho (pgid==pid), os helpers de signal de grupo seguem valendo
- creack/pty promovida de indireta a direta — já estava no grafo do módulo, binário não muda

## Testes
- E2E real: StartPTY(cat) → stdin → echo capturado no ring (com -race); stdin em processo não-pty/desconhecido/morto erra
- Dispatch do plugin com fake da capability (pty:true roteia, start plano não, no_enter, id obrigatório, sem capability erra)
- Caps: stdin nunca read-only; DescribeCall i18n ×3
- go build ./... e suítes proc + plugins + cli verdes