### PR TITLE
feat(models): refresh provider catalogs for September 2026

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,11 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -ldflags="-s -w" -o c
 
 # Build grpc_health_probe with patched dependencies:
 #   CVE-2026-34986 (go-jose/v4), GHSA-hrxh-6v49-42gf (grpc),
-#   CVE-2026-46600 (x/net), CVE-2026-56852 (x/text)
+#   CVE-2026-46600 (x/net), CVE-2026-56852 (x/text), CVE-2026-84304 (grpc <1.83.1)
 RUN git clone --depth 1 https://github.com/grpc-ecosystem/grpc-health-probe /tmp/ghp && \
     cd /tmp/ghp && \
     go get github.com/go-jose/go-jose/v4@v4.1.4 \
-        google.golang.org/grpc@v1.82.1 \
+        google.golang.org/grpc@v1.83.2 \
         golang.org/x/net@v0.57.0 \
         golang.org/x/text@v0.40.0 && \
     go mod tidy && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@ RUN git clone --depth 1 https://github.com/grpc-ecosystem/grpc-health-probe /tmp
     cd /tmp/ghp && \
     go get github.com/go-jose/go-jose/v4@v4.1.4 \
         google.golang.org/grpc@v1.83.2 \
-        golang.org/x/net@v0.57.0 \
-        golang.org/x/text@v0.40.0 && \
+        golang.org/x/net@v0.58.0 \
+        golang.org/x/text@v0.41.0 && \
     go mod tidy && \
     CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -ldflags="-s -w" -o /usr/local/bin/grpc-health-probe . && \
     rm -rf /tmp/ghp

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ helm install chatcli oci://ghcr.io/diillson/charts/chatcli \
 | **Anthropic (Claude)** | claude-sonnet-4-6 | Native | Yes | Extended thinking with cache |
 | **AWS Bedrock** | claude-sonnet-4-5 | Native | Yes | Thinking budget (Anthropic models) |
 | **Google Gemini** | gemini-2.5-flash | Native | Yes | — |
-| **xAI (Grok)** | grok-4-1 | XML fallback | — | — |
+| **xAI (Grok)** | grok-4.3 | XML fallback | — | — |
 | **ZAI (Zhipu AI)** | glm-5 | Native | Yes | `ZAI_THINKING=enabled\|disabled` · GLM Coding Plan via `ZAI_USE_CODING_PLAN` |
 | **MiniMax** | MiniMax-M2.7 | Native | Yes | — |
 | **Moonshot (Kimi)** | kimi-k2.6 | Native | Yes | `MOONSHOT_THINKING=enabled\|disabled\|auto` |

--- a/README_PT.md
+++ b/README_PT.md
@@ -291,7 +291,7 @@ helm install chatcli oci://ghcr.io/diillson/charts/chatcli \
 | **Anthropic (Claude)** | claude-sonnet-4-6 | Nativo | Sim | Extended thinking com cache |
 | **AWS Bedrock** | claude-sonnet-4-5 | Nativo | Sim | Thinking budget (Anthropic models) |
 | **Google Gemini** | gemini-2.5-flash | Nativo | Sim | — |
-| **xAI (Grok)** | grok-4-1 | XML fallback | — | — |
+| **xAI (Grok)** | grok-4.3 | XML fallback | — | — |
 | **ZAI (Zhipu AI)** | glm-5 | Nativo | Sim | `ZAI_THINKING=enabled\|disabled` · GLM Coding Plan via `ZAI_USE_CODING_PLAN` |
 | **MiniMax** | MiniMax-M2.7 | Nativo | Sim | — |
 | **Moonshot (Kimi)** | kimi-k2.6 | Nativo | Sim | `MOONSHOT_THINKING=enabled\|disabled\|auto` |

--- a/cli/cost_tracker.go
+++ b/cli/cost_tracker.go
@@ -858,6 +858,12 @@ func claudePricing(model string) (float64, float64, bool) {
 	case strings.Contains(model, "opus"):
 		// Opus 3 / 4.0 / 4.1 legacy pricing.
 		return 15.0, 75.0, true
+	case strings.Contains(model, "sonnet-5"):
+		// Sonnet 5: the $2/$10 launch rate became the permanent list price
+		// (Anthropic cancelled the Sep 1 2026 increase). Must precede the
+		// generic "sonnet" tier below; the substring also covers the
+		// Bedrock (anthropic.claude-sonnet-5) and OpenRouter spellings.
+		return 2.0, 10.0, true
 	case strings.Contains(model, "sonnet"):
 		return 3.0, 15.0, true
 	case strings.Contains(model, "haiku-4-5"):
@@ -873,19 +879,52 @@ func claudePricing(model string) (float64, float64, bool) {
 // ("gpt-4o").
 func openAIPricing(model string) (float64, float64, bool) {
 	switch {
-	// gpt-5.6 (Jul 2026): preços de lista da API por tier, já refletindo
-	// os cortes de 30/Jul/2026 (terra −20%, luna −80%; Sol inalterado —
-	// developers.openai.com/docs/pricing). O caso genérico "gpt-5.6"
-	// cobre o alias de família (que o catálogo resolve para Sol) e
-	// precisa vir depois dos tiers específicos. O surcharge de
+	// gpt-5.6 (Jul 2026): preços de lista da API por tier
+	// (developers.openai.com/api/docs/pricing, Set/2026): terra e luna
+	// desde o corte de 30/Jul; Sol caiu para $4/$20 em 21/Ago ("pelo
+	// menos até 21/Nov/2026" — revisar na virada). O caso genérico
+	// "gpt-5.6" cobre o alias de família (que o catálogo resolve para
+	// Sol) e precisa vir depois dos tiers específicos. O surcharge de
 	// long-context (>272K input = 2×/1,5×) não é modelado — cost_tracker
-	// trabalha com um único tier por modelo.
+	// trabalha com um único tier por modelo. Os mesmos casos cobrem os
+	// ids do Bedrock (global.openai.gpt-5.6-*), que a AWS cobra igual no
+	// endpoint global.
 	case strings.Contains(model, "gpt-5.6-terra"):
 		return 2.0, 12.0, true
 	case strings.Contains(model, "gpt-5.6-luna"):
 		return 0.20, 1.20, true
 	case strings.Contains(model, "gpt-5.6"):
+		return 4.0, 20.0, true
+	// gpt-5.5 … gpt-5 (developers.openai.com/api/docs/pricing, Set/2026).
+	// Antes desta tabela todo id 5.x abaixo do 5.6 caía em "desconhecido"
+	// e o /cost reportava zero. Pro/mini/nano específicos antes do tier
+	// base de cada geração; "gpt-5.1" compartilha a tarifa do gpt-5.
+	case strings.Contains(model, "gpt-5.5-pro"):
+		return 30.0, 180.0, true
+	case strings.Contains(model, "gpt-5.5"):
 		return 5.0, 30.0, true
+	case strings.Contains(model, "gpt-5.4-pro"):
+		return 30.0, 180.0, true
+	case strings.Contains(model, "gpt-5.4-mini"):
+		return 0.75, 4.50, true
+	case strings.Contains(model, "gpt-5.4-nano"):
+		return 0.20, 1.25, true
+	case strings.Contains(model, "gpt-5.4"):
+		return 2.50, 15.0, true
+	case strings.Contains(model, "gpt-5.3-codex"):
+		return 1.75, 14.0, true
+	case strings.Contains(model, "gpt-5.2-pro"):
+		return 21.0, 168.0, true
+	case strings.Contains(model, "gpt-5.2"):
+		return 1.75, 14.0, true
+	case strings.Contains(model, "gpt-5-pro"):
+		return 15.0, 120.0, true
+	case strings.Contains(model, "gpt-5-mini"):
+		return 0.25, 2.0, true
+	case strings.Contains(model, "gpt-5-nano"):
+		return 0.05, 0.40, true
+	case strings.Contains(model, "gpt-5.1"), strings.Contains(model, "gpt-5"):
+		return 1.25, 10.0, true
 	case strings.Contains(model, "gpt-4o-mini"):
 		return 0.15, 0.60, true
 	case strings.Contains(model, "gpt-4o"):
@@ -960,10 +999,15 @@ func grokPricing(model string) (float64, float64, bool) {
 		return 2.0, 6.0, true
 	case strings.Contains(model, "grok-4.3"), strings.Contains(model, "grok-4.20"):
 		return 1.25, 2.50, true
-	case strings.Contains(model, "grok-build"):
+	case strings.Contains(model, "grok-build"), strings.Contains(model, "grok-code-fast"):
+		// grok-code-fast-1 became an alias of grok-build-0.1 on May 15 2026.
 		return 1.0, 2.0, true
-	case strings.Contains(model, "grok-3"):
-		return 3.0, 15.0, true
+	case strings.Contains(model, "grok-3"), strings.Contains(model, "grok-4-"):
+		// Retired May 15 2026 (grok-3, grok-3-mini, grok-4-0709,
+		// grok-4-fast-*, grok-4-1-fast-*): xAI keeps the slugs alive but
+		// redirects them to grok-4.3 and bills grok-4.3 rates
+		// (docs.x.ai/developers/migration/may-15-retirement).
+		return 1.25, 2.50, true
 	case strings.Contains(model, "grok-2"):
 		return 2.0, 10.0, true
 	case strings.Contains(model, "grok"):
@@ -994,6 +1038,29 @@ func zaiPricing(model string) (float64, float64, bool) {
 		return 1.20, 4.00, true
 	case strings.Contains(model, "glm-5"):
 		return 1.00, 3.20, true
+	// GLM-4.x list prices (docs.z.ai/guides/overview/pricing, Set/2026).
+	// Variantes "-flash" são gratuitas (known=true com tarifa zero, como
+	// Ollama); "-flashx" e "-air/-airx/-x" têm tier próprio e precisam
+	// vir antes do id base da geração, que é prefixo delas.
+	case strings.Contains(model, "glm-4.7-flashx"):
+		return 0.07, 0.40, true
+	case strings.Contains(model, "glm-4.7-flash"), strings.Contains(model, "glm-4.5-flash"),
+		strings.Contains(model, "glm-4.6v-flash") && !strings.Contains(model, "flashx"):
+		return 0, 0, true
+	case strings.Contains(model, "glm-4.6v-flashx"):
+		return 0.04, 0.40, true
+	case strings.Contains(model, "glm-4.6v"):
+		return 0.30, 0.90, true
+	case strings.Contains(model, "glm-4.5-airx"):
+		return 1.10, 4.50, true
+	case strings.Contains(model, "glm-4.5-air"):
+		return 0.20, 1.10, true
+	case strings.Contains(model, "glm-4.5-x"):
+		return 2.20, 8.90, true
+	case strings.Contains(model, "glm-4.5v"):
+		return 0.60, 1.80, true
+	case strings.Contains(model, "glm-4.7"), strings.Contains(model, "glm-4.6"), strings.Contains(model, "glm-4.5"):
+		return 0.60, 2.20, true
 	}
 	return 0, 0, false
 }
@@ -1031,8 +1098,8 @@ func deepseekPricing(model string) (float64, float64, bool) {
 // kimi-k2.6 as of 2026-05 is $0.95/M input (cache miss) and $4.00/M
 // output; cache-hit input is $0.16/M but cost_tracker only models a
 // single tier — we charge the miss price so accounting stays
-// conservative. K2.5 and moonshot-v1-* sit below K2.6; we approximate
-// with K2.6 numbers to avoid under-reporting.
+// conservative. Retired ids (kimi-k2.5, moonshot-v1-*) keep this
+// tier so old session logs still price instead of reporting zero.
 func providerFallbackPricing(provider, model string) (float64, float64, bool) {
 	switch {
 	case strings.Contains(model, "minimax"), strings.Contains(provider, "minimax"):
@@ -1089,9 +1156,26 @@ func getCachePricing(provider, model string) (cacheWriteCost, cacheReadCost floa
 	}
 
 	switch {
+	case strings.Contains(model, "fable-5-1"), strings.Contains(model, "fable-5.1"):
+		// Fable 5.1: cache reads at $0.25/MTok = 2.5% of the $10 input
+		// price (platform.claude.com/docs/en/models/fable-5-1/overview);
+		// writes keep the 1.25x rule ($12.50). Must precede the generic
+		// Claude case, which would bill reads at 10% ($1).
+		return inputCost * 1.25, inputCost * 0.025
 	case strings.Contains(model, "claude"):
 		// Anthropic: write = 1.25x input, read = 0.1x input.
 		return inputCost * 1.25, inputCost * 0.10
+	case strings.Contains(model, "grok"):
+		// xAI (docs.x.ai/developers/pricing, Set/2026): cached input
+		// $0.50 em grok-4.6 (25% do input), $0.30 em grok-4.5 (15%),
+		// $0.20 nos demais (16% de $1.25). Sem surcharge de escrita.
+		switch {
+		case strings.Contains(model, "grok-4.6"):
+			return 0, inputCost * 0.25
+		case strings.Contains(model, "grok-4.5"):
+			return 0, inputCost * 0.15
+		}
+		return 0, inputCost * 0.16
 	case strings.Contains(model, "gemini"):
 		// Google implicit/context caching: reads at 25% of input.
 		return 0, inputCost * 0.25

--- a/cli/cost_tracker_overhaul_test.go
+++ b/cli/cost_tracker_overhaul_test.go
@@ -19,7 +19,7 @@ func TestLookupModelPricingKnownFlag(t *testing.T) {
 		wantKnown       bool
 		wantIn          float64
 	}{
-		{"CLAUDEAI", "claude-sonnet-5", true, 3.0},
+		{"CLAUDEAI", "claude-sonnet-5", true, 2.0}, // $2/$10 became the permanent Sonnet 5 price
 		{"OPENAI", "gpt-4o", true, 2.50},
 		{"DEEPSEEK", "deepseek-reasoner", true, 0.55}, // API alias of R1 — not the $0.27 generic tier
 		{"OLLAMA", "llama3.3", true, 0},               // unmetered by design
@@ -43,11 +43,19 @@ func TestGetCachePricingFamilies(t *testing.T) {
 		provider, model     string
 		wantWrite, wantRead float64
 	}{
-		{"CLAUDEAI", "claude-sonnet-5", 3.0 * 1.25, 3.0 * 0.10},
+		{"CLAUDEAI", "claude-sonnet-5", 2.0 * 1.25, 2.0 * 0.10},
+		// Fable 5.1 reads at 2.5% of input ($0.25), writes keep 1.25x.
+		{"CLAUDEAI", "claude-fable-5-1", 10.0 * 1.25, 10.0 * 0.025},
+		{"BEDROCK", "anthropic.claude-fable-5-1", 10.0 * 1.25, 10.0 * 0.025},
+		{"CLAUDEAI", "claude-fable-5", 10.0 * 1.25, 10.0 * 0.10}, // Fable 5 keeps the 10% rule
 		{"OPENAI", "gpt-4o", 0, 2.50 * 0.50},
 		{"GOOGLEAI", "gemini-2.5-pro", 0, 1.25 * 0.25},
 		{"DEEPSEEK", "deepseek-chat", 0, 0.27 * 0.25},
-		{"XAI", "grok-4.6", 0, 0}, // no published cache rate → no discount
+		// xAI cached input (docs.x.ai pricing, Sep 2026): $0.50 on 4.6,
+		// $0.30 on 4.5, $0.20 on the 4.3/4.20 tier.
+		{"XAI", "grok-4.6", 0, 0.50},
+		{"XAI", "grok-4.5", 0, 0.30},
+		{"XAI", "grok-4.3", 0, 1.25 * 0.16},
 		{"UNKNOWN", "no-such-model", 0, 0},
 	}
 	for _, c := range cases {
@@ -91,9 +99,9 @@ func TestRecomputeCostCacheSubsetSemantics(t *testing.T) {
 		IsReal:               true,
 	})
 	rec2 := ct2.modelUsage[modelKey("CLAUDEAI", "claude-sonnet-5")]
-	// 1M at $3.00 + 400K at $0.30 = 3.00 + 0.12
-	if !almostEqual(rec2.TotalCostUSD, 3.12) {
-		t.Fatalf("additive cache cost = %v, want 3.12", rec2.TotalCostUSD)
+	// 1M at $2.00 + 400K at $0.20 = 2.00 + 0.08
+	if !almostEqual(rec2.TotalCostUSD, 2.08) {
+		t.Fatalf("additive cache cost = %v, want 2.08", rec2.TotalCostUSD)
 	}
 }
 
@@ -173,15 +181,15 @@ func TestCacheSemanticsFollowReportingSchema(t *testing.T) {
 
 	t.Setenv("HOME", t.TempDir())
 	ct := NewCostTracker()
-	// 100K prompt (90K cached subset) via openrouter: 10K at $3/M + 90K at
-	// the claude cache-read rate ($0.30/M) = 0.03 + 0.027.
+	// 100K prompt (90K cached subset) via openrouter: 10K at $2/M + 90K at
+	// the claude cache-read rate ($0.20/M) = 0.02 + 0.018.
 	ct.RecordRealUsage("OPENROUTER", "anthropic/claude-sonnet-5", &models.UsageInfo{
 		PromptTokens:         100_000,
 		CacheReadInputTokens: 90_000,
 		IsReal:               true,
 	})
-	if got := ct.TotalCost(); !almostEqual(got, 0.03+0.027) {
-		t.Fatalf("openrouter claude cache math = %v, want 0.057", got)
+	if got := ct.TotalCost(); !almostEqual(got, 0.02+0.018) {
+		t.Fatalf("openrouter claude cache math = %v, want 0.038", got)
 	}
 }
 

--- a/cli/cost_tracker_pricing_test.go
+++ b/cli/cost_tracker_pricing_test.go
@@ -16,7 +16,16 @@ func TestGetModelPricing(t *testing.T) {
 		wantIn, wantOut float64
 	}{
 		// Anthropic
+		{"claude fable 5.1", "CLAUDEAI", "claude-fable-5-1", 10.0, 50.0},
+		{"claude fable 5.1 bedrock id", "BEDROCK", "anthropic.claude-fable-5-1", 10.0, 50.0},
+		{"claude fable 5.1 openrouter slug", "OPENROUTER", "anthropic/claude-fable-5.1", 10.0, 50.0},
 		{"claude fable 5", "CLAUDEAI", "claude-fable-5", 10.0, 50.0},
+		// Sonnet 5 kept its $2/$10 launch price permanently (Anthropic
+		// cancelled the Sep 2026 increase) — the specific case must win
+		// before the generic $3/$15 sonnet tier in every spelling.
+		{"claude sonnet 5", "CLAUDEAI", "claude-sonnet-5", 2.0, 10.0},
+		{"claude sonnet 5 bedrock id", "BEDROCK", "global.anthropic.claude-sonnet-5", 2.0, 10.0},
+		{"claude sonnet 5 openrouter slug", "OPENROUTER", "anthropic/claude-sonnet-5", 2.0, 10.0},
 		{"claude opus 4.8", "CLAUDEAI", "claude-opus-4-8", 5.0, 25.0},
 		{"claude opus 4.7", "CLAUDEAI", "claude-opus-4-7", 5.0, 25.0},
 		{"claude opus 4.6 bedrock id", "BEDROCK", "global.anthropic.claude-opus-4-6-20260115-v1:0", 5.0, 25.0},
@@ -39,8 +48,28 @@ func TestGetModelPricing(t *testing.T) {
 		// catalog resolves to Sol.
 		{"gpt-5.6-terra before gpt-5.6", "OPENAI", "gpt-5.6-terra", 2.0, 12.0},
 		{"gpt-5.6-luna before gpt-5.6", "OPENAI", "gpt-5.6-luna", 0.20, 1.20},
-		{"gpt-5.6 generic is sol", "OPENAI", "gpt-5.6-sol", 5.0, 30.0},
-		{"gpt-5.6 bare alias", "OPENAI", "gpt-5.6", 5.0, 30.0},
+		// Sol dropped to $4/$20 on Aug 21 2026 (promotional "at least
+		// through Nov 21 2026").
+		{"gpt-5.6 generic is sol", "OPENAI", "gpt-5.6-sol", 4.0, 20.0},
+		{"gpt-5.6 bare alias", "OPENAI", "gpt-5.6", 4.0, 20.0},
+		{"gpt-5.6 sol bedrock id", "BEDROCK", "global.openai.gpt-5.6-sol", 4.0, 20.0},
+		// gpt-5.5 … gpt-5: every id below 5.6 used to fall through to
+		// "unknown" (zero). Pro/mini/nano before the base of each
+		// generation.
+		{"gpt-5.5-pro before gpt-5.5", "OPENAI", "gpt-5.5-pro", 30.0, 180.0},
+		{"gpt-5.5", "OPENAI", "gpt-5.5", 5.0, 30.0},
+		{"gpt-5.4-pro before gpt-5.4", "OPENAI", "gpt-5.4-pro", 30.0, 180.0},
+		{"gpt-5.4-mini", "OPENAI", "gpt-5.4-mini", 0.75, 4.50},
+		{"gpt-5.4-nano", "OPENAI", "gpt-5.4-nano", 0.20, 1.25},
+		{"gpt-5.4", "OPENAI", "gpt-5.4", 2.50, 15.0},
+		{"gpt-5.3-codex", "OPENAI", "gpt-5.3-codex", 1.75, 14.0},
+		{"gpt-5.2-pro before gpt-5.2", "OPENAI", "gpt-5.2-pro", 21.0, 168.0},
+		{"gpt-5.2", "OPENAI", "gpt-5.2", 1.75, 14.0},
+		{"gpt-5-pro before gpt-5", "OPENAI", "gpt-5-pro", 15.0, 120.0},
+		{"gpt-5-mini", "OPENAI", "gpt-5-mini", 0.25, 2.0},
+		{"gpt-5-nano", "OPENAI", "gpt-5-nano", 0.05, 0.40},
+		{"gpt-5.1 same tier as gpt-5", "OPENAI", "gpt-5.1", 1.25, 10.0},
+		{"gpt-5", "OPENAI", "gpt-5", 1.25, 10.0},
 		{"gpt-4o-mini before gpt-4o", "OPENAI", "gpt-4o-mini", 0.15, 0.60},
 		{"gpt-4o", "OPENAI", "gpt-4o", 2.50, 10.0},
 		{"gpt-4-turbo", "OPENAI", "gpt-4-turbo", 10.0, 30.0},
@@ -78,7 +107,12 @@ func TestGetModelPricing(t *testing.T) {
 		{"grok-4.3", "XAI", "grok-4.3", 1.25, 2.50},
 		{"grok-4.20 reasoning", "XAI", "grok-4.20-0309-reasoning", 1.25, 2.50},
 		{"grok-build", "XAI", "grok-build-0.1", 1.0, 2.0},
-		{"grok-3", "XAI", "grok-3", 3.0, 15.0},
+		// Retired May 15 2026: xAI redirects these slugs to grok-4.3 and
+		// bills grok-4.3 rates; grok-code-fast-1 is now grok-build-0.1.
+		{"grok-3 redirected to 4.3 rates", "XAI", "grok-3", 1.25, 2.50},
+		{"grok-4-fast redirected to 4.3 rates", "XAI", "grok-4-fast-reasoning", 1.25, 2.50},
+		{"grok-code-fast-1 is grok-build", "XAI", "grok-code-fast-1", 1.0, 2.0},
+		{"grok-4.6 on bedrock", "BEDROCK", "global.xai.grok-4.6", 2.0, 6.0},
 		{"grok-2", "XAI", "grok-2", 2.0, 10.0},
 		{"grok generic", "XAI", "grok-4", 5.0, 15.0},
 
@@ -106,7 +140,15 @@ func TestGetModelPricing(t *testing.T) {
 		{"glm-5v-turbo own tier", "ZAI", "glm-5v-turbo", 1.20, 4.00},
 		{"glm-5 via glm model", "OTHER", "glm-5", 1.00, 3.20},
 		{"zai via provider", "ZAI", "anything", 0.50, 0.50},
-		{"zai legacy glm model", "OTHER", "glm-4.5", 0.50, 0.50},
+		// GLM-4.x list prices (docs.z.ai, Sep 2026): flash tiers are free,
+		// flashx/air/airx/x have their own rows ahead of the family base.
+		{"glm-4.7-flashx before glm-4.7-flash", "ZAI", "glm-4.7-flashx", 0.07, 0.40},
+		{"glm-4.7-flash is free", "ZAI", "glm-4.7-flash", 0.0, 0.0},
+		{"glm-4.5-airx before air", "ZAI", "glm-4.5-airx", 1.10, 4.50},
+		{"glm-4.5-air", "ZAI", "glm-4.5-air", 0.20, 1.10},
+		{"glm-4.5v vision tier", "ZAI", "glm-4.5v", 0.60, 1.80},
+		{"glm-4.7 base", "ZAI", "glm-4.7", 0.60, 2.20},
+		{"glm-4.5 base via other provider", "OTHER", "glm-4.5", 0.60, 2.20},
 
 		// Moonshot (Kimi) — K3 has its own list price (well above the K2
 		// line) and its specific case must win over the generic kimi match;
@@ -117,8 +159,10 @@ func TestGetModelPricing(t *testing.T) {
 		{"kimi-k2.7-code-highspeed own tier", "MOONSHOT", "kimi-k2.7-code-highspeed", 1.90, 8.00},
 		{"kimi-k2.7-code standard tier", "MOONSHOT", "kimi-k2.7-code", 0.95, 4.00},
 		{"moonshot via provider", "MOONSHOT", "kimi-k2.6", 0.95, 4.00},
-		{"kimi-k2.5", "MOONSHOT", "kimi-k2.5", 0.95, 4.00},
-		{"moonshot-v1", "MOONSHOT", "moonshot-v1-128k", 0.95, 4.00},
+		// Retired ids (Aug 31 2026) keep the generic tier so a stale
+		// session log still prices instead of reporting zero.
+		{"kimi-k2.5 retired keeps generic tier", "MOONSHOT", "kimi-k2.5", 0.95, 4.00},
+		{"moonshot-v1 retired keeps generic tier", "MOONSHOT", "moonshot-v1-128k", 0.95, 4.00},
 
 		{"copilot", "COPILOT", "gpt-4o", 2.50, 10.0},
 		{"ollama zero", "OLLAMA", "llama3", 0.0, 0.0},

--- a/client/remote/remote_client.go
+++ b/client/remote/remote_client.go
@@ -46,7 +46,7 @@ type Config struct {
 	CertFile       string            // CA certificate file for TLS (optional)
 	ClientAPIKey   string            // optional: client's own LLM API key/OAuth token (forwarded to server)
 	Provider       string            // optional: override server's default provider (e.g., "GOOGLEAI")
-	Model          string            // optional: override server's default model (e.g., "gemini-2.0-flash")
+	Model          string            // optional: override server's default model (e.g., "gemini-2.5-flash")
 	ProviderConfig map[string]string // optional: provider-specific config (StackSpot, Ollama, etc.)
 }
 

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -85,7 +85,7 @@ func RunConnect(ctx context.Context, args []string, llmMgr manager.LLMManager, l
 	fs.StringVar(&opts.ClientAPIKey, "llm-key", os.Getenv("CHATCLI_CLIENT_API_KEY"), "Your own LLM API key/OAuth token (forwarded to server)")
 	fs.BoolVar(&opts.UseLocalAuth, "use-local-auth", false, "Use OAuth/API key from local auth store (~/.chatcli/auth-profiles.json)")
 	fs.StringVar(&opts.Provider, "provider", "", "Override server's default LLM provider (e.g., OPENAI, CLAUDEAI, GOOGLEAI, XAI, ZAI, MINIMAX, STACKSPOT, OLLAMA, COPILOT)")
-	fs.StringVar(&opts.Model, "model", "", "Override server's default LLM model (e.g., gpt-4, gemini-2.0-flash)")
+	fs.StringVar(&opts.Model, "model", "", "Override server's default LLM model (e.g., gpt-5.6-sol, gemini-2.5-flash)")
 	fs.StringVar(&opts.ClientID, "client-id", "", "StackSpot: Client ID for authentication")
 	fs.StringVar(&opts.ClientKey, "client-key", "", "StackSpot: Client Key for authentication")
 	fs.StringVar(&opts.Realm, "realm", "", "StackSpot: Realm/Tenant")
@@ -266,7 +266,7 @@ Flags:
   --addr <host:port>    Server address (env: CHATCLI_REMOTE_ADDR)
   --token <string>      Server auth token (env: CHATCLI_REMOTE_TOKEN)
   --provider <string>   Override LLM provider (OPENAI, CLAUDEAI, GOOGLEAI, XAI, ZAI, MINIMAX, STACKSPOT, OLLAMA, COPILOT)
-  --model <string>      Override LLM model (e.g., gpt-4, gemini-2.0-flash)
+  --model <string>      Override LLM model (e.g., gpt-5.6-sol, gemini-2.5-flash)
   --llm-key <string>    Your own LLM API key/OAuth token (env: CHATCLI_CLIENT_API_KEY)
   --use-local-auth      Use OAuth credentials from local auth store (from /auth login)
   --tls                 Enable TLS connection

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -43,7 +43,10 @@ const (
 	DefaultGoogleAITimeout = 5 * time.Minute
 
 	// Valores padrão para xAI
-	DefaultXAIModel = "grok-4-1"
+	// grok-4.3: xAI retired the grok-4-1-fast line on May 15 2026 and now
+	// redirects those slugs to grok-4.3 (1M context, $1.25/$2.50) — the
+	// default follows the redirect target instead of a dead id.
+	DefaultXAIModel = "grok-4.3"
 	XAIAPIURL       = "https://api.x.ai/v1/chat/completions"
 
 	// Valores padrão para ZAI (Zhipu AI / z.ai)
@@ -86,7 +89,7 @@ const (
 	OpenRouterAPIURL       = "https://openrouter.ai/api/v1/chat/completions"
 
 	// Valores padrão para AWS Bedrock (modelos Anthropic Claude)
-	// Model ids seguem o formato Bedrock (ex.: "anthropic.claude-3-5-sonnet-20241022-v2:0").
+	// Model ids seguem o formato Bedrock (ex.: "global.anthropic.claude-sonnet-4-6").
 	// Para inference profiles regionais, use o prefixo apropriado (ex.: "us.anthropic.claude-sonnet-4-20250514-v1:0").
 	// Default usa inference profile global (exigido por modelos 3.7+ / 4.x+).
 	// Sonnet 4.6 espelha o DefaultClaudeAIModel — mesmo tier de preço do

--- a/llm/bedrock/bedrock_client.go
+++ b/llm/bedrock/bedrock_client.go
@@ -74,6 +74,15 @@ func isConverseOnlyVendor(model string) bool {
 	return false
 }
 
+// isConverseOnlyModel extends the vendor list with per-model catalog
+// knowledge: some ids under an otherwise InvokeModel-capable vendor prefix
+// (openai.gpt-5.6-*) only exist on Converse, and the catalog marks them
+// with the bedrock_converse_only capability.
+func isConverseOnlyModel(model string) bool {
+	return isConverseOnlyVendor(model) ||
+		catalog.HasCapability(catalog.ProviderBedrock, model, "bedrock_converse_only")
+}
+
 // resolveFamily picks the dispatch path. Precedence:
 //  1. BEDROCK_PROVIDER env var ("anthropic"/"claude", "openai"/"gpt",
 //     "converse"/"auto") — except for Converse-only vendor ids, where a
@@ -90,16 +99,23 @@ func isConverseOnlyVendor(model string) bool {
 func resolveFamily(model string) modelFamily {
 	switch strings.ToLower(strings.TrimSpace(os.Getenv("BEDROCK_PROVIDER"))) {
 	case "openai", "gpt":
-		if isConverseOnlyVendor(model) {
+		if isConverseOnlyModel(model) {
 			return familyConverse
 		}
 		return familyOpenAI
 	case "anthropic", "claude":
-		if isConverseOnlyVendor(model) {
+		if isConverseOnlyModel(model) {
 			return familyConverse
 		}
 		return familyAnthropic
 	case "converse", "auto":
+		return familyConverse
+	}
+	// Catalog entries flagged bedrock_converse_only (GPT-5.6 Sol/Terra/
+	// Luna: Converse/Responses/Chat Completions on AWS, InvokeModel
+	// unsupported) must never reach the vendor sniff below, which would
+	// route the "openai." prefix down the gpt-oss InvokeModel path.
+	if catalog.HasCapability(catalog.ProviderBedrock, model, "bedrock_converse_only") {
 		return familyConverse
 	}
 	// Um application inference profile carrega um ARN opaco sem nenhuma

--- a/llm/bedrock/family_test.go
+++ b/llm/bedrock/family_test.go
@@ -23,6 +23,15 @@ func TestResolveFamily(t *testing.T) {
 		{"openai gpt-oss 120b", "", "openai.gpt-oss-120b-1:0", familyOpenAI},
 		{"openai gpt-oss 20b", "", "openai.gpt-oss-20b-1:0", familyOpenAI},
 		{"openai via regional profile", "", "us.openai.gpt-oss-120b-1:0", familyOpenAI},
+		// GPT-5.6 on Bedrock has no InvokeModel surface: the catalog flags
+		// the ids bedrock_converse_only and they must skip the "openai."
+		// vendor sniff — with or without the BEDROCK_PROVIDER override.
+		{"gpt-5.6 sol global profile is converse", "", "global.openai.gpt-5.6-sol", familyConverse},
+		{"gpt-5.6 terra bare id is converse", "", "openai.gpt-5.6-terra", familyConverse},
+		{"gpt-5.6 luna us profile is converse", "", "us.openai.gpt-5.6-luna", familyConverse},
+		{"env openai ignored for gpt-5.6", "openai", "global.openai.gpt-5.6-sol", familyConverse},
+		{"env anthropic ignored for gpt-5.6", "anthropic", "openai.gpt-5.6-terra", familyConverse},
+		{"grok on bedrock is converse", "", "global.xai.grok-4.6", familyConverse},
 
 		// Unknown / non-Anthropic / non-OpenAI prefixes route to Converse —
 		// one schema covers Llama, Nova, Mistral, Cohere, AI21, DeepSeek,

--- a/llm/catalog/catalog.go
+++ b/llm/catalog/catalog.go
@@ -1596,7 +1596,7 @@ var registry = []ModelMeta{
 	// are served only through inference profiles (Sol: us./global.;
 	// Terra/Luna: us./in./global.). The "openai." vendor prefix would
 	// normally send them down the gpt-oss InvokeModel path, so these
-	// entries carry bedrock_converse_only, which resolveFamily honours
+	// entries carry bedrock_converse_only, which resolveFamily honors
 	// ahead of the vendor sniff. 1,050,000 context / 128K output as on
 	// the platform API (AWS lists "1M" and no output cap); prices per
 	// card: Sol $4/$20, Terra $2/$12, Luna $0.20/$1.20 (global, ≤272K).

--- a/llm/catalog/catalog.go
+++ b/llm/catalog/catalog.go
@@ -143,43 +143,61 @@ var registry = []ModelMeta{
 		PreferredAPI:    APIResponses,
 		Capabilities:    []string{"vision", "tools", "json_mode"},
 	},
+	// gpt-5.4 family — specs re-verified on developers.openai.com/api/docs/
+	// models (Sep 2026): the base model runs the same 1,050,000 / 128K
+	// profile as 5.5/5.6 (plus gpt-5.4-pro, Responses-only, $30/$180),
+	// while mini and nano sit on the 400K / 128K profile — so the tiers
+	// need their own entry. The mini entry MUST precede the base one:
+	// "gpt-5.4" is a prefix of "gpt-5.4-mini" and would swallow it in the
+	// tier-2 alias pass. The previous 200K / 100K values were guesses
+	// inherited from the o-series and undersized every 5.x request.
 	{
-		ID:              "gpt-5.4",
-		Aliases:         []string{"gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"},
-		DisplayName:     "GPT-5.4",
+		ID:              "gpt-5.4-mini",
+		Aliases:         []string{"gpt-5.4-mini", "gpt-5.4-nano"},
+		DisplayName:     "GPT-5.4 mini",
 		Provider:        ProviderOpenAI,
-		ContextWindow:   200000,
-		MaxOutputTokens: 100000,
+		ContextWindow:   400000,
+		MaxOutputTokens: 128000,
 		PreferredAPI:    APIResponses,
 		Capabilities:    []string{"vision", "json_mode", "tools"},
 	},
 	{
+		ID:              "gpt-5.4",
+		Aliases:         []string{"gpt-5.4", "gpt-5.4-pro"},
+		DisplayName:     "GPT-5.4",
+		Provider:        ProviderOpenAI,
+		ContextWindow:   1050000,
+		MaxOutputTokens: 128000,
+		PreferredAPI:    APIResponses,
+		Capabilities:    []string{"vision", "json_mode", "tools"},
+	},
+	{
+		// gpt-5.3-codex: 400K context (272K max input) / 128K output,
+		// Responses-only. The bare "gpt-5.3" / "-mini" / "-nano" aliases
+		// were dropped: no such models exist on the API (404 on the model
+		// docs, absent from /models/all). gpt-5.3-codex-spark was removed
+		// for the same reason — it is a Codex-app-only model
+		// ("API Access: false"), never a platform id.
 		ID:              "gpt-5.3-codex",
-		Aliases:         []string{"gpt-5.3-codex", "gpt-5.3", "gpt-5.3-mini", "gpt-5.3-nano"},
+		Aliases:         []string{"gpt-5.3-codex"},
 		DisplayName:     "GPT-5.3 Codex",
 		Provider:        ProviderOpenAI,
-		ContextWindow:   200000,
-		MaxOutputTokens: 100000,
+		ContextWindow:   400000,
+		MaxOutputTokens: 128000,
 		PreferredAPI:    APIResponses,
 		Capabilities:    []string{"json_mode", "tools"},
 	},
 	{
-		ID:              "gpt-5.3-codex-spark",
-		Aliases:         []string{"gpt-5.3-codex-spark"},
-		DisplayName:     "GPT-5.3 Codex Spark (Pro)",
-		Provider:        ProviderOpenAI,
-		ContextWindow:   200000,
-		MaxOutputTokens: 100000,
-		PreferredAPI:    APIResponses,
-		Capabilities:    []string{"json_mode", "tools"},
-	},
-	{
+		// gpt-5.2 (Dec 11 2025): 400K context / 128K output, Chat
+		// Completions + Responses. gpt-5.2-pro shares the window
+		// (Responses-only, $21/$168). No mini/nano tier was ever
+		// published for 5.2 — those aliases were removed.
 		ID:              "gpt-5.2",
-		Aliases:         []string{"gpt-5.2", "gpt-5.2-mini", "gpt-5.2-nano"},
+		Aliases:         []string{"gpt-5.2", "gpt-5.2-pro"},
 		DisplayName:     "GPT-5.2",
 		Provider:        ProviderOpenAI,
-		ContextWindow:   200000,
-		MaxOutputTokens: 100000,
+		ContextWindow:   400000,
+		MaxOutputTokens: 128000,
 		PreferredAPI:    APIResponses,
 		Capabilities:    []string{"vision", "json_mode", "tools"},
 	},
@@ -281,21 +299,14 @@ var registry = []ModelMeta{
 	},
 	// Claude 4 e 4.1 (sonnet/opus). Specs grounded in Anthropic's official
 	// models page (platform.claude.com/docs/en/docs/about-claude/models/overview).
-	{
-		// Sonnet 4 (claude-sonnet-4-20250514): deprecated, retires Jun 15
-		// 2026. Real specs: 200K context, 64K max output. Previous catalog
-		// value (50K/50K) was a conservative override that masked the model's
-		// actual capacity and caused premature compaction.
-		ID:              "claude-sonnet-4",
-		Aliases:         []string{"claude-4-sonnet", "sonnet-4-20250514", "claude-4-sonnet-"},
-		DisplayName:     "Claude sonnet 4",
-		Provider:        ProviderClaudeAI,
-		ContextWindow:   200000,
-		MaxOutputTokens: 64000,
-		PreferredAPI:    APIAnthropicMessages,
-		APIVersion:      config.ClaudeAIAPIVersionDefault,
-		Capabilities:    []string{"vision", "json_mode", "tools"},
-	},
+	// Retired on the Claude API (platform.claude.com/docs/en/about-claude/
+	// model-deprecations, checked Sep 2 2026) and therefore removed from
+	// the first-party block: Sonnet 4 and Opus 4 (Jun 15 2026), Opus 4.1
+	// (Aug 5 2026) and every 3.x model (Sonnet 3.5 Oct 2025, Opus 3 Jan
+	// 2026, Sonnet 3.7 / Haiku 3.5 Feb 2026, Haiku 3 Apr 2026). Requests
+	// naming them fail server-side, so a catalog entry only misleads
+	// sizing. Bedrock keeps its own lifecycle — the ones AWS still serves
+	// stay in the ProviderBedrock block.
 	{
 		// Sonnet 4.5: 200K context, 64K max output. 1M context available
 		// via beta header; default registry tracks the GA limit.
@@ -310,14 +321,17 @@ var registry = []ModelMeta{
 		Capabilities:    []string{"vision", "json_mode", "tools"},
 	},
 	{
-		// Sonnet 4.6: 1M context, 64K max output (per Anthropic). Previous
-		// catalog (200K/128K) had output inflated and ctx undersized.
+		// Sonnet 4.6: 1M context, 128K max output on the synchronous
+		// Messages API (platform.claude.com/docs/en/models/sonnet-4-6/
+		// overview, Sep 2026; 300K on Batch with the output-300k beta).
+		// The earlier 64K value was the pre-Mar-2026 limit and throttled
+		// long agent turns for no reason.
 		ID:              "claude-sonnet-4-6",
 		Aliases:         []string{"claude-4-6-sonnet", "sonnet-4-6", "claude-4-6-sonnet-", "claude-sonnet-4-6-"},
 		DisplayName:     "Claude sonnet 4.6 (1M context)",
 		Provider:        ProviderClaudeAI,
 		ContextWindow:   1000000,
-		MaxOutputTokens: 64000,
+		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
 		APIVersion:      config.ClaudeAIAPIVersionDefault,
 		Capabilities:    []string{"vision", "json_mode", "tools"},
@@ -336,16 +350,48 @@ var registry = []ModelMeta{
 		APIVersion:      config.ClaudeAIAPIVersionDefault,
 		Capabilities:    []string{"vision", "json_mode", "tools"},
 	},
-	// NOTE: Claude 4.x entries are ordered newest-first below. The Resolve()
-	// tier-2 alias match iterates the registry in order and returns on first
-	// hit. Because the 4.0 entry carries the generic alias "opus-4", which
-	// is a prefix of "opus-4-5/6/7/8", the newer entries MUST be iterated
-	// first so their exact aliases (e.g. "opus-4-8") win before 4.0's
-	// loose prefix match fires. Reversing this order reintroduces a latent
-	// bug where "opus-4-6" silently resolves to the 4.0 entry (20K ctx).
+	// NOTE: Claude 5.x/4.x entries are ordered newest-first below. The
+	// Resolve() tier-2 alias match iterates the registry in order and
+	// returns on the first prefix/contains hit, so an older entry whose
+	// alias is a prefix of a newer id ("fable-5" ⊂ "fable-5-1") MUST come
+	// after the newer one. Reversing this order silently resolves
+	// "fable-5-1" to the Fable 5 entry (wrong cache price, wrong
+	// capability flags).
 	{
-		// Fable 5 (claude-fable-5): Anthropic's most capable model — a new
-		// tier ABOVE Opus. 1M context, 128K max output, $10/$50 per MTok
+		// Fable 5.1 (claude-fable-5-1, Sep 1 2026): successor to Fable 5 in
+		// the same tier above Opus, same $10/$50 per MTok, but cache reads
+		// at $0.25/MTok (2.5% of input instead of the usual 10% — see
+		// cli/cost_tracker.go getCachePricing). 1M context, 128K max
+		// output, thinking ALWAYS on (adaptive; an explicit
+		// thinking:{type:"disabled"} or budget_tokens returns 400 — the
+		// claudeai client omits the field unless effort routing fires).
+		// Three breaking changes vs Fable 5 (platform.claude.com/docs/en/
+		// models/fable-5-1/whats-new-fable-5-1): forced tool_choice
+		// ("any"/"tool") returns 400 — this client only ever sends
+		// tool_choice auto; thinking blocks are bound to the producing
+		// model (other models drop them silently); editing earlier turns
+		// invalidates thinking blocks. mid_conversation_system is served
+		// (same as Fable 5 / Opus 5). No fast_mode, no Priority Tier.
+		// Requires 30-day data retention (ZDR orgs get 400).
+		// The bare "fable" shortcut tracks the newest Fable release.
+		ID:              "claude-fable-5-1",
+		Aliases:         []string{"claude-fable-5-1", "fable-5-1", "claude-fable-5.1", "fable-5.1", "fable"},
+		DisplayName:     "Claude Fable 5.1 (1M context)",
+		Provider:        ProviderClaudeAI,
+		ContextWindow:   1000000,
+		MaxOutputTokens: 128000,
+		PreferredAPI:    APIAnthropicMessages,
+		APIVersion:      config.ClaudeAIAPIVersionDefault,
+		Capabilities: []string{
+			"vision",
+			"json_mode", "tools",
+			"adaptive_thinking", "mid_conversation_system",
+		},
+	},
+	{
+		// Fable 5 (claude-fable-5, Jun 9 2026): legacy since Fable 5.1
+		// shipped, still served (retirement not before Jun 9 2027). Same
+		// tier above Opus: 1M context, 128K max output, $10/$50 per MTok
 		// (see cli/cost_tracker.go claudePricing). Same API surface as
 		// Opus 4.7/4.8 (no temperature/top_p/top_k; adaptive thinking only —
 		// budgeted thinking returns 400) with one extra constraint: an
@@ -354,9 +400,10 @@ var registry = []ModelMeta{
 		// already complies: it only attaches a thinking block when effort
 		// routing fires, and adaptive_thinking routes that to
 		// {type:"adaptive"}. No fast_mode: the speed parameter is not
-		// documented for Fable 5.
+		// documented for Fable 5. "fable-5" stays pinned here; the bare
+		// "fable" shortcut moved to 5.1.
 		ID:              "claude-fable-5",
-		Aliases:         []string{"claude-fable-5", "fable-5", "fable"},
+		Aliases:         []string{"claude-fable-5", "fable-5"},
 		DisplayName:     "Claude Fable 5 (1M context)",
 		Provider:        ProviderClaudeAI,
 		ContextWindow:   1000000,
@@ -395,8 +442,11 @@ var registry = []ModelMeta{
 		// Sonnet 5 (claude-sonnet-5, Jun 2026): the Sonnet-tier successor —
 		// Anthropic skipped a "Sonnet 4.7"/"4.8" and jumped straight to 5.
 		// 1M context, 128K max output, adaptive thinking (effort defaults to
-		// "high" server-side on the Claude API). $3/$15 per MTok (intro
-		// $2/$10 through Aug 31 2026 — cost_tracker uses the standard rate).
+		// "high" server-side on the Claude API). $2/$10 per MTok: the
+		// launch "introductory" rate became the permanent list price —
+		// Anthropic cancelled the Sep 1 2026 increase to $3/$15
+		// (platform.claude.com/docs/en/about-claude/pricing), so
+		// cost_tracker's claudePricing has an explicit sonnet-5 case.
 		// No fast_mode (Opus-tier research preview only) and no
 		// mid_conversation_system (documented for Opus 4.8 only). Dateless
 		// pinned-snapshot ID per the Jun 2026 models overview.
@@ -456,25 +506,10 @@ var registry = []ModelMeta{
 		APIVersion:      config.ClaudeAIAPIVersionDefault,
 		Capabilities:    []string{"vision", "json_mode", "tools", "adaptive_thinking"},
 	},
-	{
-		// Sonnet 4.7: NOT in the Anthropic GA matrix as of Apr 2026 (the
-		// current shipping line is Opus 4.7 + Sonnet 4.6 + Haiku 4.5,
-		// per https://platform.claude.com/docs/en/about-claude/models/overview).
-		// This entry is a forward-projected alias placeholder so existing
-		// tests and any caller pinning the tag don't break; the profile
-		// mirrors Sonnet 4.6 (1M / 64K). Replace with real specs the
-		// moment Anthropic publishes them — do not treat this as ground
-		// truth.
-		ID:              "claude-sonnet-4-7",
-		Aliases:         []string{"claude-4-7-sonnet", "sonnet-4-7", "claude-sonnet-4-7-"},
-		DisplayName:     "Claude sonnet 4.7",
-		Provider:        ProviderClaudeAI,
-		ContextWindow:   1000000,
-		MaxOutputTokens: 64000,
-		PreferredAPI:    APIAnthropicMessages,
-		APIVersion:      config.ClaudeAIAPIVersionDefault,
-		Capabilities:    []string{"vision", "json_mode", "tools"},
-	},
+	// There is no Sonnet 4.7: Anthropic went from Sonnet 4.6 straight to
+	// Sonnet 5. The forward-projected placeholder that used to sit here
+	// was removed once the Sep 2026 models overview confirmed it never
+	// shipped — "sonnet-4-7" now resolves to nothing, as it should.
 	{
 		// Opus 4.6: 1M context, 128K max output (per Anthropic legacy
 		// table). Previous 400K/64K underrepresented both dimensions.
@@ -500,103 +535,9 @@ var registry = []ModelMeta{
 		APIVersion:      config.ClaudeAIAPIVersionDefault,
 		Capabilities:    []string{"vision", "json_mode", "tools"},
 	},
-	{
-		// Opus 4.1: 200K context, 32K max output. Previous 20K/20K was a
-		// holdover from an early conservative override and made the model
-		// trip auto-compact at ~80K chars unnecessarily.
-		ID:              "claude-opus-4-1-20250805",
-		Aliases:         []string{"claude-opus-4-1", "opus-4-1", "claude-opus-4-1-20250805"},
-		DisplayName:     "Claude opus 4.1",
-		Provider:        ProviderClaudeAI,
-		ContextWindow:   200000,
-		MaxOutputTokens: 32000,
-		PreferredAPI:    APIAnthropicMessages,
-		APIVersion:      config.ClaudeAIAPIVersionDefault,
-		Capabilities:    []string{"vision", "json_mode", "tools"},
-	},
-	{
-		// Opus 4.0 (deprecated, retires Jun 15 2026): 200K context, 32K
-		// max output. Same correction rationale as 4.1.
-		ID:              "claude-opus-4-20250514",
-		Aliases:         []string{"opus-4", "claude-opus-4-20250514"},
-		DisplayName:     "Claude opus 4",
-		Provider:        ProviderClaudeAI,
-		ContextWindow:   200000,
-		MaxOutputTokens: 32000,
-		PreferredAPI:    APIAnthropicMessages,
-		APIVersion:      config.ClaudeAIAPIVersionDefault,
-		Capabilities:    []string{"vision", "json_mode", "tools"},
-	},
-	// Claude 3.x — specs from Anthropic's legacy/3.x docs. All 3.x models
-	// share the 200K input window; max output varies by version.
-	{
-		// Sonnet 3.5 (claude-3-5-sonnet-20241022, "v2"): 200K / 8192.
-		ID:              "claude-sonnet-3-5-20241022",
-		Aliases:         []string{"claude-3-5-sonnet", "claude-3-5-sonnet-20241022"},
-		DisplayName:     "Claude sonnet 3.5",
-		Provider:        ProviderClaudeAI,
-		ContextWindow:   200000,
-		MaxOutputTokens: 8192,
-		PreferredAPI:    APIAnthropicMessages,
-		APIVersion:      config.ClaudeAIAPIVersionDefault,
-		Capabilities:    []string{"vision", "json_mode", "tools"},
-	},
-	{
-		// Haiku 3.5 (claude-3-5-haiku-20241022): 200K / 8192. Was missing
-		// from the ProviderClaudeAI side; only Bedrock had it.
-		ID:              "claude-haiku-3-5-20241022",
-		Aliases:         []string{"claude-3-5-haiku", "claude-3-5-haiku-20241022"},
-		DisplayName:     "Claude haiku 3.5",
-		Provider:        ProviderClaudeAI,
-		ContextWindow:   200000,
-		MaxOutputTokens: 8192,
-		PreferredAPI:    APIAnthropicMessages,
-		APIVersion:      config.ClaudeAIAPIVersionDefault,
-		Capabilities:    []string{"json_mode", "tools"},
-	},
-	{
-		// Sonnet 3.7 (claude-3-7-sonnet-20250219): 200K context / 8192 max
-		// output on the synchronous Messages API (the default any client
-		// hits without opt-in headers). Extended thinking can raise
-		// output to 64K, but only when the caller explicitly sends the
-		// `output-128k-2025-02-19` beta header — pinning the catalog at
-		// 64K silently throws 400 errors for every regular call. We
-		// track the safe default; callers that opt into extended
-		// thinking can override at request time.
-		ID:              "claude-sonnet-3-7-20250219",
-		Aliases:         []string{"claude-3-7-sonnet", "claude-3-7-sonnet-20250219"},
-		DisplayName:     "Claude sonnet 3.7",
-		Provider:        ProviderClaudeAI,
-		ContextWindow:   200000,
-		MaxOutputTokens: 8192,
-		PreferredAPI:    APIAnthropicMessages,
-		APIVersion:      config.ClaudeAIAPIVersionDefault,
-		Capabilities:    []string{"vision", "json_mode", "tools"},
-	},
-	{
-		// Haiku 3 (claude-3-haiku-20240307): 200K / 4096.
-		ID:              "claude-haiku-3",
-		Aliases:         []string{"claude-3-haiku", "claude-3-haiku-20240307"},
-		DisplayName:     "Claude haiku 3",
-		Provider:        ProviderClaudeAI,
-		ContextWindow:   200000,
-		MaxOutputTokens: 4096,
-		PreferredAPI:    APIAnthropicMessages,
-		APIVersion:      config.ClaudeAIAPIVersionDefault,
-		Capabilities:    []string{"vision", "json_mode"},
-	},
-	{
-		// Opus 3 (claude-3-opus-20240229): 200K / 4096.
-		ID:              "claude-opus-3",
-		Aliases:         []string{"claude-3-opus", "claude-3-opus-20240229"},
-		DisplayName:     "Claude opus 3",
-		Provider:        ProviderClaudeAI,
-		ContextWindow:   200000,
-		MaxOutputTokens: 4096,
-		PreferredAPI:    APIAnthropicMessages,
-		APIVersion:      config.ClaudeAIAPIVersionDefault,
-		Capabilities:    []string{"vision", "json_mode", "tools"},
-	},
+	// Opus 4.1 (retired Aug 5 2026), Opus 4 (Jun 15 2026) and the whole
+	// Claude 3.x line used to sit here — see the retirement note above
+	// the Sonnet 4.5 entry.
 	// Google Gemini Models. Specs from ai.google.dev model docs:
 	// every Gemini 2.x/3.x exposes a 1,048,576-token input window with a
 	// 65,536-token max output (8,192 on the older 2.0 generation). The
@@ -604,12 +545,14 @@ var registry = []ModelMeta{
 	// is physically impossible — the API rejects requests with output
 	// over the per-model cap.
 	//
-	// Gemini 3.x generation (verified per-model on ai.google.dev, Aug
-	// 2026): 3.7-flash (GA Aug 13 2026), 3.6-flash (Jul 21 2026),
-	// 3.5-flash, 3.5-flash-lite and 3.1-flash-lite stable; 3.1-pro-preview
-	// and 3-flash-preview in preview. The whole generation shares the
-	// uniform 1,048,576 / 65,536 profile. Newest first so generic alias
-	// prefixes ("gemini-3") don't shadow the more specific ids.
+	// Gemini 3.x generation (re-verified per-model on ai.google.dev, Sep 2
+	// 2026 — nothing newer than 3.7 Flash has shipped): 3.7-flash (GA Aug
+	// 13 2026), 3.6-flash (Jul 21 2026), 3.5-flash, 3.5-flash-lite and
+	// 3.1-flash-lite stable; 3.1-pro-preview and 3-flash-preview in
+	// preview. "gemini-3.1-pro" without -preview is NOT a real model code
+	// (kept only as an alias). The whole generation shares the uniform
+	// 1,048,576 / 65,536 profile. Newest first so generic alias prefixes
+	// don't shadow the more specific ids.
 	{
 		ID:              "gemini-3.7-flash",
 		Aliases:         []string{"gemini-3.7-flash", "gemini-3.7-flash-latest"},
@@ -691,18 +634,6 @@ var registry = []ModelMeta{
 		Capabilities:    []string{"vision", "tools", "json_mode", "code_execution"},
 	},
 	{
-		// Gemini 3 Pro (preview): 1M context, 65K output. Conservative
-		// projection until Google publishes 3.x specs.
-		ID:              "gemini-3",
-		Aliases:         []string{"gemini-3-pro", "gemini-3-pro-preview"},
-		DisplayName:     "Gemini 3 Pro",
-		Provider:        ProviderGoogleAI,
-		ContextWindow:   1048576,
-		MaxOutputTokens: 65536,
-		PreferredAPI:    "gemini_api",
-		Capabilities:    []string{"vision", "tools", "json_mode", "code_execution"},
-	},
-	{
 		ID:              "gemini-2.5-flash",
 		Aliases:         []string{"gemini-2.5-flash"},
 		DisplayName:     "Gemini 2.5 Flash",
@@ -722,28 +653,13 @@ var registry = []ModelMeta{
 		PreferredAPI:    "gemini_api",
 		Capabilities:    []string{"vision", "tools", "json_mode", "multimodal_live"},
 	},
-	{
-		// Gemini 2.0 Flash (deprecated): 1,048,576 input / 8,192 output.
-		ID:              "gemini-2.0-flash",
-		Aliases:         []string{"gemini-2.0-flash"},
-		DisplayName:     "Gemini 2.0 Flash",
-		Provider:        ProviderGoogleAI,
-		ContextWindow:   1048576,
-		MaxOutputTokens: 8192,
-		PreferredAPI:    "gemini_api",
-		Capabilities:    []string{"vision", "tools", "json_mode"},
-	},
-	{
-		// Gemini 2.0 Flash Lite (deprecated): 1,048,576 input / 8,192 output.
-		ID:              "gemini-2.0-flash-lite",
-		Aliases:         []string{"gemini-2.0-flash-lite"},
-		DisplayName:     "Gemini 2.0 Flash Lite",
-		Provider:        ProviderGoogleAI,
-		ContextWindow:   1048576,
-		MaxOutputTokens: 8192,
-		PreferredAPI:    "gemini_api",
-		Capabilities:    []string{"vision", "tools", "json_mode", "multimodal_live"},
-	},
+	// Shut down by Google (ai.google.dev/gemini-api/docs/deprecations,
+	// checked Sep 2 2026) and removed from ProviderGoogleAI:
+	// gemini-2.0-flash / gemini-2.0-flash-lite (Jun 1 2026) and
+	// gemini-3-pro-preview (Mar 9 2026, replaced by gemini-3.1-pro-preview).
+	// Next scheduled: gemini-3.1-flash-lite retires May 7 2027 → migrate
+	// to gemini-3.5-flash-lite. The Copilot-side gemini-2.0-flash entries
+	// below follow GitHub's lifecycle, not Google's, and stay.
 	// GitHub Copilot Models (accessible via Copilot subscription)
 	{
 		ID:              "gpt-4o",
@@ -899,7 +815,7 @@ var registry = []ModelMeta{
 	},
 	{
 		ID:              "grok-4.5",
-		Aliases:         []string{"grok-4.5", "grok-4.5-latest"},
+		Aliases:         []string{"grok-4.5", "grok-4.5-latest", "grok-build-latest"},
 		DisplayName:     "Grok-4.5",
 		Provider:        ProviderXAI,
 		ContextWindow:   500000,
@@ -949,7 +865,7 @@ var registry = []ModelMeta{
 	},
 	{
 		ID:              "grok-build-0.1",
-		Aliases:         []string{"grok-build-0.1", "grok-build"},
+		Aliases:         []string{"grok-build-0.1", "grok-build-0", "grok-code-fast-1", "grok-code-fast"},
 		DisplayName:     "Grok Build 0.1",
 		Provider:        ProviderXAI,
 		ContextWindow:   256000,
@@ -957,64 +873,13 @@ var registry = []ModelMeta{
 		PreferredAPI:    APIChatCompletions,
 		Capabilities:    []string{"vision", "tools", "json_mode"},
 	},
-	{
-		// grok-4-fast: 2M context. xAI does not document a separate output
-		// cap; we ceil at 16K to keep the value comparable to other models
-		// and avoid runaway generations on retry.
-		ID:              "grok-4-fast",
-		Aliases:         []string{"grok-4-fast-reasoning-latest", "grok-4-fast-reasoning", "grok-4-0709"},
-		DisplayName:     "Grok-4 Fast",
-		Provider:        ProviderXAI,
-		ContextWindow:   2000000,
-		MaxOutputTokens: 16384,
-		PreferredAPI:    APIChatCompletions,
-		Capabilities:    []string{"vision", "tools", "json_mode"},
-	},
-	{
-		// grok-4-1: forward variant; tracked at the same 2M / 16K profile
-		// until xAI publishes distinct specs.
-		ID:              "grok-4-1",
-		Aliases:         []string{"grok-4-1-fast", "grok-4-1-fast-reasoning-latest"},
-		DisplayName:     "Grok-4-1",
-		Provider:        ProviderXAI,
-		ContextWindow:   2000000,
-		MaxOutputTokens: 16384,
-		PreferredAPI:    APIChatCompletions,
-		Capabilities:    []string{"vision", "tools", "json_mode"},
-	},
-	{
-		// grok-3: 131,072 context (128K), 16K max output.
-		ID:              "grok-3",
-		Aliases:         []string{"grok-3"},
-		DisplayName:     "Grok-3",
-		Provider:        ProviderXAI,
-		ContextWindow:   131072,
-		MaxOutputTokens: 16384,
-		PreferredAPI:    APIChatCompletions,
-		Capabilities:    []string{"json_mode"},
-	},
-	{
-		// grok-3-mini: same 131,072 / 16K profile as grok-3.
-		ID:              "grok-3-mini",
-		Aliases:         []string{"grok-3-mini"},
-		DisplayName:     "Grok-3 Mini",
-		Provider:        ProviderXAI,
-		ContextWindow:   131072,
-		MaxOutputTokens: 16384,
-		PreferredAPI:    APIChatCompletions,
-		Capabilities:    []string{"json_mode"},
-	},
-	{
-		// grok-code-fast-1: 256K context. Coding-tuned variant.
-		ID:              "grok-code-fast-1",
-		Aliases:         []string{"grok-code-fast-1"},
-		DisplayName:     "Grok Code Fast 1",
-		Provider:        ProviderXAI,
-		ContextWindow:   256000,
-		MaxOutputTokens: 16384,
-		PreferredAPI:    APIChatCompletions,
-		Capabilities:    []string{"json_mode"},
-	},
+	// Retired by xAI on May 15 2026 (docs.x.ai/developers/migration/
+	// may-15-retirement) and removed from ProviderXAI: grok-3, grok-3-mini,
+	// grok-4-0709, grok-4-fast-* and grok-4-1-fast-* (the API now redirects
+	// those slugs to grok-4.3 and bills grok-4.3 rates) and grok-code-fast-1
+	// (now an alias of grok-build-0.1 — kept on that entry above so pinned
+	// configs still size correctly). None of them has a model page or a
+	// pricing row anymore.
 
 	// ZAI (Zhipu AI / z.ai) Models
 	// GLM-5 family. All entries below verified against Z.AI's per-model
@@ -1160,16 +1025,11 @@ var registry = []ModelMeta{
 		PreferredAPI:    APIChatCompletions,
 		Capabilities:    []string{"vision"},
 	},
-	{
-		ID:              "codegeex-4",
-		Aliases:         []string{"codegeex-4", "codegeex"},
-		DisplayName:     "CodeGeeX-4",
-		Provider:        ProviderZAI,
-		ContextWindow:   128000,
-		MaxOutputTokens: 16384,
-		PreferredAPI:    APIChatCompletions,
-		Capabilities:    []string{"tools"},
-	},
+	// codegeex-4 was removed: it is not served by the Z.AI international
+	// API anymore (no pricing row, no model page — docs.z.ai 404s, Sep
+	// 2026). GLM-4.x variants without an entry (glm-4.7-flash/-flashx,
+	// glm-4.5-air/-airx/-x) resolve by prefix to their family entry
+	// above, which already carries the right window.
 
 	// MiniMax Models
 	{
@@ -1280,76 +1140,13 @@ var registry = []ModelMeta{
 		PreferredAPI:    APIChatCompletions,
 		Capabilities:    []string{"tools", "vision", "thinking", "json_mode"},
 	},
-	{
-		ID:              "kimi-k2.5",
-		Aliases:         []string{"kimi-k2.5", "kimi-k2-5", "k2.5", "k2-5"},
-		DisplayName:     "Kimi K2.5",
-		Provider:        ProviderMoonshot,
-		ContextWindow:   262144,
-		MaxOutputTokens: 98304,
-		PreferredAPI:    APIChatCompletions,
-		Capabilities:    []string{"tools", "vision", "thinking", "json_mode"},
-	},
-	{
-		ID:              "kimi-latest",
-		Aliases:         []string{"kimi-latest"},
-		DisplayName:     "Kimi (latest)",
-		Provider:        ProviderMoonshot,
-		ContextWindow:   262144,
-		MaxOutputTokens: 131072,
-		PreferredAPI:    APIChatCompletions,
-		Capabilities:    []string{"tools", "vision", "thinking", "json_mode"},
-	},
-	{
-		ID:              "kimi-k2-turbo-preview",
-		Aliases:         []string{"kimi-k2-turbo-preview", "kimi-k2-turbo"},
-		DisplayName:     "Kimi K2 Turbo (preview)",
-		Provider:        ProviderMoonshot,
-		ContextWindow:   262144,
-		MaxOutputTokens: 65536,
-		PreferredAPI:    APIChatCompletions,
-		Capabilities:    []string{"tools", "json_mode"},
-	},
-	{
-		ID:              "kimi-thinking-preview",
-		Aliases:         []string{"kimi-thinking-preview"},
-		DisplayName:     "Kimi Thinking (preview)",
-		Provider:        ProviderMoonshot,
-		ContextWindow:   131072,
-		MaxOutputTokens: 65536,
-		PreferredAPI:    APIChatCompletions,
-		Capabilities:    []string{"tools", "thinking", "json_mode"},
-	},
-	{
-		ID:              "moonshot-v1-128k",
-		Aliases:         []string{"moonshot-v1-128k"},
-		DisplayName:     "Moonshot v1 (128k)",
-		Provider:        ProviderMoonshot,
-		ContextWindow:   131072,
-		MaxOutputTokens: 32768,
-		PreferredAPI:    APIChatCompletions,
-		Capabilities:    []string{"tools", "json_mode"},
-	},
-	{
-		ID:              "moonshot-v1-32k",
-		Aliases:         []string{"moonshot-v1-32k"},
-		DisplayName:     "Moonshot v1 (32k)",
-		Provider:        ProviderMoonshot,
-		ContextWindow:   32768,
-		MaxOutputTokens: 16384,
-		PreferredAPI:    APIChatCompletions,
-		Capabilities:    []string{"tools", "json_mode"},
-	},
-	{
-		ID:              "moonshot-v1-8k",
-		Aliases:         []string{"moonshot-v1-8k"},
-		DisplayName:     "Moonshot v1 (8k)",
-		Provider:        ProviderMoonshot,
-		ContextWindow:   8192,
-		MaxOutputTokens: 4096,
-		PreferredAPI:    APIChatCompletions,
-		Capabilities:    []string{"tools", "json_mode"},
-	},
+	// Retired by Moonshot (platform.kimi.ai/docs/models, platform
+	// changelog — checked Sep 2 2026) and removed from ProviderMoonshot:
+	// kimi-k2.5 and the whole moonshot-v1-* series (Aug 31 2026, now 404
+	// "model not found"), kimi-k2-turbo-preview and the other K2
+	// previews (May 25 2026), kimi-latest (Jan 28 2026) and
+	// kimi-thinking-preview (Nov 11 2025). Migration target for all of
+	// them is kimi-k3. Closes the dated follow-up in issue #1344.
 
 	// OpenRouter Models (multi-provider gateway)
 	// Models use provider/model-name format. Only popular defaults are listed;
@@ -1392,6 +1189,18 @@ var registry = []ModelMeta{
 		ID:              "anthropic/claude-sonnet-5",
 		Aliases:         []string{"openrouter-claude-sonnet-5"},
 		DisplayName:     "Claude Sonnet 5 (OpenRouter)",
+		Provider:        ProviderOpenRouter,
+		ContextWindow:   1000000,
+		MaxOutputTokens: 128000,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"vision", "tools", "json_mode"},
+	},
+	{
+		// OpenRouter spells the 5.1 slug with a dot; listed before the
+		// Fable 5 slug because "anthropic/claude-fable-5" is its prefix.
+		ID:              "anthropic/claude-fable-5.1",
+		Aliases:         []string{"openrouter-claude-fable-5.1", "openrouter-claude-fable-5-1", "anthropic/claude-fable-5-1"},
+		DisplayName:     "Claude Fable 5.1 (OpenRouter)",
 		Provider:        ProviderOpenRouter,
 		ContextWindow:   1000000,
 		MaxOutputTokens: 128000,
@@ -1500,6 +1309,25 @@ var registry = []ModelMeta{
 	// Claude on Bedrock; only the top-level automatic cache parameter is
 	// first-party-only, and this client never emits it.
 
+	// Fable 5.1 (Sep 1 2026, AWS what's-new 2026/09 + Bedrock model card
+	// anthropic-claude-fable-5-1). Same shape as Fable 5: dateless id,
+	// us./global. profiles only, 1M / 128K, $10/$50 with $0.25 cache
+	// reads, mandatory 30-day (aws_review) data retention — so the same
+	// bedrock_mantle_only routing applies (InvokeModel under default
+	// retention answers the same ValidationException Fable 5 does; the
+	// Mantle→runtime fallback still covers accounts that opted in). MUST
+	// precede the Fable 5 entry: "claude-fable-5" is a prefix of
+	// "claude-fable-5-1" in the tier-2 alias pass.
+	{
+		ID:              "anthropic.claude-fable-5-1",
+		Aliases:         []string{"bedrock-fable-5-1", "global.anthropic.claude-fable-5-1", "us.anthropic.claude-fable-5-1", "claude-fable-5-1", "fable-5-1", "claude-fable-5.1", "fable-5.1"},
+		DisplayName:     "Claude Fable 5.1 (Bedrock, 1M ctx)",
+		Provider:        ProviderBedrock,
+		ContextWindow:   1000000,
+		MaxOutputTokens: 128000,
+		PreferredAPI:    APIAnthropicMessages,
+		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking", "bedrock_mantle_only"},
+	},
 	// Fable 5 (Jun 9 2026). Dateless ID per Anthropic's Bedrock docs —
 	// Fable 5, Opus 4.8 and Opus 4.7 have NO ARN-versioned model IDs on
 	// Bedrock. Fable 5 is served EXCLUSIVELY by the Claude-in-Amazon-
@@ -1575,18 +1403,10 @@ var registry = []ModelMeta{
 		},
 	},
 
-	// Claude 4.7. Sonnet 4.7 mirrors 4.6's profile (forward-projected),
-	// Opus 4.7 = 1M / 128K per Anthropic (dateless id, same rule as 4.8).
-	{
-		ID:              "global.anthropic.claude-sonnet-4-7-20260401-v1:0",
-		Aliases:         []string{"bedrock-sonnet-4-7", "anthropic.claude-sonnet-4-7-20260401-v1:0", "claude-sonnet-4-7"},
-		DisplayName:     "Claude Sonnet 4.7 (Bedrock, global)",
-		Provider:        ProviderBedrock,
-		ContextWindow:   1000000,
-		MaxOutputTokens: 64000,
-		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode"},
-	},
+	// Claude 4.7: Opus only — there is no Sonnet 4.7 on Bedrock (absent
+	// from the model-cards index and from Anthropic's pricing table); the
+	// forward-projected placeholder was dropped. Opus 4.7 = 1M / 128K
+	// per Anthropic (dateless id, same rule as 4.8).
 	{
 		ID: "global.anthropic.claude-opus-4-7",
 		Aliases: []string{
@@ -1602,8 +1422,10 @@ var registry = []ModelMeta{
 		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking"},
 	},
 
-	// Claude 4.6 (abr 2026). Bedrock specs follow the Anthropic models
-	// page: Sonnet 4.6 = 1M / 64K, Opus 4.6 = 1M / 128K. Real Bedrock IDs
+	// Claude 4.6 (abr 2026). Bedrock specs follow the AWS model cards:
+	// Sonnet 4.6 = 1M / 64K ON BEDROCK (the first-party API raised it to
+	// 128K in Mar 2026 but the Bedrock card still lists 64K — do not
+	// mirror the CLAUDEAI value here), Opus 4.6 = 1M / 128K. Real Bedrock IDs
 	// per the docs: anthropic.claude-sonnet-4-6 and
 	// anthropic.claude-opus-4-6-v1 behind a global. inference profile.
 	// The previously-shipped dated IDs (…-20260115-v1:0) never existed on
@@ -1669,8 +1491,11 @@ var registry = []ModelMeta{
 		Capabilities:    []string{"tools", "vision", "json_mode"},
 	},
 	{
-		ID:              "global.anthropic.claude-opus-4-5-20251001-v1:0",
-		Aliases:         []string{"bedrock-opus-4-5", "anthropic.claude-opus-4-5-20251001-v1:0", "claude-opus-4-5"},
+		// Opus 4.5 snapshot date is 20251101 (Bedrock model card and the
+		// Anthropic overview). The previously shipped 20251001 spelling
+		// never existed on AWS; it stays as an alias for pinned configs.
+		ID:              "global.anthropic.claude-opus-4-5-20251101-v1:0",
+		Aliases:         []string{"bedrock-opus-4-5", "anthropic.claude-opus-4-5-20251101-v1:0", "global.anthropic.claude-opus-4-5-20251001-v1:0", "anthropic.claude-opus-4-5-20251001-v1:0", "claude-opus-4-5"},
 		DisplayName:     "Claude Opus 4.5 (Bedrock, global)",
 		Provider:        ProviderBedrock,
 		ContextWindow:   200000,
@@ -1715,16 +1540,11 @@ var registry = []ModelMeta{
 		PreferredAPI:    APIAnthropicMessages,
 		Capabilities:    []string{"tools", "vision", "json_mode"},
 	},
-	{
-		ID:              "us.anthropic.claude-opus-4-20250514-v1:0",
-		Aliases:         []string{"bedrock-opus-4", "anthropic.claude-opus-4-20250514-v1:0", "claude-opus-4"},
-		DisplayName:     "Claude Opus 4 (Bedrock, us)",
-		Provider:        ProviderBedrock,
-		ContextWindow:   200000,
-		MaxOutputTokens: 32000,
-		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode"},
-	},
+	// Bedrock lifecycle (docs.aws.amazon.com/bedrock/latest/userguide/
+	// model-lifecycle.html, Sep 2 2026): Sonnet 4 is Legacy with EOL Oct
+	// 14 2026 and Opus 4.1 is Legacy with EOL Jan 8 2027 — both still
+	// invokable today, so they stay. Opus 4 is retired on Bedrock and was
+	// removed.
 	{
 		ID:              "us.anthropic.claude-opus-4-1-20250805-v1:0",
 		Aliases:         []string{"bedrock-opus-4-1", "anthropic.claude-opus-4-1-20250805-v1:0", "claude-opus-4-1"},
@@ -1736,86 +1556,13 @@ var registry = []ModelMeta{
 		Capabilities:    []string{"tools", "vision", "json_mode"},
 	},
 
-	// Claude 3.7 Sonnet (Bedrock mirrors). Same correction as the
-	// upstream ProviderClaudeAI entry: synchronous Messages API caps
-	// output at 8192. The 64K ceiling only unlocks via the
-	// `output-128k-2025-02-19` extended-thinking beta header. Pinning
-	// the catalog at the safe default keeps regular calls from being
-	// rejected with 400 errors.
-	{
-		ID:              "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
-		Aliases:         []string{"bedrock-sonnet-3-7", "anthropic.claude-3-7-sonnet-20250219-v1:0", "claude-3-7-sonnet"},
-		DisplayName:     "Claude 3.7 Sonnet (Bedrock, us)",
-		Provider:        ProviderBedrock,
-		ContextWindow:   200000,
-		MaxOutputTokens: 8192,
-		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode"},
-	},
-	{
-		ID:              "eu.anthropic.claude-3-7-sonnet-20250219-v1:0",
-		Aliases:         []string{"bedrock-sonnet-3-7-eu"},
-		DisplayName:     "Claude 3.7 Sonnet (Bedrock, eu)",
-		Provider:        ProviderBedrock,
-		ContextWindow:   200000,
-		MaxOutputTokens: 8192,
-		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode"},
-	},
-
-	// Claude 3.5 — aceitam on-demand direto (sem prefixo)
-	{
-		ID:              "anthropic.claude-3-5-sonnet-20241022-v2:0",
-		Aliases:         []string{"bedrock-sonnet-3-5-v2", "claude-3-5-sonnet-v2"},
-		DisplayName:     "Claude 3.5 Sonnet v2 (Bedrock)",
-		Provider:        ProviderBedrock,
-		ContextWindow:   200000,
-		MaxOutputTokens: 8192,
-		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode"},
-	},
-	{
-		ID:              "anthropic.claude-3-5-sonnet-20240620-v1:0",
-		Aliases:         []string{"bedrock-sonnet-3-5-v1"},
-		DisplayName:     "Claude 3.5 Sonnet v1 (Bedrock)",
-		Provider:        ProviderBedrock,
-		ContextWindow:   200000,
-		MaxOutputTokens: 8192,
-		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode"},
-	},
-	{
-		ID:              "anthropic.claude-3-5-haiku-20241022-v1:0",
-		Aliases:         []string{"bedrock-haiku-3-5", "claude-3-5-haiku"},
-		DisplayName:     "Claude 3.5 Haiku (Bedrock)",
-		Provider:        ProviderBedrock,
-		ContextWindow:   200000,
-		MaxOutputTokens: 8192,
-		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "json_mode"},
-	},
-
-	// Claude 3 — legado (ainda suportado on-demand)
-	{
-		ID:              "anthropic.claude-3-opus-20240229-v1:0",
-		Aliases:         []string{"bedrock-opus-3", "claude-3-opus"},
-		DisplayName:     "Claude 3 Opus (Bedrock)",
-		Provider:        ProviderBedrock,
-		ContextWindow:   200000,
-		MaxOutputTokens: 4096,
-		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode"},
-	},
-	{
-		ID:              "anthropic.claude-3-haiku-20240307-v1:0",
-		Aliases:         []string{"bedrock-haiku-3", "claude-3-haiku"},
-		DisplayName:     "Claude 3 Haiku (Bedrock)",
-		Provider:        ProviderBedrock,
-		ContextWindow:   200000,
-		MaxOutputTokens: 4096,
-		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode"},
-	},
+	// Claude 3.x on Bedrock — all gone (model-cards index + lifecycle
+	// table, Sep 2 2026): Sonnet 3.7 and Opus 3 retired, Haiku 3.5 past
+	// its Jun 19 2026 EOL, Sonnet 3.5 v1/v2 off the cards (only a
+	// "public extended access" pricing row remains), Haiku 3 EOL Sep 10
+	// 2026. Their entries were removed; a stray 3.x id now falls back to
+	// bedrockFallbackMaxTokens (64K for anthropic ids), which AWS rejects
+	// with a clear ValidationException instead of silently sizing wrong.
 
 	// ── AWS Bedrock — OpenAI GPT-OSS (open-weights) ──────────────────
 	// Modelos OpenAI open-weights hospedados no Bedrock. Usam schema
@@ -1841,6 +1588,47 @@ var registry = []ModelMeta{
 		MaxOutputTokens: 16384,
 		PreferredAPI:    APIChatCompletions,
 		Capabilities:    []string{"tools", "json_mode"},
+	},
+
+	// ── AWS Bedrock — OpenAI GPT-5.6 (frontier, Jul 13 2026) ──────────
+	// Sol/Terra/Luna on Bedrock (model cards openai-gpt-5-6-*) speak
+	// Converse, Responses and Chat Completions but NOT InvokeModel, and
+	// are served only through inference profiles (Sol: us./global.;
+	// Terra/Luna: us./in./global.). The "openai." vendor prefix would
+	// normally send them down the gpt-oss InvokeModel path, so these
+	// entries carry bedrock_converse_only, which resolveFamily honours
+	// ahead of the vendor sniff. 1,050,000 context / 128K output as on
+	// the platform API (AWS lists "1M" and no output cap); prices per
+	// card: Sol $4/$20, Terra $2/$12, Luna $0.20/$1.20 (global, ≤272K).
+	{
+		ID:              "global.openai.gpt-5.6-sol",
+		Aliases:         []string{"bedrock-gpt-5.6-sol", "openai.gpt-5.6-sol", "us.openai.gpt-5.6-sol"},
+		DisplayName:     "GPT-5.6 Sol (Bedrock, global)",
+		Provider:        ProviderBedrock,
+		ContextWindow:   1050000,
+		MaxOutputTokens: 128000,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"tools", "vision", "json_mode", "bedrock_converse_only"},
+	},
+	{
+		ID:              "global.openai.gpt-5.6-terra",
+		Aliases:         []string{"bedrock-gpt-5.6-terra", "openai.gpt-5.6-terra", "us.openai.gpt-5.6-terra", "in.openai.gpt-5.6-terra"},
+		DisplayName:     "GPT-5.6 Terra (Bedrock, global)",
+		Provider:        ProviderBedrock,
+		ContextWindow:   1050000,
+		MaxOutputTokens: 128000,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"tools", "vision", "json_mode", "bedrock_converse_only"},
+	},
+	{
+		ID:              "global.openai.gpt-5.6-luna",
+		Aliases:         []string{"bedrock-gpt-5.6-luna", "openai.gpt-5.6-luna", "us.openai.gpt-5.6-luna", "in.openai.gpt-5.6-luna"},
+		DisplayName:     "GPT-5.6 Luna (Bedrock, global)",
+		Provider:        ProviderBedrock,
+		ContextWindow:   1050000,
+		MaxOutputTokens: 128000,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"tools", "vision", "json_mode", "bedrock_converse_only"},
 	},
 
 	// ── AWS Bedrock — Amazon Nova ────────────────────────────────────
@@ -1882,13 +1670,39 @@ var registry = []ModelMeta{
 		PreferredAPI:    APIChatCompletions,
 		Capabilities:    []string{"tools", "vision", "json_mode"},
 	},
+	// Nova Premier (us.amazon.nova-premier-v1:0) is Legacy since Mar 13
+	// 2026 with EOL Sep 14 2026 — removed. Its successor on Bedrock is
+	// Nova 2 Lite (model card amazon-nova-2-lite, Dec 2025): 1M context,
+	// 64K max output, Converse + InvokeModel, served ONLY through
+	// inference profiles (us./eu./jp./global. — no bare in-region id), so
+	// the canonical spelling carries the global. prefix. Nova 2 Pro/Omni
+	// are not on Bedrock (Nova Forge preview only) and stay out.
 	{
-		ID:              "us.amazon.nova-premier-v1:0",
-		Aliases:         []string{"bedrock-nova-premier", "amazon.nova-premier-v1:0", "nova-premier"},
-		DisplayName:     "Amazon Nova Premier (Bedrock, 1M ctx)",
+		ID:              "global.amazon.nova-2-lite-v1:0",
+		Aliases:         []string{"bedrock-nova-2-lite", "amazon.nova-2-lite-v1:0", "us.amazon.nova-2-lite-v1:0", "eu.amazon.nova-2-lite-v1:0", "jp.amazon.nova-2-lite-v1:0", "nova-2-lite"},
+		DisplayName:     "Amazon Nova 2 Lite (Bedrock, global, 1M ctx)",
 		Provider:        ProviderBedrock,
 		ContextWindow:   1000000,
-		MaxOutputTokens: 5120,
+		MaxOutputTokens: 65536,
+		PreferredAPI:    APIChatCompletions,
+		Capabilities:    []string{"tools", "vision", "json_mode"},
+	},
+
+	// ── AWS Bedrock — xAI Grok ────────────────────────────────────────
+	// Grok 4.6 landed on Bedrock on Aug 18 2026 (model card xai-grok-4-6):
+	// Converse + InvokeModel + Responses, served only through us./global.
+	// inference profiles. The "xai." vendor is not a Converse-only
+	// vendor string, but resolveFamily already routes every non-Anthropic,
+	// non-OpenAI id through Converse, which is the surface AWS documents
+	// for it. 500K context; xAI publishes no output cap, so the 16K
+	// convention from the ProviderXAI block applies.
+	{
+		ID:              "global.xai.grok-4.6",
+		Aliases:         []string{"bedrock-grok-4.6", "xai.grok-4.6", "us.xai.grok-4.6", "bedrock-grok-4-6"},
+		DisplayName:     "Grok 4.6 (Bedrock, global)",
+		Provider:        ProviderBedrock,
+		ContextWindow:   500000,
+		MaxOutputTokens: 16384,
 		PreferredAPI:    APIChatCompletions,
 		Capabilities:    []string{"tools", "vision", "json_mode"},
 	},
@@ -1933,14 +1747,29 @@ func Resolve(provider, model string) (ModelMeta, bool) {
 		}
 	}
 
-	// 2) match por provedor + aliases (contém/prefixo)
+	// 2a) match por provedor + alias EXATO. Roda antes do passe frouxo
+	// para que um apelido curto de uma entrada anterior ("fable" na
+	// Fable 5.1, que precisa vir antes da Fable 5) nunca engula, por
+	// Contains, o apelido exato de outra entrada ("fable-5").
+	for _, meta := range registry {
+		if meta.Provider != "" && meta.Provider != p {
+			continue
+		}
+		for _, alias := range meta.Aliases {
+			if m == strings.ToLower(alias) {
+				return meta, true
+			}
+		}
+	}
+
+	// 2b) match por provedor + aliases (contém/prefixo)
 	for _, meta := range registry {
 		if meta.Provider != "" && meta.Provider != p {
 			continue
 		}
 		for _, alias := range meta.Aliases {
 			a := strings.ToLower(alias)
-			if m == a || strings.HasPrefix(m, a) || strings.Contains(m, a) {
+			if strings.HasPrefix(m, a) || strings.Contains(m, a) {
 				return meta, true
 			}
 		}

--- a/llm/catalog/catalog.go
+++ b/llm/catalog/catalog.go
@@ -902,7 +902,7 @@ var registry = []ModelMeta{
 		Capabilities:    []string{"tools", "json_mode", "vision"},
 	},
 	{
-		// GLM-5.3 (Aug 14 2026): 1M-token context, 128K max output
+		// GLM-5.3 (Aug 18 2026): 1M-token context, 128K max output
 		// (docs.z.ai/guides/llm/glm-5.3). Same base model as GLM-5.2 with
 		// scaled-up post-training (coding/agentic focus). Text-only input;
 		// reasoning always on. Tool calling and structured output.

--- a/llm/catalog/catalog_devin.go
+++ b/llm/catalog/catalog_devin.go
@@ -30,7 +30,11 @@ func init() {
 		out int
 	}
 	devinModels := []devinModel{
-		// Anthropic family (specs mirror the CLAUDEAI entries).
+		// Anthropic family (specs mirror the CLAUDEAI entries). Fable 5.1
+		// (Cognition blog, Aug 31 2026) and Fable 5 are back in the Devin
+		// model table; 5.1 MUST precede 5 (dotted prefix rule above).
+		{"claude-fable-5.1", 1000000, 128000},
+		{"claude-fable-5", 1000000, 128000},
 		{"claude-opus-5", 1000000, 128000},
 		{"claude-sonnet-5", 1000000, 128000},
 		{"claude-opus-4.8", 1000000, 128000},
@@ -53,6 +57,7 @@ func init() {
 		{"gpt-5.1", 400000, 128000},
 		{"gpt-4.1", 1047576, 32768},
 		// Google family (Gemini 3.x: 1M window / 65K output).
+		{"gemini-3.7-flash", 1048576, 65536},
 		{"gemini-3.6-flash", 1048576, 65536},
 		{"gemini-3.5-flash", 1048576, 65536},
 		{"gemini-3.1-pro", 1048576, 65536},
@@ -67,6 +72,12 @@ func init() {
 		{"kimi-k2.7", 262144, 131072},
 		{"kimi-k2.6", 262144, 131072},
 		{"deepseek-v4-pro", 1000000, 32000},
+		{"deepseek-v4-flash", 1000000, 32000},
+		// xAI (docs.devin.ai/desktop/models: grok-4-6-* / grok-4-5-*):
+		// 500K window per docs.x.ai; output follows the XAI block's 16K
+		// convention since xAI publishes no cap.
+		{"grok-4.6", 500000, 16384},
+		{"grok-4.5", 500000, 16384},
 		// Cognition in-house (Windsurf SWE line): no published specs —
 		// conservative profile until Cognition documents them.
 		{"swe-1.7-lightning", 200000, 32000},

--- a/llm/catalog/catalog_test.go
+++ b/llm/catalog/catalog_test.go
@@ -15,27 +15,45 @@ func TestResolve(t *testing.T) {
 		shouldFind bool
 	}{
 		{"Exact Match OpenAI", ProviderOpenAI, "gpt-4o-mini", "gpt-4o-mini", true},
-		{"Alias Match ClaudeAI", ProviderClaudeAI, "claude-3-5-sonnet", "claude-sonnet-3-5-20241022", true},
-		{"Prefix Match ClaudeAI", ProviderClaudeAI, "claude-3-5-sonnet-20241022-preview", "claude-sonnet-3-5-20241022", true},
+		{"Alias Match ClaudeAI", ProviderClaudeAI, "claude-4-5-sonnet", "claude-sonnet-4-5", true},
+		{"Prefix Match ClaudeAI", ProviderClaudeAI, "claude-sonnet-4-5-20250929", "claude-sonnet-4-5", true},
 		{"Case Insensitive", ProviderOpenAI, "GPT-4O", "gpt-4o", true},
-		{"Gemini Flash Lite", ProviderGoogleAI, "gemini-2.0-flash-lite", "gemini-2.0-flash-lite", true},
+		{"Gemini Flash Lite", ProviderGoogleAI, "gemini-3.5-flash-lite", "gemini-3.5-flash-lite", true},
 		{"GPT-5 Alias", ProviderOpenAI, "gpt-5-mini", "gpt-5", true},
 		{"Not Found", ProviderOpenAI, "gpt-nonexistent", "", false},
 		{"Wrong Provider", ProviderStackSpot, "gpt-4o", "", false},
-		// Regression: the bare "opus-4" alias on the 4.0 entry is a prefix
-		// of all opus-4-X shortcuts. Newer entries MUST be declared first
-		// in the registry so their exact-alias match wins over 4.0's
-		// loose prefix match. Each of these silently resolved to the 4.0
-		// entry (ctx=20K) before the fix.
+		// Regression: newer entries MUST be declared first in the registry
+		// so their exact-alias match wins over an older entry's loose
+		// prefix match ("fable-5" ⊂ "fable-5-1", "gpt-5.4" ⊂ "gpt-5.4-mini").
 		{"Claude Opus 4.5 shortcut", ProviderClaudeAI, "opus-4-5", "claude-opus-4-5", true},
 		{"Claude Opus 4.6 shortcut", ProviderClaudeAI, "opus-4-6", "claude-opus-4-6", true},
 		{"Claude Opus 4.7 shortcut", ProviderClaudeAI, "opus-4-7", "claude-opus-4-7", true},
 		{"Claude Opus 4.7 full ID", ProviderClaudeAI, "claude-opus-4-7", "claude-opus-4-7", true},
 		{"Claude Opus 4.8 shortcut", ProviderClaudeAI, "opus-4-8", "claude-opus-4-8", true},
 		{"Claude Opus 4.8 full ID", ProviderClaudeAI, "claude-opus-4-8", "claude-opus-4-8", true},
-		{"Claude Sonnet 4.7 shortcut", ProviderClaudeAI, "sonnet-4-7", "claude-sonnet-4-7", true},
-		// Backward compat: bare "opus-4" still resolves to the 4.0 entry
-		{"Claude Opus 4 bare alias", ProviderClaudeAI, "opus-4", "claude-opus-4-20250514", true},
+		{"Claude Fable 5.1 shortcut", ProviderClaudeAI, "fable-5-1", "claude-fable-5-1", true},
+		{"Claude Fable 5.1 dotted", ProviderClaudeAI, "claude-fable-5.1", "claude-fable-5-1", true},
+		{"Claude Fable 5 stays pinned", ProviderClaudeAI, "fable-5", "claude-fable-5", true},
+		// Retired on the Claude API (Sep 2026) and removed: a stale pin
+		// must NOT silently land on another entry.
+		{"Claude Sonnet 4.7 never shipped", ProviderClaudeAI, "sonnet-4-7", "", false},
+		{"Claude Opus 4 retired", ProviderClaudeAI, "claude-opus-4-20250514", "", false},
+		{"Claude Sonnet 4 retired", ProviderClaudeAI, "claude-sonnet-4-20250514", "", false},
+		{"Claude 3.5 Sonnet retired", ProviderClaudeAI, "claude-3-5-sonnet-20241022", "", false},
+		// "gpt-5.3" (never a real model) rides the gpt-5 generation entry
+		// by prefix — same 400K / 128K profile, so the loose match is
+		// harmless; what matters is that it no longer lands on a bogus
+		// 200K / 100K entry.
+		{"GPT-5.3 bare rides gpt-5 by prefix", ProviderOpenAI, "gpt-5.3", "gpt-5", true},
+		{"GPT-5.4 mini own entry", ProviderOpenAI, "gpt-5.4-mini", "gpt-5.4-mini", true},
+		{"GPT-5.4 nano rides mini", ProviderOpenAI, "gpt-5.4-nano", "gpt-5.4-mini", true},
+		{"GPT-5.4 pro rides base", ProviderOpenAI, "gpt-5.4-pro", "gpt-5.4", true},
+		{"Gemini 2.0 shut down", ProviderGoogleAI, "gemini-2.0-flash", "", false},
+		{"Gemini 3 Pro preview shut down", ProviderGoogleAI, "gemini-3-pro-preview", "", false},
+		{"Grok 3 retired", ProviderXAI, "grok-3", "", false},
+		{"Grok code fast rides build", ProviderXAI, "grok-code-fast-1", "grok-build-0.1", true},
+		{"Kimi K2.5 retired", ProviderMoonshot, "kimi-k2.5", "", false},
+		{"moonshot-v1 retired", ProviderMoonshot, "moonshot-v1-128k", "", false},
 		// gpt-5.5 family — released Apr 23 2026. Pin both the base and
 		// the pro variant; the registry order also matters here so 5.5
 		// is not shadowed by an earlier 5.x prefix match.
@@ -59,11 +77,15 @@ func TestGetMaxTokens(t *testing.T) {
 	tokens := GetMaxTokens(ProviderOpenAI, "gpt-4o", 12345)
 	assert.Equal(t, 12345, tokens, "Override should have the highest priority")
 
-	// Caso 2: Valor do catálogo. Haiku 3 expõe 4096 tokens de output
-	// (limite real publicado pela Anthropic, não o número conservador
-	// inflado de 42K que o catálogo carregava antes da auditoria).
+	// Caso 2: Valor do catálogo. Haiku 4.5 expõe 64K tokens de output
+	// (limite real publicado pela Anthropic).
+	tokens = GetMaxTokens(ProviderClaudeAI, "claude-haiku-4-5", 0)
+	assert.Equal(t, 64000, tokens, "Should get value from catalog for claude-haiku-4-5")
+
+	// Caso 2b: modelo Claude aposentado (removido do catálogo) cai no
+	// fallback do provider em vez de um valor obsoleto.
 	tokens = GetMaxTokens(ProviderClaudeAI, "claude-3-haiku", 0)
-	assert.Equal(t, 4096, tokens, "Should get value from catalog for claude-3-haiku")
+	assert.Equal(t, 64000, tokens, "retired claude-3-haiku must use the ClaudeAI fallback")
 
 	// Caso 3: Fallback para modelo desconhecido. Após a auditoria de
 	// catálogo (Abr 2026) os fallbacks foram alinhados com os limites
@@ -168,25 +190,34 @@ func TestMoonshotCatalogEntries(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, "kimi-k2.7-code", bare.ID)
 
-	// Pin the public specs of the Kimi K2.6/K2.5 entries so silent drift on
-	// the model card (e.g. catalog edits during a refactor) shows up here
+	// Pin the public specs of the Kimi K2.6 entry so silent drift on the
+	// model card (e.g. catalog edits during a refactor) shows up here
 	// instead of at runtime.
-	for _, id := range []string{"kimi-k2.6", "kimi-k2.5", "kimi-latest"} {
-		meta, ok := Resolve(ProviderMoonshot, id)
-		assert.True(t, ok, "expected %s to resolve", id)
-		assert.Equal(t, 262144, meta.ContextWindow, "%s context window", id)
-		assert.Contains(t, meta.Capabilities, "tools", "%s should advertise tools", id)
-		assert.Contains(t, meta.Capabilities, "thinking", "%s should advertise thinking", id)
+	k26, ok := Resolve(ProviderMoonshot, "kimi-k2.6")
+	assert.True(t, ok, "expected kimi-k2.6 to resolve")
+	assert.Equal(t, 262144, k26.ContextWindow)
+	assert.Contains(t, k26.Capabilities, "tools")
+	assert.Contains(t, k26.Capabilities, "thinking")
+
+	// Retired by Moonshot (kimi-k2.5 + moonshot-v1-* on Aug 31 2026, the
+	// K2 previews on May 25 2026, kimi-latest on Jan 28 2026,
+	// kimi-thinking-preview on Nov 11 2025): the API answers 404, so the
+	// catalog must not resolve them to anything — the provider fallback
+	// (256K / 128K) is the honest answer for a stale pin.
+	for _, id := range []string{
+		"kimi-k2.5", "kimi-latest", "kimi-k2-turbo-preview", "kimi-thinking-preview",
+		"moonshot-v1-8k", "moonshot-v1-32k", "moonshot-v1-128k",
+	} {
+		_, ok := Resolve(ProviderMoonshot, id)
+		assert.False(t, ok, "%s was retired by Moonshot and must not resolve", id)
+		assert.Equal(t, 262144, GetContextWindow(ProviderMoonshot, id), "%s fallback window", id)
 	}
-
-	// moonshot-v1-* family is the classic split — verify both ends.
-	v18k, ok := Resolve(ProviderMoonshot, "moonshot-v1-8k")
-	assert.True(t, ok)
-	assert.Equal(t, 8192, v18k.ContextWindow)
-
-	v1128k, ok := Resolve(ProviderMoonshot, "moonshot-v1-128k")
-	assert.True(t, ok)
-	assert.Equal(t, 131072, v1128k.ContextWindow)
+	// The registry must hold exactly the four ids Moonshot still serves.
+	var ids []string
+	for _, m := range ListByProvider(ProviderMoonshot) {
+		ids = append(ids, m.ID)
+	}
+	assert.ElementsMatch(t, []string{"kimi-k3", "kimi-k2.7-code-highspeed", "kimi-k2.7-code", "kimi-k2.6"}, ids)
 }
 
 func TestGetPreferredAPI(t *testing.T) {
@@ -212,8 +243,52 @@ func TestGetPreferredAPI(t *testing.T) {
 // fast_mode must NOT be advertised — the speed parameter is not documented
 // for Fable 5, and advertising it would make the claudeai client emit
 // `speed:"fast"` on a model that may reject it.
+// TestClaudeFable51Specs pins Fable 5.1 (Sep 1 2026): same 1M / 128K
+// profile and capability flags as Fable 5, listed AHEAD of it because
+// "fable-5" is a prefix of "fable-5-1" in Resolve's alias pass. The bare
+// "fable" shortcut now tracks 5.1 (the newest Fable), while "fable-5"
+// stays pinned on the legacy entry.
+func TestClaudeFable51Specs(t *testing.T) {
+	for _, id := range []string{"claude-fable-5-1", "fable-5-1", "claude-fable-5.1", "fable-5.1", "fable"} {
+		meta, ok := Resolve(ProviderClaudeAI, id)
+		if !assert.True(t, ok, "expected %s to resolve on ProviderClaudeAI", id) {
+			continue
+		}
+		assert.Equal(t, "claude-fable-5-1", meta.ID, "alias %s must resolve to claude-fable-5-1", id)
+		assert.Equal(t, 1000000, meta.ContextWindow, "Fable 5.1 context window is 1M tokens")
+		assert.Equal(t, 128000, meta.MaxOutputTokens, "Fable 5.1 max output is 128K")
+		assert.Equal(t, APIAnthropicMessages, meta.PreferredAPI)
+	}
+	for _, capability := range []string{
+		"tools", "json_mode", "vision", "adaptive_thinking", "mid_conversation_system",
+	} {
+		assert.True(t,
+			HasCapability(ProviderClaudeAI, "claude-fable-5-1", capability),
+			"claude-fable-5-1 should advertise %q capability", capability)
+	}
+	assert.False(t,
+		HasCapability(ProviderClaudeAI, "claude-fable-5-1", "fast_mode"),
+		"claude-fable-5-1 must not advertise fast_mode (Opus 5 / 4.8 only)")
+	assert.Equal(t, 1000000, GetContextWindow(ProviderClaudeAI, "claude-fable-5-1"))
+	assert.Equal(t, 128000, GetMaxTokens(ProviderClaudeAI, "claude-fable-5-1", 0))
+}
+
+// TestClaudeSonnet46Output pins the Sep 2026 correction: Sonnet 4.6 is
+// 128K max output on the synchronous Claude API (model page), while its
+// Bedrock mirror stays at the 64K the AWS model card documents.
+func TestClaudeSonnet46Output(t *testing.T) {
+	meta, ok := Resolve(ProviderClaudeAI, "claude-sonnet-4-6")
+	assert.True(t, ok)
+	assert.Equal(t, 1000000, meta.ContextWindow)
+	assert.Equal(t, 128000, meta.MaxOutputTokens, "Sonnet 4.6 output on the Claude API is 128K")
+
+	bedrock, ok := Resolve(ProviderBedrock, "global.anthropic.claude-sonnet-4-6")
+	assert.True(t, ok)
+	assert.Equal(t, 64000, bedrock.MaxOutputTokens, "Sonnet 4.6 output on Bedrock is 64K per the AWS card")
+}
+
 func TestClaudeFable5Specs(t *testing.T) {
-	for _, id := range []string{"claude-fable-5", "fable-5", "fable"} {
+	for _, id := range []string{"claude-fable-5", "fable-5"} {
 		meta, ok := Resolve(ProviderClaudeAI, id)
 		assert.True(t, ok, "expected %s to resolve on ProviderClaudeAI", id)
 		assert.Equal(t, "claude-fable-5", meta.ID, "alias %s must resolve to claude-fable-5", id)
@@ -305,9 +380,11 @@ func TestClaudeOpus5Specs(t *testing.T) {
 	m48, ok := Resolve(ProviderClaudeAI, "claude-opus-4-8")
 	assert.True(t, ok)
 	assert.Equal(t, "claude-opus-4-8", m48.ID)
+	// Opus 4 was retired (Jun 15 2026) and its entry removed: the bare
+	// "opus-4" alias must resolve to nothing rather than to Opus 5 or to
+	// an opus-4.x entry by loose prefix.
 	m40, ok := Resolve(ProviderClaudeAI, "opus-4")
-	assert.True(t, ok)
-	assert.NotEqual(t, "claude-opus-5", m40.ID, "generic opus-4 alias must not land on Opus 5")
+	assert.False(t, ok, "retired opus-4 must not resolve (got %q)", m40.ID)
 }
 
 // TestClaudeSonnet5Specs pins the published Sonnet 5 specs (models
@@ -409,6 +486,7 @@ func TestOpenRouterAnthropic5Family(t *testing.T) {
 	for _, id := range []string{
 		"anthropic/claude-opus-5",
 		"anthropic/claude-sonnet-5",
+		"anthropic/claude-fable-5.1",
 		"anthropic/claude-fable-5",
 	} {
 		meta, ok := Resolve(ProviderOpenRouter, id)
@@ -560,9 +638,14 @@ func TestGPT56FamilyEntries(t *testing.T) {
 // provider filter keeps DEVIN entries from shadowing other providers.
 func TestDevinCatalogEntries(t *testing.T) {
 	for id, wantCtx := range map[string]int{
+		"claude-fable-5.1":  1000000,
+		"claude-fable-5":    1000000,
 		"claude-opus-5":     1000000,
 		"claude-sonnet-5":   1000000,
 		"claude-sonnet-4.6": 1000000,
+		"gemini-3.7-flash":  1048576,
+		"grok-4.6":          500000,
+		"deepseek-v4-flash": 1000000,
 		"claude-sonnet-4.5": 200000,
 		"claude-sonnet-4":   200000,
 		"gpt-5.6-luna":      1050000,
@@ -720,12 +803,13 @@ func TestOpenAIAssistantContextWindowFallback(t *testing.T) {
 // windows collapsed onto the provider fallback.
 func TestBedrockNovaEntries(t *testing.T) {
 	for model, wantCtx := range map[string]int{
-		"amazon.nova-micro-v1:0":      128000,
-		"amazon.nova-lite-v1:0":       300000,
-		"amazon.nova-pro-v1:0":        300000,
-		"amazon.nova-premier-v1:0":    1000000,
-		"us.amazon.nova-pro-v1:0":     300000, // cross-region inference profile spelling
-		"us.amazon.nova-premier-v1:0": 1000000,
+		"amazon.nova-micro-v1:0":         128000,
+		"amazon.nova-lite-v1:0":          300000,
+		"amazon.nova-pro-v1:0":           300000,
+		"us.amazon.nova-pro-v1:0":        300000, // cross-region inference profile spelling
+		"amazon.nova-2-lite-v1:0":        1000000,
+		"global.amazon.nova-2-lite-v1:0": 1000000,
+		"eu.amazon.nova-2-lite-v1:0":     1000000,
 	} {
 		meta, ok := Resolve(ProviderBedrock, model)
 		assert.True(t, ok, "expected %s to resolve for BEDROCK", model)
@@ -742,15 +826,18 @@ func TestBedrockNovaEntries(t *testing.T) {
 // whatever spelling the operator configured.
 func TestBedrockFamily5ProfileAliases(t *testing.T) {
 	cases := map[string]string{
-		"us.anthropic.claude-fable-5":      "anthropic.claude-fable-5",
-		"global.anthropic.claude-fable-5":  "anthropic.claude-fable-5",
-		"us.anthropic.claude-opus-5":       "anthropic.claude-opus-5",
-		"eu.anthropic.claude-opus-5":       "anthropic.claude-opus-5",
-		"au.anthropic.claude-opus-5":       "anthropic.claude-opus-5",
-		"us.anthropic.claude-sonnet-5":     "anthropic.claude-sonnet-5",
-		"eu.anthropic.claude-sonnet-5":     "anthropic.claude-sonnet-5",
-		"au.anthropic.claude-sonnet-5":     "anthropic.claude-sonnet-5",
-		"global.anthropic.claude-sonnet-5": "anthropic.claude-sonnet-5",
+		"us.anthropic.claude-fable-5-1":     "anthropic.claude-fable-5-1",
+		"global.anthropic.claude-fable-5-1": "anthropic.claude-fable-5-1",
+		"claude-fable-5-1":                  "anthropic.claude-fable-5-1",
+		"us.anthropic.claude-fable-5":       "anthropic.claude-fable-5",
+		"global.anthropic.claude-fable-5":   "anthropic.claude-fable-5",
+		"us.anthropic.claude-opus-5":        "anthropic.claude-opus-5",
+		"eu.anthropic.claude-opus-5":        "anthropic.claude-opus-5",
+		"au.anthropic.claude-opus-5":        "anthropic.claude-opus-5",
+		"us.anthropic.claude-sonnet-5":      "anthropic.claude-sonnet-5",
+		"eu.anthropic.claude-sonnet-5":      "anthropic.claude-sonnet-5",
+		"au.anthropic.claude-sonnet-5":      "anthropic.claude-sonnet-5",
+		"global.anthropic.claude-sonnet-5":  "anthropic.claude-sonnet-5",
 	}
 	for id, want := range cases {
 		meta, ok := Resolve(ProviderBedrock, id)


### PR DESCRIPTION
## Summary

Catalog refresh across Anthropic, OpenAI, Google, xAI, Z.AI, Moonshot, Devin and Bedrock, verified against each provider's official docs on 2026-09-02.

### New
- **Claude Fable 5.1** (`claude-fable-5-1`, Sep 1 2026) on CLAUDEAI, Bedrock (`anthropic.claude-fable-5-1`), OpenRouter (`anthropic/claude-fable-5.1`) and Devin. 1M / 128K, $10/$50, cache reads at $0.25 (2.5% of input — own case in `getCachePricing`). The bare `fable` shortcut now tracks 5.1; `fable-5` stays pinned.
- **Bedrock**: GPT-5.6 Sol/Terra/Luna (`global.openai.gpt-5.6-*`) behind a new `bedrock_converse_only` capability — AWS serves them on Converse/Responses only, so `resolveFamily` honours the flag ahead of the `openai.` vendor sniff; Grok 4.6 (`global.xai.grok-4.6`); Nova 2 Lite (`global.amazon.nova-2-lite-v1:0`).
- Devin: `claude-fable-5.1`, `claude-fable-5`, `gemini-3.7-flash`, `grok-4.6`, `grok-4.5`, `deepseek-v4-flash`.

### Corrections
- `Resolve()` gains an exact-alias pass before the prefix/contains pass (order-independent exact matches).
- Sonnet 4.6: 128K output on the Claude API (Bedrock mirror stays 64K per the AWS card).
- GPT-5.4 → 1.05M / 128K (+`gpt-5.4-pro` alias); `gpt-5.4-mini`/`-nano` own entry at 400K / 128K; `gpt-5.3-codex` and `gpt-5.2` → 400K / 128K; dropped the nonexistent `gpt-5.3`, `gpt-5.x-mini/nano` aliases and `gpt-5.3-codex-spark` (Codex-app only).
- Bedrock Opus 4.5 id date `20251101` (old spelling kept as alias).
- **Default `XAI_MODEL` → `grok-4.3`** (grok-4-1 was retired May 15 2026; xAI redirects it to 4.3). Exported const value change → `breaking-change` label.

### Removed (retired by the provider)
- Claude API: Opus 4 / Opus 4.1 / Sonnet 4, all 3.x, and the `claude-sonnet-4-7` placeholder (never shipped).
- Google: `gemini-2.0-flash(-lite)`, `gemini-3(-pro-preview)`.
- xAI: `grok-3`, `grok-3-mini`, `grok-4-fast`, `grok-4-1`; `grok-code-fast-1` is now an alias of `grok-build-0.1`.
- Moonshot: `kimi-k2.5`, `moonshot-v1-*`, `kimi-latest`, `kimi-k2-turbo-preview`, `kimi-thinking-preview` (closes #1344).
- Z.AI: `codegeex-4`.
- Bedrock: Sonnet 4.7 placeholder, Opus 4, every 3.x id, Nova Premier (EOL Sep 14).

### Cost tracking
- Sonnet 5 at the permanent $2/$10; GPT-5.5…GPT-5 tiers priced (were reported as $0); Sol $4/$20 (Aug 21 cut); xAI cached-input discounts; retired Grok slugs billed at grok-4.3 rates; GLM-4.x tiers.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` green (catalog, bedrock family routing, cost tracker pricing/cache tests updated + new pins for Fable 5.1, Sonnet 4.6, GPT-5.4 split, retired ids)
- [x] Quality Gate
