### PR TITLE
perf(coder): make post-edit diagnostics non-blocking with background LSP warm-up

### DIFF
--- a/cli/agent/lsp/pool.go
+++ b/cli/agent/lsp/pool.go
@@ -32,13 +32,21 @@ const (
 	// poolIdleTTL is how long an unused language server stays alive. Long
 	// enough to survive a conversation lull; short enough that a session
 	// that moved on from Rust doesn't keep rust-analyzer resident forever.
-	poolIdleTTL = 5 * time.Minute
+	// Field data moved this from 5 to 15 minutes: agent sessions routinely
+	// pause longer than 5 minutes between edits (model turns, the user
+	// reading output), and every reap re-bills the next post-edit check
+	// with a full cold start and re-index.
+	poolIdleTTL = 15 * time.Minute
 
 	// maxDocumentBytes bounds one didOpen/didChange payload. Files past this
 	// are almost certainly generated artifacts a language server would choke
 	// on anyway; the tool reports a clear error instead of stalling.
 	maxDocumentBytes = 2 << 20 // 2MiB
 
+	// warmupTimeout bounds one background warm-up spawn kicked off by
+	// AcquireReady. Generous — nothing waits on it — but finite, so a hung
+	// server binary cannot pin a goroutine for the whole session.
+	warmupTimeout = 30 * time.Second
 )
 
 // rootMarkers, in priority order, identify a project root when walking up
@@ -53,6 +61,11 @@ type Pool struct {
 
 	mu      sync.Mutex
 	entries map[string]*poolEntry
+	// warming tracks in-flight background warm-ups (single-flight per key).
+	warming map[string]bool
+	// closed marks a pool torn down by Close: no further spawns, so a
+	// warm-up racing session shutdown can never leak a live server.
+	closed bool
 
 	// spawn is the client factory — swapped by tests for a pipe-backed fake.
 	spawn func(ctx context.Context, spec ServerSpec, logger *zap.Logger) (*Client, error)
@@ -120,6 +133,9 @@ func (p *Pool) Acquire(ctx context.Context, absPath string) (*Session, error) {
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	if p.closed {
+		return nil, fmt.Errorf("lsp: pool is closed")
+	}
 	p.reapIdleLocked()
 
 	entry, ok := p.entries[key]
@@ -156,6 +172,76 @@ func (p *Pool) Acquire(ctx context.Context, absPath string) (*Session, error) {
 		return nil, syncErr
 	}
 	return &Session{Client: entry.client, URI: uri, Root: root}, nil
+}
+
+// AcquireReady returns a ready Session for absPath only when the pooled
+// server for its (project root, language) is ALREADY initialized — it never
+// spawns synchronously. A cold pool instead kicks off a single-flight
+// background warm-up and reports not-ready, so advisory callers (the
+// post-edit diagnostics hook above all) skip cheaply now and find a warm
+// server on their next call. TryLock keeps the same promise against a busy
+// pool: if another caller holds it — typically a cold spawn in flight —
+// report not-ready rather than queue behind seconds of initialization.
+func (p *Pool) AcquireReady(absPath string) (*Session, bool) {
+	spec, ok := ServerForFile(absPath)
+	if !ok {
+		return nil, false
+	}
+	data, err := os.ReadFile(absPath) //#nosec G304 -- agent-requested source file, same trust boundary as Acquire
+	if err != nil || len(data) > maxDocumentBytes {
+		return nil, false
+	}
+	root := findProjectRoot(absPath)
+	key := root + "\x00" + strings.Join(spec.Command, " ")
+
+	if !p.mu.TryLock() {
+		return nil, false
+	}
+	defer p.mu.Unlock()
+	if p.closed {
+		return nil, false
+	}
+	p.reapIdleLocked()
+
+	entry, ok := p.entries[key]
+	if !ok {
+		p.warmLocked(key, absPath)
+		return nil, false
+	}
+	entry.lastUse = p.now()
+
+	uri := "file://" + absPath
+	if syncErr := entry.syncDocument(uri, spec.LanguageID, string(data)); syncErr != nil {
+		return nil, false
+	}
+	return &Session{Client: entry.client, URI: uri, Root: root}, true
+}
+
+// warmLocked starts one background warm-up for key unless one is already in
+// flight. Caller holds p.mu. The goroutine reuses Acquire wholesale — same
+// spawn, same initialization, same entry bookkeeping — and discards the
+// session; only the pooled server matters. Acquire's own closed-pool guard
+// makes a warm-up racing Close shut down cleanly instead of leaking.
+func (p *Pool) warmLocked(key, absPath string) {
+	if p.warming == nil {
+		p.warming = map[string]bool{}
+	}
+	if p.warming[key] {
+		return
+	}
+	p.warming[key] = true
+	go func() {
+		defer func() {
+			p.mu.Lock()
+			delete(p.warming, key)
+			p.mu.Unlock()
+		}()
+		ctx, cancel := context.WithTimeout(context.Background(), warmupTimeout)
+		defer cancel()
+		if _, err := p.Acquire(ctx, absPath); err != nil {
+			p.logger.Debug("lsp: background warm-up failed", zap.Error(err))
+		}
+	}()
 }
 
 // syncDocument opens the document on first use and sends a versioned full
@@ -201,6 +287,7 @@ func (p *Pool) reapIdleLocked() {
 func (p *Pool) Close() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	p.closed = true
 	for key, e := range p.entries {
 		e.shutdown = true
 		e.client.Shutdown()

--- a/cli/agent/lsp/pool_test.go
+++ b/cli/agent/lsp/pool_test.go
@@ -194,3 +194,86 @@ func TestFindProjectRootPrefersMarkers(t *testing.T) {
 		t.Fatalf("markerless root = %q, want file dir", got)
 	}
 }
+
+// TestAcquireReadyColdPoolWarmsInBackground pins the non-blocking contract:
+// a cold pool reports not-ready immediately, warms the server in the
+// background exactly once, and a later call finds it ready.
+func TestAcquireReadyColdPoolWarmsInBackground(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	file := writeGoFile(t, dir, "a.go", "package x\n")
+
+	var spawns atomic.Int32
+	p := NewPool(zap.NewNop())
+	p.spawn = pipeSpawner(t, &spawns)
+	defer p.Close()
+
+	if _, ready := p.AcquireReady(file); ready {
+		t.Fatal("cold pool must report not-ready, never spawn synchronously")
+	}
+	// Second immediate call must not start a second warm-up (single-flight).
+	_, _ = p.AcquireReady(file)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if sess, ready := p.AcquireReady(file); ready {
+			if sess.Client == nil || sess.Root != dir {
+				t.Fatalf("warm session malformed: %+v", sess)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("background warm-up never produced a ready server")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if spawns.Load() != 1 {
+		t.Fatalf("spawned %d servers, want 1 (single-flight warm-up)", spawns.Load())
+	}
+}
+
+// TestAcquireReadyUnsupportedAndMissing pins the cheap-refusal paths: no
+// server for the extension and an unreadable file are not-ready, no spawn.
+func TestAcquireReadyUnsupportedAndMissing(t *testing.T) {
+	var spawns atomic.Int32
+	p := NewPool(zap.NewNop())
+	p.spawn = pipeSpawner(t, &spawns)
+	defer p.Close()
+
+	if _, ready := p.AcquireReady(writeGoFile(t, t.TempDir(), "notes.txt", "x")); ready {
+		t.Fatal("unsupported extension must be not-ready")
+	}
+	if _, ready := p.AcquireReady(filepath.Join(t.TempDir(), "gone.go")); ready {
+		t.Fatal("missing file must be not-ready")
+	}
+	if spawns.Load() != 0 {
+		t.Fatalf("cheap refusals must not spawn, got %d", spawns.Load())
+	}
+}
+
+// TestPoolClosedRefusesAcquire pins the shutdown guard: after Close, both
+// acquire surfaces refuse and no server can leak into a dead pool.
+func TestPoolClosedRefusesAcquire(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	file := writeGoFile(t, dir, "a.go", "package x\n")
+
+	var spawns atomic.Int32
+	p := NewPool(zap.NewNop())
+	p.spawn = pipeSpawner(t, &spawns)
+	p.Close()
+
+	if _, err := p.Acquire(context.Background(), file); err == nil {
+		t.Fatal("Acquire on a closed pool must error")
+	}
+	if _, ready := p.AcquireReady(file); ready {
+		t.Fatal("AcquireReady on a closed pool must be not-ready")
+	}
+	if spawns.Load() != 0 {
+		t.Fatalf("closed pool must never spawn, got %d", spawns.Load())
+	}
+}

--- a/cli/lsp_tool_adapter.go
+++ b/cli/lsp_tool_adapter.go
@@ -34,6 +34,14 @@ const (
 	// server's publish after (re)opening a document.
 	lspDiagnosticsWait = 12 * time.Second
 
+	// lspQuickDiagnosticsWait bounds the publish wait for the ADVISORY
+	// post-edit check. A warm, indexed server publishes in well under a
+	// second; one that takes longer is still indexing, and an advisory
+	// block must report "inconclusive" quickly rather than tax every write
+	// with the full explicit-diagnostics wait. Field post-mortem: 12s per
+	// touched file, silently, before the tool result rendered.
+	lspQuickDiagnosticsWait = 4 * time.Second
+
 	// lspDefaultRefLimit / lspMaxRefLimit bound reference listings so one
 	// popular symbol cannot flood the conversation.
 	lspDefaultRefLimit = 50
@@ -130,12 +138,26 @@ func renderDiagnosticsList(root, abs string, diags []lsp.Diagnostic) string {
 // Diagnostics, plus an explicit hasIssues flag so the post-edit auto-check
 // can stay silent on clean (or inconclusive) files instead of spending
 // tokens announcing cleanliness.
+//
+// Unlike the explicit tool surfaces it NEVER cold-spawns a server: the check
+// is advisory and runs inline before every write's tool result, so a cold
+// pool means "inconclusive now" — AcquireReady warms the server in the
+// background and the NEXT edit gets real findings. The publish wait is the
+// short quick-check budget for the same reason.
 func (a *lspToolAdapter) QuickDiagnostics(file string) (string, bool, error) {
-	sess, abs, err := a.acquire(file)
+	expanded, err := utils.ExpandPath(file)
+	if err != nil {
+		expanded = file
+	}
+	abs, err := filepath.Abs(expanded)
 	if err != nil {
 		return "", false, err
 	}
-	diags, ok := sess.Client.Diagnostics(sess.URI, lspDiagnosticsWait)
+	sess, ready := a.pool().AcquireReady(abs)
+	if !ready {
+		return "", false, nil
+	}
+	diags, ok := sess.Client.Diagnostics(sess.URI, lspQuickDiagnosticsWait)
 	if !ok || len(diags) == 0 {
 		return "", false, nil
 	}

--- a/cli/plugins/coder_autodiag.go
+++ b/cli/plugins/coder_autodiag.go
@@ -17,8 +17,12 @@
  *
  * Degrades to a no-op when: the env kill switch is set, no LSP adapter is
  * wired (one-shot surfaces without a pool), the adapter lacks the quick
- * capability, or the language has no server. A clean file appends nothing —
- * silence means clean, keeping the happy path at zero token cost.
+ * capability, the language has no server, or the session pool is still cold
+ * (the adapter then warms it in the background and the NEXT edit gets real
+ * findings). A clean file appends nothing — silence means clean, keeping
+ * the happy path at zero token cost. The whole pass also runs under a
+ * wall-clock budget: this hook sits between the edit and its tool result,
+ * so a slow language server must degrade the check, never the edit.
  */
 package plugins
 
@@ -27,6 +31,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 )
 
 // coderAutoDiagEnv is the kill switch for post-edit diagnostics. Unset or
@@ -63,6 +68,12 @@ const (
 	// thousand parse errors) cannot flood the tool result.
 	maxAutoDiagBytes = 3000
 )
+
+// autoDiagPassBudget caps the WHOLE post-edit pass in wall-clock time. Each
+// file's check already has a per-file publish wait in the adapter; this is
+// the defense in depth for a multipatch over several slow files. A var, not
+// a const, purely as a test seam.
+var autoDiagPassBudget = 8 * time.Second
 
 // mutatingCoderSubcommands are the @coder subcommands whose success means
 // file content changed on disk.
@@ -142,7 +153,12 @@ func appendAutoDiagnostics(subcmd string, args []string, output string) string {
 	}
 
 	var b strings.Builder
-	for _, file := range targets {
+	started := time.Now()
+	for i, file := range targets {
+		if time.Since(started) > autoDiagPassBudget {
+			b.WriteString(fmt.Sprintf("- %d file(s) not checked (diagnostics time budget) — run @lsp diagnostics on them if needed.\n", len(targets)-i))
+			break
+		}
 		text, hasIssues, err := qd.QuickDiagnostics(file)
 		if err != nil || !hasIssues || strings.TrimSpace(text) == "" {
 			continue

--- a/cli/plugins/coder_autodiag_test.go
+++ b/cli/plugins/coder_autodiag_test.go
@@ -16,6 +16,7 @@ package plugins
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 // fakeDiagAdapter implements LSPAdapter plus the LSPQuickDiagnoser capability.
@@ -168,5 +169,39 @@ func TestAppendAutoDiagnostics_FileCap(t *testing.T) {
 	appendAutoDiagnostics("multipatch", []string{"--edits", edits}, "done")
 	if len(fake.calls) != maxAutoDiagFiles {
 		t.Fatalf("expected at most %d diagnostics calls, got %d", maxAutoDiagFiles, len(fake.calls))
+	}
+}
+
+// slowDiagAdapter is a fakeDiagAdapter whose every QuickDiagnostics call burns
+// wall-clock time, to exercise the pass-level budget.
+type slowDiagAdapter struct {
+	fakeDiagAdapter
+	delay time.Duration
+}
+
+func (s *slowDiagAdapter) QuickDiagnostics(file string) (string, bool, error) {
+	time.Sleep(s.delay)
+	return s.fakeDiagAdapter.QuickDiagnostics(file)
+}
+
+func TestAppendAutoDiagnostics_TimeBudget(t *testing.T) {
+	prev := autoDiagPassBudget
+	autoDiagPassBudget = 50 * time.Millisecond
+	t.Cleanup(func() { autoDiagPassBudget = prev })
+
+	slow := &slowDiagAdapter{
+		fakeDiagAdapter: fakeDiagAdapter{findings: map[string]string{}},
+		delay:           40 * time.Millisecond,
+	}
+	withLSPAdapter(t, slow)
+
+	edits := `[{"file":"a.go"},{"file":"b.go"},{"file":"c.go"},{"file":"d.go"},{"file":"e.go"}]`
+	out := appendAutoDiagnostics("multipatch", []string{"--edits", edits}, "done")
+
+	if len(slow.calls) >= 5 {
+		t.Fatalf("time budget must stop the pass early, but all %d files were checked", len(slow.calls))
+	}
+	if !strings.Contains(out, "not checked (diagnostics time budget)") {
+		t.Fatalf("skipped files must be reported explicitly, got:\n%s", out)
 	}
 }


### PR DESCRIPTION
## Problem

Follow-up to #1429 (second factor from the same field post-mortem). The advisory post-edit diagnostics hook ran on the write's critical path with the budgets of the explicit tool surfaces:

- A **cold session pool** paid the full language-server spawn + initialization **synchronously** before the write's tool result rendered.
- Every touched file waited up to **12s** for a diagnostics publish (×5 files worst case = 60s of silent spinner).
- The pool reaped idle servers after **5 minutes** — ordinary pauses between edits (model turns, the user reading) re-billed the next write with a complete cold start, over and over.

## Fix

The check is advisory by contract — `hasIssues=false` already means "clean or inconclusive" — so it now degrades instead of blocking:

1. **`Pool.AcquireReady`** (new, additive): returns a session only when the server for that (project root, language) is already initialized — it never spawns synchronously. A cold pool kicks off a **single-flight background warm-up** (bounded, 30s) so the *next* edit gets real findings; a busy pool (cold spawn in flight) reports not-ready via `TryLock` instead of queuing behind seconds of initialization.
2. **Short publish budget for the quick check** (4s): a warm, indexed server publishes in well under a second; one that takes longer is still indexing and the advisory check reports inconclusive. The explicit `/lsp` and `@lsp diagnostics` surfaces keep the full 12s.
3. **Wall-clock budget for the whole pass** (8s): defense in depth for a multipatch over several slow files; skipped files are reported explicitly in the `[DIAGNOSTICS]` block.
4. **Idle TTL 5min → 15min**, with rationale documented at the constant.
5. **Shutdown safety**: the pool now refuses acquisition after `Close`, so a warm-up racing session shutdown shuts the fresh server down cleanly instead of leaking it.

## Non-changes

- `plugins.LSPAdapter` and `plugins.LSPQuickDiagnoser` interfaces untouched (no breaking change); `Pool.AcquireReady` is additive.
- Explicit `/lsp` and `@lsp` behavior unchanged (same spawn path, same waits).
- No new env vars.

## Coverage

New tests: cold-pool not-ready + single-flight background warm-up converging to ready (fake pipe spawner), cheap refusals (unsupported extension, missing file) spawn nothing, closed pool refuses both acquire surfaces, autodiag pass-level time budget stops early with an explicit note (sleepy fake adapter). Full suite + `-race` green; qg floors pass locally against main.

Docs (chatcli.ai en+pt) updated: autodiag guardrails now document the never-blocks-on-cold-server behavior and the pass budget; pool TTL mention updated to 15 minutes.