### PR TITLE
fix(chat): count cached input tokens in the ctx% footer

### DIFF
--- a/cli/chat_envelope_footer_test.go
+++ b/cli/chat_envelope_footer_test.go
@@ -113,3 +113,34 @@ func TestClampPct_Bounds(t *testing.T) {
 	assert.Equal(t, 12, clampPct(12.4))
 	assert.Equal(t, 13, clampPct(12.6))
 }
+
+// TestTelemetryParts_ContextPctCountsCachedInput pins the ctx% semantics
+// per usage schema. Bedrock Converse / Anthropic report inputTokens as the
+// uncached delta only, so a 1M-window session holding 600K tokens with
+// prompt caching active reports ~20K PromptTokens and ~580K cache reads:
+// the footer must say 60%, not 2% (which is what users saw right before
+// auto-compaction fired, and read as compaction at "2% usage").
+func TestTelemetryParts_ContextPctCountsCachedInput(t *testing.T) {
+	bedrock := &ChatCLI{Provider: "BEDROCK", Model: "global.anthropic.claude-sonnet-5"}
+	usage := &models.UsageInfo{PromptTokens: 20000, CompletionTokens: 800, CacheReadInputTokens: 570000, CacheCreationInputTokens: 10000, IsReal: true}
+	joined := strings.Join(bedrock.telemetryParts(usage, 0, false), " · ")
+	assert.Contains(t, joined, "ctx 60%", "additive schema: prompt + cache read + cache write over the 1M window")
+
+	// Subset schema: OpenAI's prompt_tokens already includes cached_tokens,
+	// so adding them again would double count.
+	openai := &ChatCLI{Provider: "OPENAI", Model: "gpt-4o"}
+	sub := &models.UsageInfo{PromptTokens: 64000, CompletionTokens: 100, CacheReadInputTokens: 60000, IsReal: true}
+	joined = strings.Join(openai.telemetryParts(sub, 0, false), " · ")
+	assert.Contains(t, joined, "ctx 50%", "subset schema: prompt tokens alone over the 128K window")
+}
+
+func TestContextTokens_SchemaAware(t *testing.T) {
+	u := &models.UsageInfo{PromptTokens: 100, CacheReadInputTokens: 900, CacheCreationInputTokens: 50}
+	assert.Equal(t, 1050, contextTokens("CLAUDEAI", "claude-sonnet-5", u))
+	assert.Equal(t, 1050, contextTokens("BEDROCK", "us.anthropic.claude-opus-5", u))
+	assert.Equal(t, 1050, contextTokens("BEDROCK", "amazon.nova-pro-v1:0", u), "Converse reports every vendor's inputTokens as uncached-only")
+	assert.Equal(t, 100, contextTokens("BEDROCK", "openai.gpt-5.6-sol", u), "OpenAI family on Bedrock keeps subset semantics")
+	assert.Equal(t, 100, contextTokens("OPENAI", "gpt-5.5", u))
+	assert.Equal(t, 100, contextTokens("OPENROUTER", "anthropic/claude-sonnet-5", u))
+	assert.Equal(t, 0, contextTokens("OPENAI", "gpt-5.5", nil))
+}

--- a/cli/chat_pipeline.go
+++ b/cli/chat_pipeline.go
@@ -881,7 +881,9 @@ func (cli *ChatCLI) telemetryParts(usage *models.UsageInfo, costUSD float64, inc
 		parts = append(parts, formatTurnCost(costUSD))
 	}
 	if window := catalog.GetContextWindow(cli.Provider, cli.Model); window > 0 {
-		pct := float64(usage.PromptTokens) / float64(window) * 100
+		// Cached input counts: see contextTokens — PromptTokens alone is
+		// only the uncached delta on Anthropic/Bedrock schemas.
+		pct := float64(contextTokens(cli.Provider, cli.Model, usage)) / float64(window) * 100
 		parts = append(parts, i18n.T("chat.envelope.context_pct", clampPct(pct)))
 	}
 	// Compression savings SINCE THE LAST RENDER — per-turn, matching the cost

--- a/cli/cost_tracker.go
+++ b/cli/cost_tracker.go
@@ -1137,10 +1137,43 @@ func providerFallbackPricing(provider, model string) (float64, float64, bool) {
 // an OpenAI-compatible gateway (OpenRouter) reports subset-style
 // cached_tokens, so the provider decides when it implies the schema.
 func cacheTokensAdditive(provider, model string) bool {
-	if strings.Contains(strings.ToLower(provider), "openrouter") {
+	p := strings.ToLower(provider)
+	m := strings.ToLower(model)
+	if strings.Contains(p, "openrouter") {
 		return false // OpenAI-compatible schema regardless of the model
 	}
-	return strings.Contains(strings.ToLower(model), "claude")
+	if strings.Contains(p, "bedrock") {
+		// Converse TokenUsage and the InvokeModel/Mantle Anthropic envelope
+		// both report inputTokens as the NON-cached input only ("total
+		// input tokens = inputTokens + cacheReadInputTokens +
+		// cacheWriteInputTokens", Bedrock prompt-caching guide) — for
+		// every vendor served through Converse, not just Claude. The
+		// OpenAI family on Bedrock (gpt-oss InvokeModel, GPT-5.x on the
+		// Responses/Chat Completions surface) keeps OpenAI's subset
+		// semantics (input_tokens includes cached_tokens).
+		return !strings.Contains(m, "gpt") && !strings.Contains(m, "openai")
+	}
+	return strings.Contains(m, "claude")
+}
+
+// contextTokens is the input the model actually held for the turn — what
+// the ctx% figure must measure against the window. Additive schemas
+// (Anthropic, Bedrock Converse) report cache reads and writes ALONGSIDE
+// PromptTokens, so a long cached conversation shows a tiny PromptTokens
+// (only the uncached delta) while the model is holding the whole
+// history; subset schemas (OpenAI, Gemini, OpenRouter) already include
+// cached tokens in PromptTokens. Without this, a Bedrock session at 60%
+// of a 1M window rendered "ctx 2%" right before auto-compaction fired —
+// the compactor sizes the real history, the footer sized the delta.
+func contextTokens(provider, model string, usage *models.UsageInfo) int {
+	if usage == nil {
+		return 0
+	}
+	n := usage.PromptTokens
+	if cacheTokensAdditive(provider, model) {
+		n += usage.CacheReadInputTokens + usage.CacheCreationInputTokens
+	}
+	return n
 }
 
 // getCachePricing returns cache write and cache read cost per 1M tokens.

--- a/cli/cost_tracker_overhaul_test.go
+++ b/cli/cost_tracker_overhaul_test.go
@@ -175,6 +175,15 @@ func TestCacheSemanticsFollowReportingSchema(t *testing.T) {
 	if !cacheTokensAdditive("CLAUDEAI", "claude-sonnet-5") {
 		t.Fatal("native claude lost additive semantics")
 	}
+	if !cacheTokensAdditive("BEDROCK", "amazon.nova-pro-v1:0") {
+		t.Fatal("Bedrock Converse reports inputTokens as uncached-only for every vendor: additive")
+	}
+	if cacheTokensAdditive("BEDROCK", "openai.gpt-5.6-terra") {
+		t.Fatal("OpenAI family on Bedrock reports OpenAI-style subset usage: not additive")
+	}
+	if cacheTokensAdditive("BEDROCK", "openai.gpt-oss-120b-1:0") {
+		t.Fatal("gpt-oss on Bedrock InvokeModel is OpenAI-schema: not additive")
+	}
 	if !cacheTokensAdditive("BEDROCK", "anthropic.claude-sonnet-5") {
 		t.Fatal("bedrock claude lost additive semantics")
 	}


### PR DESCRIPTION
## Summary

- On Anthropic and Bedrock Converse, `inputTokens` is the **non-cached** input only; the model is holding `inputTokens + cacheReadInputTokens + cacheWriteInputTokens` (Bedrock prompt-caching guide: *"When prompt caching is enabled, the inputTokens field represents only the non-cached input tokens"*).
- The chat/coder footer divided `PromptTokens` alone by the window. With prompt caching active, a long Bedrock session holding ~600K of a 1M window rendered `ctx 2%`, and auto-compaction (which sizes the real history in chars) fired right after — reading as "compacting at 2% usage". The compaction was right; the number was wrong.
- New `contextTokens(provider, model, usage)`: `PromptTokens + CacheRead + CacheCreation` on additive schemas, `PromptTokens` alone on subset schemas (OpenAI, Gemini, OpenRouter) where cached tokens are already included.
- `cacheTokensAdditive` (shared with the cost math) now treats every vendor served through Bedrock Converse as additive (Nova, Llama, … — same TokenUsage semantics), while the OpenAI family on Bedrock (`openai.gpt-*`, gpt-oss) keeps subset semantics.

## Verification

- `go test ./cli/ ./llm/...` green with go1.26.6; `golangci-lint v1.64.8` clean on `cli`.
- New tests: `TestTelemetryParts_ContextPctCountsCachedInput` (Bedrock Claude 20K prompt + 580K cache over 1M → `ctx 60%`; OpenAI subset stays `ctx 50%`), `TestContextTokens_SchemaAware`, and the Bedrock vendor split in the `cacheTokensAdditive` test.
