### PR TITLE
feat(workers): capability parity — plugin grants, per-task skills, learning digest

### DIFF
--- a/cli/agent/workers/dispatcher.go
+++ b/cli/agent/workers/dispatcher.go
@@ -348,6 +348,9 @@ func (d *Dispatcher) executeAgent(ctx context.Context, call AgentCall) AgentResu
 	// meaningful context (agent name, task description) in security prompts.
 	agentCtx := context.WithValue(ctx, CtxKeyAgentName, string(call.Agent))
 	agentCtx = context.WithValue(agentCtx, CtxKeyAgentTask, call.Task)
+	if call.Plugins != nil && len(call.Plugins.Plugins) > 0 {
+		agentCtx = context.WithValue(agentCtx, CtxKeyPluginGrant, call.Plugins)
+	}
 
 	// Attach effort hint to ctx (no-op when agent.Effort() is empty).
 	if effort := client.NormalizeEffort(agent.Effort()); effort != client.EffortUnset {

--- a/cli/agent/workers/parser.go
+++ b/cli/agent/workers/parser.go
@@ -76,6 +76,13 @@ func ParseAgentCalls(text string) ([]AgentCall, error) {
 			ID:    nextCallID(),
 			Raw:   raw,
 		}
+		// Optional per-task session-plugin grant:
+		// <agent_call agent="coder" task="..." tools="@browser,@websearch" />
+		if toolsAttr := extractAgentAttr(tagContent, "tools"); toolsAttr != "" {
+			if grant := NormalizePluginGrant(strings.Split(toolsAttr, ",")); len(grant) > 0 {
+				call.Plugins = &PluginGrant{Plugins: grant}
+			}
+		}
 
 		calls = append(calls, call)
 		remaining = remaining[len(raw):]

--- a/cli/agent/workers/parser_test.go
+++ b/cli/agent/workers/parser_test.go
@@ -225,3 +225,22 @@ python_functions = test_*" />`
 		t.Errorf("call 2 task truncated: %q", calls[2].Task)
 	}
 }
+
+func TestParseAgentCallsToolsAttr(t *testing.T) {
+	calls, _ := ParseAgentCalls(`<agent_call agent="coder" task="check the page" tools="@browser, websearch, @ask" />`)
+	if len(calls) != 1 {
+		t.Fatalf("want 1 call, got %d", len(calls))
+	}
+	if calls[0].Plugins == nil {
+		t.Fatal("tools attr must populate Plugins")
+	}
+	got := calls[0].Plugins.Plugins
+	if len(got) != 2 || got[0] != "@browser" || got[1] != "@websearch" {
+		t.Fatalf("normalized grant wrong (denylisted @ask must drop): %v", got)
+	}
+	// No tools attr → nil grant.
+	plain, _ := ParseAgentCalls(`<agent_call agent="coder" task="x" />`)
+	if plain[0].Plugins != nil {
+		t.Fatal("no tools attr → nil Plugins")
+	}
+}

--- a/cli/agent/workers/plugin_tools.go
+++ b/cli/agent/workers/plugin_tools.go
@@ -1,0 +1,197 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+/*
+ * Per-task plugin tool grants for squad workers.
+ *
+ * A worker's tool surface is deliberately narrow (engine subcommands +
+ * read-only context tools). This file adds the OPT-IN escape hatch: a
+ * dispatch call may grant specific session plugins (@browser, @websearch,
+ * mcp_* …) to the worker it spawns. The workers package never touches the
+ * plugin or MCP managers — the cli package registers a definer (grant names
+ * → native tool definitions) and a runner (one call → output), mirroring
+ * the context-tools seam. Definitions without a registered runner are never
+ * emitted: a definition without an executor would guarantee a failing call.
+ *
+ * Grants ride the dispatch context (CtxKeyPluginGrant) so every agent type
+ * and the quality pipeline inherit them with zero signature changes, and
+ * AgentCall carries them via a POINTER field — the struct must remain
+ * comparable (Floor 13 treats losing comparability as a breaking change).
+ */
+package workers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/diillson/chatcli/models"
+)
+
+// PluginGrant names the session plugins a dispatched worker may call.
+// Builtin names are canonical with their "@" prefix ("@browser"); MCP tools
+// keep their proxy name ("mcp_search_docs").
+type PluginGrant struct {
+	Plugins []string
+}
+
+// CtxKeyPluginGrant carries a *PluginGrant through the dispatch context.
+const CtxKeyPluginGrant ctxKey = "plugin_grant"
+
+// pluginGrantDenylist lists tools that must never be granted to a worker:
+// they are intercepted by the orchestrator loop or own session-level state
+// (interactive overlays, vision staging, the task-graph engine itself,
+// session model routing, park/resume semantics).
+var pluginGrantDenylist = map[string]bool{
+	"@ask": true, "@view": true, "@taskgraph": true, "@model": true, "@park": true,
+}
+
+// Model-facing prompt strings, named per house style (never inline literals).
+const (
+	grantedPluginsPromptHeader = "## GRANTED SESSION TOOLS\nThis task additionally grants you: "
+	grantedPluginsPromptUsage  = ".\nInvoke them as native tools with {\"cmd\": <subcommand>, \"args\": {...}}; every call passes the session security policy."
+)
+
+var (
+	// pluginToolRunner executes one granted plugin call. tool is the
+	// canonical grant name; argsJSON is the {"cmd":…,"args":{…}} envelope.
+	pluginToolRunner func(ctx context.Context, tool string, argsJSON string) (string, error)
+
+	// pluginToolDefiner maps grant names to native tool definitions.
+	pluginToolDefiner func(names []string) []models.ToolDefinition
+)
+
+// RegisterPluginToolRunner wires (or clears, with nil) the executor for
+// granted plugin tools.
+func RegisterPluginToolRunner(fn func(ctx context.Context, tool string, argsJSON string) (string, error)) {
+	workerHooksMu.Lock()
+	pluginToolRunner = fn
+	workerHooksMu.Unlock()
+}
+
+// RegisterPluginToolDefiner wires (or clears, with nil) the translator from
+// grant names to native tool definitions.
+func RegisterPluginToolDefiner(fn func(names []string) []models.ToolDefinition) {
+	workerHooksMu.Lock()
+	pluginToolDefiner = fn
+	workerHooksMu.Unlock()
+}
+
+func currentPluginToolRunner() func(context.Context, string, string) (string, error) {
+	workerHooksMu.RLock()
+	defer workerHooksMu.RUnlock()
+	return pluginToolRunner
+}
+
+func currentPluginToolDefiner() func([]string) []models.ToolDefinition {
+	workerHooksMu.RLock()
+	defer workerHooksMu.RUnlock()
+	return pluginToolDefiner
+}
+
+// NormalizePluginGrant canonicalizes and filters grant names: lowercase,
+// "@" prefix restored for builtins, denylisted and empty entries dropped,
+// duplicates removed. Order is preserved.
+func NormalizePluginGrant(names []string) []string {
+	seen := make(map[string]bool, len(names))
+	out := make([]string, 0, len(names))
+	for _, raw := range names {
+		name := strings.ToLower(strings.TrimSpace(raw))
+		if name == "" {
+			continue
+		}
+		if !strings.HasPrefix(name, "@") && !strings.HasPrefix(name, "mcp_") {
+			name = "@" + name
+		}
+		if pluginGrantDenylist[name] || seen[name] {
+			continue
+		}
+		seen[name] = true
+		out = append(out, name)
+	}
+	return out
+}
+
+// grantFromContext returns the normalized grant carried by the dispatch
+// context, or nil.
+func grantFromContext(ctx context.Context) []string {
+	g, _ := ctx.Value(CtxKeyPluginGrant).(*PluginGrant)
+	if g == nil {
+		return nil
+	}
+	return NormalizePluginGrant(g.Plugins)
+}
+
+// pluginDefName is the native function name a grant is exposed under:
+// builtins drop the "@" ("browser"); MCP proxies keep their name verbatim.
+func pluginDefName(grant string) string {
+	return strings.TrimPrefix(grant, "@")
+}
+
+// pluginGrantForName maps a resolved call name back to its canonical grant
+// ("browser" or "@browser" → "@browser"; "mcp_x" → "mcp_x").
+func pluginGrantForName(pluginTools []string, name string) (string, bool) {
+	name = strings.ToLower(strings.TrimSpace(name))
+	for _, grant := range pluginTools {
+		if name == grant || name == pluginDefName(grant) {
+			return grant, true
+		}
+	}
+	return "", false
+}
+
+// PluginToolDefinitionsFor returns the native definitions for the granted
+// tools, nil when no runner or definer is registered.
+func PluginToolDefinitionsFor(names []string) []models.ToolDefinition {
+	if len(names) == 0 || currentPluginToolRunner() == nil {
+		return nil
+	}
+	definer := currentPluginToolDefiner()
+	if definer == nil {
+		return nil
+	}
+	return definer(names)
+}
+
+// pluginEnvelopeJSON renders the {"cmd":…,"args":{…}} envelope for a
+// resolved plugin call — the shape every builtin's own parser accepts, and
+// the policy surface NormalizeCoderArgs understands.
+func pluginEnvelopeJSON(rtc resolvedToolCall) string {
+	if rtc.Native {
+		if len(rtc.NativeArgs) > 0 {
+			if data, err := json.Marshal(rtc.NativeArgs); err == nil {
+				return string(data)
+			}
+		}
+		return "{}"
+	}
+	raw := strings.TrimSpace(rtc.RawArgs)
+	if raw == "" {
+		return "{}"
+	}
+	return raw
+}
+
+// executePluginTool routes one granted plugin call through the registered
+// runner, with the standard truncation policy.
+func executePluginTool(ctx context.Context, v validatedTC) execResult {
+	runner := currentPluginToolRunner()
+	name := v.rtc.pluginName
+	if runner == nil {
+		err := fmt.Errorf("%s is not available in this session", name)
+		record := ToolCallRecord{Name: name, Args: v.rtc.RawArgs, Error: err}
+		return execResult{index: v.index, record: record, output: fmt.Sprintf("[%s] %v\n", name, err), failed: true, toolID: v.rtc.ID}
+	}
+	output, err := runner(ctx, name, pluginEnvelopeJSON(v.rtc))
+	if err != nil {
+		record := ToolCallRecord{Name: name, Args: v.rtc.RawArgs, Error: err}
+		return execResult{index: v.index, record: record, output: fmt.Sprintf("[%s] %v\n", name, err), failed: true, toolID: v.rtc.ID}
+	}
+	output = TruncateToolResult(name, output)
+	record := ToolCallRecord{Name: name, Args: v.rtc.RawArgs, Output: output}
+	return execResult{index: v.index, record: record, output: fmt.Sprintf("[%s] %s\n", name, output), toolID: v.rtc.ID}
+}

--- a/cli/agent/workers/plugin_tools_test.go
+++ b/cli/agent/workers/plugin_tools_test.go
@@ -1,0 +1,141 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package workers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+)
+
+// AgentCall and WorkerDeps MUST stay comparable (Floor 13). This fails to
+// compile if a slice/map/func field ever sneaks in.
+func TestAgentCallStaysComparable(t *testing.T) {
+	_ = map[AgentCall]bool{}
+	_ = map[WorkerDeps]bool{}
+	a := AgentCall{Agent: "coder", ID: "x"}
+	b := AgentCall{Agent: "coder", ID: "x"}
+	if a != b {
+		t.Fatal("equal AgentCalls must compare equal")
+	}
+}
+
+func TestNormalizePluginGrant(t *testing.T) {
+	got := NormalizePluginGrant([]string{" Browser ", "@websearch", "browser", "mcp_search", "@ask", "@view", "", "@TASKGRAPH"})
+	want := []string{"@browser", "@websearch", "mcp_search"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}
+
+func TestGrantFromContext(t *testing.T) {
+	ctx := context.WithValue(context.Background(), CtxKeyPluginGrant, &PluginGrant{Plugins: []string{"@browser", "@ask"}})
+	got := grantFromContext(ctx)
+	if len(got) != 1 || got[0] != "@browser" {
+		t.Fatalf("denylisted @ask must be dropped: %v", got)
+	}
+	if grantFromContext(context.Background()) != nil {
+		t.Fatal("no grant → nil")
+	}
+}
+
+func TestPluginGrantForName(t *testing.T) {
+	tools := []string{"@browser", "mcp_search"}
+	for name, want := range map[string]string{
+		"browser":    "@browser",
+		"@browser":   "@browser",
+		"mcp_search": "mcp_search",
+		"forge":      "",
+	} {
+		got, ok := pluginGrantForName(tools, name)
+		if (want == "" && ok) || (want != "" && got != want) {
+			t.Fatalf("pluginGrantForName(%q) = %q,%v want %q", name, got, ok, want)
+		}
+	}
+}
+
+func TestPluginToolDefinitionsForRequiresRunner(t *testing.T) {
+	RegisterPluginToolRunner(nil)
+	RegisterPluginToolDefiner(func(names []string) []models.ToolDefinition {
+		return []models.ToolDefinition{{Function: models.ToolFunctionDef{Name: "browser"}}}
+	})
+	t.Cleanup(func() { RegisterPluginToolDefiner(nil) })
+	if PluginToolDefinitionsFor([]string{"@browser"}) != nil {
+		t.Fatal("no runner → nil defs (a def without an executor guarantees a failing call)")
+	}
+	RegisterPluginToolRunner(func(context.Context, string, string) (string, error) { return "", nil })
+	t.Cleanup(func() { RegisterPluginToolRunner(nil) })
+	if len(PluginToolDefinitionsFor([]string{"@browser"})) != 1 {
+		t.Fatal("runner+definer → defs")
+	}
+	if PluginToolDefinitionsFor(nil) != nil {
+		t.Fatal("empty names → nil")
+	}
+}
+
+func TestExecutePluginToolRoutesToRunner(t *testing.T) {
+	var gotTool, gotArgs string
+	RegisterPluginToolRunner(func(_ context.Context, tool, args string) (string, error) {
+		gotTool, gotArgs = tool, args
+		return "page loaded", nil
+	})
+	t.Cleanup(func() { RegisterPluginToolRunner(nil) })
+
+	v := validatedTC{rtc: resolvedToolCall{
+		ID: "1", pluginName: "@browser", Native: true,
+		NativeArgs: map[string]interface{}{"cmd": "open", "args": map[string]interface{}{"url": "http://x"}},
+	}}
+	res := executePluginTool(context.Background(), v)
+	if res.failed {
+		t.Fatalf("unexpected failure: %s", res.output)
+	}
+	if gotTool != "@browser" || gotArgs == "" {
+		t.Fatalf("runner got tool=%q args=%q", gotTool, gotArgs)
+	}
+}
+
+func TestResolveToolCallsMarksGrantedPlugins(t *testing.T) {
+	tools := []string{"@browser"}
+	// Native call named after the def ("browser").
+	resolved, _ := resolveToolCalls(true, []models.ToolCall{
+		{ID: "1", Name: "browser", Arguments: map[string]interface{}{"cmd": "open"}},
+	}, "", 0, tools)
+	if len(resolved) != 1 || resolved[0].pluginName != "@browser" {
+		t.Fatalf("native plugin not marked: %+v", resolved)
+	}
+	// Non-granted native call stays a normal (unmarked) call.
+	resolved, _ = resolveToolCalls(true, []models.ToolCall{
+		{ID: "2", Name: "read", Arguments: map[string]interface{}{}},
+	}, "", 0, tools)
+	if resolved[0].pluginName != "" {
+		t.Fatal("non-granted call must not be marked as plugin")
+	}
+}
+
+func TestPolicyCallSurfaceUsesRealPluginName(t *testing.T) {
+	rtc := resolvedToolCall{
+		pluginName: "@browser", Native: true,
+		NativeArgs: map[string]interface{}{"cmd": "eval"},
+	}
+	name, args := policyCallSurface(rtc)
+	if name != "@browser" {
+		t.Fatalf("plugin call must surface under its real name, got %q", name)
+	}
+	if args == "" {
+		t.Fatal("envelope args expected")
+	}
+	// A normal engine call still canonicalizes to @coder.
+	name, _ = policyCallSurface(resolvedToolCall{Subcmd: "write", Native: true})
+	if name != "@coder" {
+		t.Fatalf("engine call must stay @coder, got %q", name)
+	}
+}

--- a/cli/agent/workers/types.go
+++ b/cli/agent/workers/types.go
@@ -36,6 +36,10 @@ type AgentCall struct {
 	Task  string    // natural language task description
 	ID    string    // unique call ID for tracking
 	Raw   string    // raw XML for logging/debugging
+	// Plugins is the optional per-task session-plugin grant. A POINTER on
+	// purpose: AgentCall must stay comparable (Floor 13 treats losing
+	// comparability as a breaking API change).
+	Plugins *PluginGrant
 }
 
 // AgentResult is the output of a single agent execution.

--- a/cli/agent/workers/worker_react.go
+++ b/cli/agent/workers/worker_react.go
@@ -30,6 +30,10 @@ type resolvedToolCall struct {
 	RawArgs    string                 // original args string for display/logging
 	Native     bool                   // true if from native function calling
 	NativeArgs map[string]interface{} // structured args (native only)
+	// pluginName is the canonical grant ("@browser", "mcp_x") when this
+	// call targets a granted session plugin; empty otherwise. Set during
+	// resolution so classification, policy and execution route on it.
+	pluginName string
 }
 
 // validatedTC is a resolved tool call after policy/allowlist classification.
@@ -54,7 +58,10 @@ type WorkerReActConfig struct {
 	MaxTurns        int
 	SystemPrompt    string
 	AllowedCommands []string // which @coder subcommands this worker can use
-	ReadOnly        bool     // if true, only read/search/tree/git-read allowed
+	// PluginTools are per-task session-plugin grants (canonical names, see
+	// NormalizePluginGrant). Usually injected from the dispatch context.
+	PluginTools []string
+	ReadOnly    bool // if true, only read/search/tree/git-read allowed
 }
 
 // DefaultWorkerMaxTurns is the default maximum number of ReAct turns per worker.
@@ -90,6 +97,16 @@ func RunWorkerReAct(
 	liveRun := runs.FromContext(ctx)
 
 	maxTurns := resolveWorkerMaxTurns(config)
+
+	// Per-task plugin grants ride the dispatch context so every agent type
+	// inherits them without signature changes. Read-only workers never
+	// receive grants: their contract is inspection, and plugin side effects
+	// (@browser click, @forge create) would bypass isWriteCommand.
+	if !config.ReadOnly {
+		if grant := grantFromContext(ctx); len(grant) > 0 {
+			config.PluginTools = NormalizePluginGrant(append(append([]string{}, config.PluginTools...), grant...))
+		}
+	}
 
 	// Detect if we can use native function calling
 	toolAware, useNativeTools := client.AsToolAware(llmClient)
@@ -140,6 +157,11 @@ func RunWorkerReAct(
 	// Universal CCR recall (see RecallToolDefinition) — only when wired.
 	if currentCCRRecaller() != nil {
 		allowed[recallSubcmd] = true
+	}
+	// Granted session plugins (resolution canonicalizes both native and XML
+	// calls to the def name — see resolveToolCalls).
+	for _, grant := range config.PluginTools {
+		allowed[pluginDefName(grant)] = true
 	}
 
 	// Worker-loop microcompact: long runs (up to maxTurns) accumulate tool
@@ -199,7 +221,7 @@ func RunWorkerReAct(
 		history = newHistory
 
 		// --- Resolve tool calls to unified format ---
-		resolved, parseErrRecords := resolveToolCalls(useNativeTools, nativeToolCalls, responseText, turn)
+		resolved, parseErrRecords := resolveToolCalls(useNativeTools, nativeToolCalls, responseText, turn, config.PluginTools)
 		allToolCalls = append(allToolCalls, parseErrRecords...)
 
 		if len(resolved) == 0 {
@@ -353,6 +375,8 @@ func buildWorkerToolDefs(config WorkerReActConfig) []models.ToolDefinition {
 	if currentCCRRecaller() != nil {
 		toolDefs = append(toolDefs, RecallToolDefinition())
 	}
+	// Per-task plugin grants (nil without a registered runner+definer).
+	toolDefs = append(toolDefs, PluginToolDefinitionsFor(config.PluginTools)...)
 	return toolDefs
 }
 
@@ -367,6 +391,12 @@ func buildWorkerSystemPrompt(config WorkerReActConfig, useNativeTools bool, task
 		// XML mode keeps the specialist prompt and gains the same
 		// context-navigation guidance native mode embeds.
 		systemPrompt += "\n\n" + workerContextGuidance
+	}
+
+	// Granted session plugins: name them so the model knows the surface
+	// exists (definitions alone are easy to overlook mid-task).
+	if len(config.PluginTools) > 0 {
+		systemPrompt += "\n\n" + grantedPluginsPromptHeader + strings.Join(config.PluginTools, ", ") + grantedPluginsPromptUsage
 	}
 
 	// Proactive recall: give the worker the same [MEMORY AUTO-RECALL] /
@@ -454,6 +484,11 @@ func executeToolCall(ctx context.Context, v validatedTC, lockMgr *FileLockManage
 	}
 	if isContextToolSubcmd(v.rtc.Subcmd) {
 		return executeContextTool(ctx, v)
+	}
+	// Granted session plugins (policy already checked above — plugin calls
+	// are never in isPolicyExemptSubcmd).
+	if v.rtc.pluginName != "" {
+		return executePluginTool(ctx, v)
 	}
 
 	filePath := extractFilePathFromResolved(v.rtc)
@@ -585,7 +620,7 @@ func executeDelegate(ctx context.Context, v validatedTC) execResult {
 // into the unified resolvedToolCall representation. It returns the resolved
 // calls plus any ToolCallRecords for parse failures that the caller should
 // append to its running log.
-func resolveToolCalls(useNativeTools bool, nativeToolCalls []models.ToolCall, responseText string, turn int) ([]resolvedToolCall, []ToolCallRecord) {
+func resolveToolCalls(useNativeTools bool, nativeToolCalls []models.ToolCall, responseText string, turn int, pluginTools []string) ([]resolvedToolCall, []ToolCallRecord) {
 	var resolved []resolvedToolCall
 	var parseErrRecords []ToolCallRecord
 
@@ -594,6 +629,11 @@ func resolveToolCalls(useNativeTools bool, nativeToolCalls []models.ToolCall, re
 			subcmd, found := NativeToolNameToSubcmd(ntc.Name)
 			if !found {
 				subcmd = ntc.Name
+			}
+			pluginName := ""
+			if grant, ok := pluginGrantForName(pluginTools, ntc.Name); ok {
+				pluginName = grant
+				subcmd = pluginDefName(grant)
 			}
 			flags := NativeToolArgsToFlags(subcmd, ntc.Arguments)
 			argsJSON, _ := json.Marshal(ntc.Arguments)
@@ -606,6 +646,7 @@ func resolveToolCalls(useNativeTools bool, nativeToolCalls []models.ToolCall, re
 				RawArgs:    string(argsJSON),
 				Native:     true,
 				NativeArgs: ntc.Arguments,
+				pluginName: pluginName,
 			})
 		}
 	} else if !useNativeTools {
@@ -617,13 +658,21 @@ func resolveToolCalls(useNativeTools bool, nativeToolCalls []models.ToolCall, re
 				parseErrRecords = append(parseErrRecords, ToolCallRecord{Name: tc.Name, Args: tc.Args, Error: parseErr})
 				continue
 			}
-			resolved = append(resolved, resolvedToolCall{
+			rtc := resolvedToolCall{
 				ID:      fmt.Sprintf("xml_%d", turn),
 				Name:    tc.Name,
 				Subcmd:  subcmd,
 				Args:    args,
 				RawArgs: tc.Args,
-			})
+			}
+			// XML mode keeps the plugin identity in tc.Name ("@browser") —
+			// the envelope's inner cmd landed in Subcmd and would otherwise
+			// be blocked by the allowlist.
+			if grant, ok := pluginGrantForName(pluginTools, tc.Name); ok {
+				rtc.pluginName = grant
+				rtc.Subcmd = pluginDefName(grant)
+			}
+			resolved = append(resolved, rtc)
 		}
 	}
 
@@ -757,6 +806,13 @@ func isPolicyExemptSubcmd(subcmd string) bool {
 // subcommand, so rules like "@coder exec" never matched and the read-only
 // exec auto-allow never fired (every worker exec degraded to "ask").
 func policyCallSurface(rtc resolvedToolCall) (string, string) {
+	// Granted plugin calls surface under their REAL name so user rules
+	// ("@browser eval"), the read-only capability auto-allow and safety
+	// immunity all match — canonicalizing them to "@coder" would show the
+	// wrong prompt and consult the wrong rules.
+	if rtc.pluginName != "" {
+		return rtc.pluginName, pluginEnvelopeJSON(rtc)
+	}
 	if !rtc.Native {
 		return rtc.Name, rtc.RawArgs
 	}

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -4062,7 +4062,7 @@ func (a *AgentMode) initMultiAgent(ctx context.Context) bool {
 			a.policyAdapter.unattended = a.cli.unattended
 			a.policyAdapter.autoApprove = a.askAutoApproved
 		}
-		workers.RegisterWorkerContextProvider(a.followUpRecallBlocks)
+		workers.RegisterWorkerContextProvider(a.workerTaskContext)
 		if a.agentDispatcher != nil {
 			provider := a.cli.Provider
 			if provider == "" {
@@ -4160,7 +4160,7 @@ func (a *AgentMode) initMultiAgent(ctx context.Context) bool {
 	// Proactive recall for workers: each dispatched task gets the same
 	// [MEMORY AUTO-RECALL] / [SESSION RECALL] surfaces the orchestrator's
 	// system prompt carries, keyed off the task text.
-	workers.RegisterWorkerContextProvider(a.followUpRecallBlocks)
+	workers.RegisterWorkerContextProvider(a.workerTaskContext)
 
 	// Attach the seven-pattern quality pipeline (Self-Refine, CoVe,
 	// Reflexion, …). Pipeline starts with the hooks selected by the

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -864,6 +864,11 @@ func NewChatCLI(ctx context.Context, manager manager.LLMManager, logger *zap.Log
 	// Read-only memory/session/knowledge views for workers that opt in
 	// (persona frontmatter tools: Memory, Session, Knowledge).
 	workers.RegisterContextToolRunner(cli.runWorkerContextTool)
+	// Per-task plugin grants: workers can be granted session plugins
+	// (@browser, @websearch, mcp_*) opt-in per task; these wire the executor
+	// and the grant-name → native-def translator.
+	workers.RegisterPluginToolRunner(cli.runWorkerPluginTool)
+	workers.RegisterPluginToolDefiner(cli.workerPluginToolDefs)
 
 	// Wire the @knowledge tool to this session's context manager so the agent
 	// can interrogate attached knowledge bases on demand.

--- a/cli/taskgraph/dash/assets/dash.html
+++ b/cli/taskgraph/dash/assets/dash.html
@@ -154,6 +154,10 @@ async function tick() {
     renderHeader(g);
     if ($('results').style.display !== 'none') renderResults(g);
     if (state.fitPending) { fit(); state.fitPending = false; }
+    // Always repaint on fresh state: the rAF loop only animates while tasks
+    // are active, so without this the final transition (last task → done)
+    // would stay invisible until a manual reload.
+    draw();
     const ev = await fetchJSON('/api/events?run=' + encodeURIComponent(state.run) + '&since=' + state.eventsNext);
     if (ev.events && ev.events.length) {
       state.eventsNext = ev.next;

--- a/cli/taskgraph/engine.go
+++ b/cli/taskgraph/engine.go
@@ -516,11 +516,16 @@ func (e *Engine) dispatchExecutor(ctx context.Context, t *Task, attempt int, fee
 	e.trackCall(callID, t.ID)
 	defer e.untrackCall(callID)
 	prompt := e.buildExecutorPrompt(t, attempt, feedback)
-	batch := e.cfg.Dispatcher.Dispatch(ctx, []workers.AgentCall{{
+	call := workers.AgentCall{
 		Agent: workers.AgentType(t.Agent),
 		Task:  prompt,
 		ID:    callID,
-	}})
+	}
+	// The executor (never the reviewer) inherits this task's plugin grant.
+	if len(t.Tools) > 0 {
+		call.Plugins = &workers.PluginGrant{Plugins: t.Tools}
+	}
+	batch := e.cfg.Dispatcher.Dispatch(ctx, []workers.AgentCall{call})
 	if len(batch) == 0 {
 		return workers.AgentResult{CallID: callID, Error: errors.New("dispatcher returned no result")}
 	}

--- a/cli/taskgraph/engine_test.go
+++ b/cli/taskgraph/engine_test.go
@@ -27,6 +27,7 @@ type fakeDispatcher struct {
 	failExecutorOnce map[string]bool
 	reviewFailOnce   map[string]bool
 	reviewOutput     string
+	grants           map[string][]string
 }
 
 func newFakeDispatcher() *fakeDispatcher {
@@ -42,6 +43,12 @@ func (f *fakeDispatcher) Dispatch(_ context.Context, calls []workers.AgentCall) 
 	for _, c := range calls {
 		f.mu.Lock()
 		f.order = append(f.order, c.ID)
+		if c.Plugins != nil {
+			if f.grants == nil {
+				f.grants = map[string][]string{}
+			}
+			f.grants[c.ID] = c.Plugins.Plugins
+		}
 		execFail := f.failExecutorOnce[c.ID]
 		delete(f.failExecutorOnce, c.ID)
 		reviewFail := f.reviewFailOnce[c.ID]
@@ -423,5 +430,20 @@ func TestHeartbeatLabel(t *testing.T) {
 		if got := heartbeatLabel(c.callID, c.agent); got != c.want {
 			t.Fatalf("heartbeatLabel(%q,%q) = %q, want %q", c.callID, c.agent, got, c.want)
 		}
+	}
+}
+
+func TestEngineGrantsToolsToExecutorNotReviewer(t *testing.T) {
+	g, store := testGraph(t, `{"name":"x","tasks":[{"id":"T1","prompt":"work","tools":["@browser"]}]}`)
+	disp := newFakeDispatcher()
+	e := newTestEngine(t, g, store, disp, &fakeGate{})
+	if _, err := e.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := disp.grants["tg:T1:e1"]; len(got) != 1 || got[0] != "@browser" {
+		t.Fatalf("executor must receive the task grant: %v", got)
+	}
+	if _, ok := disp.grants["tg:T1:r1"]; ok {
+		t.Fatal("reviewer must NEVER receive a plugin grant")
 	}
 }

--- a/cli/taskgraph/graph.go
+++ b/cli/taskgraph/graph.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/diillson/chatcli/cli/agent/quality"
+	"github.com/diillson/chatcli/cli/agent/workers"
 )
 
 // Status is the lifecycle state of a task (and, at run level, of the graph).
@@ -140,6 +141,9 @@ type Task struct {
 	Validation    ValidationList `json:"validation,omitempty"`
 	RequireReview *bool          `json:"require_review,omitempty"` // nil = inherit graph default
 	MaxAttempts   int            `json:"max_attempts,omitempty"`   // default defaultMaxAttempts
+	// Tools grants the EXECUTOR worker session plugins for this task
+	// (@browser, @websearch, mcp_*). Opt-in; the reviewer never gets them.
+	Tools []string `json:"tools,omitempty"`
 
 	// Runtime state — owned by the engine, persisted with the graph.
 	Status    Status    `json:"status,omitempty"`
@@ -229,6 +233,9 @@ func (g *Graph) Normalize() {
 		t.Agent = strings.ToLower(strings.TrimSpace(t.Agent))
 		if t.Agent == "" {
 			t.Agent = "coder"
+		}
+		if len(t.Tools) > 0 {
+			t.Tools = workers.NormalizePluginGrant(t.Tools)
 		}
 		if strings.TrimSpace(t.Title) == "" {
 			t.Title = firstLine(t.Prompt)

--- a/cli/taskgraph/graph_test.go
+++ b/cli/taskgraph/graph_test.go
@@ -112,3 +112,14 @@ func TestCountByStatusAndCost(t *testing.T) {
 		t.Fatalf("total cost: %v", got)
 	}
 }
+
+func TestParseGraphNormalizesTaskTools(t *testing.T) {
+	g, err := ParseGraph(`{"name":"x","tasks":[{"id":"T1","prompt":"p","tools":["@browser"," websearch ","@ask"]}]}`)
+	if err != nil {
+		t.Fatalf("ParseGraph: %v", err)
+	}
+	got := g.Tasks[0].Tools
+	if len(got) != 2 || got[0] != "@browser" || got[1] != "@websearch" {
+		t.Fatalf("task tools not normalized (denylist @ask): %v", got)
+	}
+}

--- a/cli/taskgraph_adapter.go
+++ b/cli/taskgraph_adapter.go
@@ -411,7 +411,11 @@ func (a *taskGraphAdapter) execute(ctx context.Context, g *taskgraph.Graph, stor
 		a.mu.Unlock()
 	}()
 
-	return engine.Run(ctx)
+	report, runErr := engine.Run(ctx)
+	// Feed what the graph learned back into long-term memory (best-effort;
+	// WithoutCancel so a digest of a canceled run still enqueues).
+	a.queueLearningDigest(context.WithoutCancel(ctx), g)
+	return report, runErr
 }
 
 // loadRun opens runID, or the most recent run when empty.

--- a/cli/taskgraph_learning.go
+++ b/cli/taskgraph_learning.go
@@ -1,0 +1,135 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+/*
+ * Learning digest: at the end of a @taskgraph run, feed what the graph
+ * discovered back into the session's long-term memory — the same pipeline
+ * that learns from normal turns. A run's verdicts, evidence and retries are
+ * exactly the material the memory extractor (facts + episodes + topics) and
+ * self-evolution (skill candidates) need; without this, everything the
+ * graph learned evaporated with the report.
+ *
+ * Two sinks, both best-effort (nothing here can fail or block a run):
+ *   1. a compact digest segment → memWorker.nudgeSegment (facts/episodes/
+ *      self-evolve, on the normal cadence via the durable WAL);
+ *   2. one Reflexion lesson per FAILED task → the lesson queue.
+ */
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/diillson/chatcli/cli/agent/quality"
+	"github.com/diillson/chatcli/cli/taskgraph"
+	"github.com/diillson/chatcli/models"
+)
+
+// taskGraphDigestMaxChars bounds each digest message: the memory extractor
+// truncates the middle of any message past this, so the digest must fit.
+const taskGraphDigestMaxChars = 1400
+
+// queueLearningDigest enqueues a memory segment for the finished run and a
+// Reflexion lesson per failed task. Best-effort throughout.
+func (a *taskGraphAdapter) queueLearningDigest(ctx context.Context, g *taskgraph.Graph) {
+	if a.cli == nil || g == nil {
+		return
+	}
+	if a.cli.memWorker != nil {
+		digest := formatTaskGraphDigest(g)
+		a.cli.memWorker.nudgeSegment(ctx, []models.Message{
+			{Role: "user", Content: fmt.Sprintf("I orchestrated the @taskgraph run %s (%s) — record what it delivered and what to remember.", g.RunID, g.Name)},
+			{Role: "assistant", Content: digest},
+		})
+	}
+	a.queueFailedTaskLessons(ctx, g)
+}
+
+// formatTaskGraphDigest condenses the final graph into a <taskGraphDigestMaxChars
+// summary: run outcome, then one line per task with verdict and the first
+// line of evidence or failure reason.
+func formatTaskGraphDigest(g *taskgraph.Graph) string {
+	var b strings.Builder
+	counts := g.CountByStatus()
+	fmt.Fprintf(&b, "Task graph %q finished: status=%s, %d tasks (%d done, %d failed/blocked)",
+		g.Name, g.Status, len(g.Tasks), counts[taskgraph.StatusDone], counts[taskgraph.StatusFailed]+counts[taskgraph.StatusBlocked])
+	if cost := g.TotalCostUSD(); cost > 0 {
+		fmt.Fprintf(&b, ", cost $%.4f", cost)
+	}
+	b.WriteString(".\n")
+	for _, t := range g.Tasks {
+		line := fmt.Sprintf("- [%s] %s: %s", t.ID, firstLineTrim(t.Title, 60), t.Status)
+		if note := lastAttemptNote(t); note != "" {
+			line += " — " + firstLineTrim(note, 120)
+		}
+		if b.Len()+len(line) > taskGraphDigestMaxChars {
+			b.WriteString("- …(truncated)\n")
+			break
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// queueFailedTaskLessons enqueues one Reflexion lesson per failed task, so
+// the "what went wrong / do differently" knowledge is generalized. Gated by
+// the session's reflexion config (the enqueuer is nil when disabled).
+func (a *taskGraphAdapter) queueFailedTaskLessons(ctx context.Context, g *taskgraph.Graph) {
+	if a.cli.agentMode == nil {
+		return
+	}
+	enqueuer := a.cli.reflexionEnqueuer(ctx, a.cli.agentMode.qualityConfig.Reflexion.Queue)
+	if enqueuer == nil {
+		return
+	}
+	for _, t := range g.Tasks {
+		if t.Status != taskgraph.StatusFailed {
+			continue
+		}
+		var last taskgraph.Attempt
+		if n := len(t.Attempts); n > 0 {
+			last = t.Attempts[n-1]
+		}
+		outcome := strings.TrimSpace(last.FailureReason + " " + last.Evidence)
+		if outcome == "" {
+			outcome = "task failed without a recorded reason"
+		}
+		_ = enqueuer.Enqueue(ctx, quality.LessonRequest{
+			Task:    t.Title,
+			Attempt: firstLineTrim(last.ExecutorOutput, 800),
+			Outcome: firstLineTrim(outcome, 400),
+			Trigger: "error",
+		})
+	}
+}
+
+// firstLineTrim returns the first non-empty line of s, capped at n runes.
+func firstLineTrim(s string, n int) string {
+	for _, line := range strings.Split(s, "\n") {
+		if t := strings.TrimSpace(line); t != "" {
+			if r := []rune(t); len(r) > n {
+				return string(r[:n]) + "…"
+			}
+			return t
+		}
+	}
+	return ""
+}
+
+// lastAttemptNote returns the most informative note of a task's last attempt.
+func lastAttemptNote(t *taskgraph.Task) string {
+	n := len(t.Attempts)
+	if n == 0 {
+		return ""
+	}
+	last := t.Attempts[n-1]
+	if last.Evidence != "" {
+		return last.Evidence
+	}
+	return last.FailureReason
+}

--- a/cli/taskgraph_learning.go
+++ b/cli/taskgraph_learning.go
@@ -33,6 +33,12 @@ import (
 // truncates the middle of any message past this, so the digest must fit.
 const taskGraphDigestMaxChars = 1400
 
+// digestUserFmt frames the digest for the memory extractor. This is NOT
+// user-facing UI text — it is the synthetic "user" turn of a memory
+// segment the extractor reads, so it stays a plain English const (not
+// i18n) like the rest of the model-facing digest strings.
+const digestUserFmt = "I orchestrated the @taskgraph run %s (%s) — record what it delivered and what to remember."
+
 // queueLearningDigest enqueues a memory segment for the finished run and a
 // Reflexion lesson per failed task. Best-effort throughout.
 func (a *taskGraphAdapter) queueLearningDigest(ctx context.Context, g *taskgraph.Graph) {
@@ -42,7 +48,7 @@ func (a *taskGraphAdapter) queueLearningDigest(ctx context.Context, g *taskgraph
 	if a.cli.memWorker != nil {
 		digest := formatTaskGraphDigest(g)
 		a.cli.memWorker.nudgeSegment(ctx, []models.Message{
-			{Role: "user", Content: fmt.Sprintf("I orchestrated the @taskgraph run %s (%s) — record what it delivered and what to remember.", g.RunID, g.Name)},
+			{Role: "user", Content: fmt.Sprintf(digestUserFmt, g.RunID, g.Name)},
 			{Role: "assistant", Content: digest},
 		})
 	}

--- a/cli/taskgraph_learning_test.go
+++ b/cli/taskgraph_learning_test.go
@@ -1,0 +1,52 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/cli/taskgraph"
+)
+
+func TestFormatTaskGraphDigest(t *testing.T) {
+	pass := "PASS"
+	g := &taskgraph.Graph{
+		Name: "feature-x", Status: taskgraph.StatusDone,
+		Tasks: []*taskgraph.Task{
+			{ID: "T1", Title: "endpoint", Status: taskgraph.StatusDone, CostUSD: 0.5,
+				Attempts: []taskgraph.Attempt{{Verdict: pass, Evidence: "tests green, /foo covered"}}},
+			{ID: "T2", Title: "client", Status: taskgraph.StatusFailed,
+				Attempts: []taskgraph.Attempt{{FailureReason: "build broke on missing import"}}},
+		},
+	}
+	d := formatTaskGraphDigest(g)
+	if len(d) > taskGraphDigestMaxChars {
+		t.Fatalf("digest exceeds cap: %d", len(d))
+	}
+	for _, want := range []string{"feature-x", "T1", "T2", "tests green", "build broke"} {
+		if !strings.Contains(d, want) {
+			t.Fatalf("digest missing %q:\n%s", want, d)
+		}
+	}
+}
+
+func TestFormatTaskGraphDigestTruncatesManyTasks(t *testing.T) {
+	g := &taskgraph.Graph{Name: "big", Status: taskgraph.StatusDone}
+	for i := 0; i < 200; i++ {
+		g.Tasks = append(g.Tasks, &taskgraph.Task{
+			ID: "T", Title: strings.Repeat("x", 50), Status: taskgraph.StatusDone,
+		})
+	}
+	if got := len(formatTaskGraphDigest(g)); got > taskGraphDigestMaxChars {
+		t.Fatalf("digest must stay under cap even with many tasks: %d", got)
+	}
+}
+
+func TestQueueLearningDigestNilMemWorker(t *testing.T) {
+	a := &taskGraphAdapter{cli: &ChatCLI{}}                 // memWorker nil, agentMode nil
+	a.queueLearningDigest(nil, &taskgraph.Graph{Name: "x"}) // must not panic
+}

--- a/cli/taskgraph_learning_test.go
+++ b/cli/taskgraph_learning_test.go
@@ -6,6 +6,7 @@
 package cli
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -47,6 +48,6 @@ func TestFormatTaskGraphDigestTruncatesManyTasks(t *testing.T) {
 }
 
 func TestQueueLearningDigestNilMemWorker(t *testing.T) {
-	a := &taskGraphAdapter{cli: &ChatCLI{}}                 // memWorker nil, agentMode nil
-	a.queueLearningDigest(nil, &taskgraph.Graph{Name: "x"}) // must not panic
+	a := &taskGraphAdapter{cli: &ChatCLI{}}                                  // memWorker nil, agentMode nil
+	a.queueLearningDigest(context.Background(), &taskgraph.Graph{Name: "x"}) // must not panic
 }

--- a/cli/worker_plugin_tools.go
+++ b/cli/worker_plugin_tools.go
@@ -1,0 +1,195 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+/*
+ * cli-side wiring for the workers' per-task plugin grants (see
+ * cli/agent/workers/plugin_tools.go). The workers package cannot reach the
+ * plugin or MCP managers, so this file provides:
+ *   - runWorkerPluginTool: execute one granted call (builtin or mcp_*),
+ *   - workerPluginToolDefs: translate grant names into native tool defs.
+ *
+ * Concurrency: @browser (and any plugin declaring IsConcurrencySafe=false)
+ * drives one process-wide stateful session; parallel workers would corrupt
+ * it. We serialize non-concurrency-safe plugins with a per-plugin mutex —
+ * the first such enforcement in the process. This prevents interleaved CDP
+ * ops; it does NOT prevent one worker's snapshot refs being invalidated by
+ * another worker's navigation, so the skill advises granting @browser to a
+ * single task.
+ */
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/diillson/chatcli/cli/agent/workers"
+	"github.com/diillson/chatcli/cli/plugins"
+	"github.com/diillson/chatcli/models"
+)
+
+var (
+	workerPluginLocksMu sync.Mutex
+	workerPluginLocks   = map[string]*sync.Mutex{}
+)
+
+// workerPluginLock returns the process-wide serialization mutex for a plugin.
+func workerPluginLock(name string) *sync.Mutex {
+	workerPluginLocksMu.Lock()
+	defer workerPluginLocksMu.Unlock()
+	mu, ok := workerPluginLocks[name]
+	if !ok {
+		mu = &sync.Mutex{}
+		workerPluginLocks[name] = mu
+	}
+	return mu
+}
+
+// runWorkerPluginTool executes one granted plugin call. tool is the canonical
+// grant name ("@browser" | "mcp_x"); argsJSON is the {cmd,args} envelope.
+// The worker already applied the security policy — this must NOT re-check.
+func (cli *ChatCLI) runWorkerPluginTool(ctx context.Context, tool, argsJSON string) (string, error) {
+	tool = strings.TrimSpace(tool)
+	if strings.HasPrefix(tool, "mcp_") {
+		if cli.mcpManager == nil {
+			return "", fmt.Errorf("%s: MCP not available in this session", tool)
+		}
+		return cli.RunMCPProxyTool(ctx, tool, json.RawMessage(argsJSON))
+	}
+	name := tool
+	if !strings.HasPrefix(name, "@") {
+		name = "@" + name
+	}
+	plugin, ok := cli.pluginManager.GetPlugin(name)
+	if !ok {
+		return "", fmt.Errorf("%s: plugin not found", name)
+	}
+	argv := []string{argsJSON}
+	if !plugins.IsConcurrencySafe(plugin, argv) {
+		mu := workerPluginLock(name)
+		mu.Lock()
+		defer mu.Unlock()
+	}
+	return execBuiltin(ctx, plugin, argv)
+}
+
+// workerPluginToolDefs translates grant names into native tool definitions:
+// mcp_* filtered from the MCP catalog (origin schema verbatim), the six
+// natively-mapped builtins from the worker catalog, and every other builtin
+// synthesized from its Schema().
+func (cli *ChatCLI) workerPluginToolDefs(names []string) []models.ToolDefinition {
+	mapped := workers.PluginToolDefinitions()
+	mappedByName := make(map[string]models.ToolDefinition, len(mapped))
+	for _, d := range mapped {
+		mappedByName[d.Function.Name] = d
+	}
+	var mcpDefs []models.ToolDefinition
+	if cli.mcpManager != nil {
+		mcpDefs = cli.mcpManager.GetTools()
+	}
+	mcpByName := make(map[string]models.ToolDefinition, len(mcpDefs))
+	for _, d := range mcpDefs {
+		mcpByName[d.Function.Name] = d
+	}
+
+	out := make([]models.ToolDefinition, 0, len(names))
+	for _, grant := range names {
+		if strings.HasPrefix(grant, "mcp_") {
+			if d, ok := mcpByName[grant]; ok {
+				out = append(out, d)
+			}
+			continue
+		}
+		defName := strings.TrimPrefix(grant, "@")
+		// A builtin already exposed as a native tool keeps that mapping so
+		// its args schema matches what ResolveNativePluginTool expects.
+		if d, ok := mappedByName[nativeNameForBuiltin(grant)]; ok {
+			renamed := d
+			renamed.Function.Name = defName
+			out = append(out, renamed)
+			continue
+		}
+		if plugin, ok := cli.pluginManager.GetPlugin(grant); ok {
+			if d, ok := synthesizePluginDef(defName, plugin); ok {
+				out = append(out, d)
+			}
+		}
+	}
+	return out
+}
+
+// nativeNameForBuiltin maps a grant to the native function name the six
+// mapped builtins use (e.g. "@websearch" → "web_search"), or "".
+func nativeNameForBuiltin(grant string) string {
+	switch grant {
+	case "@websearch":
+		return "web_search"
+	case "@webfetch":
+		return "web_fetch"
+	case "@mail":
+		return "squad_mail"
+	case "@agents":
+		return "agents_runs"
+	case "@board":
+		return "board_cards"
+	}
+	return ""
+}
+
+// synthesizePluginDef builds a native tool definition from a builtin's
+// Schema() — a {cmd: enum(subcommands), args: object} envelope that matches
+// every builtin's own lenient parser.
+func synthesizePluginDef(defName string, plugin plugins.Plugin) (models.ToolDefinition, bool) {
+	var schema struct {
+		Description string `json:"description"`
+		ArgsFormat  string `json:"argsFormat"`
+		Subcommands []struct {
+			Name        string `json:"name"`
+			Description string `json:"description"`
+		} `json:"subcommands"`
+	}
+	if json.Unmarshal([]byte(plugin.Schema()), &schema) != nil {
+		return models.ToolDefinition{}, false
+	}
+	cmds := make([]string, 0, len(schema.Subcommands))
+	var b strings.Builder
+	b.WriteString(schema.Description)
+	if len(schema.Subcommands) > 0 {
+		b.WriteString(" Subcommands: ")
+	}
+	for i, sc := range schema.Subcommands {
+		cmds = append(cmds, sc.Name)
+		if i > 0 {
+			b.WriteString("; ")
+		}
+		fmt.Fprintf(&b, "%s (%s)", sc.Name, sc.Description)
+	}
+	desc := plugin.Description()
+	if d := strings.TrimSpace(b.String()); d != "" {
+		desc = d
+	}
+	cmdProp := map[string]interface{}{"type": "string", "description": "subcommand"}
+	if len(cmds) > 0 {
+		cmdProp["enum"] = cmds
+	}
+	return models.ToolDefinition{
+		Type: "function",
+		Function: models.ToolFunctionDef{
+			Name:        defName,
+			Description: desc,
+			Parameters: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"cmd":  cmdProp,
+					"args": map[string]interface{}{"type": "object", "description": "subcommand arguments"},
+				},
+				"required": []string{"cmd"},
+			},
+		},
+	}, true
+}

--- a/cli/worker_plugin_tools_test.go
+++ b/cli/worker_plugin_tools_test.go
@@ -1,0 +1,92 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/diillson/chatcli/cli/plugins"
+	"go.uber.org/zap"
+)
+
+func TestSynthesizePluginDefFromSchema(t *testing.T) {
+	// @forge has a rich Schema() with subcommands but no native def.
+	def, ok := synthesizePluginDef("forge", plugins.NewBuiltinForgePlugin())
+	if !ok {
+		t.Fatal("forge schema must synthesize a def")
+	}
+	if def.Function.Name != "forge" {
+		t.Fatalf("def name: %q", def.Function.Name)
+	}
+	params, _ := json.Marshal(def.Function.Parameters)
+	var parsed struct {
+		Properties struct {
+			Cmd struct {
+				Enum []string `json:"enum"`
+			} `json:"cmd"`
+		} `json:"properties"`
+		Required []string `json:"required"`
+	}
+	if json.Unmarshal(params, &parsed) != nil {
+		t.Fatal("params must be valid JSON schema")
+	}
+	if len(parsed.Properties.Cmd.Enum) == 0 {
+		t.Fatal("cmd enum must list subcommands")
+	}
+	if len(parsed.Required) != 1 || parsed.Required[0] != "cmd" {
+		t.Fatalf("cmd must be required: %v", parsed.Required)
+	}
+}
+
+func TestNativeNameForBuiltin(t *testing.T) {
+	if nativeNameForBuiltin("@websearch") != "web_search" {
+		t.Fatal("websearch → web_search")
+	}
+	if nativeNameForBuiltin("@browser") != "" {
+		t.Fatal("browser has no native mapping")
+	}
+}
+
+func TestWorkerPluginToolDefsFiltersAndSynthesizes(t *testing.T) {
+	mgr, _ := plugins.NewManager(zap.NewNop())
+	cli := &ChatCLI{pluginManager: mgr}
+	cli.pluginManager.RegisterBuiltinPlugin(plugins.NewBuiltinForgePlugin())
+	defs := cli.workerPluginToolDefs([]string{"@websearch", "@forge", "mcp_nope"})
+	names := map[string]bool{}
+	for _, d := range defs {
+		names[d.Function.Name] = true
+	}
+	if !names["websearch"] {
+		t.Fatal("mapped builtin @websearch must appear under its grant def name")
+	}
+	if !names["forge"] {
+		t.Fatal("unmapped builtin @forge must be synthesized as forge")
+	}
+	if names["mcp_nope"] {
+		t.Fatal("unknown mcp tool must be dropped (no mcp manager)")
+	}
+}
+
+func TestRunWorkerPluginToolSerializesUnsafe(t *testing.T) {
+	mgr, _ := plugins.NewManager(zap.NewNop())
+	cli := &ChatCLI{pluginManager: mgr}
+	// @browser is IsConcurrencySafe=false → runWorkerPluginTool must take
+	// the per-plugin lock. Without a real browser the call errors, but the
+	// routing (GetPlugin + lock path) is what we exercise.
+	cli.pluginManager.RegisterBuiltinPlugin(plugins.NewBuiltinBrowserPlugin())
+	_, err := cli.runWorkerPluginTool(context.Background(), "@browser", `{"cmd":"status"}`)
+	_ = err // may error without Chrome; must not panic/deadlock
+	// Unknown plugin surfaces a clean error, never a panic.
+	if _, err := cli.runWorkerPluginTool(context.Background(), "@nope", "{}"); err == nil {
+		t.Fatal("unknown plugin must error")
+	}
+	// mcp_ without a manager errors cleanly.
+	if _, err := cli.runWorkerPluginTool(context.Background(), "mcp_x", "{}"); err == nil {
+		t.Fatal("mcp_ without manager must error")
+	}
+}

--- a/cli/worker_skill_context.go
+++ b/cli/worker_skill_context.go
@@ -62,7 +62,7 @@ func (a *AgentMode) workerSkillBlock(task string) string {
 	}
 
 	seen := make(map[string]bool)
-	var skills []*persona.Skill
+	skills := make([]*persona.Skill, 0, maxWorkerSkills+2)
 
 	// Pinned skills always reach the worker (explicit user intent), no
 	// trigger needed and not subject to the trigger-match cap.

--- a/cli/worker_skill_context.go
+++ b/cli/worker_skill_context.go
@@ -1,0 +1,101 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+/*
+ * Worker task context provider: what a dispatched squad/taskgraph worker
+ * receives in its system prompt beyond its charter.
+ *
+ * Historically this was only the proactive recall block (memory/session).
+ * This file layers the user's own SKILL.md on top, trigger-matched against
+ * the worker's task text — so a worker executing "validate the login page"
+ * gets the same curated knowledge the orchestrator would. Pinned skills are
+ * always included (explicit user intent); trigger matches are capped and
+ * budgeted. Everything is inlined (a worker cannot expand a global skill
+ * pointer — validatePath confines its reads to the workspace).
+ *
+ * 100% cli-side: the registered workers.RegisterWorkerContextProvider hook
+ * now points at workerTaskContext, no changes in cli/agent/workers.
+ *
+ * Note: persona.Skill (user SKILL.md) is unrelated to workers.SkillSet
+ * (executable macros) — do not conflate.
+ */
+package cli
+
+import (
+	"strings"
+
+	"github.com/diillson/chatcli/pkg/persona"
+)
+
+const (
+	// maxWorkerSkills caps trigger-matched skills injected per worker task.
+	maxWorkerSkills = 3
+	// workerSkillBudget bounds the injected skill characters per worker.
+	workerSkillBudget = 8 * 1024
+)
+
+// workerTaskContext is the provider registered with the workers package: the
+// proactive recall block plus the trigger-matched skill block for one task.
+func (a *AgentMode) workerTaskContext(task string) string {
+	var parts []string
+	if rb := a.followUpRecallBlocks(task); strings.TrimSpace(rb) != "" {
+		parts = append(parts, rb)
+	}
+	if sb := a.workerSkillBlock(task); strings.TrimSpace(sb) != "" {
+		parts = append(parts, sb)
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+// workerSkillBlock resolves pinned + trigger-matched skills for the task and
+// renders them inline under a task-specific header.
+func (a *AgentMode) workerSkillBlock(task string) string {
+	if a.cli == nil || a.cli.personaHandler == nil {
+		return ""
+	}
+	mgr := a.cli.personaHandler.GetManager()
+	if mgr == nil {
+		return ""
+	}
+
+	seen := make(map[string]bool)
+	var skills []*persona.Skill
+
+	// Pinned skills always reach the worker (explicit user intent), no
+	// trigger needed and not subject to the trigger-match cap.
+	if a.cli.skillHandler != nil {
+		for _, s := range a.cli.skillHandler.GetPinnedSkills() {
+			if s != nil && !seen[s.Name] {
+				seen[s.Name] = true
+				skills = append(skills, s)
+			}
+		}
+	}
+
+	// Trigger + path matches on the task text, capped. Use the pure matchers
+	// directly (not FindAutoActivatedSkills) to avoid recording per-worker
+	// usage analytics on every parallel dispatch. DisableModelInvocation is
+	// already honored by FindTriggeredSkills.
+	matched := mgr.FindTriggeredSkills(task)
+	matched = append(matched, mgr.FindPathMatchedSkills(extractFilePaths(task))...)
+	added := 0
+	for _, s := range matched {
+		if s == nil || seen[s.Name] || added >= maxWorkerSkills {
+			continue
+		}
+		seen[s.Name] = true
+		skills = append(skills, s)
+		added++
+	}
+	if len(skills) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("[SKILL AUTO-ACTIVATION — TASK]\n")
+	renderSkillEntriesLimited(&b, skills, workerSkillBudget, false)
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/cli/worker_skill_context_test.go
+++ b/cli/worker_skill_context_test.go
@@ -1,0 +1,31 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWorkerSkillBlockNilSafe(t *testing.T) {
+	a := &AgentMode{cli: &ChatCLI{}} // no personaHandler
+	if got := a.workerSkillBlock("do the thing"); got != "" {
+		t.Fatalf("no persona handler → empty, got %q", got)
+	}
+	if got := a.workerTaskContext("do the thing"); got != "" {
+		t.Fatalf("no context → empty, got %q", got)
+	}
+}
+
+func TestWorkerTaskContextJoinsBlocks(t *testing.T) {
+	// A bare AgentMode's followUpRecallBlocks returns "" (no memory wired),
+	// and workerSkillBlock returns "" (no persona) — the join is empty, not
+	// a stray separator.
+	a := &AgentMode{cli: &ChatCLI{}}
+	if strings.TrimSpace(a.workerTaskContext("x")) != "" {
+		t.Fatal("empty parts must join to empty, no stray newlines")
+	}
+}


### PR DESCRIPTION
## Why

Squad and task-graph workers already inherit proactive recall, CCR and read-only context tools — but were capped on three axes the user wanted open: **no plugin tools** (@browser/@websearch/@forge/MCP), **no user skills** (trigger rescan was orchestrator-only), and **no learning back** (what a graph discovered evaporated with the report). This brings workers the session's full arsenal — opt-in and safe.

## What

### Phase 1 — plugin grants (opt-in, per task)
A dispatch call can grant specific session plugins to the worker it spawns.
- Grant rides the **dispatch context** (`CtxKeyPluginGrant`) so all 14 agent types + the quality pipeline inherit it with zero signature changes; `AgentCall` carries it via a **pointer** (`*PluginGrant`) so the struct stays comparable — **apidiff-clean** (verified against main).
- Plugin calls surface under their **real name** (`policyCallSurface` fix) so user rules (`@browser eval`), the read-only capability auto-allow, and safety immunity all match — instead of everything canonicalizing to `@coder`.
- **Denylist** blocks loop-intercepted tools (`@ask`, `@view`, `@taskgraph`, `@model`, `@park`); reviewer never gets a grant; **non-concurrency-safe plugins (@browser) serialize** on a per-plugin lock (the process's first `IsConcurrencySafe` enforcement).
- Definitions: native catalog (6 mapped builtins) → MCP catalog (`GetTools`, origin schema) → **synthesized from `plugin.Schema()`** (`{cmd: enum, args: object}`) for the rest.
- Opt-in surfaces: `task.tools` in a task-graph plan (executor only), `tools="@browser,@http"` on `<agent_call>`.

### Phase 2 — per-task user skills (100% cli-side)
The worker context provider now also injects the user's own **trigger-matched SKILL.md**: pinned always, others capped (3) and budgeted (8KB), bodies inlined. Uses the pure matchers (no per-worker usage analytics). Zero changes in `cli/agent/workers`.

### Phase 3 — learning digest
At the end of a task-graph run, a compact digest (<1400 chars) feeds the **long-term memory pipeline** (facts + episodes + self-evolve skill candidates, on the normal cadence via the durable WAL), and one **Reflexion lesson** is queued per failed task. Best-effort — nothing here can fail or block a run.

### Fix
Dashboard froze on the final transition (canvas only repainted while tasks animated) — now repaints on every 1s poll.

## Tests
- workers: comparability guard (`map[AgentCall]bool`), grant normalize/denylist/ctx, native+XML plugin resolution, `policyCallSurface` real name, executor-tool routing.
- cli: def synthesis from Schema(), mapped/MCP filtering, runner routing + unsafe-plugin lock path.
- taskgraph: `task.tools` normalize, executor receives grant / reviewer never does, digest formatter (cap + all tasks), nil-mem no-op.
- Full suite green; ai-smells, cyclo-new, i18n-parity, **api-breaking** all clean locally.

## Follow-up
Docs (README + site: task-graph `task.tools`, agent-squad `agent_call tools=`) after merge.