### PR TITLE
fix(context): cache-stable prompt prefix, reversible guided compact and fsync durability

### DIFF
--- a/cli/agent/microcompact.go
+++ b/cli/agent/microcompact.go
@@ -14,8 +14,13 @@
  *   - Tool results 2+ turns old: truncated to head+tail preview
  *   - Tool results 4+ turns old: replaced with one-line summary
  *
- * Only applies to read-only tool results (file reads, search, git status, etc.).
- * Write/exec results are preserved as they contain critical error information.
+ * Applies to every tool result (and squad feedback block) above MinContentSize,
+ * regardless of the tool that produced it: exec/test output is the bulkiest
+ * content in a long coder loop, and with a CCR layer configured nothing is
+ * lost — the stub carries a <<ccr:KEY>> marker the model expands with @recall.
+ * The only exemption is structural: a message flagged
+ * MessageMeta.PreserveVerbatim (the output of @recall itself) is never
+ * re-reduced, otherwise the model would be forced into a recall loop.
  */
 package agent
 
@@ -138,6 +143,12 @@ func ApplyMicrocompact(history []models.Message, currentTurn int, config Microco
 		msg := &history[i]
 		isAgentFeedback := msg.Role == "user" && msg.Meta != nil && msg.Meta.AgentFeedback
 		if msg.Role != "tool" && !isAgentFeedback {
+			continue
+		}
+		// @recall output is the model explicitly asking to see an archived
+		// original in full; reducing it again would just trigger another
+		// recall. Same structural flag the history trimmer honors.
+		if msg.Meta != nil && msg.Meta.PreserveVerbatim {
 			continue
 		}
 		if len(msg.Content) < config.MinContentSize {

--- a/cli/agent/microcompact_test.go
+++ b/cli/agent/microcompact_test.go
@@ -163,3 +163,30 @@ func TestApplyMicrocompact_PlainUserMessageUntouched(t *testing.T) {
 		t.Error("plain user message content changed")
 	}
 }
+
+// A @recall result is the model explicitly asking to see an archived original
+// in full; microcompact must leave it alone (structural PreserveVerbatim flag,
+// the same one the history trimmer honors) or the model is pushed into a
+// recall loop.
+func TestApplyMicrocompact_PreserveVerbatimIsExempt(t *testing.T) {
+	cfg := DefaultMicrocompactConfig()
+	content := strings.Repeat("recalled line\n", 600)
+	history := microcompactHistory(content, cfg.TurnsBeforeSummarize)
+	history[2].Meta = &models.MessageMeta{PreserveVerbatim: true}
+
+	got, report := ApplyMicrocompact(history, cfg.TurnsBeforeSummarize, cfg, zap.NewNop())
+	if got[2].Content != content {
+		t.Fatalf("PreserveVerbatim tool result was reduced:\n%q", got[2].Content[:80])
+	}
+	if report.Truncated != 0 || report.Summarized != 0 {
+		t.Fatalf("report should be empty, got %+v", report)
+	}
+
+	// Same history without the flag IS compacted — proves the exemption is
+	// what protected the message, not the fixture.
+	plain := microcompactHistory(content, cfg.TurnsBeforeSummarize)
+	got, report = ApplyMicrocompact(plain, cfg.TurnsBeforeSummarize, cfg, zap.NewNop())
+	if got[2].Content == content || report.Summarized != 1 {
+		t.Fatalf("unflagged control was not summarized, report=%+v", report)
+	}
+}

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -1133,6 +1133,17 @@ func (a *AgentMode) Run(ctx context.Context, query string, additionalContext str
 		channelsText = a.cli.mcpManager.Channels().FormatForPrompt(5)
 	}
 
+	// The scratch dir path is per-process, so it rides in the uncached
+	// dynamic tail rather than the cacheable tools block (see
+	// buildSessionWorkspaceHint).
+	if wsLine := sessionWorkspaceDynamicLine(); wsLine != "" {
+		if dynamicText == "" {
+			dynamicText = wsLine
+		} else {
+			dynamicText = strings.TrimRight(dynamicText, "\n") + "\n" + wsLine
+		}
+	}
+
 	sysMsg := buildAgentSystemMessage(coreText, toolsText, workspaceText, skillsText, orchestratorText, channelsText, dynamicText)
 
 	// Inicializa ou atualiza o histórico com o System Prompt correto.
@@ -4222,7 +4233,18 @@ func (a *AgentMode) initMultiAgent(ctx context.Context) bool {
 	return true
 }
 
-// buildSessionWorkspaceHint returns a compact prompt block that teaches the
+// sessionWorkspaceDynamicLine states the session scratch directory's concrete
+// path. It belongs to the UNCACHED dynamic block: the path changes on every
+// process start, so keeping it out of the stable tools prefix is what lets
+// that prefix cache-hit across CLI restarts.
+func sessionWorkspaceDynamicLine() string {
+	ws := agent.GetSessionWorkspace()
+	if ws == nil || ws.ScratchDir == "" {
+		return ""
+	}
+	return "Session scratch directory (CHATCLI_AGENT_TMPDIR): " + ws.ScratchDir
+}
+
 // buildMCPToolsSection renders the system-prompt block listing MCP
 // tools available this turn, plus the routing hint that biases the
 // model toward `mcp_*` when an MCP server covers the requested op.
@@ -4321,6 +4343,7 @@ func mcpToolHasRequiredParams(schema map[string]interface{}) bool {
 	return true
 }
 
+// buildSessionWorkspaceHint returns a compact prompt block that teaches the
 // model how to use the per-session scratch dir and how to recover data from
 // truncated tool results. Returns an empty string when the session workspace
 // hasn't been initialized (shouldn't happen during normal startup).
@@ -4329,10 +4352,16 @@ func buildSessionWorkspaceHint() string {
 	if ws == nil {
 		return ""
 	}
+	// The concrete path is deliberately NOT embedded here: this block lives
+	// in the cacheable tools prefix, and the scratch dir is random per
+	// process, so interpolating it guaranteed a cold prompt cache on every
+	// new CLI start. The literal path rides in the uncached dynamic block
+	// (sessionWorkspaceDynamicLine) instead.
 	return "\n\n## SESSION WORKSPACE & LARGE OUTPUTS\n" +
 		"\n" +
 		"You have an isolated scratch directory for this session, exposed via the\n" +
-		"environment variable `CHATCLI_AGENT_TMPDIR` (current value: `" + ws.ScratchDir + "`).\n" +
+		"environment variable `CHATCLI_AGENT_TMPDIR` (its current path is stated in the\n" +
+		"dynamic context at the end of this prompt).\n" +
 		"Both read and write are ALLOWED in this directory and in its subtree —\n" +
 		"use it whenever you need to:\n" +
 		"- stage a temporary shell script before exec'ing it;\n" +

--- a/cli/agent_native_results.go
+++ b/cli/agent_native_results.go
@@ -15,6 +15,7 @@ package cli
 
 import (
 	"github.com/diillson/chatcli/cli/agent"
+	"github.com/diillson/chatcli/cli/plugins"
 	"github.com/diillson/chatcli/models"
 )
 
@@ -94,7 +95,15 @@ func buildBatchResults(
 		}
 		if idx < len(executed) {
 			res := executed[idx]
-			results = append(results, models.NewToolResultMessage(ntc.ID, res.Output, res.IsError, res.ErrorCode))
+			msg := models.NewToolResultMessage(ntc.ID, res.Output, res.IsError, res.ErrorCode)
+			// Native-protocol counterpart of buildBatchFeedbackMessage: a
+			// @recall result returns an archived original verbatim, so it
+			// must survive trimming and microcompact intact (otherwise the
+			// model is forced to recall it again).
+			if plugins.IsRecallTool(ntc.Name) {
+				msg.Meta = &models.MessageMeta{PreserveVerbatim: true}
+			}
+			results = append(results, msg)
 			continue
 		}
 		results = append(results, models.NewToolResultMessage(

--- a/cli/agent_native_results_test.go
+++ b/cli/agent_native_results_test.go
@@ -128,3 +128,28 @@ func TestBuildParkBatchClosure_SingleParkCallEmpty(t *testing.T) {
 	calls := []models.ToolCall{{ID: "park:0", Name: "park"}}
 	assert.Empty(t, buildParkBatchClosure(calls, nil, 0))
 }
+
+// A native @recall result must carry PreserveVerbatim (the XML feedback path
+// already does via buildBatchFeedbackMessage): it is an archived original the
+// model asked to see in full, and trimming/microcompact would otherwise force
+// another recall.
+func TestBuildNativeBatchResults_RecallMarkedPreserveVerbatim(t *testing.T) {
+	calls := []models.ToolCall{
+		{ID: "c1", Name: "@recall"},
+		{ID: "c2", Name: "@read"},
+	}
+	executed := []agent.ToolResult{
+		{Output: "original bytes"},
+		{Output: "file bytes"},
+	}
+	results := buildNativeBatchResults(calls, executed, toolResultNotExecutedBatchError)
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if results[0].Meta == nil || !results[0].Meta.PreserveVerbatim {
+		t.Fatalf("@recall result must be PreserveVerbatim, got meta=%+v", results[0].Meta)
+	}
+	if results[1].Meta != nil {
+		t.Fatalf("non-recall result must not carry meta, got %+v", results[1].Meta)
+	}
+}

--- a/cli/compact_command.go
+++ b/cli/compact_command.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/diillson/chatcli/cli/compress"
 	"github.com/diillson/chatcli/cli/hooks"
 	"github.com/diillson/chatcli/i18n"
 	"github.com/diillson/chatcli/models"
@@ -105,6 +106,15 @@ func (cli *ChatCLI) guidedCompact(ctx context.Context, instruction string) {
 		fmt.Println(colorize("  "+i18n.T("compact.error.not_enough_with_instruction"), ColorGray))
 		return
 	}
+	// Never split an assistant tool_calls message from its tool results —
+	// same boundary rule as the automatic pipeline (structuredSummarize).
+	// A cut landing on a tool result would leave orphan results at the head
+	// of the kept tail, which strict tool-pairing providers reject outright.
+	recentStart = snapToToolBlockBoundary(cli.history, recentStart, systemEnd)
+	if recentStart <= systemEnd {
+		fmt.Println(colorize("  "+i18n.T("compact.error.not_enough_with_instruction"), ColorGray))
+		return
+	}
 
 	middleMessages := cli.history[systemEnd:recentStart]
 	if len(middleMessages) < 2 {
@@ -160,13 +170,25 @@ CONVERSATION TO COMPACT:
 		return
 	}
 
+	// Archive the FULL middle segment before replacing it, exactly as the
+	// automatic pipeline does: guided compaction was the last irreversible
+	// cut in the codebase. Best-effort — a disabled CCR layer keeps the
+	// legacy lossy behavior.
+	recallNote := ""
+	if cli.compressionLayer != nil {
+		if key, ok := cli.compressionLayer.Archive(renderMessagesForArchive(middleMessages)); ok {
+			recallNote = "\n\n[full transcript of the summarized segment recoverable via @recall " +
+				compress.FormatMarker(key) + "]"
+		}
+	}
+
 	// Reconstruct: system + summary + recent
 	before := len(cli.history)
-	result := make([]models.Message, 0, systemEnd+1+minKeepRecent)
+	result := make([]models.Message, 0, systemEnd+1+(len(cli.history)-recentStart))
 	result = append(result, cli.history[:systemEnd]...)
 	result = append(result, models.Message{
 		Role:    "user",
-		Content: fmt.Sprintf("[COMPACTED CONTEXT — %d messages summarized per user instruction: \"%s\"]\n\n%s", len(middleMessages), instruction, response),
+		Content: fmt.Sprintf("[COMPACTED CONTEXT — %d messages summarized per user instruction: \"%s\"]\n\n%s%s", len(middleMessages), instruction, response, recallNote),
 		Meta: &models.MessageMeta{
 			IsSummary: true,
 			SummaryOf: len(middleMessages),

--- a/cli/context_cache_prefix_test.go
+++ b/cli/context_cache_prefix_test.go
@@ -1,0 +1,167 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Guards for the prompt-cache prefix contract and for the reversibility of
+ * the guided /compact path (P0 items of the context audit).
+ */
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/cli/agent"
+	"github.com/diillson/chatcli/cli/compress"
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+// The scratch dir is random per process. If its literal path lands in the
+// cacheable tools block, every CLI start is a guaranteed cold prompt cache
+// for that block and everything after it. The path must ride in the dynamic
+// (uncached) line instead.
+func TestSessionWorkspaceHint_KeepsRandomPathOutOfCachedBlock(t *testing.T) {
+	ws, err := agent.InitSessionWorkspace(zap.NewNop())
+	if err != nil {
+		t.Fatalf("init workspace: %v", err)
+	}
+	if ws == nil || ws.ScratchDir == "" {
+		t.Fatal("workspace not initialized")
+	}
+
+	hint := buildSessionWorkspaceHint()
+	if hint == "" {
+		t.Fatal("hint must be emitted when a workspace exists")
+	}
+	if strings.Contains(hint, ws.ScratchDir) {
+		t.Fatalf("cached tools block embeds the per-process scratch path:\n%s", hint)
+	}
+	if !strings.Contains(hint, "CHATCLI_AGENT_TMPDIR") {
+		t.Fatal("hint must still teach the env var name")
+	}
+
+	line := sessionWorkspaceDynamicLine()
+	if !strings.Contains(line, ws.ScratchDir) {
+		t.Fatalf("dynamic line must carry the concrete path, got %q", line)
+	}
+	if !strings.Contains(line, "CHATCLI_AGENT_TMPDIR") {
+		t.Fatalf("dynamic line must name the env var, got %q", line)
+	}
+}
+
+// guidedCompactClient returns a fixed summary and records the prompt it saw.
+type guidedCompactClient struct {
+	summary string
+	prompts []string
+}
+
+func (c *guidedCompactClient) GetModelName() string { return "test/model" }
+func (c *guidedCompactClient) SendPrompt(_ context.Context, prompt string, _ []models.Message, _ int) (string, error) {
+	c.prompts = append(c.prompts, prompt)
+	return c.summary, nil
+}
+
+// Guided /compact was the only irreversible cut left: it must archive the
+// full middle segment in the CCR store (so @recall can restore it) and must
+// never split an assistant tool_calls message from its tool results.
+func TestGuidedCompact_ArchivesSegmentAndSnapsToolBoundary(t *testing.T) {
+	layer := compress.NewLayer(compress.Config{
+		Mode:      compress.ModeLossyWithCCR,
+		Store:     compress.NewMemoryStore(),
+		Threshold: 100,
+	})
+	c := &guidedCompactClient{summary: "## Decisions\n- keep the auth refactor"}
+	cli := &ChatCLI{
+		Client:           c,
+		logger:           zap.NewNop(),
+		compressionLayer: layer,
+		history: []models.Message{
+			{Role: "system", Content: "sys"},
+			{Role: "user", Content: "u1 " + strings.Repeat("alpha ", 40)},
+			{Role: "assistant", Content: "a1"},
+			{Role: "user", Content: "u2"},
+			{Role: "assistant", Content: "a2"},
+			{Role: "assistant", Content: "calling", ToolCalls: []models.ToolCall{{ID: "tc1", Name: "@read"}}},
+			{Role: "tool", Content: "file bytes", ToolCallID: "tc1"},
+			{Role: "tool", Content: "more bytes", ToolCallID: "tc2"},
+			{Role: "user", Content: "u4"},
+			{Role: "assistant", Content: "a4"},
+		},
+	}
+
+	cli.guidedCompact(context.Background(), "keep the auth decisions")
+
+	// len=10, keep 4 → naive cut at index 6 (a tool result) → snapped to 5.
+	if len(cli.history) != 7 {
+		t.Fatalf("expected system + summary + 5 kept messages, got %d", len(cli.history))
+	}
+	if cli.history[0].Role != "system" {
+		t.Fatalf("system prefix lost: %+v", cli.history[0])
+	}
+	summary := cli.history[1]
+	if summary.Meta == nil || !summary.Meta.IsSummary || summary.Meta.SummaryOf != 4 {
+		t.Fatalf("summary meta wrong: %+v", summary.Meta)
+	}
+	if cli.history[2].Role != "assistant" || len(cli.history[2].ToolCalls) != 1 {
+		t.Fatalf("tool block head must stay in the verbatim tail, got %+v", cli.history[2])
+	}
+	if !strings.Contains(summary.Content, c.summary) {
+		t.Fatalf("summary content missing model output: %q", summary.Content)
+	}
+
+	// The archived original is recoverable through the marker in the note.
+	idx := strings.Index(summary.Content, "<<ccr:")
+	if idx < 0 {
+		t.Fatalf("summary carries no @recall marker:\n%s", summary.Content)
+	}
+	end := strings.Index(summary.Content[idx:], ">>")
+	if end < 0 {
+		t.Fatal("malformed ccr marker")
+	}
+	key := strings.TrimPrefix(summary.Content[idx:idx+end], "<<ccr:")
+	original, ok := layer.Recall(key)
+	if !ok {
+		t.Fatalf("archived segment not recallable for key %q", key)
+	}
+	for _, want := range []string{"u1 alpha", "[assistant]: a2"} {
+		if !strings.Contains(original, want) {
+			t.Fatalf("archive missing %q:\n%s", want, original)
+		}
+	}
+	// The tool block (assistant calling + its results) was snapped into the
+	// verbatim tail, so it must NOT be in the archived middle segment.
+	for _, tail := range []string{"[assistant]: calling", "file bytes"} {
+		if strings.Contains(original, tail) {
+			t.Fatalf("archive must not include the kept tail %q", tail)
+		}
+	}
+}
+
+// Without a CCR layer the legacy behavior is kept verbatim: no marker, no
+// panic, same reconstruction.
+func TestGuidedCompact_NoLayerKeepsLegacyShape(t *testing.T) {
+	cli := &ChatCLI{
+		Client: &guidedCompactClient{summary: "note"},
+		logger: zap.NewNop(),
+		history: []models.Message{
+			{Role: "user", Content: "u1"},
+			{Role: "assistant", Content: "a1"},
+			{Role: "user", Content: "u2"},
+			{Role: "assistant", Content: "a2"},
+			{Role: "user", Content: "u3"},
+			{Role: "assistant", Content: "a3"},
+			{Role: "user", Content: "u4"},
+			{Role: "assistant", Content: "a4"},
+		},
+	}
+	cli.guidedCompact(context.Background(), "keep everything")
+	if len(cli.history) != 5 {
+		t.Fatalf("expected summary + 4 kept, got %d", len(cli.history))
+	}
+	if strings.Contains(cli.history[0].Content, "<<ccr:") {
+		t.Fatal("no layer configured, yet a marker was emitted")
+	}
+}

--- a/cli/ctxmgr/storage.go
+++ b/cli/ctxmgr/storage.go
@@ -22,26 +22,14 @@ import (
 // silently on every start.
 var errContextCorrupt = errors.New("context file corrupt")
 
-// atomicWrite persists data via a same-directory temp file and an atomic
-// rename. Context files embed the whole corpus (multi-MB for knowledge
-// bases); a plain WriteFile interrupted mid-write leaves a torn file and the
-// knowledge base silently vanishes from the next load.
+// atomicWrite persists data via a same-directory temp file, fsync and an
+// atomic rename (utils.AtomicWriteFile). Context files embed the whole corpus
+// (multi-MB for knowledge bases); a plain WriteFile interrupted mid-write
+// leaves a torn file and the knowledge base silently vanishes from the next
+// load, and a rename without fsync can survive a crash while the bytes it
+// points to do not.
 func atomicWrite(path string, data []byte) error {
-	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*.tmp")
-	if err != nil {
-		return err
-	}
-	tmpName := tmp.Name()
-	_ = tmp.Close()
-	if err := os.WriteFile(tmpName, data, 0o600); err != nil {
-		_ = os.Remove(tmpName)
-		return err
-	}
-	if err := os.Rename(tmpName, path); err != nil {
-		_ = os.Remove(tmpName)
-		return err
-	}
-	return nil
+	return utils.AtomicWriteFile(path, data, 0o600)
 }
 
 // Storage gerencia a persistência de contextos em disco

--- a/cli/mcp/manager.go
+++ b/cli/mcp/manager.go
@@ -739,6 +739,11 @@ func (m *Manager) GetToolsSummary() []models.ToolDefinition {
 			},
 		})
 	}
+	// m.tools is a map: without an explicit order the catalog could reshuffle
+	// between turns, and both consumers (chat Part 3, agent MCP section) place
+	// it inside the cached system-prompt prefix, where any reordering busts
+	// the prompt cache for everything after it.
+	sort.Slice(defs, func(i, j int) bool { return defs[i].Function.Name < defs[j].Function.Name })
 	return defs
 }
 

--- a/cli/mcp/manager_extensions_test.go
+++ b/cli/mcp/manager_extensions_test.go
@@ -267,3 +267,23 @@ func sliceEq(a, b []string) bool {
 // shim documents what we're filtering on.
 var _ = defsToNames
 var _ = toolNames
+
+// GetToolsSummary feeds the cached system-prompt prefix in both chat and
+// agent mode; a map-derived order would reshuffle between turns and bust the
+// prompt cache, so the catalog must come out sorted by name.
+func TestManager_GetToolsSummary_SortedByName(t *testing.T) {
+	m := newMgrWithFixture(t, ServerConfig{}, ServerConfig{})
+	for i := 0; i < 5; i++ {
+		defs := m.GetToolsSummary()
+		names := make([]string, 0, len(defs))
+		for _, d := range defs {
+			names = append(names, d.Function.Name)
+		}
+		if !sort.StringsAreSorted(names) {
+			t.Fatalf("iteration %d: catalog not sorted: %v", i, names)
+		}
+		if len(names) != 5 {
+			t.Fatalf("expected 5 tools, got %v", names)
+		}
+	}
+}

--- a/cli/session_manager.go
+++ b/cli/session_manager.go
@@ -81,25 +81,13 @@ func (sm *SessionManager) getSessionPath(name string) string {
 	return filepath.Join(sm.sessionsDir, safeName+".json")
 }
 
-// atomicWriteSessionFile persists data via a same-directory temp file and an
-// atomic rename (the same durability pattern as ctxmgr's context store), so a
-// crash mid-write can never leave a torn session file behind.
+// atomicWriteSessionFile persists data via a same-directory temp file, fsync
+// and an atomic rename (the shared durability contract in
+// utils.AtomicWriteFile, also used by the context store, memory and task
+// graphs), so a crash or power loss mid-write can never leave a torn or
+// unflushed session file behind.
 func atomicWriteSessionFile(path string, data []byte) error {
-	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*.tmp")
-	if err != nil {
-		return err
-	}
-	tmpName := tmp.Name()
-	_ = tmp.Close()
-	if err := os.WriteFile(tmpName, data, 0o600); err != nil {
-		_ = os.Remove(tmpName)
-		return err
-	}
-	if err := os.Rename(tmpName, path); err != nil {
-		_ = os.Remove(tmpName)
-		return err
-	}
-	return nil
+	return utils.AtomicWriteFile(path, data, 0o600)
 }
 
 // CleanExpiredSessions removes sessions older than the configured TTL (L6).

--- a/cli/taskgraph/store.go
+++ b/cli/taskgraph/store.go
@@ -22,6 +22,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/diillson/chatcli/utils"
 )
 
 const (
@@ -227,35 +229,11 @@ func PruneRuns(baseDir string, olderThan time.Duration, skipRunID string) (int, 
 	return removed, nil
 }
 
-// atomicWriteFile writes via a same-directory temp file and rename, so a
-// crash mid-write can never leave a torn state.json under the real name.
+// atomicWriteFile writes via a same-directory temp file, fsync and rename
+// (utils.AtomicWriteFile), so a crash mid-write can never leave a torn or
+// unflushed state.json under the real name.
 func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
-	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".*.tmp")
-	if err != nil {
-		return err
-	}
-	tmpName := tmp.Name()
-	cleanup := func() { _ = os.Remove(tmpName) }
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		cleanup()
-		return err
-	}
-	if err := tmp.Chmod(perm); err != nil {
-		_ = tmp.Close()
-		cleanup()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		cleanup()
-		return err
-	}
-	if err := os.Rename(tmpName, path); err != nil {
-		cleanup()
-		return err
-	}
-	return nil
+	return utils.AtomicWriteFile(path, data, perm)
 }
 
 // quarantineCorrupt renames an unparseable state file aside so the original

--- a/cli/workspace/memory/persist.go
+++ b/cli/workspace/memory/persist.go
@@ -20,41 +20,16 @@ package memory
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"time"
+
+	"github.com/diillson/chatcli/utils"
 )
 
-// atomicWriteFile writes data to path via a same-directory temp file and an
-// atomic rename, so readers (and crashes) only ever observe the old or the new
-// content — never a torn write.
+// atomicWriteFile writes data to path via a same-directory temp file, fsync
+// and an atomic rename (utils.AtomicWriteFile), so readers, crashes and power
+// loss only ever observe the old or the new content — never a torn write.
 func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
-	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".*.tmp")
-	if err != nil {
-		return err
-	}
-	tmpName := tmp.Name()
-	cleanup := func() { _ = os.Remove(tmpName) }
-
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		cleanup()
-		return err
-	}
-	if err := tmp.Chmod(perm); err != nil {
-		_ = tmp.Close()
-		cleanup()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		cleanup()
-		return err
-	}
-	if err := os.Rename(tmpName, path); err != nil {
-		cleanup()
-		return err
-	}
-	return nil
+	return utils.AtomicWriteFile(path, data, perm)
 }
 
 // quarantineCorrupt moves an unparseable store file aside as

--- a/utils/atomic_write.go
+++ b/utils/atomic_write.go
@@ -1,0 +1,79 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// AtomicWriteFile persists data under path so that readers, crashes and
+// power loss only ever observe the old or the new content — never a torn or
+// half-flushed file.
+//
+// Sequence: same-directory temp file → write → fsync(file) → chmod → close →
+// rename over path → fsync(dir). The rename alone makes the swap atomic with
+// respect to other processes; the two fsyncs are what make it durable: without
+// fsync(file) a rename can land on disk before the bytes it points to, and
+// without fsync(dir) the directory entry itself may not survive a crash. The
+// directory sync is best-effort — Windows does not support opening a
+// directory for fsync, and some filesystems reject it — so its failure is
+// ignored once the file itself has been synced.
+//
+// Every durable store in ChatCLI (sessions, contexts, memory, task graphs)
+// delegates here so the durability contract lives in one place.
+func AtomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpName) }
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return err
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		cleanup()
+		return err
+	}
+	syncDir(dir)
+	return nil
+}
+
+// syncDir flushes a directory's entries to disk after a rename. Best-effort by
+// design: the caller's data is already durable at this point, and platforms
+// that cannot fsync a directory (Windows) or filesystems that refuse it must
+// not turn a successful write into an error.
+func syncDir(dir string) {
+	if runtime.GOOS == "windows" {
+		return
+	}
+	d, err := os.Open(dir) // #nosec G304 -- dir is the parent of a store path the caller already validated
+	if err != nil {
+		return
+	}
+	_ = d.Sync()
+	_ = d.Close()
+}

--- a/utils/atomic_write_test.go
+++ b/utils/atomic_write_test.go
@@ -1,0 +1,83 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestAtomicWriteFile_WritesContentAndPerm(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "store.json")
+
+	if err := AtomicWriteFile(path, []byte(`{"v":1}`), 0o600); err != nil {
+		t.Fatalf("AtomicWriteFile: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != `{"v":1}` {
+		t.Fatalf("content = %q, want %q", got, `{"v":1}`)
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("Stat: %v", err)
+		}
+		if perm := info.Mode().Perm(); perm != 0o600 {
+			t.Fatalf("perm = %o, want 0600", perm)
+		}
+	}
+}
+
+func TestAtomicWriteFile_ReplacesExistingWholeFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "store.json")
+	if err := os.WriteFile(path, []byte(strings.Repeat("x", 4096)), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := AtomicWriteFile(path, []byte("short"), 0o600); err != nil {
+		t.Fatalf("AtomicWriteFile: %v", err)
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != "short" {
+		t.Fatalf("stale bytes survived the replace: %q", got)
+	}
+}
+
+func TestAtomicWriteFile_LeavesNoTempBehind(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "store.json")
+	if err := AtomicWriteFile(path, []byte("ok"), 0o600); err != nil {
+		t.Fatalf("AtomicWriteFile: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "store.json" {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("directory should hold only the target, got %v", names)
+	}
+}
+
+func TestAtomicWriteFile_MissingDirFailsWithoutTouchingTarget(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nope", "store.json")
+	if err := AtomicWriteFile(path, []byte("ok"), 0o600); err == nil {
+		t.Fatal("expected error when parent directory is missing")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("target must not exist after a failed write, stat err = %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

P0 items of the context-engineering audit: correctness and durability fixes with no behavior change for users who did not hit the bugs.

- **Cache-stable prefix**: the agent tools block no longer embeds the per-process scratch dir path (it now rides in the uncached dynamic tail), and the MCP tool catalog is sorted by name. Both sat inside the cached system-prompt prefix and were busting the prompt cache on every CLI start / turn.
- **Reversible guided `/compact <instruction>`**: archives the full summarized segment in the CCR store with an `@recall` marker (parity with the automatic pipeline) and snaps the keep-recent cut to a tool block boundary so tool_calls are never split from their results.
- **Microcompact contract**: honors `PreserveVerbatim` (recall output is never re-reduced); native-protocol `@recall` results now carry the flag like the XML feedback path already did; header comment corrected to describe the real policy.
- **fsync durability**: sessions, contexts, memory and task graphs now share one `utils.AtomicWriteFile` (write, fsync, chmod, close, rename, best-effort dir sync) instead of four rename-only copies.

## Cross-impact checked

- `GetToolsSummary` has two consumers (chat Part 3, agent MCP section); both benefit from deterministic order.
- `ApplyMicrocompact` also runs in squad workers; the new exemption is a no-op there.
- `buildBatchResults` is the single emitter of native tool results; the meta flag serializes with `omitempty` and is already honored by the trimmer.
- No new environment variables, no user-facing strings, no exported declaration changed.

## Verification

- `go build ./...`, `go vet`, `gofmt` clean
- `golangci-lint run --new-from-rev=main ./...` clean (GOTOOLCHAIN=go1.26.6)
- `go test ./...`: 107 packages ok
- New tests: `utils/atomic_write_test.go`, `cli/context_cache_prefix_test.go` (scratch path out of cached block; guided compact archive + boundary snap; legacy shape without CCR layer), microcompact PreserveVerbatim exemption, MCP catalog ordering, native recall flag.
