### PR TITLE
feat(coder): checkpoints shadow-git — snapshot automático antes de mutação + restore

### DIFF
--- a/cli/config_sections.go
+++ b/cli/config_sections.go
@@ -687,6 +687,7 @@ func (cli *ChatCLI) showConfigAgent() {
 	kv(p, "CHATCLI_AGENT_TMPDIR", envOr("CHATCLI_AGENT_TMPDIR"))
 	kv(p, "CHATCLI_AGENT_KEEP_TMPDIR", envBool("CHATCLI_AGENT_KEEP_TMPDIR"))
 	kv(p, "CHATCLI_MAX_COMMAND_OUTPUT", envOr("CHATCLI_MAX_COMMAND_OUTPUT"))
+	kv(p, "CHATCLI_CODER_CHECKPOINTS", envBool("CHATCLI_CODER_CHECKPOINTS"))
 
 	fmt.Println(p)
 	subheader(p, "cfg.sub.agent.coder_denial")

--- a/cli/plugins/builtin_coder_caps.go
+++ b/cli/plugins/builtin_coder_caps.go
@@ -25,6 +25,11 @@ func (p *BuiltinCoderPlugin) IsReadOnly(args []string) bool {
 	switch sub {
 	case "read", "search", "tree", "list", "stat":
 		return true
+	case "checkpoint":
+		// Listing/creating snapshots only records state; restore REWRITES
+		// the working tree and must face the security gate. Fail closed on
+		// any mention of restore.
+		return !strings.Contains(strings.ToLower(strings.Join(args, " ")), "restore")
 	}
 	return false
 }

--- a/pkg/coder/engine/checkpoint.go
+++ b/pkg/coder/engine/checkpoint.go
@@ -1,0 +1,217 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+/*
+ * checkpoint.go — shadow-git safety net for the coder engine.
+ *
+ * Before every mutating subcommand (write, patch, multipatch, exec) the
+ * engine snapshots the workspace into a SHADOW git repository that lives
+ * under the user's ChatCLI home — a separate GIT_DIR pointed at the
+ * workspace as its work tree. The user's own .git is never touched (git
+ * skips nested .git directories), the project's .gitignore is honored, and
+ * `checkpoint restore` rewinds the tree to any snapshot — a stronger net
+ * than the per-file .bak rollback, covering multi-file edits and exec side
+ * effects.
+ *
+ * Guardrails: snapshots are best-effort (a checkpoint failure never blocks
+ * the edit), throttled (at most one per checkpointMinInterval), disabled
+ * when git is absent, and switched off entirely with
+ * CHATCLI_CODER_CHECKPOINTS=off.
+ */
+package engine
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// checkpointEnv is the kill switch for automatic workspace snapshots.
+const checkpointEnv = "CHATCLI_CODER_CHECKPOINTS"
+
+// checkpointMinInterval throttles automatic snapshots: a burst of writes in
+// one batch produces one checkpoint, not one per file.
+const checkpointMinInterval = 15 * time.Second
+
+// checkpointMaxList bounds a listing.
+const checkpointMaxList = 30
+
+var (
+	checkpointMu   sync.Mutex
+	lastCheckpoint = map[string]time.Time{} // workspace root -> last snapshot
+)
+
+// checkpointsEnabled honors CHATCLI_CODER_CHECKPOINTS=0|false|off|no.
+func checkpointsEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(checkpointEnv))) {
+	case "0", "false", "off", "no":
+		return false
+	}
+	return true
+}
+
+// shadowGitDir resolves the shadow repository path for a workspace root.
+func shadowGitDir(root string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256([]byte(root))
+	return filepath.Join(home, ".chatcli", "checkpoints", hex.EncodeToString(sum[:8])), nil
+}
+
+// shadowGit runs one git command against the shadow repo/worktree pair.
+func shadowGit(gitDir, workTree string, args ...string) (string, error) {
+	base := []string{"--git-dir=" + gitDir, "--work-tree=" + workTree}
+	cmd := exec.Command("git", append(base, args...)...) // #nosec G204 -- fixed git binary; args are engine-built, never model-provided verbatim
+	// The shadow repo must never inherit the user's hooks or identity
+	// requirements: commits are local bookkeeping, not authored history.
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=chatcli-checkpoint", "GIT_AUTHOR_EMAIL=checkpoint@chatcli.local",
+		"GIT_COMMITTER_NAME=chatcli-checkpoint", "GIT_COMMITTER_EMAIL=checkpoint@chatcli.local",
+		"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+	)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+// ensureShadowRepo initializes the shadow repository once.
+func ensureShadowRepo(gitDir, workTree string) error {
+	if _, err := os.Stat(filepath.Join(gitDir, "HEAD")); err == nil {
+		return nil
+	}
+	if err := os.MkdirAll(gitDir, 0o750); err != nil {
+		return err
+	}
+	_, err := shadowGit(gitDir, workTree, "init", "-q")
+	return err
+}
+
+// snapshotWorkspace takes one checkpoint of the workspace (best-effort
+// semantics belong to the caller). label lands in the commit subject.
+func snapshotWorkspace(root, label string) error {
+	gitDir, err := shadowGitDir(root)
+	if err != nil {
+		return err
+	}
+	if err := ensureShadowRepo(gitDir, root); err != nil {
+		return err
+	}
+	if _, err := shadowGit(gitDir, root, "add", "-A"); err != nil {
+		return err
+	}
+	// Nothing staged → nothing to record; keep the log meaningful.
+	if _, err := shadowGit(gitDir, root, "diff", "--cached", "--quiet"); err == nil {
+		return nil
+	}
+	_, err = shadowGit(gitDir, root, "commit", "-q", "-m",
+		fmt.Sprintf("checkpoint before %s (%s)", label, time.Now().Format(time.RFC3339)))
+	return err
+}
+
+// autoCheckpoint snapshots the workspace before a mutating subcommand:
+// best-effort, throttled, and silent on success. Failures are reported to
+// the human stream once but never block the edit.
+func (e *Engine) autoCheckpoint(label string) {
+	if !checkpointsEnabled() {
+		return
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		return
+	}
+	root := e.WorkspaceRoot
+	if root == "" {
+		return
+	}
+	checkpointMu.Lock()
+	if time.Since(lastCheckpoint[root]) < checkpointMinInterval {
+		checkpointMu.Unlock()
+		return
+	}
+	lastCheckpoint[root] = time.Now()
+	checkpointMu.Unlock()
+
+	if err := snapshotWorkspace(root, label); err != nil {
+		e.errorf("checkpoint skipped: %v\n", err)
+	}
+}
+
+// handleCheckpoint is the model/user-facing surface: list snapshots, take one
+// explicitly, or restore the workspace to one.
+func (e *Engine) handleCheckpoint(args []string) error {
+	fs := flag.NewFlagSet("checkpoint", flag.ContinueOnError)
+	list := fs.Bool("list", false, "")
+	create := fs.Bool("create", false, "")
+	restore := fs.String("restore", "", "")
+	label := fs.String("label", "manual", "")
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	// Positional spelling: "checkpoint list" / "checkpoint restore <hash>".
+	if rest := fs.Args(); len(rest) > 0 {
+		switch rest[0] {
+		case "list":
+			*list = true
+		case "create":
+			*create = true
+		case "restore":
+			if len(rest) > 1 {
+				*restore = rest[1]
+			}
+		}
+	}
+
+	root := e.WorkspaceRoot
+	gitDir, err := shadowGitDir(root)
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case *restore != "":
+		if _, statErr := os.Stat(filepath.Join(gitDir, "HEAD")); statErr != nil {
+			return fmt.Errorf("no checkpoints exist for this workspace yet")
+		}
+		if out, err := shadowGit(gitDir, root, "checkout", *restore, "--", "."); err != nil {
+			return fmt.Errorf("restore %s: %s", *restore, out)
+		}
+		e.printf("Workspace restored to checkpoint %s. Files added AFTER that checkpoint still exist (restore never deletes untracked files).\n", *restore)
+		return nil
+
+	case *create:
+		if err := snapshotWorkspace(root, *label); err != nil {
+			return fmt.Errorf("checkpoint: %w", err)
+		}
+		e.printf("Checkpoint recorded.\n")
+		return nil
+
+	case *list:
+		fallthrough
+	default:
+		if _, statErr := os.Stat(filepath.Join(gitDir, "HEAD")); statErr != nil {
+			e.printf("No checkpoints for this workspace yet — they are recorded automatically before write/patch/exec.\n")
+			return nil
+		}
+		out, err := shadowGit(gitDir, root, "log", fmt.Sprintf("--max-count=%d", checkpointMaxList),
+			"--pretty=format:%h  %ad  %s", "--date=format:%Y-%m-%d %H:%M:%S")
+		if err != nil {
+			return fmt.Errorf("checkpoint list: %s", out)
+		}
+		if strings.TrimSpace(out) == "" {
+			e.printf("No checkpoints recorded yet.\n")
+			return nil
+		}
+		e.printf("Checkpoints (newest first — restore with checkpoint --restore <hash>):\n%s\n", out)
+		return nil
+	}
+}

--- a/pkg/coder/engine/checkpoint_test.go
+++ b/pkg/coder/engine/checkpoint_test.go
@@ -1,0 +1,139 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+/*
+ * checkpoint_test.go
+ *
+ * Shadow-git checkpoints: an automatic snapshot before a mutation, a listing,
+ * and a restore that rewinds tracked files — all against a temp workspace and
+ * a temp HOME so the real ChatCLI home is never touched. Skips cleanly where
+ * git is absent.
+ */
+package engine
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func checkpointTestEngine(t *testing.T) (*Engine, *bytes.Buffer, string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv(checkpointEnv, "on")
+	checkpointMu.Lock()
+	lastCheckpoint = map[string]time.Time{}
+	checkpointMu.Unlock()
+
+	work := t.TempDir()
+	var out bytes.Buffer
+	return NewEngine(&out, &out, work), &out, work
+}
+
+func writeWorkspaceFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func resetCheckpointThrottle() {
+	checkpointMu.Lock()
+	lastCheckpoint = map[string]time.Time{}
+	checkpointMu.Unlock()
+}
+
+func TestAutoCheckpointAndRestore(t *testing.T) {
+	e, out, work := checkpointTestEngine(t)
+	ctx := context.Background()
+
+	writeWorkspaceFile(t, work, "app.go", "package main // v1\n")
+	if err := snapshotWorkspace(work, "seed"); err != nil {
+		t.Fatalf("seed snapshot: %v", err)
+	}
+
+	resetCheckpointThrottle()
+	target := filepath.Join(work, "app.go")
+	if err := e.Execute(ctx, "write", []string{"--file", target, "--content", "package main // v2\n"}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if data, _ := os.ReadFile(target); !strings.Contains(string(data), "v2") {
+		t.Fatal("write did not land")
+	}
+
+	out.Reset()
+	if err := e.Execute(ctx, "checkpoint", []string{"--list"}); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if !strings.Contains(out.String(), "checkpoint before seed") {
+		t.Fatalf("listing missing seed checkpoint:\n%s", out.String())
+	}
+
+	gitDir, _ := shadowGitDir(work)
+	hash, err := shadowGit(gitDir, work, "rev-list", "--max-count=1", "--reverse", "HEAD")
+	if err != nil {
+		t.Fatalf("rev-list: %v", err)
+	}
+	hash = strings.Fields(hash)[0]
+	out.Reset()
+	if err := e.Execute(ctx, "checkpoint", []string{"--restore", hash}); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if data, _ := os.ReadFile(target); !strings.Contains(string(data), "v1") {
+		t.Fatalf("restore did not rewind the file: %s", data)
+	}
+}
+
+func TestCheckpointDisabledAndEmpty(t *testing.T) {
+	e, out, work := checkpointTestEngine(t)
+
+	if err := e.Execute(context.Background(), "checkpoint", []string{"--list"}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "No checkpoints") {
+		t.Fatalf("empty listing wrong:\n%s", out.String())
+	}
+
+	t.Setenv(checkpointEnv, "off")
+	resetCheckpointThrottle()
+	writeWorkspaceFile(t, work, "x.go", "package x\n")
+	e.autoCheckpoint("write")
+	gitDir, _ := shadowGitDir(work)
+	if _, err := os.Stat(filepath.Join(gitDir, "HEAD")); err == nil {
+		t.Fatal("kill switch must prevent shadow repo creation")
+	}
+}
+
+func TestCheckpointNeverTouchesUserGit(t *testing.T) {
+	e, _, work := checkpointTestEngine(t)
+	userGit := filepath.Join(work, ".git")
+	if err := os.MkdirAll(userGit, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeWorkspaceFile(t, work, ".git/CANARY", "do-not-touch\n")
+
+	resetCheckpointThrottle()
+	e.autoCheckpoint("write")
+
+	data, err := os.ReadFile(filepath.Join(userGit, "CANARY"))
+	if err != nil || !strings.Contains(string(data), "do-not-touch") {
+		t.Fatalf("user .git was disturbed: %v", err)
+	}
+	gitDir, _ := shadowGitDir(work)
+	if !strings.Contains(gitDir, ".chatcli") {
+		t.Fatalf("shadow git dir not under chatcli home: %s", gitDir)
+	}
+}

--- a/pkg/coder/engine/engine.go
+++ b/pkg/coder/engine/engine.go
@@ -201,16 +201,22 @@ func (e *Engine) Execute(ctx context.Context, cmd string, args []string) error {
 	case "read":
 		return e.handleRead(args)
 	case "write":
+		e.autoCheckpoint("write")
 		return e.handleWrite(args)
 	case "patch":
+		e.autoCheckpoint("patch")
 		return e.handlePatch(args)
 	case "multipatch":
+		e.autoCheckpoint("multipatch")
 		return e.handleMultipatch(args)
 	case "tree":
 		return e.handleTree(args)
+	case "checkpoint":
+		return e.handleCheckpoint(args)
 	case "search":
 		return e.handleSearch(ctx, args)
 	case "exec":
+		e.autoCheckpoint("exec")
 		return e.handleExec(ctx, args)
 	case "rollback":
 		return e.handleRollback(args)

--- a/pkg/coder/engine/metadata.go
+++ b/pkg/coder/engine/metadata.go
@@ -81,6 +81,20 @@ func GetSchema() string {
 				},
 			},
 			{
+				Name:        "checkpoint",
+				Description: "Snapshots shadow-git do workspace (automáticos antes de write/patch/multipatch/exec): list, create e restore para rebobinar a árvore a qualquer snapshot sem tocar o .git do usuário.",
+				Flags: []FlagDefinition{
+					{Name: "--list", Type: "bool", Description: "Lista os snapshots (default)."},
+					{Name: "--create", Type: "bool", Description: "Grava um snapshot agora."},
+					{Name: "--restore", Type: "string", Description: "Hash do snapshot para restaurar o workspace."},
+					{Name: "--label", Type: "string", Default: "manual", Description: "Rótulo do snapshot em --create."},
+				},
+				Examples: []string{
+					"checkpoint --list",
+					"checkpoint --restore a1b2c3d",
+				},
+			},
+			{
 				Name:        "write",
 				Description: "Escreve arquivo (com backup) com suporte a base64 e append.",
 				Flags: []FlagDefinition{


### PR DESCRIPTION
## O que muda

Rede de segurança mais forte que o rollback por .bak (o checkpoint/rewind do Gemini CLI e do Claude Code):

- Antes de **todo** write/patch/multipatch/exec, o engine faz snapshot do workspace num repositório git SOMBRA sob ~/.chatcli/checkpoints/<hash> — GIT_DIR separado com o workspace como work-tree
- O **.git do usuário nunca é tocado** (git pula .git aninhado; canary testado), .gitignore respeitado, identidade/hooks/config global e system neutralizados
- Novo subcomando **checkpoint**: --list, --create, --restore <hash> (rebobina a árvore; nunca apaga untracked)
- Best-effort (falha de snapshot nunca bloqueia a edição), throttle de 1 por 15s (rajada de writes = 1 checkpoint), no-op sem git, kill switch CHATCLI_CODER_CHECKPOINTS=off (exposto no /config)
- Caps: list/create read-only; **restore passa pelo security gate** (fail-closed em qualquer menção a restore)

## Testes
- Snapshot automático no write → list mostra → restore rebobina o arquivo (HOME e workspace temporários)
- Kill switch impede criação do repo sombra; listagem vazia; **canary prova que o .git do usuário fica intacto** e o repo sombra vive sob .chatcli
- go build ./... e suítes engine + plugins + cli verdes