### PR TITLE
fix(tools): @tools describe renders @browser/@forge/@view subcommands

### DIFF
--- a/cli/plugins/builtin_browser.go
+++ b/cli/plugins/builtin_browser.go
@@ -104,8 +104,9 @@ func (*BuiltinBrowserPlugin) Path() string { return "[builtin]" }
 func (*BuiltinBrowserPlugin) Schema() string {
 	schema := map[string]interface{}{
 		"name":        "@browser",
-		"description": "Drive a real local browser over the DevTools protocol: navigate, snapshot, click, type, eval, screenshot, console, network.",
-		"commands": []map[string]interface{}{
+		"description": "Drive a real local browser over the DevTools protocol.",
+		"argsFormat":  "JSON envelope {cmd, args} preferred (e.g. {\"cmd\":\"open\",\"args\":{\"url\":\"...\"}}); flat argv also accepted.",
+		"subcommands": []map[string]interface{}{
 			{"name": "open", "description": "navigate to a URL and return a page snapshot", "examples": []string{`{"cmd":"open","args":{"url":"http://localhost:3000"}}`}},
 			{"name": "snapshot", "description": "current page as text with numbered interactive elements", "examples": []string{`{"cmd":"snapshot"}`}},
 			{"name": "click", "description": "click an element by snapshot ref or CSS selector", "examples": []string{`{"cmd":"click","args":{"target":"3"}}`, `{"cmd":"click","args":{"target":"#submit"}}`}},

--- a/cli/plugins/builtin_forge.go
+++ b/cli/plugins/builtin_forge.go
@@ -109,7 +109,8 @@ func (*BuiltinForgePlugin) Schema() string {
 	schema := map[string]interface{}{
 		"name":        "@forge",
 		"description": "Pull requests, issues and CI via the user's authenticated gh/glab CLI.",
-		"commands": []map[string]interface{}{
+		"argsFormat":  "JSON envelope {cmd, args} (e.g. {\"cmd\":\"pr-view\",\"args\":{\"number\":42}}); two-token (pr view 42) and flat argv also accepted.",
+		"subcommands": []map[string]interface{}{
 			{"name": "pr-list", "description": "open pull requests", "examples": []string{`{"cmd":"pr-list"}`}},
 			{"name": "pr-view", "description": "one PR in detail", "examples": []string{`{"cmd":"pr-view","args":{"number":42}}`}},
 			{"name": "pr-diff", "description": "the PR's diff", "examples": []string{`{"cmd":"pr-diff","args":{"number":42}}`}},

--- a/cli/plugins/builtin_view.go
+++ b/cli/plugins/builtin_view.go
@@ -90,7 +90,8 @@ func (*BuiltinViewPlugin) Schema() string {
 	schema := map[string]interface{}{
 		"name":        "@view",
 		"description": "Attach a local image to the conversation through the vision pipeline.",
-		"commands": []map[string]interface{}{
+		"argsFormat":  "JSON envelope {cmd, args} (e.g. {\"cmd\":\"view\",\"args\":{\"file\":\"shot.png\"}}); a bare path also works.",
+		"subcommands": []map[string]interface{}{
 			{"name": "view", "description": "attach a local image (png, jpeg, gif, webp)", "examples": []string{`{"cmd":"view","args":{"file":"shot.png"}}`}},
 		},
 	}

--- a/cli/tool_catalog_test.go
+++ b/cli/tool_catalog_test.go
@@ -127,3 +127,27 @@ func TestFirstSentenceBounds(t *testing.T) {
 		t.Fatalf("unterminated description not bounded: %d bytes", len(got))
 	}
 }
+
+// TestNewToolsRenderSubcommands guards the Schema contract: @tools describe
+// renders a plugin's subcommands only when its Schema() uses the "subcommands"
+// key. The first cut of @browser/@forge/@view used "commands", so describe
+// showed an empty subcommand list and the model could not learn the format.
+func TestNewToolsRenderSubcommands(t *testing.T) {
+	cases := []struct {
+		p    plugins.Plugin
+		want string // a subcommand that must appear in the rendered block
+	}{
+		{plugins.NewBuiltinBrowserPlugin(), "open"},
+		{plugins.NewBuiltinForgePlugin(), "pr-view"},
+		{plugins.NewBuiltinViewPlugin(), "view"},
+	}
+	for _, tc := range cases {
+		block := renderToolBlock(tc.p, false)
+		if !strings.Contains(block, "Subcomandos Disponíveis") {
+			t.Fatalf("%s: describe block has no subcommand section:\n%s", tc.p.Name(), block)
+		}
+		if !strings.Contains(block, tc.want) {
+			t.Fatalf("%s: describe block missing subcommand %q — Schema() likely uses \"commands\" not \"subcommands\":\n%s", tc.p.Name(), tc.want, block)
+		}
+	}
+}


### PR DESCRIPTION
## What the user hit

Driving `@browser` after coding a form, the agent floundered — `@tools describe @browser` returned an **empty** subcommand list ("Subcomandos Disponíveis:" with nothing), so the model never learned the call format, kept emitting malformed cmd-less calls, and those tripped the security gate turn after turn.

## Root cause

`@browser`/`@forge`/`@view` `Schema()` used a `"commands"` key, but the catalog renderer (`renderToolBlock`) reads `"subcommands"` (the contract every other builtin follows). So the describe output had zero subcommands and zero examples.

This compounded with the flattened-arg bug (fixed in #1407): an empty describe → the model guesses → wrong/cmd-less args → gate friction + `--url` navigation.

## Fix

Switch the key to `"subcommands"` and add `argsFormat` in all three. `@tools describe` now renders the full subcommand list **with examples** (verified for @browser: format line + 12 subcommands + JSON examples). A read-only `open` from a well-formed `{"cmd":"open","args":{"url":...}}` then auto-approves through the capability gate — no more spurious prompts.

## Test

`TestNewToolsRenderSubcommands` asserts @browser/@forge/@view render their subcommands in the describe block (guards the Schema-key contract). Full `cli`/`cli/plugins` suites + build + vet green.