### PR TITLE
fix(operator): pin libexpat 2.8.4-r0 to clear four libexpat CVEs in the Alpine runtime image

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -36,6 +36,7 @@ RUN apk update && apk upgrade --no-cache && \
     apk add --no-cache \
         "libcrypto3>=3.5.8-r0" \
         "libssl3>=3.5.8-r0" \
+        "libexpat>=2.8.4-r0" \
         git ca-certificates tzdata && \
     adduser -D -u 65532 -g 65532 nonroot
 WORKDIR /


### PR DESCRIPTION
## Summary

artifacthub.io flags the operator image (`alpine 3.24.1`) with four libexpat findings on `2.8.3-r0`, all fixed in `2.8.4-r0`:

| CVE | Severity |
|---|---|
| CVE-2026-66046 | HIGH |
| CVE-2026-76641 | HIGH |
| CVE-2026-76956 | MEDIUM |
| CVE-2026-76957 | MEDIUM |

Same mechanism as the existing `libcrypto3`/`libssl3` pins: an explicit `apk add "libexpat>=2.8.4-r0"` so the build fails loudly if the fixed package is not in the Alpine repo, instead of silently shipping whatever `apk upgrade` finds. `2.8.4-r0` is already published in the Alpine v3.24 `main` APKINDEX (checked 2026-09-02), so the pin resolves.

The `manager` Go target already rated A; nothing changes there.

## Test plan
- [x] libexpat 2.8.4-r0 present in `dl-cdn.alpinelinux.org/alpine/v3.24/main` APKINDEX
- [x] Security Scan → Trivy — Operator Image green
