### PR TITLE
fix(tools): honor flattened --flag args in @browser/@forge/@view parsers

### DIFF
--- a/cli/plugins/argv_flags.go
+++ b/cli/plugins/argv_flags.go
@@ -127,3 +127,45 @@ func argvInner(tail []string, primaryKey string, arrayKeys, intKeys map[string]b
 	}
 	return inner
 }
+
+// splitFlatArgs generically parses the flag-style argv tail the agent produces
+// from a flattened {cmd,args} envelope: "--key value" and "--key=value" pairs
+// become entries in flags (lowercased keys), a "--key" with no following value
+// becomes a true entry in bools, and bare tokens accumulate in positionals.
+// Shared by the hand-rolled tool parsers (@browser, @forge) so their command
+// mappers stay small — a flag they do not recognize is preserved in the map
+// rather than mistaken for a positional value.
+func splitFlatArgs(rest []string) (flags map[string]string, bools map[string]bool, positionals []string) {
+	flags = map[string]string{}
+	bools = map[string]bool{}
+	for i := 0; i < len(rest); i++ {
+		a := rest[i]
+		if !strings.HasPrefix(a, "--") {
+			positionals = append(positionals, a)
+			continue
+		}
+		name := strings.TrimPrefix(a, "--")
+		if eq := strings.IndexByte(name, '='); eq >= 0 {
+			flags[strings.ToLower(name[:eq])] = name[eq+1:]
+			continue
+		}
+		key := strings.ToLower(name)
+		if i+1 < len(rest) && !strings.HasPrefix(rest[i+1], "--") {
+			flags[key] = rest[i+1]
+			i++
+		} else {
+			bools[key] = true
+		}
+	}
+	return flags, bools, positionals
+}
+
+// firstFlag returns the first present value among keys, or "".
+func firstFlag(flags map[string]string, keys ...string) string {
+	for _, k := range keys {
+		if v, ok := flags[k]; ok {
+			return v
+		}
+	}
+	return ""
+}

--- a/cli/plugins/builtin_browser.go
+++ b/cli/plugins/builtin_browser.go
@@ -353,65 +353,25 @@ func parseBrowserInvocation(args []string) (browserInvocation, error) {
 
 	// The agent loop flattens a JSON envelope {"cmd":"open","args":{"url":X}}
 	// into argv ["open","--url",X], so every args-map key arrives as a
-	// `--flag value` (or `--flag=value`) pair. Collect those generically —
-	// treating an unknown --flag as its own key — plus bare positionals, then
-	// map both onto the invocation. A strict parser that ignored these flags
-	// mistook "--url" itself for the URL (navigating to a bogus host).
-	flags := map[string]string{}
-	bools := map[string]bool{}
-	var positionals []string
-	for i := 0; i < len(rest); i++ {
-		a := rest[i]
-		if strings.HasPrefix(a, "--") {
-			name := strings.TrimPrefix(a, "--")
-			if eq := strings.IndexByte(name, '='); eq >= 0 {
-				flags[strings.ToLower(name[:eq])] = name[eq+1:]
-				continue
-			}
-			key := strings.ToLower(name)
-			// A flag followed by another flag (or nothing) is a boolean.
-			if i+1 < len(rest) && !strings.HasPrefix(rest[i+1], "--") {
-				flags[key] = rest[i+1]
-				i++
-			} else {
-				bools[key] = true
-			}
-			continue
-		}
-		positionals = append(positionals, a)
-	}
-	flagAny := func(keys ...string) string {
-		for _, k := range keys {
-			if v, ok := flags[k]; ok {
-				return v
-			}
-		}
-		return ""
-	}
+	// `--flag value` (or `--flag=value`) pair. splitFlatArgs collects those
+	// generically (an unknown --flag is kept, not mistaken for a positional),
+	// then the keys are mapped onto the invocation. A strict parser that
+	// ignored these flags mistook "--url" itself for the URL.
+	flags, bools, positionals := splitFlatArgs(rest)
 	inv.submit = bools["submit"]
-	if v := flagAny("file", "path"); v != "" {
-		inv.file = v
+	inv.file = firstFlag(flags, "file", "path")
+	inv.url = firstFlag(flags, "url", "href")
+	inv.target = firstFlag(flags, "target", "selector", "ref", "to")
+	inv.text = firstFlag(flags, "text", "value")
+	inv.js = firstFlag(flags, "js", "expression", "script", "code")
+	if v := firstFlag(flags, "direction", "dir"); v != "" {
+		inv.dir = strings.ToLower(v)
 	}
-	if v := flagAny("tail"); v != "" {
+	if v := firstFlag(flags, "tail"); v != "" {
 		inv.tail = atoiDefault(v, browserDefaultTail)
 	}
-	if v := flagAny("max"); v != "" {
+	if v := firstFlag(flags, "max"); v != "" {
 		inv.max = atoiDefault(v, 0)
-	}
-	if v := flagAny("url", "href"); v != "" {
-		inv.url = v
-	}
-	if v := flagAny("target", "selector", "ref", "to"); v != "" {
-		inv.target = v
-	}
-	if v := flagAny("text", "value"); v != "" {
-		inv.text = v
-	}
-	if v := flagAny("js", "expression", "script", "code"); v != "" {
-		inv.js = v
-	}
-	if v := flagAny("direction", "dir"); v != "" {
-		inv.dir = strings.ToLower(v)
 	}
 
 	switch inv.cmd {

--- a/cli/plugins/builtin_browser.go
+++ b/cli/plugins/builtin_browser.go
@@ -351,61 +351,92 @@ func parseBrowserInvocation(args []string) (browserInvocation, error) {
 	inv.cmd = strings.ToLower(strings.TrimSpace(args[0]))
 	rest := args[1:]
 
-	// Flags anywhere in the tail; positionals fill the per-command slots.
+	// The agent loop flattens a JSON envelope {"cmd":"open","args":{"url":X}}
+	// into argv ["open","--url",X], so every args-map key arrives as a
+	// `--flag value` (or `--flag=value`) pair. Collect those generically —
+	// treating an unknown --flag as its own key — plus bare positionals, then
+	// map both onto the invocation. A strict parser that ignored these flags
+	// mistook "--url" itself for the URL (navigating to a bogus host).
+	flags := map[string]string{}
+	bools := map[string]bool{}
 	var positionals []string
 	for i := 0; i < len(rest); i++ {
 		a := rest[i]
-		next := func() string {
-			if i+1 < len(rest) {
-				i++
-				return rest[i]
+		if strings.HasPrefix(a, "--") {
+			name := strings.TrimPrefix(a, "--")
+			if eq := strings.IndexByte(name, '='); eq >= 0 {
+				flags[strings.ToLower(name[:eq])] = name[eq+1:]
+				continue
 			}
-			return ""
+			key := strings.ToLower(name)
+			// A flag followed by another flag (or nothing) is a boolean.
+			if i+1 < len(rest) && !strings.HasPrefix(rest[i+1], "--") {
+				flags[key] = rest[i+1]
+				i++
+			} else {
+				bools[key] = true
+			}
+			continue
 		}
-		switch {
-		case a == "--submit":
-			inv.submit = true
-		case a == "--file":
-			inv.file = next()
-		case strings.HasPrefix(a, "--file="):
-			inv.file = strings.TrimPrefix(a, "--file=")
-		case a == "--tail":
-			inv.tail = atoiDefault(next(), browserDefaultTail)
-		case strings.HasPrefix(a, "--tail="):
-			inv.tail = atoiDefault(strings.TrimPrefix(a, "--tail="), browserDefaultTail)
-		case a == "--max":
-			inv.max = atoiDefault(next(), 0)
-		case strings.HasPrefix(a, "--max="):
-			inv.max = atoiDefault(strings.TrimPrefix(a, "--max="), 0)
-		case a == "--to":
-			inv.target = next()
-		case strings.HasPrefix(a, "--to="):
-			inv.target = strings.TrimPrefix(a, "--to=")
-		default:
-			positionals = append(positionals, a)
+		positionals = append(positionals, a)
+	}
+	flagAny := func(keys ...string) string {
+		for _, k := range keys {
+			if v, ok := flags[k]; ok {
+				return v
+			}
 		}
+		return ""
+	}
+	inv.submit = bools["submit"]
+	if v := flagAny("file", "path"); v != "" {
+		inv.file = v
+	}
+	if v := flagAny("tail"); v != "" {
+		inv.tail = atoiDefault(v, browserDefaultTail)
+	}
+	if v := flagAny("max"); v != "" {
+		inv.max = atoiDefault(v, 0)
+	}
+	if v := flagAny("url", "href"); v != "" {
+		inv.url = v
+	}
+	if v := flagAny("target", "selector", "ref", "to"); v != "" {
+		inv.target = v
+	}
+	if v := flagAny("text", "value"); v != "" {
+		inv.text = v
+	}
+	if v := flagAny("js", "expression", "script", "code"); v != "" {
+		inv.js = v
+	}
+	if v := flagAny("direction", "dir"); v != "" {
+		inv.dir = strings.ToLower(v)
 	}
 
 	switch inv.cmd {
 	case "open":
-		if len(positionals) > 0 {
+		if inv.url == "" && len(positionals) > 0 {
 			inv.url = positionals[0]
 		}
 	case "click":
-		if len(positionals) > 0 {
+		if inv.target == "" && len(positionals) > 0 {
 			inv.target = positionals[0]
 		}
 	case "type":
-		if len(positionals) > 0 {
+		if inv.target == "" && len(positionals) > 0 {
 			inv.target = positionals[0]
+			positionals = positionals[1:]
 		}
-		if len(positionals) > 1 {
-			inv.text = strings.Join(positionals[1:], " ")
+		if inv.text == "" && len(positionals) > 0 {
+			inv.text = strings.Join(positionals, " ")
 		}
 	case "eval":
-		inv.js = strings.Join(positionals, " ")
+		if inv.js == "" {
+			inv.js = strings.Join(positionals, " ")
+		}
 	case "scroll":
-		if len(positionals) > 0 {
+		if inv.dir == "" && len(positionals) > 0 {
 			inv.dir = strings.ToLower(positionals[0])
 		}
 	case "console", "network":

--- a/cli/plugins/builtin_browser_test.go
+++ b/cli/plugins/builtin_browser_test.go
@@ -321,3 +321,43 @@ func TestBrowserDescribeCallAndMeta(t *testing.T) {
 		}
 	}
 }
+
+// TestParseBrowserInvocation_FlattenedEnvelopeArgv reproduces the real agent
+// bug: the loop flattens {"cmd":"open","args":{"url":X}} into argv
+// ["open","--url",X], which the strict parser mistook for the URL "--url".
+func TestParseBrowserInvocation_FlattenedEnvelopeArgv(t *testing.T) {
+	url := "file:///tmp/form.html"
+	inv, err := parseBrowserInvocation([]string{"open", "--url", url})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inv.cmd != "open" || inv.url != url {
+		t.Fatalf("flattened open broke: cmd=%q url=%q (want open/%q)", inv.cmd, inv.url, url)
+	}
+
+	inv, _ = parseBrowserInvocation([]string{"click", "--target", "3"})
+	if inv.target != "3" {
+		t.Fatalf("flattened click target: %q", inv.target)
+	}
+	inv, _ = parseBrowserInvocation([]string{"type", "--target", "2", "--text", "golang", "--submit"})
+	if inv.target != "2" || inv.text != "golang" || !inv.submit {
+		t.Fatalf("flattened type: %+v", inv)
+	}
+	inv, _ = parseBrowserInvocation([]string{"eval", "--js", "document.title"})
+	if inv.js != "document.title" {
+		t.Fatalf("flattened eval js: %q", inv.js)
+	}
+	inv, _ = parseBrowserInvocation([]string{"scroll", "--direction", "down"})
+	if inv.dir != "down" {
+		t.Fatalf("flattened scroll dir: %q", inv.dir)
+	}
+	inv, _ = parseBrowserInvocation([]string{"screenshot", "--file", "/tmp/s.png"})
+	if inv.file != "/tmp/s.png" {
+		t.Fatalf("flattened screenshot file: %q", inv.file)
+	}
+	// Bare positional still works (open example.com).
+	inv, _ = parseBrowserInvocation([]string{"open", "example.com"})
+	if inv.url != "example.com" {
+		t.Fatalf("positional open regressed: %q", inv.url)
+	}
+}

--- a/cli/plugins/builtin_forge.go
+++ b/cli/plugins/builtin_forge.go
@@ -379,62 +379,28 @@ func parseForgeInvocation(args []string) (forgeInvocation, error) {
 		rest = rest[1:]
 	}
 
-	var positionals []string
-	for i := 0; i < len(rest); i++ {
-		a := rest[i]
-		next := func() string {
-			if i+1 < len(rest) {
-				i++
-				return rest[i]
-			}
-			return ""
-		}
-		switch {
-		case a == "--draft":
-			inv.draft = true
-		case a == "--title":
-			inv.title = next()
-		case a == "--body":
-			inv.body = next()
-		case a == "--base":
-			inv.base = next()
-		case a == "--branch":
-			inv.branch = next()
-		case a == "--limit":
-			inv.limit = forgeAtoi(next(), 0)
-		case a == "--host":
-			inv.host = next()
-		// The agent loop flattens {"cmd":"pr-view","args":{"number":42}} into
-		// argv ["pr-view","--number","42"], so number/run arrive as flags too
-		// — recognize them or they'd be mistaken for the positional target.
-		case a == "--number" || a == "--id" || a == "--pr" || a == "--mr":
-			inv.number = next()
-		case a == "--run" || a == "--run-id" || a == "--runid":
-			inv.run = next()
-		case strings.HasPrefix(a, "--number=") || strings.HasPrefix(a, "--id=") || strings.HasPrefix(a, "--pr=") || strings.HasPrefix(a, "--mr="):
-			inv.number = a[strings.IndexByte(a, '=')+1:]
-		case strings.HasPrefix(a, "--run=") || strings.HasPrefix(a, "--run-id=") || strings.HasPrefix(a, "--runid="):
-			inv.run = a[strings.IndexByte(a, '=')+1:]
-		case strings.HasPrefix(a, "--title="):
-			inv.title = strings.TrimPrefix(a, "--title=")
-		case strings.HasPrefix(a, "--body="):
-			inv.body = strings.TrimPrefix(a, "--body=")
-		case strings.HasPrefix(a, "--base="):
-			inv.base = strings.TrimPrefix(a, "--base=")
-		case strings.HasPrefix(a, "--branch="):
-			inv.branch = strings.TrimPrefix(a, "--branch=")
-		case strings.HasPrefix(a, "--limit="):
-			inv.limit = forgeAtoi(strings.TrimPrefix(a, "--limit="), 0)
-		case strings.HasPrefix(a, "--host="):
-			inv.host = strings.TrimPrefix(a, "--host=")
-		default:
-			positionals = append(positionals, a)
-		}
+	// The agent loop flattens {"cmd":"pr-view","args":{"number":42}} into argv
+	// ["pr-view","--number","42"], so every args-map key arrives as a flag.
+	// splitFlatArgs collects them generically; number/run must be recognized
+	// here or they'd be mistaken for the positional target.
+	flags, bools, positionals := splitFlatArgs(rest)
+	inv.draft = bools["draft"]
+	inv.title = firstFlag(flags, "title")
+	inv.body = firstFlag(flags, "body")
+	inv.base = firstFlag(flags, "base")
+	inv.branch = firstFlag(flags, "branch")
+	inv.host = firstFlag(flags, "host")
+	inv.number = firstFlag(flags, "number", "id", "pr", "mr")
+	inv.run = firstFlag(flags, "run", "run-id", "runid")
+	if v := firstFlag(flags, "limit"); v != "" {
+		inv.limit = forgeAtoi(v, 0)
 	}
 	if len(positionals) > 0 {
 		if inv.cmd == "ci-logs" {
-			inv.run = positionals[0]
-		} else {
+			if inv.run == "" {
+				inv.run = positionals[0]
+			}
+		} else if inv.number == "" {
 			inv.number = positionals[0]
 		}
 	}

--- a/cli/plugins/builtin_forge.go
+++ b/cli/plugins/builtin_forge.go
@@ -404,6 +404,17 @@ func parseForgeInvocation(args []string) (forgeInvocation, error) {
 			inv.limit = forgeAtoi(next(), 0)
 		case a == "--host":
 			inv.host = next()
+		// The agent loop flattens {"cmd":"pr-view","args":{"number":42}} into
+		// argv ["pr-view","--number","42"], so number/run arrive as flags too
+		// — recognize them or they'd be mistaken for the positional target.
+		case a == "--number" || a == "--id" || a == "--pr" || a == "--mr":
+			inv.number = next()
+		case a == "--run" || a == "--run-id" || a == "--runid":
+			inv.run = next()
+		case strings.HasPrefix(a, "--number=") || strings.HasPrefix(a, "--id=") || strings.HasPrefix(a, "--pr=") || strings.HasPrefix(a, "--mr="):
+			inv.number = a[strings.IndexByte(a, '=')+1:]
+		case strings.HasPrefix(a, "--run=") || strings.HasPrefix(a, "--run-id=") || strings.HasPrefix(a, "--runid="):
+			inv.run = a[strings.IndexByte(a, '=')+1:]
 		case strings.HasPrefix(a, "--title="):
 			inv.title = strings.TrimPrefix(a, "--title=")
 		case strings.HasPrefix(a, "--body="):

--- a/cli/plugins/builtin_forge_test.go
+++ b/cli/plugins/builtin_forge_test.go
@@ -258,3 +258,25 @@ func TestForge_DescribeCallAndMeta(t *testing.T) {
 		t.Fatal("concurrency caps must mirror read-only")
 	}
 }
+
+func TestForge_FlattenedEnvelopeArgv(t *testing.T) {
+	// The agent loop flattens {"cmd":"pr-view","args":{"number":42}} to
+	// ["pr-view","--number","42"] — number/run must not become the target.
+	inv, err := parseForgeInvocation([]string{"pr-view", "--number", "42"})
+	if err != nil || inv.number != "42" {
+		t.Fatalf("flattened pr-view number: %q (%v)", inv.number, err)
+	}
+	inv, _ = parseForgeInvocation([]string{"ci-logs", "--run", "9987"})
+	if inv.run != "9987" {
+		t.Fatalf("flattened ci-logs run: %q", inv.run)
+	}
+	inv, _ = parseForgeInvocation([]string{"pr-comment", "--number=7", "--body", "hi"})
+	if inv.number != "7" || inv.body != "hi" {
+		t.Fatalf("flattened pr-comment: %+v", inv)
+	}
+	// Positional still works.
+	inv, _ = parseForgeInvocation([]string{"pr", "view", "5"})
+	if inv.number != "5" {
+		t.Fatalf("positional pr view regressed: %q", inv.number)
+	}
+}

--- a/cli/plugins/builtin_proc_test.go
+++ b/cli/plugins/builtin_proc_test.go
@@ -235,3 +235,26 @@ func TestProcStdinCapsNotReadOnly(t *testing.T) {
 		t.Fatal("DescribeCall(stdin) empty")
 	}
 }
+
+func TestProcPTYFlattenedArgv(t *testing.T) {
+	fake := &fakeInteractiveProcAdapter{}
+	SetProcAdapter(fake)
+	t.Cleanup(func() { SetProcAdapter(nil) })
+	p := NewBuiltinProcPlugin()
+
+	// The agent flattener turns {"cmd":"start","args":{"command":"python3",
+	// "pty":true}} into ["start","--command","python3","--pty"].
+	if _, err := p.Execute(context.Background(), []string{"start", "--command", "python3", "--pty"}); err != nil {
+		t.Fatal(err)
+	}
+	if fake.lastCall != "startpty" || fake.ptyCommand != "python3" {
+		t.Fatalf("flattened pty start not routed: %+v", fake)
+	}
+	// stdin flattened: ["stdin","--id","p1","--text","1+1"].
+	if _, err := p.Execute(context.Background(), []string{"stdin", "--id", "p1", "--text", "1+1"}); err != nil {
+		t.Fatal(err)
+	}
+	if fake.stdinID != "p1" || fake.stdinText != "1+1" {
+		t.Fatalf("flattened stdin not routed: %+v", fake)
+	}
+}

--- a/cli/plugins/builtin_view.go
+++ b/cli/plugins/builtin_view.go
@@ -153,7 +153,21 @@ func parseViewInvocation(args []string) (string, error) {
 	if strings.EqualFold(args[0], "view") {
 		rest = args[1:]
 	}
-	if len(rest) == 0 || strings.TrimSpace(rest[0]) == "" {
+	// The agent loop flattens {"cmd":"view","args":{"file":X}} into argv
+	// ["view","--file",X]; pull the value out of the --file/--path/--image
+	// flag so it is not mistaken for a literal path like "--file X".
+	for i := 0; i < len(rest); i++ {
+		a := rest[i]
+		for _, fl := range []string{"--file", "--path", "--image"} {
+			if a == fl && i+1 < len(rest) {
+				return strings.TrimSpace(rest[i+1]), nil
+			}
+			if v, ok := strings.CutPrefix(a, fl+"="); ok && strings.TrimSpace(v) != "" {
+				return strings.TrimSpace(v), nil
+			}
+		}
+	}
+	if len(rest) == 0 || strings.TrimSpace(rest[0]) == "" || strings.HasPrefix(rest[0], "--") {
 		return "", errors.New("@view: missing file path")
 	}
 	return strings.TrimSpace(strings.Join(rest, " ")), nil

--- a/cli/plugins/builtin_view_test.go
+++ b/cli/plugins/builtin_view_test.go
@@ -76,3 +76,23 @@ func TestViewWithoutAdapterErrors(t *testing.T) {
 		t.Fatal("missing adapter must error")
 	}
 }
+
+func TestViewParse_FlattenedEnvelopeArgv(t *testing.T) {
+	// ["view","--file",X] from the flattened envelope must yield X, not "--file X".
+	got, err := parseViewInvocation([]string{"view", "--file", "/tmp/shot.png"})
+	if err != nil || got != "/tmp/shot.png" {
+		t.Fatalf("flattened view --file: %q (%v)", got, err)
+	}
+	got, _ = parseViewInvocation([]string{"view", "--path=/tmp/a b.png"})
+	if got != "/tmp/a b.png" {
+		t.Fatalf("flattened --path=: %q", got)
+	}
+	if _, err := parseViewInvocation([]string{"view", "--file"}); err == nil {
+		t.Fatal("dangling --file must error, not return a bogus path")
+	}
+	// Bare positional still works.
+	got, _ = parseViewInvocation([]string{"shot.png"})
+	if got != "shot.png" {
+		t.Fatalf("bare path regressed: %q", got)
+	}
+}


### PR DESCRIPTION
## Bug

Using `@browser` after coding an HTML form, the agent's `open` navigated to the literal host `--url` (DNS_PROBE_STARTED on "--url"), and kept failing.

## Root cause

The agent loop's `buildArgvFromJSONMap` flattens a JSON envelope `{"cmd":"open","args":{"url":X}}` into argv `["open","--url",X]` — every args-map key becomes a `--flag value` pair (this is how @coder/@lsp work, via flag.FlagSet). The three NEW tools rolled their own flat parsers that only knew a few flags and treated any other `--flag` as a **positional**, so the flag NAME became the value:
- `@browser` → `inv.url = "--url"` (navigated to a bogus host)
- `@forge` → `inv.number = "--number"`
- `@view` → path `"--file X"`

Same class as the memory rule *"parsing estrito = IA falha e repete"* — the model burned several turns and hit the security gate retrying.

## Fix

Each parser now collects `--flag=value` / `--flag value` pairs (with key aliases: url/href, target/selector/ref, text/value, js/expression/script/code, direction/dir, number/id/pr/mr, run, file/path/image) **before** falling back to positionals. The flattened envelope, the inline `{...}` form and bare positionals (`open example.com`) all work.

## Tests

Regression tests for the flattened argv of all four new tools (@browser open/click/type/eval/scroll/screenshot, @forge pr-view/ci-logs/pr-comment, @view --file/--path, and @proc pty/stdin), plus the existing positional forms to prevent regressions. Full `cli/plugins` suite + build + vet green.