### PR TITLE
feat(quality): route high-complexity auto plan-first to @taskgraph

### DIFF
--- a/cli/agent/quality/config.go
+++ b/cli/agent/quality/config.go
@@ -132,7 +132,20 @@ type ReflexionQueueConfig struct {
 type PlanFirstConfig struct {
 	Mode                string // "off" | "auto" | "always"
 	ComplexityThreshold int    // 0..10; auto triggers when score >= threshold
+	// Strategy chooses what an auto/always trigger routes to:
+	//   "taskgraph"  → steer the orchestrator to the verified @taskgraph DAG
+	//                  (default; the engine runs gates, an independent
+	//                  reviewer signs done).
+	//   "plan-solve" → the legacy in-loop Plan-and-Solve runner (no gates,
+	//                  no reviewer). Kept for parity / opt-out.
+	Strategy string
 }
+
+// PlanFirst strategy values.
+const (
+	PlanStrategyTaskGraph = "taskgraph"
+	PlanStrategyPlanSolve = "plan-solve"
+)
 
 // HyDEConfig controls Hypothetical Document Embeddings retrieval (#4).
 //
@@ -205,6 +218,7 @@ func Defaults() Config {
 		PlanFirst: PlanFirstConfig{
 			Mode:                "auto",
 			ComplexityThreshold: 6,
+			Strategy:            PlanStrategyTaskGraph,
 		},
 		HyDE: HyDEConfig{
 			Enabled:     false,
@@ -370,6 +384,9 @@ func loadPlanFirstEnv(c *PlanFirstConfig) {
 	}
 	if v := os.Getenv("CHATCLI_QUALITY_PLAN_FIRST_THRESHOLD"); v != "" {
 		c.ComplexityThreshold = parseInt(v, c.ComplexityThreshold)
+	}
+	if v := os.Getenv("CHATCLI_QUALITY_PLAN_FIRST_STRATEGY"); v != "" {
+		c.Strategy = normalizeMode(v, c.Strategy, []string{PlanStrategyTaskGraph, PlanStrategyPlanSolve})
 	}
 }
 

--- a/cli/agent/quality/plan_first_strategy_test.go
+++ b/cli/agent/quality/plan_first_strategy_test.go
@@ -1,0 +1,33 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package quality
+
+import (
+	"os"
+	"testing"
+)
+
+func TestPlanFirstStrategyDefaultAndEnv(t *testing.T) {
+	if got := Defaults().PlanFirst.Strategy; got != PlanStrategyTaskGraph {
+		t.Fatalf("default strategy must be taskgraph, got %q", got)
+	}
+
+	c := PlanFirstConfig{Strategy: PlanStrategyTaskGraph}
+	t.Setenv("CHATCLI_QUALITY_PLAN_FIRST_STRATEGY", "plan-solve")
+	loadPlanFirstEnv(&c)
+	if c.Strategy != PlanStrategyPlanSolve {
+		t.Fatalf("env override failed: %q", c.Strategy)
+	}
+
+	// Invalid value keeps the current strategy (normalizeMode fallback).
+	os.Unsetenv("CHATCLI_QUALITY_PLAN_FIRST_STRATEGY")
+	c2 := PlanFirstConfig{Strategy: PlanStrategyTaskGraph}
+	t.Setenv("CHATCLI_QUALITY_PLAN_FIRST_STRATEGY", "bogus")
+	loadPlanFirstEnv(&c2)
+	if c2.Strategy != PlanStrategyTaskGraph {
+		t.Fatalf("invalid env must keep current, got %q", c2.Strategy)
+	}
+}

--- a/cli/agent_plan_first.go
+++ b/cli/agent_plan_first.go
@@ -29,6 +29,32 @@ import (
 	"go.uber.org/zap"
 )
 
+// taskGraphSteerDirective is the model-facing instruction appended to the
+// user turn when auto plan-first routes a substantial task to @taskgraph.
+// It steers without forcing: the model still judges whether the work truly
+// decomposes (the task-graph skill teaches "<5 independent tasks → dispatch
+// workers directly"), so genuinely serial work is not shoehorned into a graph.
+const taskGraphSteerDirective = "\n\n[ORCHESTRATION HINT] This looks like a substantial, multi-step delivery. Strongly prefer the @taskgraph tool: decompose it into a DAG of tasks with per-task validation contracts (`validation` commands), and let the engine verify each task with an independent reviewer before it counts as done. If — and only if — the work is actually serial or fewer than ~5 genuinely independent tasks, skip the graph and proceed directly. Do not mention this hint to the user."
+
+// steerToTaskGraph nudges the orchestrator toward @taskgraph for an
+// auto-triggered substantial task, by appending the hint to the just-added
+// user turn (single user message — no alternation break) and letting the
+// ReAct loop run. The task-graph skill's full guidance arrives via the
+// mid-loop rescan once the model commits to the tool.
+func (a *AgentMode) steerToTaskGraph(userQuery string) {
+	a.logger.Info("Plan-First routed to @taskgraph",
+		zap.Int("complexity", quality.ComplexityScore(userQuery)))
+	fmt.Println(colorize("  "+i18n.T("plan_first.routed_taskgraph"), ColorCyan))
+	n := len(a.cli.history)
+	if n == 0 {
+		return
+	}
+	last := &a.cli.history[n-1]
+	if last.Role == "user" {
+		last.Content += taskGraphSteerDirective
+	}
+}
+
 // queryInvokesTaskGraph reports whether the user explicitly asked for the
 // task-graph orchestrator ("@taskgraph", "taskgraph", "task graph").
 func queryInvokesTaskGraph(query string) bool {
@@ -78,6 +104,16 @@ func (a *AgentMode) runPlanFirstIfApplicable(ctx context.Context, userQuery stri
 	}
 
 	if !forced && !dryRun && !quality.ShouldPlanFirst(a.qualityConfig.PlanFirst, userQuery) {
+		return
+	}
+
+	// Auto/always trigger fired. By default a substantial task routes to the
+	// VERIFIED @taskgraph DAG (engine-run gates + independent reviewer)
+	// instead of the legacy in-loop Plan-and-Solve, which has neither. An
+	// explicit /plan (forced/dryRun) still uses the planner preview/runner,
+	// and CHATCLI_QUALITY_PLAN_FIRST_STRATEGY=plan-solve opts back out.
+	if !forced && !dryRun && a.qualityConfig.PlanFirst.Strategy != quality.PlanStrategyPlanSolve {
+		a.steerToTaskGraph(userQuery)
 		return
 	}
 

--- a/cli/agent_plan_first_taskgraph_test.go
+++ b/cli/agent_plan_first_taskgraph_test.go
@@ -5,7 +5,13 @@
  */
 package cli
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
 
 // TestQueryInvokesTaskGraph: an explicit task-graph request must defer
 // auto plan-first to the @taskgraph orchestrator (executor ≠ reviewer),
@@ -29,5 +35,26 @@ func TestQueryInvokesTaskGraph(t *testing.T) {
 		if queryInvokesTaskGraph(q) {
 			t.Fatalf("must NOT defer: %q", q)
 		}
+	}
+}
+
+// TestSteerToTaskGraphAppendsHint verifies the auto-routing hint is folded
+// into the existing user turn (single message, no alternation break) and
+// carries the @taskgraph steer.
+func TestSteerToTaskGraphAppendsHint(t *testing.T) {
+	cli := &ChatCLI{}
+	cli.history = append(cli.history, models.Message{Role: "user", Content: "build the whole feature"})
+	a := &AgentMode{cli: cli, logger: zap.NewNop()}
+	a.steerToTaskGraph("build the whole feature")
+
+	if len(cli.history) != 1 {
+		t.Fatalf("must not add a new turn, got %d messages", len(cli.history))
+	}
+	last := cli.history[len(cli.history)-1]
+	if last.Role != "user" {
+		t.Fatalf("last turn must stay user, got %q", last.Role)
+	}
+	if !strings.Contains(last.Content, "@taskgraph") || !strings.Contains(last.Content, "build the whole feature") {
+		t.Fatalf("hint must ride the user turn: %q", last.Content)
 	}
 }

--- a/cli/config_quality.go
+++ b/cli/config_quality.go
@@ -97,6 +97,7 @@ func (cli *ChatCLI) showConfigQuality() {
 	subheader(p, "cfg.sub.quality.plan_first")
 	kv(p, "CHATCLI_QUALITY_PLAN_FIRST_MODE", cfg.PlanFirst.Mode)
 	kv(p, "CHATCLI_QUALITY_PLAN_FIRST_THRESHOLD", fmt.Sprintf("%d", cfg.PlanFirst.ComplexityThreshold))
+	kv(p, "CHATCLI_QUALITY_PLAN_FIRST_STRATEGY", cfg.PlanFirst.Strategy)
 
 	// HyDE
 	fmt.Println(p)

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -2301,6 +2301,7 @@
   "plan_first.orchestrator_handoff": "Use the report above as ground truth for the user-facing answer; do not re-run completed steps.",
   "plan_first.spinner_planning": "planning structured steps (Plan-and-Solve)...",
   "plan_first.spinner_executing": "executing structured plan...",
+  "plan_first.routed_taskgraph": "substantial task — routing to the verified @taskgraph DAG (engine gates + independent review)",
   "plan_first.preview_header": "Generated plan (dry-run — nothing will be executed)",
   "plan_first.preview_task": "Summary",
   "plan_first.preview_parallel": "Parallel groups",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -2301,6 +2301,7 @@
   "plan_first.orchestrator_handoff": "Use the report above as ground truth for the user-facing answer; do not re-run completed steps.",
   "plan_first.spinner_planning": "planning structured steps (Plan-and-Solve)...",
   "plan_first.spinner_executing": "executing structured plan...",
+  "plan_first.routed_taskgraph": "substantial task — routing to the verified @taskgraph DAG (engine gates + independent review)",
   "plan_first.preview_header": "Generated plan (dry-run — nothing will be executed)",
   "plan_first.preview_task": "Summary",
   "plan_first.preview_parallel": "Parallel groups",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -2301,6 +2301,7 @@
   "plan_first.orchestrator_handoff": "Use o relatório acima como verdade absoluta para a resposta final; não re-execute passos já concluídos.",
   "plan_first.spinner_planning": "planejando estrutura (Plan-and-Solve)...",
   "plan_first.spinner_executing": "executando plano estruturado...",
+  "plan_first.routed_taskgraph": "tarefa grande — roteando para o @taskgraph verificado (gates do engine + review independente)",
   "plan_first.preview_header": "Plano gerado (dry-run — nada será executado)",
   "plan_first.preview_task": "Resumo",
   "plan_first.preview_parallel": "Grupos paralelizáveis",


### PR DESCRIPTION
## The gap

Two auto-planning paths existed and only one was verified:

| Prompt | Before |
|---|---|
| explicit `@taskgraph` / matches skill triggers | **@taskgraph** (plan-first defers) |
| complex task, no mention, no trigger (ComplexityScore ≥ 6) | **legacy Plan-and-Solve** — no gates, no reviewer |
| simple task | direct tool calls |

So a substantial delivery you *didn't* name for the graph silently fell to the legacy in-loop runner, which executes steps with none of the graph's verification. This closes that.

## What changes

An auto/always plan-first trigger now **routes to the verified @taskgraph DAG by default**. It *steers* rather than forces: a one-line orchestration hint is folded into the just-added user turn (single message, no alternation break), pointing the model at `@taskgraph` and telling it to decompose into a DAG with per-task validation contracts. The model still judges fit — the task-graph skill says "skip the graph for serial or <5 independent tasks" — so genuinely serial work isn't shoehorned into a graph.

- `PlanFirstConfig.Strategy` — `taskgraph` (default) | `plan-solve` (legacy opt-out) via `CHATCLI_QUALITY_PLAN_FIRST_STRATEGY`, shown in `/config quality`.
- Explicit `/plan` (forced + dry-run preview) keeps the planner preview/runner unchanged.
- Explicit `@taskgraph` requests were already deferred — unchanged.

## Tests
- steer folds the hint into the user turn without adding a message or breaking alternation;
- strategy default is `taskgraph`, env override + invalid-value fallback.
- Full suite green; ai-smells, cyclo-new, i18n-parity clean locally.