### PR TITLE
fix(taskgraph): field-test hardening — plan-first deferral, prompt-safe streaming, plan-from-file

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -3437,13 +3437,35 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 								// First real output ends the spinner so streamed
 								// lines don't clash with its carriage-return repaint.
 								a.cli.animation.StopThinkingAnimation()
-								if !isCompact {
-									renderer.StreamOutput(line)
+								if isCompact {
+									return
 								}
+								// Serialize with worker security prompts: a tool
+								// that dispatches workers (@taskgraph) streams from
+								// background goroutines, and an ungated print lands
+								// on top of the prompt box — corrupting both the
+								// render and the answer the user is typing.
+								if a.policyAdapter != nil {
+									a.policyAdapter.withPromptGate(func() { renderer.StreamOutput(line) })
+									return
+								}
+								renderer.StreamOutput(line)
 							}
 
 							// Marca tarefa como em andamento ANTES de executar
 							agent.MarkTaskInProgress(a.taskTracker)
+
+							// @taskgraph dispatches workers whose security
+							// prompts run on the shared policy adapter — re-arm
+							// its spinner/stdin/cbreak hooks exactly like the
+							// <agent_call> dispatch path does, otherwise the
+							// prompts race the central stdin reader for keys and
+							// typed answers get mangled into denials.
+							if strings.EqualFold(strings.TrimSpace(toolName), "@taskgraph") && a.policyAdapter != nil {
+								a.policyAdapter.setSpinner(a.turnTimer)
+								a.policyAdapter.setStdinCh(a.stdinLines)
+								a.policyAdapter.setRestoreInput(a.reapplyStdinCbreak)
+							}
 
 							// Delegate interception: if this is an @coder call with
 							// cmd=delegate, it's a subagent spawn — NOT a plugin

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -3444,9 +3444,20 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 								// that dispatches workers (@taskgraph) streams from
 								// background goroutines, and an ungated print lands
 								// on top of the prompt box — corrupting both the
-								// render and the answer the user is typing.
+								// render and the answer the user is typing. When
+								// the turn spinner is live (taskgraph runs), the
+								// print also pauses/resumes it so event lines and
+								// the spinner/preview repaint never interleave.
 								if a.policyAdapter != nil {
-									a.policyAdapter.withPromptGate(func() { renderer.StreamOutput(line) })
+									a.policyAdapter.withPromptGate(func() {
+										if t := a.turnTimer; t != nil && t.IsRunning() {
+											t.Pause()
+											renderer.StreamOutput(line)
+											t.Resume()
+											return
+										}
+										renderer.StreamOutput(line)
+									})
 									return
 								}
 								renderer.StreamOutput(line)
@@ -3460,11 +3471,28 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 							// its spinner/stdin/cbreak hooks exactly like the
 							// <agent_call> dispatch path does, otherwise the
 							// prompts race the central stdin reader for keys and
-							// typed answers get mangled into denials.
+							// typed answers get mangled into denials. The turn
+							// spinner also runs for the whole graph execution so
+							// the user's typing renders as the live ❯ …▌ preview
+							// (streamed event lines pause/resume it — see
+							// streamCallback) instead of a dead keyboard.
+							taskGraphTimerStarted := false
+							tgHadPreview := false
 							if strings.EqualFold(strings.TrimSpace(toolName), "@taskgraph") && a.policyAdapter != nil {
 								a.policyAdapter.setSpinner(a.turnTimer)
 								a.policyAdapter.setStdinCh(a.stdinLines)
 								a.policyAdapter.setRestoreInput(a.reapplyStdinCbreak)
+								a.turnTimer.SetOnPause(func() {
+									fmt.Print(metrics.ClearLine())
+									fmt.Print(spinnerPreviewWipe(tgHadPreview))
+									tgHadPreview = false
+								})
+								a.turnTimer.Start(ctx, func(d time.Duration) {
+									var frame string
+									frame, tgHadPreview = a.buildTurnSpinnerFrame(d, taskGraphSpinnerLabel, tgHadPreview)
+									fmt.Print(frame)
+								})
+								taskGraphTimerStarted = true
 							}
 
 							// Delegate interception: if this is an @coder call with
@@ -3514,6 +3542,13 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 									toolOutput, execErr = plugin.ExecuteWithStream(ctx, toolArgs, streamCallback)
 									a.cli.animation.StopThinkingAnimation()
 								}
+							}
+
+							if taskGraphTimerStarted {
+								a.turnTimer.Stop()
+								a.turnTimer.SetOnPause(nil)
+								fmt.Print(metrics.ClearLine())
+								fmt.Print(spinnerPreviewWipe(tgHadPreview))
 							}
 
 							if !isCompact {

--- a/cli/agent_plan_first.go
+++ b/cli/agent_plan_first.go
@@ -29,6 +29,15 @@ import (
 	"go.uber.org/zap"
 )
 
+// queryInvokesTaskGraph reports whether the user explicitly asked for the
+// task-graph orchestrator ("@taskgraph", "taskgraph", "task graph").
+func queryInvokesTaskGraph(query string) bool {
+	lower := strings.ToLower(query)
+	return strings.Contains(lower, "@taskgraph") ||
+		strings.Contains(lower, "taskgraph") ||
+		strings.Contains(lower, "task graph")
+}
+
 // runPlanFirstIfApplicable checks the quality config and the one-shot
 // /plan flag, then optionally runs a structured Plan-and-Solve cycle.
 //
@@ -56,6 +65,17 @@ func (a *AgentMode) runPlanFirstIfApplicable(ctx context.Context, userQuery stri
 	dryRun := a.cli.pendingPlanDryRun
 	a.cli.pendingPlanFirst = false
 	a.cli.pendingPlanDryRun = false
+
+	// A query that explicitly asks for the task-graph orchestrator must not
+	// be hijacked by auto plan-first: @taskgraph carries its own plan,
+	// parallelism and verification (executor ≠ reviewer), and running the
+	// PlanRunner here would execute the work outside the graph — no gates,
+	// no verdicts, and a confusing "who did this?" for the user. An explicit
+	// /plan still wins (forced).
+	if !forced && !dryRun && queryInvokesTaskGraph(userQuery) {
+		a.logger.Info("Plan-First deferred to @taskgraph (explicitly requested in the query)")
+		return
+	}
 
 	if !forced && !dryRun && !quality.ShouldPlanFirst(a.qualityConfig.PlanFirst, userQuery) {
 		return

--- a/cli/agent_plan_first_taskgraph_test.go
+++ b/cli/agent_plan_first_taskgraph_test.go
@@ -1,0 +1,33 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import "testing"
+
+// TestQueryInvokesTaskGraph: an explicit task-graph request must defer
+// auto plan-first to the @taskgraph orchestrator (executor ≠ reviewer),
+// instead of the PlanRunner executing the work outside the graph.
+func TestQueryInvokesTaskGraph(t *testing.T) {
+	invokes := []string{
+		"Use o @taskgraph para construir o CLI",
+		"execute com o TASKGRAPH em paralelo",
+		"rode isso como um task graph com review",
+	}
+	for _, q := range invokes {
+		if !queryInvokesTaskGraph(q) {
+			t.Fatalf("must defer to task graph: %q", q)
+		}
+	}
+	plain := []string{
+		"implemente OAuth com testes e me entregue revisado",
+		"crie um grafo de chamadas do pacote http",
+	}
+	for _, q := range plain {
+		if queryInvokesTaskGraph(q) {
+			t.Fatalf("must NOT defer: %q", q)
+		}
+	}
+}

--- a/cli/agent_side_commands.go
+++ b/cli/agent_side_commands.go
@@ -66,6 +66,24 @@ func (a *AgentMode) onSideCommand(ctx context.Context, line string) {
 		}()
 		return
 	}
+	// No live panel — but the loop may be holding the turn inside a long
+	// streaming tool call (@taskgraph run streams for minutes), and a
+	// silently queued command reads as a dead keyboard. Execute now under
+	// the prompt gate so the output serializes with the stream lines —
+	// via TryLock, NEVER a blocking lock: this runs on the stdin reader
+	// goroutine, and a security prompt holds the gate while waiting for a
+	// line only this goroutine can deliver.
+	if pa := a.policyAdapter; pa != nil {
+		ran := pa.tryPromptGate(func() {
+			fmt.Println(colorize("  ⚡ "+line, ColorCyan))
+			a.execSideCommand(ctx, line)
+		})
+		if ran {
+			return
+		}
+	}
+	// Gate contended (a security prompt owns the screen and the keyboard):
+	// queue for the turn boundary, as before.
 	a.sideCmdMu.Lock()
 	a.sideCmdQueue = append(a.sideCmdQueue, line)
 	a.sideCmdMu.Unlock()

--- a/cli/agent_side_commands.go
+++ b/cli/agent_side_commands.go
@@ -54,36 +54,42 @@ func isSideCommand(line string) bool {
 // turn boundary when no live display is active (e.g. a security prompt
 // owns the terminal — printing into its card would corrupt it).
 func (a *AgentMode) onSideCommand(ctx context.Context, line string) {
-	timer := a.turnTimer
-	if timer != nil && timer.IsRunning() {
-		timer.Pause()
-		func() {
+	// runNow pauses a live display (nested-pause safe), prints and executes.
+	runNow := func() {
+		timer := a.turnTimer
+		if timer != nil && timer.IsRunning() {
+			timer.Pause()
 			// Resume via defer: with nested pause depths, a handler that
 			// panics mid-print must not leave the display frozen forever.
 			defer timer.Resume()
-			fmt.Println(colorize("  ⚡ "+line, ColorCyan))
-			a.execSideCommand(ctx, line)
-		}()
-		return
+		}
+		fmt.Println(colorize("  ⚡ "+line, ColorCyan))
+		a.execSideCommand(ctx, line)
 	}
-	// No live panel — but the loop may be holding the turn inside a long
-	// streaming tool call (@taskgraph run streams for minutes), and a
-	// silently queued command reads as a dead keyboard. Execute now under
-	// the prompt gate so the output serializes with the stream lines —
-	// via TryLock, NEVER a blocking lock: this runs on the stdin reader
-	// goroutine, and a security prompt holds the gate while waiting for a
-	// line only this goroutine can deliver.
+
+	// Execute now under the prompt gate so the output serializes with both
+	// streamed tool lines and worker security prompts (a graph run streams
+	// for minutes — a silently queued command reads as a dead keyboard).
+	// The gate is taken with TryLock, NEVER a blocking lock: this runs on
+	// the stdin reader goroutine, and a security prompt holds the gate
+	// while waiting for a line only this goroutine can deliver.
 	if pa := a.policyAdapter; pa != nil {
-		ran := pa.tryPromptGate(func() {
-			fmt.Println(colorize("  ⚡ "+line, ColorCyan))
-			a.execSideCommand(ctx, line)
-		})
-		if ran {
+		if pa.tryPromptGate(runNow) {
 			return
 		}
+		// Gate contended (a security prompt owns the screen and the
+		// keyboard): queue for the turn boundary, as before.
+		a.sideCmdMu.Lock()
+		a.sideCmdQueue = append(a.sideCmdQueue, line)
+		a.sideCmdMu.Unlock()
+		return
 	}
-	// Gate contended (a security prompt owns the screen and the keyboard):
-	// queue for the turn boundary, as before.
+
+	// No policy adapter wired (tests, minimal sessions): pre-gate behavior.
+	if timer := a.turnTimer; timer != nil && timer.IsRunning() {
+		runNow()
+		return
+	}
 	a.sideCmdMu.Lock()
 	a.sideCmdQueue = append(a.sideCmdQueue, line)
 	a.sideCmdMu.Unlock()

--- a/cli/agent_side_commands_test.go
+++ b/cli/agent_side_commands_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestIsSideCommand pins the mid-run allowlist: observation commands match
@@ -119,5 +120,46 @@ func TestSideCommandRootsRouteSafely(t *testing.T) {
 		case "/agent", "/coder", "/run", "/plan", "/exit":
 			t.Errorf("mode-switch command %q must never be side-runnable", root)
 		}
+	}
+}
+
+// TestOnSideCommandExecutesImmediatelyUnderFreeGate pins the streaming-run
+// responsiveness fix: with no live display but a free prompt gate, the
+// command runs NOW (serialized with stream output); with the gate held by a
+// security prompt, it queues — and never blocks the caller, because this
+// path runs on the stdin reader goroutine the prompt depends on.
+func TestOnSideCommandExecutesImmediatelyUnderFreeGate(t *testing.T) {
+	var executed []string
+	pa := &workerPolicyAdapter{}
+	a := &AgentMode{
+		policyAdapter: pa,
+		sideCmdExec:   func(line string) { executed = append(executed, line) },
+	}
+	ctx := context.Background()
+
+	a.onSideCommand(ctx, "/taskgraph status")
+	if len(executed) != 1 || executed[0] != "/taskgraph status" {
+		t.Fatalf("free gate must execute immediately, got %v", executed)
+	}
+
+	// Gate held (a prompt on screen): must queue without blocking.
+	pa.mu.Lock()
+	done := make(chan struct{})
+	go func() {
+		a.onSideCommand(ctx, "/agents")
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("onSideCommand must never block on a held prompt gate")
+	}
+	pa.mu.Unlock()
+	if len(executed) != 1 {
+		t.Fatalf("held gate must queue, not execute, got %v", executed)
+	}
+	a.applySideCommands(ctx)
+	if len(executed) != 2 || executed[1] != "/agents" {
+		t.Fatalf("queued command must run at the boundary, got %v", executed)
 	}
 }

--- a/cli/agent_typeahead.go
+++ b/cli/agent_typeahead.go
@@ -150,3 +150,7 @@ func (a *AgentMode) buildTurnSpinnerFrame(d time.Duration, modelName string, had
 	suffix, had := formatTypeaheadPreviewBelow(a.typeaheadPreviewSnapshot(), hadPreview)
 	return metrics.FormatTimerStatus(d, modelName, msg) + "\033[K" + suffix, had
 }
+
+// taskGraphSpinnerLabel names the live turn spinner while a @taskgraph run
+// holds the turn (rendered where the model name usually goes).
+const taskGraphSpinnerLabel = "@taskgraph"

--- a/cli/plugins/builtin_taskgraph.go
+++ b/cli/plugins/builtin_taskgraph.go
@@ -22,6 +22,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 )
@@ -93,7 +95,7 @@ func (*BuiltinTaskGraphPlugin) Usage() string {
 
 <tool_call name="@taskgraph" args='{"cmd":"run","args":{"graph":{"name":"my-feature","tasks":[{"id":"T1","title":"...","prompt":"...","validation":[{"run":"go test ./...","expect":"all green"}]},{"id":"T2","prompt":"...","deps":["T1"]}]}}}' />
 
-run executes the WHOLE graph (streamed); status/show/list inspect; retry re-opens a failed task; cancel stops the active run; dash serves the live browser dashboard.`
+For real graphs write the plan JSON to a file first and pass {"cmd":"run","args":{"file":"/tmp/plan.json"}} — long inline args get truncated. run executes the WHOLE graph (streamed); status/show/list inspect; retry re-opens a failed task; cancel stops the active run; dash serves the live browser dashboard.`
 }
 
 // Version returns the plugin contract version.
@@ -115,18 +117,20 @@ func (*BuiltinTaskGraphPlugin) Schema() string {
 				"name":        "plan",
 				"description": "Validate and persist a graph plan without executing (returns the run id).",
 				"flags": []map[string]interface{}{
-					{"name": "graph", "type": "object", "required": true, "description": graphDesc},
+					{"name": "graph", "type": "object", "required": false, "description": graphDesc},
+					{"name": "file", "type": "string", "required": false, "description": "path to a JSON file holding the plan — REQUIRED in practice for real graphs (long inline args get truncated); write the plan with @coder write first"},
 				},
-				"examples": []string{`{"cmd":"plan","args":{"graph":{"name":"feature-x","tasks":[{"id":"T1","prompt":"..."}]}}}`},
+				"examples": []string{`{"cmd":"plan","args":{"file":"/tmp/plan.json"}}`, `{"cmd":"plan","args":{"graph":{"name":"feature-x","tasks":[{"id":"T1","prompt":"..."}]}}}`},
 			},
 			{
 				"name":        "run",
 				"description": "Execute a graph to completion (streams progress; the call returns the final report). Give a graph to plan+run in one call, or an id to run/resume a persisted plan (latest when omitted).",
 				"flags": []map[string]interface{}{
-					{"name": "graph", "type": "object", "required": false, "description": graphDesc},
+					{"name": "file", "type": "string", "required": false, "description": "path to a JSON file holding the plan — the RELIABLE form for real graphs: write it with @coder write, then run with file (long inline args get truncated into 'unexpected end of JSON input')"},
+					{"name": "graph", "type": "object", "required": false, "description": graphDesc + " (inline form — only for small graphs)"},
 					{"name": "id", "type": "string", "required": false, "description": "run id from plan/list (default: latest)"},
 				},
-				"examples": []string{`{"cmd":"run","args":{"graph":{"name":"feature-x","tasks":[...]}}}`, `{"cmd":"run","args":{"id":"tg-20260829-153000"}}`},
+				"examples": []string{`{"cmd":"run","args":{"file":"/tmp/plan.json"}}`, `{"cmd":"run","args":{"id":"tg-20260829-153000"}}`},
 			},
 			{
 				"name":        "status",
@@ -195,6 +199,14 @@ func (p *BuiltinTaskGraphPlugin) ExecuteWithStream(ctx context.Context, args []s
 	}
 	get := func(keys ...string) string { return strings.TrimSpace(jsonString(payload, keys...)) }
 	graphJSON := taskGraphPlanJSON(payload)
+	switch sub {
+	case "plan", "create", "validate", "run", "start", "resume", "exec":
+		if graphJSON == "" {
+			if graphJSON, err = taskGraphPlanFromFile(get("file", "path", "graph_file", "graphFile", "plan_file")); err != nil {
+				return "", err
+			}
+		}
+	}
 
 	switch sub {
 	case "plan", "create", "validate":
@@ -231,6 +243,54 @@ func (p *BuiltinTaskGraphPlugin) ExecuteWithStream(ctx context.Context, args []s
 	default:
 		return "", fmt.Errorf("@taskgraph: unknown subcommand %q (expected plan|run|status|show|retry|cancel|list|dash)", sub)
 	}
+}
+
+// taskGraphMaxPlanFileBytes bounds a plan file read.
+const taskGraphMaxPlanFileBytes = 1 << 20
+
+// taskGraphPlanFromFile loads a graph plan from a JSON file — the reliable
+// path for real graphs: long inline args get truncated by output-token
+// limits ("unexpected end of JSON input"), a file never does. The file may
+// contain the bare graph, {"graph":{...}}, or a full {cmd,args} envelope.
+func taskGraphPlanFromFile(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	if strings.HasPrefix(path, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			path = filepath.Join(home, path[2:])
+		}
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("@taskgraph: plan file %q: %w", path, err)
+	}
+	if info.Size() > taskGraphMaxPlanFileBytes {
+		return "", fmt.Errorf("@taskgraph: plan file %q too large (%d bytes, max %d)", path, info.Size(), taskGraphMaxPlanFileBytes)
+	}
+	data, err := os.ReadFile(path) // #nosec G304 -- explicit plan-file path requested by the tool call; size-capped above
+	if err != nil {
+		return "", fmt.Errorf("@taskgraph: read plan file %q: %w", path, err)
+	}
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(data, &top); err != nil {
+		return "", fmt.Errorf("@taskgraph: plan file %q is not valid JSON: %w", path, err)
+	}
+	// Unwrap {cmd,args:{graph}} and {graph:{...}} shapes down to the plan.
+	for range [2]struct{}{} {
+		if inner, ok := top["args"]; ok {
+			var next map[string]json.RawMessage
+			if json.Unmarshal(inner, &next) == nil {
+				top = next
+				continue
+			}
+		}
+		break
+	}
+	if g := taskGraphPlanJSON(top); g != "" {
+		return g, nil
+	}
+	return "", fmt.Errorf("@taskgraph: plan file %q has no graph (expected a plan object with \"tasks\")", path)
 }
 
 // taskGraphPlanJSON extracts the graph plan object (aliases tolerated) as a

--- a/cli/plugins/builtin_taskgraph.go
+++ b/cli/plugins/builtin_taskgraph.go
@@ -56,6 +56,13 @@ type TaskGraphDashboarder interface {
 	Dash(runID string) (string, error)
 }
 
+// TaskGraphPruner is the OPTIONAL retention capability: remove persisted
+// runs older than a retention ("30d", "72h", "all"); the active run is
+// never removed.
+type TaskGraphPruner interface {
+	Prune(olderThan string) (string, error)
+}
+
 type taskGraphAdapterHolder struct{ a TaskGraphAdapter }
 
 var taskGraphAdapterAtom atomic.Value // taskGraphAdapterHolder
@@ -91,7 +98,7 @@ func (*BuiltinTaskGraphPlugin) Description() string {
 
 // Usage explains the canonical invocation forms.
 func (*BuiltinTaskGraphPlugin) Usage() string {
-	return `@taskgraph plan|run|status|show|retry|cancel|list|dash
+	return `@taskgraph plan|run|status|show|retry|cancel|list|dash|prune
 
 <tool_call name="@taskgraph" args='{"cmd":"run","args":{"graph":{"name":"my-feature","tasks":[{"id":"T1","title":"...","prompt":"...","validation":[{"run":"go test ./...","expect":"all green"}]},{"id":"T2","prompt":"...","deps":["T1"]}]}}}' />
 
@@ -169,6 +176,14 @@ func (*BuiltinTaskGraphPlugin) Schema() string {
 				"examples":    []string{`{"cmd":"list"}`},
 			},
 			{
+				"name":        "prune",
+				"description": "Remove persisted runs older than a retention (default 30d; the active run is never removed). Runs also auto-prune at 30d.",
+				"flags": []map[string]interface{}{
+					{"name": "older_than", "type": "string", "required": false, "description": "retention: Go duration, Nd days, or all (default 30d)"},
+				},
+				"examples": []string{`{"cmd":"prune"}`, `{"cmd":"prune","args":{"older_than":"7d"}}`, `{"cmd":"prune","args":{"older_than":"all"}}`},
+			},
+			{
 				"name":        "dash",
 				"description": "Serve the live browser dashboard (animated DAG, swimlanes, per-task evidence and cost) and return its local URL.",
 				"flags": []map[string]interface{}{
@@ -234,6 +249,12 @@ func (p *BuiltinTaskGraphPlugin) ExecuteWithStream(ctx context.Context, args []s
 		return adapter.Cancel()
 	case "list", "ls", "runs":
 		return adapter.List()
+	case "prune", "gc", "clean":
+		pr, ok := adapter.(TaskGraphPruner)
+		if !ok {
+			return "", errors.New("@taskgraph prune: retention not available in this session")
+		}
+		return pr.Prune(get("older_than", "olderThan", "age", "retention"))
 	case "dash", "dashboard", "ui":
 		d, ok := adapter.(TaskGraphDashboarder)
 		if !ok {
@@ -241,7 +262,7 @@ func (p *BuiltinTaskGraphPlugin) ExecuteWithStream(ctx context.Context, args []s
 		}
 		return d.Dash(get("id", "run_id", "runId", "run"))
 	default:
-		return "", fmt.Errorf("@taskgraph: unknown subcommand %q (expected plan|run|status|show|retry|cancel|list|dash)", sub)
+		return "", fmt.Errorf("@taskgraph: unknown subcommand %q (expected plan|run|status|show|retry|cancel|list|dash|prune)", sub)
 	}
 }
 
@@ -378,6 +399,8 @@ func parseTaskGraphInvocation(args []string) (string, map[string]json.RawMessage
 	switch sub {
 	case "show", "task", "inspect", "get", "retry", "reopen":
 		setIfMissing("task", positional)
+	case "prune", "gc", "clean":
+		setIfMissing("older_than", positional)
 	default:
 		setIfMissing("id", positional)
 	}

--- a/cli/plugins/builtin_taskgraph_caps.go
+++ b/cli/plugins/builtin_taskgraph_caps.go
@@ -52,6 +52,8 @@ func (p *BuiltinTaskGraphPlugin) DescribeCall(args []string) string {
 		return i18n.T("plugins.taskgraph.describe_retry", describeTrim(jsonString(payload, "task", "task_id", "taskId")))
 	case "cancel", "stop", "abort":
 		return i18n.T("plugins.taskgraph.describe_cancel")
+	case "prune", "gc", "clean":
+		return i18n.T("plugins.taskgraph.describe_prune")
 	case "dash", "dashboard", "ui":
 		return i18n.T("plugins.taskgraph.describe_dash")
 	default:

--- a/cli/plugins/builtin_taskgraph_test.go
+++ b/cli/plugins/builtin_taskgraph_test.go
@@ -304,3 +304,34 @@ func TestTaskGraphRunFromFileRouting(t *testing.T) {
 		t.Fatalf("status must ignore file param: %v", err)
 	}
 }
+
+// pruneRecordingAdapter layers the optional retention capability.
+type pruneRecordingAdapter struct {
+	recordingTaskGraphAdapter
+	pruneArg string
+}
+
+func (p *pruneRecordingAdapter) Prune(olderThan string) (string, error) {
+	p.pruneArg, p.method = olderThan, "prune"
+	return "pruned", nil
+}
+
+func TestTaskGraphPruneCapability(t *testing.T) {
+	SetTaskGraphAdapter(&recordingTaskGraphAdapter{})
+	t.Cleanup(func() { SetTaskGraphAdapter(nil) })
+	p := NewBuiltinTaskGraphPlugin()
+	if _, err := p.Execute(context.Background(), []string{`{"cmd":"prune"}`}); err == nil {
+		t.Fatal("prune without the capability must error")
+	}
+	rec := &pruneRecordingAdapter{}
+	SetTaskGraphAdapter(rec)
+	if _, err := p.Execute(context.Background(), []string{"prune", "7d"}); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if rec.method != "prune" || rec.pruneArg != "7d" {
+		t.Fatalf("prune routing: %q %q", rec.method, rec.pruneArg)
+	}
+	if p.IsReadOnly([]string{`{"cmd":"prune"}`}) {
+		t.Fatal("prune deletes runs — never read-only")
+	}
+}

--- a/cli/plugins/builtin_taskgraph_test.go
+++ b/cli/plugins/builtin_taskgraph_test.go
@@ -8,6 +8,8 @@ package plugins
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -245,5 +247,60 @@ func TestTaskGraphDashCapability(t *testing.T) {
 	}
 	if p.IsReadOnly([]string{`{"cmd":"dash"}`}) {
 		t.Fatal("dash starts a server and opens a browser — never read-only")
+	}
+}
+
+func TestTaskGraphPlanFromFile(t *testing.T) {
+	dir := t.TempDir()
+	plan := `{"name":"x","tasks":[{"id":"T1","prompt":"p"}]}`
+	shapes := map[string]string{
+		"bare.json":     plan,
+		"graph.json":    `{"graph":` + plan + `}`,
+		"envelope.json": `{"cmd":"run","args":{"graph":` + plan + `}}`,
+	}
+	for name, content := range shapes {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		got, err := taskGraphPlanFromFile(path)
+		if err != nil {
+			t.Fatalf("plan from %s: %v", name, err)
+		}
+		if !strings.Contains(got, `"tasks"`) {
+			t.Fatalf("plan from %s: %q", name, got)
+		}
+	}
+	if _, err := taskGraphPlanFromFile(filepath.Join(dir, "missing.json")); err == nil {
+		t.Fatal("missing file must error")
+	}
+	noGraph := filepath.Join(dir, "nograph.json")
+	_ = os.WriteFile(noGraph, []byte(`{"cmd":"status"}`), 0o600)
+	if _, err := taskGraphPlanFromFile(noGraph); err == nil {
+		t.Fatal("file without a plan must error")
+	}
+	if got, err := taskGraphPlanFromFile(""); err != nil || got != "" {
+		t.Fatalf("empty path must be a no-op: %q %v", got, err)
+	}
+}
+
+func TestTaskGraphRunFromFileRouting(t *testing.T) {
+	rec := &recordingTaskGraphAdapter{}
+	SetTaskGraphAdapter(rec)
+	t.Cleanup(func() { SetTaskGraphAdapter(nil) })
+	path := filepath.Join(t.TempDir(), "plan.json")
+	if err := os.WriteFile(path, []byte(`{"name":"x","tasks":[{"id":"T1","prompt":"p"}]}`), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	p := NewBuiltinTaskGraphPlugin()
+	if _, err := p.Execute(context.Background(), []string{`{"cmd":"run","args":{"file":"` + path + `"}}`}); err != nil {
+		t.Fatalf("run from file: %v", err)
+	}
+	if rec.method != "run" || !strings.Contains(rec.graphJSON, `"tasks"`) {
+		t.Fatalf("file plan not threaded to Run: %q %q", rec.method, rec.graphJSON)
+	}
+	// A status call carrying a stray file param must not attempt a read.
+	if _, err := p.Execute(context.Background(), []string{`{"cmd":"status","args":{"file":"/nope.json"}}`}); err != nil {
+		t.Fatalf("status must ignore file param: %v", err)
 	}
 }

--- a/cli/policy_adapter.go
+++ b/cli/policy_adapter.go
@@ -107,6 +107,20 @@ func (a *workerPolicyAdapter) withPromptGate(fn func()) {
 	fn()
 }
 
+// tryPromptGate is the non-blocking variant for callers that MUST NOT wait
+// on the gate — the stdin reader goroutine above all: a security prompt
+// holds the mutex while waiting for a line that only that goroutine can
+// deliver, so blocking there would deadlock the prompt forever. Returns
+// false (fn not run) when the gate is contended.
+func (a *workerPolicyAdapter) tryPromptGate(fn func()) bool {
+	if !a.mu.TryLock() {
+		return false
+	}
+	defer a.mu.Unlock()
+	fn()
+	return true
+}
+
 // buildSecurityContext extracts agent metadata from the context to provide
 // rich information in security prompts.
 func buildSecurityContext(ctx context.Context) *coder.SecurityContext {

--- a/cli/policy_adapter.go
+++ b/cli/policy_adapter.go
@@ -96,6 +96,17 @@ func (a *workerPolicyAdapter) resumeSpinner() {
 	}
 }
 
+// withPromptGate runs fn serialized on the same mutex the interactive
+// security prompts hold for their whole render-and-read lifetime. Live
+// stream output printed through it can never interleave with a prompt box
+// or pollute the line the user is typing the answer on; while a prompt is
+// on screen the printing goroutine simply waits.
+func (a *workerPolicyAdapter) withPromptGate(fn func()) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	fn()
+}
+
 // buildSecurityContext extracts agent metadata from the context to provide
 // rich information in security prompts.
 func buildSecurityContext(ctx context.Context) *coder.SecurityContext {

--- a/cli/taskgraph/engine.go
+++ b/cli/taskgraph/engine.go
@@ -37,6 +37,10 @@ type Event struct {
 
 // Event types emitted by the engine.
 const (
+	// EventProgress is a TRANSIENT heartbeat (streamed, never persisted):
+	// which workers are alive, their turn and current action — so a long
+	// executor loop never reads as a frozen terminal.
+	EventProgress      = "progress"
 	EventRunStarted    = "run_started"
 	EventTaskStarted   = "task_started"
 	EventGateResult    = "gate_result"
@@ -206,6 +210,9 @@ func (e *Engine) Run(ctx context.Context) (string, error) {
 	e.mu.Unlock()
 	e.emit(Event{Type: EventRunStarted, Detail: e.graph.Name})
 
+	stopHeartbeat := e.startHeartbeat(regCtx, liveRun.ID())
+	defer stopHeartbeat()
+
 	type doneMsg struct{ id string }
 	doneCh := make(chan doneMsg)
 	inFlight := 0
@@ -255,6 +262,46 @@ func (e *Engine) Run(ctx context.Context) (string, error) {
 		return report, fmt.Errorf("task graph run canceled: %w", err)
 	}
 	return report, nil
+}
+
+// heartbeatInterval paces the transient worker-progress stream (var: test seam).
+var heartbeatInterval = 5 * time.Second
+
+// startHeartbeat polls the run registry for this run's live children and
+// streams a transient progress line while any are active. Polling (instead
+// of Registry.OnEvent) is deliberate: the registry has a single observer
+// slot and the hub bridge owns it.
+func (e *Engine) startHeartbeat(ctx context.Context, parentRunID string) func() {
+	if e.cfg.OnEvent == nil || parentRunID == "" {
+		return func() {}
+	}
+	hbCtx, cancel := context.WithCancel(ctx)
+	go func() {
+		ticker := time.NewTicker(heartbeatInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-hbCtx.Done():
+				return
+			case <-ticker.C:
+				var parts []string
+				for _, child := range runs.Default().Children(parentRunID) {
+					line := fmt.Sprintf("[%s]", child.Agent)
+					if child.Turn > 0 {
+						line += fmt.Sprintf(" turn %d/%d", child.Turn, child.MaxTurns)
+					}
+					if child.Action != "" {
+						line += " · " + child.Action
+					}
+					parts = append(parts, line)
+				}
+				if len(parts) > 0 {
+					e.cfg.OnEvent(Event{TS: time.Now(), Type: EventProgress, Detail: strings.Join(parts, "  ")})
+				}
+			}
+		}
+	}()
+	return cancel
 }
 
 // readyTasks returns pending tasks whose deps are all done.

--- a/cli/taskgraph/engine.go
+++ b/cli/taskgraph/engine.go
@@ -279,6 +279,8 @@ func (e *Engine) startHeartbeat(ctx context.Context, parentRunID string) func() 
 	go func() {
 		ticker := time.NewTicker(heartbeatInterval)
 		defer ticker.Stop()
+		lastDetail := ""
+		lastPrint := time.Now()
 		for {
 			select {
 			case <-hbCtx.Done():
@@ -286,7 +288,7 @@ func (e *Engine) startHeartbeat(ctx context.Context, parentRunID string) func() 
 			case <-ticker.C:
 				var parts []string
 				for _, child := range runs.Default().Children(parentRunID) {
-					line := fmt.Sprintf("[%s]", child.Agent)
+					line := "[" + heartbeatLabel(child.CallID, child.Agent) + "]"
 					if child.Turn > 0 {
 						line += fmt.Sprintf(" turn %d/%d", child.Turn, child.MaxTurns)
 					}
@@ -295,13 +297,40 @@ func (e *Engine) startHeartbeat(ctx context.Context, parentRunID string) func() 
 					}
 					parts = append(parts, line)
 				}
-				if len(parts) > 0 {
-					e.cfg.OnEvent(Event{TS: time.Now(), Type: EventProgress, Detail: strings.Join(parts, "  ")})
+				if len(parts) == 0 {
+					continue
 				}
+				detail := strings.Join(parts, "  ")
+				// Only print on change (or as a rare keepalive): an unchanged
+				// line every tick is noise, not signal.
+				if detail == lastDetail && time.Since(lastPrint) < heartbeatKeepalive {
+					continue
+				}
+				lastDetail = detail
+				lastPrint = time.Now()
+				e.cfg.OnEvent(Event{TS: time.Now(), Type: EventProgress, Detail: detail})
 			}
 		}
 	}()
 	return cancel
+}
+
+// heartbeatKeepalive bounds the silence between identical heartbeats.
+const heartbeatKeepalive = 30 * time.Second
+
+// heartbeatLabel names a worker in the heartbeat line: the task id from the
+// engine's call-ID scheme (tg:<task>:e<n>/r<n>) plus the agent type, so two
+// parallel coders are distinguishable.
+func heartbeatLabel(callID, agent string) string {
+	parts := strings.Split(callID, ":")
+	if len(parts) == 3 && parts[0] == "tg" {
+		role := "exec"
+		if strings.HasPrefix(parts[2], "r") {
+			role = "review"
+		}
+		return parts[1] + " " + role + "·" + agent
+	}
+	return agent
 }
 
 // readyTasks returns pending tasks whose deps are all done.

--- a/cli/taskgraph/engine_test.go
+++ b/cli/taskgraph/engine_test.go
@@ -11,7 +11,9 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/diillson/chatcli/cli/agent/runs"
 	"github.com/diillson/chatcli/cli/agent/workers"
 	"github.com/diillson/chatcli/models"
 )
@@ -364,5 +366,48 @@ func TestEngineCancelMidRun(t *testing.T) {
 	}
 	if g.Status != StatusFailed {
 		t.Fatalf("graph after cancel: %s", g.Status)
+	}
+}
+
+func TestEngineHeartbeatStreamsChildProgress(t *testing.T) {
+	old := heartbeatInterval
+	heartbeatInterval = 20 * time.Millisecond
+	defer func() { heartbeatInterval = old }()
+
+	g, store := testGraph(t, `{"name":"x","tasks":[{"id":"T1","prompt":"work"}]}`)
+	var mu sync.Mutex
+	var progress []string
+	e, err := NewEngine(g, store, Config{
+		Dispatcher: newFakeDispatcher(),
+		OnEvent: func(ev Event) {
+			if ev.Type == EventProgress {
+				mu.Lock()
+				progress = append(progress, ev.Detail)
+				mu.Unlock()
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	parentCtx, parent := runs.Default().Begin(context.Background(), runs.Info{Kind: runs.KindTaskGraph, Agent: "taskgraph", Task: "hb"})
+	_, child := runs.Default().Begin(parentCtx, runs.Info{Kind: runs.KindWorker, Agent: "coder", Task: "t"})
+	child.SetTurn(3, 30)
+	child.SetAction("patch main.go")
+
+	stop := e.startHeartbeat(parentCtx, parent.ID())
+	time.Sleep(120 * time.Millisecond)
+	stop()
+	child.End(nil)
+	parent.End(nil)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(progress) == 0 {
+		t.Fatal("heartbeat must stream progress while a child is live")
+	}
+	if !strings.Contains(progress[0], "[coder]") || !strings.Contains(progress[0], "turn 3/30") || !strings.Contains(progress[0], "patch main.go") {
+		t.Fatalf("heartbeat detail: %q", progress[0])
 	}
 }

--- a/cli/taskgraph/engine_test.go
+++ b/cli/taskgraph/engine_test.go
@@ -411,3 +411,17 @@ func TestEngineHeartbeatStreamsChildProgress(t *testing.T) {
 		t.Fatalf("heartbeat detail: %q", progress[0])
 	}
 }
+
+func TestHeartbeatLabel(t *testing.T) {
+	cases := []struct{ callID, agent, want string }{
+		{"tg:T3:e2", "coder", "T3 exec·coder"},
+		{"tg:T3:r1", "reviewer", "T3 review·reviewer"},
+		{"call-7", "coder", "coder"},
+		{"", "tester", "tester"},
+	}
+	for _, c := range cases {
+		if got := heartbeatLabel(c.callID, c.agent); got != c.want {
+			t.Fatalf("heartbeatLabel(%q,%q) = %q, want %q", c.callID, c.agent, got, c.want)
+		}
+	}
+}

--- a/cli/taskgraph/store.go
+++ b/cli/taskgraph/store.go
@@ -191,6 +191,42 @@ func ListRuns(baseDir string) ([]RunSummary, error) {
 	return out, nil
 }
 
+// DefaultRetention is how long runs are kept before the automatic prune
+// removes them (age = last state write). Matches the house pattern of
+// bounded on-disk stores (cost snapshots, hub purge).
+const DefaultRetention = 30 * 24 * time.Hour
+
+// PruneRuns removes run directories whose state was last written before
+// olderThan ago. skipRunID (the session's active run) is never removed.
+// olderThan <= 0 means "prune every run except skipRunID". Returns how many
+// runs were removed; unreadable entries are skipped, not fatal.
+func PruneRuns(baseDir string, olderThan time.Duration, skipRunID string) (int, error) {
+	entries, err := os.ReadDir(baseDir)
+	if os.IsNotExist(err) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	cutoff := time.Now().Add(-olderThan)
+	removed := 0
+	for _, e := range entries {
+		if !e.IsDir() || !strings.HasPrefix(e.Name(), "tg-") || e.Name() == skipRunID {
+			continue
+		}
+		if olderThan > 0 {
+			info, statErr := os.Stat(filepath.Join(baseDir, e.Name(), stateFileName))
+			if statErr != nil || info.ModTime().After(cutoff) {
+				continue
+			}
+		}
+		if err := os.RemoveAll(filepath.Join(baseDir, e.Name())); err == nil {
+			removed++
+		}
+	}
+	return removed, nil
+}
+
 // atomicWriteFile writes via a same-directory temp file and rename, so a
 // crash mid-write can never leave a torn state.json under the real name.
 func atomicWriteFile(path string, data []byte, perm os.FileMode) error {

--- a/cli/taskgraph/store_test.go
+++ b/cli/taskgraph/store_test.go
@@ -103,3 +103,51 @@ func TestAppendEventAndOpenRunValidation(t *testing.T) {
 		t.Fatal("missing run must error")
 	}
 }
+
+func TestPruneRuns(t *testing.T) {
+	base := t.TempDir()
+	mk := func(name string) *RunStore {
+		g := &Graph{Name: name, Tasks: []*Task{{ID: "T1", Prompt: "p", Status: StatusDone}}}
+		s, err := CreateRun(base, g)
+		if err != nil {
+			t.Fatalf("CreateRun: %v", err)
+		}
+		return s
+	}
+	old1, old2, fresh, active := mk("old1"), mk("old2"), mk("fresh"), mk("active")
+	past := time.Now().Add(-48 * time.Hour)
+	for _, s := range []*RunStore{old1, old2, active} {
+		if err := os.Chtimes(filepath.Join(s.Dir(), stateFileName), past, past); err != nil {
+			t.Fatalf("chtimes: %v", err)
+		}
+	}
+
+	removed, err := PruneRuns(base, 24*time.Hour, active.RunID())
+	if err != nil {
+		t.Fatalf("PruneRuns: %v", err)
+	}
+	if removed != 2 {
+		t.Fatalf("want 2 removed, got %d", removed)
+	}
+	rows, _ := ListRuns(base)
+	left := map[string]bool{}
+	for _, r := range rows {
+		left[r.RunID] = true
+	}
+	if !left[fresh.RunID()] || !left[active.RunID()] || len(rows) != 2 {
+		t.Fatalf("survivors wrong: %+v", rows)
+	}
+
+	// olderThan<=0 removes everything except the skip id.
+	removed, err = PruneRuns(base, 0, active.RunID())
+	if err != nil || removed != 1 {
+		t.Fatalf("prune all: %d %v", removed, err)
+	}
+	if rows, _ := ListRuns(base); len(rows) != 1 || rows[0].RunID != active.RunID() {
+		t.Fatalf("active run must survive prune all: %+v", rows)
+	}
+
+	if n, err := PruneRuns(filepath.Join(base, "missing"), time.Hour, ""); err != nil || n != 0 {
+		t.Fatalf("missing dir must be a no-op: %d %v", n, err)
+	}
+}

--- a/cli/taskgraph_adapter.go
+++ b/cli/taskgraph_adapter.go
@@ -307,7 +307,9 @@ func (a *taskGraphAdapter) execute(ctx context.Context, g *taskgraph.Graph, stor
 		Logger: a.logger,
 	}
 	if onOutput != nil {
-		cfg.OnEvent = func(ev taskgraph.Event) { onOutput(taskgraph.FormatEvent(ev) + "\n") }
+		// No trailing newline: the stream renderer prints one line per
+		// callback and an extra \n renders as a blank spacer line.
+		cfg.OnEvent = func(ev taskgraph.Event) { onOutput(taskgraph.FormatEvent(ev)) }
 	}
 
 	engine, err := taskgraph.NewEngine(g, store, cfg)

--- a/cli/taskgraph_adapter.go
+++ b/cli/taskgraph_adapter.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/diillson/chatcli/cli/agent/workers"
 	"github.com/diillson/chatcli/cli/taskgraph"
@@ -56,9 +57,13 @@ type taskGraphAdapter struct {
 	baseDirFn    func() (string, error)
 	dispatcherFn func() (taskGraphDispatcher, error)
 
-	mu      sync.Mutex
-	active  *taskgraph.Engine
-	dashSrv *dash.Server
+	mu       sync.Mutex
+	active   *taskgraph.Engine
+	activeID string
+	dashSrv  *dash.Server
+
+	// pruneOnce runs the automatic retention sweep on first store access.
+	pruneOnce sync.Once
 }
 
 // newTaskGraphAdapter builds the adapter.
@@ -80,10 +85,82 @@ func (a *taskGraphAdapter) dispatcher() (taskGraphDispatcher, error) {
 }
 
 func (a *taskGraphAdapter) baseDir() (string, error) {
+	base, err := a.resolveBaseDir()
+	if err != nil {
+		return "", err
+	}
+	// Bounded store: runs are working state, not an archive. One sweep per
+	// session removes anything older than the default retention.
+	a.pruneOnce.Do(func() {
+		if n, pruneErr := taskgraph.PruneRuns(base, taskgraph.DefaultRetention, a.activeRunID()); pruneErr != nil {
+			a.logger.Warn("taskgraph auto-prune failed", zap.Error(pruneErr))
+		} else if n > 0 {
+			a.logger.Info("taskgraph auto-prune", zap.Int("removed", n))
+		}
+	})
+	return base, nil
+}
+
+func (a *taskGraphAdapter) resolveBaseDir() (string, error) {
 	if a.baseDirFn != nil {
 		return a.baseDirFn()
 	}
 	return taskgraph.DefaultBaseDir()
+}
+
+// activeRunID names the in-flight run (never pruned), or "".
+func (a *taskGraphAdapter) activeRunID() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.active == nil {
+		return ""
+	}
+	return a.activeID
+}
+
+// Prune implements plugins.TaskGraphPruner: removes persisted runs older
+// than the given retention ("30d", "72h", "all" = every run). The active
+// run is never removed. Empty input uses the default retention.
+func (a *taskGraphAdapter) Prune(olderThan string) (string, error) {
+	base, err := a.baseDir()
+	if err != nil {
+		return "", err
+	}
+	retention, err := parseRetention(olderThan)
+	if err != nil {
+		return "", err
+	}
+	n, err := taskgraph.PruneRuns(base, retention, a.activeRunID())
+	if err != nil {
+		return "", fmt.Errorf("@taskgraph prune: %w", err)
+	}
+	scope := "older than " + retention.String()
+	if retention <= 0 {
+		scope = "all (active run kept)"
+	}
+	return fmt.Sprintf("pruned %d run(s), scope: %s", n, scope), nil
+}
+
+// parseRetention accepts "", "all", Go durations ("72h") and day suffixes
+// ("30d") — lenient like every tool-arg parser in the house.
+func parseRetention(s string) (time.Duration, error) {
+	s = strings.ToLower(strings.TrimSpace(s))
+	switch s {
+	case "":
+		return taskgraph.DefaultRetention, nil
+	case "all", "everything", "0":
+		return 0, nil
+	}
+	if strings.HasSuffix(s, "d") {
+		if days, err := strconv.Atoi(strings.TrimSuffix(s, "d")); err == nil && days > 0 {
+			return time.Duration(days) * 24 * time.Hour, nil
+		}
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil || d < 0 {
+		return 0, fmt.Errorf("@taskgraph prune: invalid retention %q (use \"30d\", \"72h\" or \"all\")", s)
+	}
+	return d, nil
 }
 
 // Plan implements plugins.TaskGraphAdapter.
@@ -323,12 +400,14 @@ func (a *taskGraphAdapter) execute(ctx context.Context, g *taskgraph.Graph, stor
 		return "", errors.New("@taskgraph: a run is already active in this session (cancel it or wait)")
 	}
 	a.active = engine
+	a.activeID = store.RunID()
 	a.mu.Unlock()
 	disp.SetCallUsageRecorder(engine.RecordCallUsage)
 	defer func() {
 		disp.SetCallUsageRecorder(nil)
 		a.mu.Lock()
 		a.active = nil
+		a.activeID = ""
 		a.mu.Unlock()
 	}()
 

--- a/cli/taskgraph_adapter_test.go
+++ b/cli/taskgraph_adapter_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/diillson/chatcli/cli/agent/workers"
 	"github.com/diillson/chatcli/cli/taskgraph"
@@ -235,4 +236,41 @@ func TestTaskGraphAdapterDashServesAndReuses(t *testing.T) {
 	}
 	a.shutdownDash(context.Background())
 	a.shutdownDash(context.Background()) // idempotent
+}
+
+func TestParseRetention(t *testing.T) {
+	cases := []struct {
+		in   string
+		want time.Duration
+	}{
+		{"", taskgraph.DefaultRetention},
+		{"all", 0},
+		{"7d", 7 * 24 * time.Hour},
+		{"72h", 72 * time.Hour},
+	}
+	for _, c := range cases {
+		got, err := parseRetention(c.in)
+		if err != nil || got != c.want {
+			t.Fatalf("parseRetention(%q) = %v, %v", c.in, got, err)
+		}
+	}
+	for _, bad := range []string{"bogus", "-2h", "0d"} {
+		if _, err := parseRetention(bad); err == nil {
+			t.Fatalf("parseRetention(%q) must error", bad)
+		}
+	}
+}
+
+func TestTaskGraphAdapterPrune(t *testing.T) {
+	a := newTestTaskGraphAdapter(t)
+	if _, err := a.Plan(testPlanJSON); err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	out, err := a.Prune("all")
+	if err != nil || !strings.Contains(out, "pruned 1 run(s)") {
+		t.Fatalf("Prune: %q %v", out, err)
+	}
+	if _, err := a.Prune("bogus"); err == nil {
+		t.Fatal("invalid retention must error")
+	}
 }

--- a/cli/taskgraph_command.go
+++ b/cli/taskgraph_command.go
@@ -63,6 +63,8 @@ func (cli *ChatCLI) handleTaskGraphCommand(userInput string) {
 		out, err = adapter.List()
 	case "dash", "dashboard", "ui":
 		out, err = adapter.Dash(arg)
+	case "prune", "gc":
+		out, err = adapter.Prune(arg)
 	case "cancel", "stop":
 		out, err = adapter.Cancel()
 	case "help":

--- a/cli/taskgraph_completer.go
+++ b/cli/taskgraph_completer.go
@@ -21,6 +21,7 @@ func taskGraphSubcommandSuggestions() []prompt.Suggest {
 		{Text: "show", Description: i18n.T("complete.taskgraph.show")},
 		{Text: "list", Description: i18n.T("complete.taskgraph.list")},
 		{Text: "dash", Description: i18n.T("complete.taskgraph.dash")},
+		{Text: "prune", Description: i18n.T("complete.taskgraph.prune")},
 		{Text: "cancel", Description: i18n.T("complete.taskgraph.cancel")},
 		{Text: "help", Description: i18n.T("complete.taskgraph.help")},
 	}

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -3606,7 +3606,7 @@
   "plugins.taskgraph.describe_retry": "Retrying task graph task %s",
   "plugins.taskgraph.describe_cancel": "Canceling the active task graph run",
   "plugins.taskgraph.describe_status": "Inspecting task graph state",
-  "help.command.taskgraph": "Task graph runs: status [id], show <task> [id], list, dash, cancel",
+  "help.command.taskgraph": "Task graph runs: status [id], show <task> [id], list, dash, prune, cancel",
   "complete.taskgraph.status": "Current run state: per-task status, verdicts, cost",
   "complete.taskgraph.show": "One task in full: attempts, gate outputs, evidence",
   "complete.taskgraph.list": "List persisted runs, newest first",
@@ -3616,9 +3616,11 @@
   "taskgraph.task.missing": "Missing task ID (e.g. /taskgraph show T3)",
   "taskgraph.subcommand.unknown": "Unknown subcommand %s",
   "taskgraph.usage.title": "/taskgraph — observe task graph runs",
-  "taskgraph.usage.body": "status [id] · show <task> [id] · list · dash [id] · cancel — runs are created and executed by the model via @taskgraph; tasks only count as done after the engine's validation gate and an independent reviewer verdict.",
+  "taskgraph.usage.body": "status [id] · show <task> [id] · list · dash [id] · prune [30d|all] · cancel — runs are created and executed by the model via @taskgraph; tasks only count as done after the engine's validation gate and an independent reviewer verdict.",
   "cfg.section.taskgraph.title": "Task graph (@taskgraph)",
   "cfg.taskgraph.about": "Executes approved multi-task plans as a DAG: parallel squad workers, engine-run validation gates, independent reviewer verdicts. No dedicated envs — parallelism reuses CHATCLI_AGENT_MAX_WORKERS and review is set per plan (require_review, default true). Watch runs with /taskgraph or the live browser dashboard (/taskgraph dash).",
   "complete.taskgraph.dash": "Open the live browser dashboard (animated DAG, evidence, cost)",
-  "plugins.taskgraph.describe_dash": "Serving the task graph dashboard"
+  "plugins.taskgraph.describe_dash": "Serving the task graph dashboard",
+  "complete.taskgraph.prune": "Remove old runs (default 30d; \"all\" clears everything but the active run)",
+  "plugins.taskgraph.describe_prune": "Pruning old task graph runs"
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -3606,7 +3606,7 @@
   "plugins.taskgraph.describe_retry": "Retrying task graph task %s",
   "plugins.taskgraph.describe_cancel": "Canceling the active task graph run",
   "plugins.taskgraph.describe_status": "Inspecting task graph state",
-  "help.command.taskgraph": "Task graph runs: status [id], show <task> [id], list, dash, cancel",
+  "help.command.taskgraph": "Task graph runs: status [id], show <task> [id], list, dash, prune, cancel",
   "complete.taskgraph.status": "Current run state: per-task status, verdicts, cost",
   "complete.taskgraph.show": "One task in full: attempts, gate outputs, evidence",
   "complete.taskgraph.list": "List persisted runs, newest first",
@@ -3616,9 +3616,11 @@
   "taskgraph.task.missing": "Missing task ID (e.g. /taskgraph show T3)",
   "taskgraph.subcommand.unknown": "Unknown subcommand %s",
   "taskgraph.usage.title": "/taskgraph — observe task graph runs",
-  "taskgraph.usage.body": "status [id] · show <task> [id] · list · dash [id] · cancel — runs are created and executed by the model via @taskgraph; tasks only count as done after the engine's validation gate and an independent reviewer verdict.",
+  "taskgraph.usage.body": "status [id] · show <task> [id] · list · dash [id] · prune [30d|all] · cancel — runs are created and executed by the model via @taskgraph; tasks only count as done after the engine's validation gate and an independent reviewer verdict.",
   "cfg.section.taskgraph.title": "Task graph (@taskgraph)",
   "cfg.taskgraph.about": "Executes approved multi-task plans as a DAG: parallel squad workers, engine-run validation gates, independent reviewer verdicts. No dedicated envs — parallelism reuses CHATCLI_AGENT_MAX_WORKERS and review is set per plan (require_review, default true). Watch runs with /taskgraph or the live browser dashboard (/taskgraph dash).",
   "complete.taskgraph.dash": "Open the live browser dashboard (animated DAG, evidence, cost)",
-  "plugins.taskgraph.describe_dash": "Serving the task graph dashboard"
+  "plugins.taskgraph.describe_dash": "Serving the task graph dashboard",
+  "complete.taskgraph.prune": "Remove old runs (default 30d; \"all\" clears everything but the active run)",
+  "plugins.taskgraph.describe_prune": "Pruning old task graph runs"
 }

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -3606,7 +3606,7 @@
   "plugins.taskgraph.describe_retry": "Repetindo a task %s do task graph",
   "plugins.taskgraph.describe_cancel": "Cancelando a run ativa do task graph",
   "plugins.taskgraph.describe_status": "Inspecionando o estado do task graph",
-  "help.command.taskgraph": "Runs de task graph: status [id], show <task> [id], list, dash, cancel",
+  "help.command.taskgraph": "Runs de task graph: status [id], show <task> [id], list, dash, prune, cancel",
   "complete.taskgraph.status": "Estado atual da run: status por task, vereditos, custo",
   "complete.taskgraph.show": "Uma task completa: tentativas, saídas do gate, evidências",
   "complete.taskgraph.list": "Lista runs persistidas, mais recentes primeiro",
@@ -3616,9 +3616,11 @@
   "taskgraph.task.missing": "Faltou o ID da task (ex.: /taskgraph show T3)",
   "taskgraph.subcommand.unknown": "Subcomando desconhecido %s",
   "taskgraph.usage.title": "/taskgraph — observe runs de task graph",
-  "taskgraph.usage.body": "status [id] · show <task> [id] · list · dash [id] · cancel — as runs são criadas e executadas pelo modelo via @taskgraph; uma task só conta como done após o gate de validação do engine e o veredito de um reviewer independente.",
+  "taskgraph.usage.body": "status [id] · show <task> [id] · list · dash [id] · prune [30d|all] · cancel — as runs são criadas e executadas pelo modelo via @taskgraph; uma task só conta como done após o gate de validação do engine e o veredito de um reviewer independente.",
   "cfg.section.taskgraph.title": "Task graph (@taskgraph)",
   "cfg.taskgraph.about": "Executa planos multi-task aprovados como um DAG: squad workers paralelos, gates de validação executados pelo engine, vereditos de reviewer independente. Sem envs dedicadas — o paralelismo reusa CHATCLI_AGENT_MAX_WORKERS e o review é definido por plano (require_review, default true). Acompanhe runs com /taskgraph ou pela dashboard live no browser (/taskgraph dash).",
   "complete.taskgraph.dash": "Abre a dashboard live no browser (DAG animado, evidências, custo)",
-  "plugins.taskgraph.describe_dash": "Servindo a dashboard do task graph"
+  "plugins.taskgraph.describe_dash": "Servindo a dashboard do task graph",
+  "complete.taskgraph.prune": "Remove runs antigas (default 30d; \"all\" limpa tudo menos a run ativa)",
+  "plugins.taskgraph.describe_prune": "Removendo runs antigas do task graph"
 }

--- a/pkg/coder/engine/commands_exec.go
+++ b/pkg/coder/engine/commands_exec.go
@@ -65,10 +65,21 @@ func resolveShell() (shell, flag string) {
 	return `C:\Windows\System32\cmd.exe`, "/C"
 }
 
+// registerDirAliases makes the working-directory flag lenient: models keep
+// inventing --workingDir/--workdir/--cwd spellings, and a strict parser
+// turns each one into a failed call plus a retry loop. All aliases write
+// into the same destination; the last one parsed wins.
+func registerDirAliases(fs *flag.FlagSet, dir *string) {
+	fs.Func("workingDir", "", func(v string) error { *dir = v; return nil })
+	fs.Func("workdir", "", func(v string) error { *dir = v; return nil })
+	fs.Func("cwd", "", func(v string) error { *dir = v; return nil })
+}
+
 func (e *Engine) handleExec(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("exec", flag.ContinueOnError)
 	cmdStr := fs.String("cmd", "", "")
 	dir := fs.String("dir", "", "")
+	registerDirAliases(fs, dir)
 	timeout := fs.Int("timeout", 600, "")
 	allowUnsafe := fs.Bool("allow-unsafe", false, "")
 	allowSudo := fs.Bool("allow-sudo", false, "")
@@ -140,6 +151,7 @@ func (e *Engine) handleExec(ctx context.Context, args []string) error {
 func (e *Engine) handleTest(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	dir := fs.String("dir", ".", "")
+	registerDirAliases(fs, dir)
 	cmd := fs.String("cmd", "", "")
 	timeout := fs.Int("timeout", 1800, "")
 	if err := parseFlags(fs, args); err != nil {

--- a/pkg/coder/engine/commands_exec_alias_test.go
+++ b/pkg/coder/engine/commands_exec_alias_test.go
@@ -1,0 +1,30 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package engine
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestExecDirAliases: --workingDir/--workdir/--cwd must be accepted as
+// spellings of --dir instead of failing the whole call (models keep
+// inventing them, and a strict parser turns each into a retry loop).
+func TestExecDirAliases(t *testing.T) {
+	for _, alias := range []string{"--workingDir", "--workdir", "--cwd"} {
+		dir := t.TempDir()
+		var out strings.Builder
+		e := NewEngine(&out, &out, dir)
+		err := e.Execute(context.Background(), "exec", []string{"--cmd", "pwd", alias, dir})
+		if err != nil {
+			t.Fatalf("exec with %s: %v (out: %s)", alias, err, out.String())
+		}
+		if !strings.Contains(out.String(), dir) {
+			t.Fatalf("exec with %s did not run in the aliased dir: %s", alias, out.String())
+		}
+	}
+}

--- a/pkg/persona/builtin/skills/task-graph/SKILL.md
+++ b/pkg/persona/builtin/skills/task-graph/SKILL.md
@@ -67,10 +67,25 @@ Rules that matter:
 - `require_review` (graph or per task) defaults to **true**. Waive it only for trivial
   mechanical tasks, and say so in the delivery summary.
 
+## Invoking with a real graph: file first
+
+Inline `graph` args longer than ~2KB get **truncated by output-token limits**
+("Args parsing error: unexpected end of JSON input"). For any real graph, write the
+plan to a file and run from it — two calls, zero truncation risk:
+
+```
+<tool_call name="@coder" args='{"cmd":"write","args":{"file":"/tmp/plan.json","encoding":"base64","content":"<base64 of the plan JSON>"}}' />
+<tool_call name="@taskgraph" args='{"cmd":"run","args":{"file":"/tmp/plan.json"}}' />
+```
+
+The file may hold the bare plan object, `{"graph":{...}}`, or the full envelope —
+all three parse. Keep the inline form only for tiny graphs.
+
 ## Subcommands
 
 ```
-{"cmd":"run","args":{"graph":{...}}}     plan + execute in one call (streams progress)
+{"cmd":"run","args":{"file":"/tmp/plan.json"}}  run a plan from a file (RECOMMENDED)
+{"cmd":"run","args":{"graph":{...}}}     plan + execute in one call (small graphs only)
 {"cmd":"run","args":{"id":"tg-..."}}     run/resume a persisted plan (also resumes after failures)
 {"cmd":"plan","args":{"graph":{...}}}    validate + persist only (returns the run id)
 {"cmd":"status"}                         per-task status, attempts, verdicts, cost

--- a/pkg/persona/builtin/skills/task-graph/SKILL.md
+++ b/pkg/persona/builtin/skills/task-graph/SKILL.md
@@ -94,6 +94,7 @@ all three parse. Keep the inline form only for tiny graphs.
 {"cmd":"cancel"}                         stop the active run
 {"cmd":"list"}                           persisted runs
 {"cmd":"dash"}                           serve the live browser dashboard, returns its URL
+{"cmd":"prune","args":{"older_than":"7d"}}  remove old runs (auto-prune at 30d; "all" keeps only the active run)
 ```
 
 ## Discipline


### PR DESCRIPTION
Hardening from the first three real `@taskgraph` runs. Each commit fixes one observed failure:

## 1. Auto plan-first hijacked explicit taskgraph requests (`8c966448`)
Plan-and-Solve executed the plan outside the graph — no gates, no verdicts, long dead-air. Auto plan-first now defers when the query names the task graph (forced `/plan` still wins). Plus: worker heartbeats streamed during runs, and `--workingDir`/`--workdir`/`--cwd` accepted as `--dir` spellings.

## 2. Stream output collided with security prompts (`895bc1f0`)
Streamed events printed over the worker security prompt boxes and polluted the line the user was typing — approvals got mangled into denials. Streamed tool output now goes through the policy adapter's prompt gate (same mutex the prompts hold), and the taskgraph tool path re-arms the adapter's spinner/stdin/cbreak hooks exactly like the agent-call dispatch path. Heartbeats print only on change (30s keepalive) and name workers by task and role.

## 3. Real graphs truncated inline (`25407f43`)
A six-task graph is 4KB+ of inline args — output-token limits truncate it into "unexpected end of JSON input", and the model's natural recovery (write the plan to a file) had no way back in. `plan` and `run` now accept `{"file":"/tmp/plan.json"}` (bare plan, wrapped graph or full envelope; 1MB cap); schema and the embedded skill teach file-first for real graphs.

## Tests
Every fix carries its regression test; full suite green, local gates (ai-smells, cyclo-new, gofmt, i18n-parity) clean.