### PR TITLE
fix(agent): follow the @model route in delegation and never report an empty worker as success

### DIFF
--- a/cli/agent/workers/dispatcher.go
+++ b/cli/agent/workers/dispatcher.go
@@ -44,6 +44,9 @@ type Dispatcher struct {
 	callUsageRecorder *callUsageRecorderBox
 	budgetGate        *budgetGateBox
 	logger            *zap.Logger
+	// configMu guards config.Provider/Model: written by UpdateProviderModel
+	// from the orchestrator goroutine, read by executeAgent from workers.
+	configMu sync.RWMutex
 }
 
 // NewDispatcher creates a Dispatcher with the given dependencies.
@@ -74,10 +77,23 @@ func (d *Dispatcher) MaxWorkers() int {
 }
 
 // UpdateProviderModel updates the provider and model used by worker instances.
-// This ensures that runtime provider/model changes are respected by parallel agents.
+// The orchestrator calls it before every dispatch wave so runtime changes —
+// /switch, /model, and the AI's own @model route override taken mid-task —
+// reach the workers instead of freezing the values captured at Run() start.
+// Guarded because executeAgent reads the pair from worker goroutines.
 func (d *Dispatcher) UpdateProviderModel(provider, model string) {
+	d.configMu.Lock()
 	d.config.Provider = provider
 	d.config.Model = model
+	d.configMu.Unlock()
+}
+
+// ProviderModel returns the provider and model the next dispatched worker
+// will be built on (absent a per-agent model hint).
+func (d *Dispatcher) ProviderModel() (provider, model string) {
+	d.configMu.RLock()
+	defer d.configMu.RUnlock()
+	return d.config.Provider, d.config.Model
 }
 
 // SetPolicyChecker sets the policy checker for enforcing security policies
@@ -299,16 +315,18 @@ func (d *Dispatcher) executeAgent(ctx context.Context, call AgentCall) AgentResu
 	//     reasoning_effort for every LLM call in this worker's ReAct loop.
 	//
 	// The dispatcher's config.Provider/Model are NOT mutated — swap is
-	// scoped to this single worker invocation.
-	effProvider := d.config.Provider
-	effModel := d.config.Model
+	// scoped to this single worker invocation. Snapshot the session pair
+	// under the lock: the orchestrator refreshes it before each wave.
+	sessionProvider, sessionModel := d.ProviderModel()
+	effProvider := sessionProvider
+	effModel := sessionModel
 
 	var llmClient client.LLMClient
 	if hint := strings.TrimSpace(agent.Model()); hint != "" {
 		resolution := client.ResolveModelRouting(client.ResolveModelRoutingInput{
 			Router:       d.llmMgr,
-			UserProvider: d.config.Provider,
-			UserModel:    d.config.Model,
+			UserProvider: sessionProvider,
+			UserModel:    sessionModel,
 			Hint:         hint,
 			Logger:       d.logger,
 		})
@@ -319,9 +337,9 @@ func (d *Dispatcher) executeAgent(ctx context.Context, call AgentCall) AgentResu
 			d.logger.Info("worker model hint honored",
 				zap.String("agent", string(call.Agent)),
 				zap.String("note", resolution.Note),
-				zap.String("from_provider", d.config.Provider),
+				zap.String("from_provider", sessionProvider),
 				zap.String("to_provider", effProvider),
-				zap.String("from_model", d.config.Model),
+				zap.String("from_model", sessionModel),
 				zap.String("to_model", effModel))
 		} else if resolution.UserMessage != "" {
 			d.logger.Warn("worker model hint fell back",
@@ -447,7 +465,13 @@ func FormatResults(results []AgentResult) string {
 
 	failed := 0
 	for i, r := range results {
-		if r.Error != nil {
+		// A worker that ended with neither an error nor any output did not
+		// do the task; rendering it as OK told the orchestrator the
+		// delegation succeeded with nothing to show, which is exactly the
+		// shape that made it loop or absorb the work itself. It counts as a
+		// failure so the re-dispatch nudge below fires.
+		emptyOK := r.Error == nil && strings.TrimSpace(r.Output) == ""
+		if r.Error != nil || emptyOK {
 			failed++
 		}
 		fmt.Fprintf(&b, "[%s] (call %s, %s)\n", r.Agent, r.CallID, r.Duration.Round(time.Millisecond))
@@ -455,9 +479,12 @@ func FormatResults(results []AgentResult) string {
 			fmt.Fprintf(&b, "Run: %s\n", runID)
 		}
 		fmt.Fprintf(&b, "Task: %s\n", r.Task)
-		if r.Error != nil {
+		switch {
+		case r.Error != nil:
 			fmt.Fprintf(&b, "Status: FAILED — %v\n", r.Error)
-		} else {
+		case emptyOK:
+			b.WriteString("Status: EMPTY — the worker returned no output (no text, no tool calls); treat as failed\n")
+		default:
 			b.WriteString("Status: OK\n")
 		}
 		if r.Output != "" {

--- a/cli/agent/workers/worker_empty_response_test.go
+++ b/cli/agent/workers/worker_empty_response_test.go
@@ -1,0 +1,156 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Guards for the "delegate returned nothing" failure class: an empty
+ * completion must never be reported as a successful worker result, and the
+ * session route (provider/model) must reach workers dispatched after a
+ * mid-task switch.
+ */
+package workers
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+// truncatedMockClient returns an empty completion and reports a max_tokens
+// stop reason, the shape of a thinking-only turn that ran out of budget.
+type truncatedMockClient struct{ calls int }
+
+func (m *truncatedMockClient) GetModelName() string { return "mock-truncated" }
+func (m *truncatedMockClient) SendPrompt(_ context.Context, _ string, _ []models.Message, _ int) (string, error) {
+	m.calls++
+	return "", nil
+}
+func (m *truncatedMockClient) LastStopReason() string { return "max_tokens" }
+
+func TestRunWorkerReAct_EmptyResponseIsNudgedThenSucceeds(t *testing.T) {
+	client := &mockLLMClient{responses: []string{"", "final answer after nudge"}}
+	config := WorkerReActConfig{MaxTurns: 5, SystemPrompt: "test", AllowedCommands: []string{"read"}, ReadOnly: true}
+
+	result, err := RunWorkerReAct(context.Background(), config, "task", client, nil, NewSkillSet(), nil, zap.NewNop())
+	if err != nil {
+		t.Fatalf("one empty turn must be recoverable, got error: %v", err)
+	}
+	if !strings.Contains(result.Output, "final answer after nudge") {
+		t.Fatalf("output = %q, want the post-nudge answer", result.Output)
+	}
+	if client.turn != 2 {
+		t.Fatalf("expected exactly 2 LLM calls (empty + nudged), got %d", client.turn)
+	}
+}
+
+func TestRunWorkerReAct_PersistentlyEmptyResponseFails(t *testing.T) {
+	client := &mockLLMClient{responses: []string{"", "", "", ""}}
+	config := WorkerReActConfig{MaxTurns: 10, SystemPrompt: "test", AllowedCommands: []string{"read"}, ReadOnly: true}
+
+	result, err := RunWorkerReAct(context.Background(), config, "task", client, nil, NewSkillSet(), nil, zap.NewNop())
+	if err == nil {
+		t.Fatal("a persistently empty worker must fail, not report success")
+	}
+	if result == nil || result.Error == nil {
+		t.Fatalf("result must carry the error, got %+v", result)
+	}
+	if !strings.Contains(err.Error(), "empty response") || !strings.Contains(err.Error(), "mock") {
+		t.Fatalf("error must name the failure and the model, got: %v", err)
+	}
+	// Two nudges are tolerated, the third empty turn fails → 3 calls.
+	if client.turn != maxEmptyWorkerTurns+1 {
+		t.Fatalf("expected %d LLM calls, got %d", maxEmptyWorkerTurns+1, client.turn)
+	}
+}
+
+func TestRunWorkerReAct_TruncatedEmptyResponseFailsImmediately(t *testing.T) {
+	client := &truncatedMockClient{}
+	config := WorkerReActConfig{MaxTurns: 5, SystemPrompt: "test", AllowedCommands: []string{"read"}, ReadOnly: true}
+
+	_, err := RunWorkerReAct(context.Background(), config, "task", client, nil, NewSkillSet(), nil, zap.NewNop())
+	if err == nil {
+		t.Fatal("expected a truncation error")
+	}
+	if !strings.Contains(err.Error(), "stop_reason=max_tokens") {
+		t.Fatalf("error must surface the stop reason, got: %v", err)
+	}
+	if client.calls != 1 {
+		t.Fatalf("a truncated empty turn must not be nudged (retry cannot help), got %d calls", client.calls)
+	}
+}
+
+// Native mode with zero structured calls must still parse a textual
+// <tool_call> block, exactly like the orchestrator loop does.
+func TestResolveToolCalls_NativeModeFallsBackToXML(t *testing.T) {
+	text := `<tool_call name="@coder" args="read --file main.go" />`
+	resolved, parseErrs := resolveToolCalls(true, nil, text, 0, nil)
+	if len(parseErrs) != 0 {
+		t.Fatalf("unexpected parse errors: %+v", parseErrs)
+	}
+	if len(resolved) != 1 || resolved[0].Subcmd != "read" {
+		t.Fatalf("expected one resolved read call, got %+v", resolved)
+	}
+	if resolved[0].Native {
+		t.Fatal("XML-parsed call must not be flagged native")
+	}
+}
+
+func TestFormatResults_EmptyOutputIsFlaggedAndCountsAsFailure(t *testing.T) {
+	out := FormatResults([]AgentResult{{
+		CallID:   "ac-1",
+		Agent:    AgentTypePlanner,
+		Task:     "plan it",
+		Output:   "   \n",
+		Duration: 10 * time.Millisecond,
+	}})
+	if strings.Contains(out, "Status: OK") {
+		t.Fatalf("empty worker rendered as OK:\n%s", out)
+	}
+	if !strings.Contains(out, "Status: EMPTY") {
+		t.Fatalf("expected EMPTY status:\n%s", out)
+	}
+	if !strings.Contains(out, "SQUAD FLOW") {
+		t.Fatalf("empty result must trigger the re-dispatch nudge:\n%s", out)
+	}
+
+	// A real output still renders OK with no nudge.
+	ok := FormatResults([]AgentResult{{CallID: "ac-2", Agent: AgentTypePlanner, Task: "t", Output: "done"}})
+	if !strings.Contains(ok, "Status: OK") || strings.Contains(ok, "SQUAD FLOW") {
+		t.Fatalf("non-empty result regressed:\n%s", ok)
+	}
+}
+
+// The orchestrator refreshes the dispatcher's provider/model before every
+// wave; workers built afterwards must be created on the refreshed pair.
+func TestDispatcher_UpdateProviderModelReachesNextWave(t *testing.T) {
+	mgr := &fullMockMgr{hintTrackingManager: &hintTrackingManager{providers: []string{"CLAUDEAI", "GOOGLEAI"}}}
+	registry := NewRegistry()
+	registry.Register(&mockAgent{agentType: AgentTypePlanner})
+
+	d := NewDispatcher(registry, mgr, DispatcherConfig{
+		MaxWorkers: 1, Provider: "CLAUDEAI", Model: "claude-sonnet-5", WorkerTimeout: 5 * time.Second,
+	}, zap.NewNop())
+
+	d.UpdateProviderModel("GOOGLEAI", "gemini-2.5-flash")
+	if p, m := d.ProviderModel(); p != "GOOGLEAI" || m != "gemini-2.5-flash" {
+		t.Fatalf("ProviderModel = %s/%s after update", p, m)
+	}
+
+	results := d.Dispatch(context.Background(), []AgentCall{{Agent: AgentTypePlanner, Task: "plan", ID: "c1"}})
+	if len(results) != 1 || results[0].Error != nil {
+		t.Fatalf("unexpected results: %+v", results)
+	}
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+	if len(mgr.getClientLog) == 0 {
+		t.Fatal("dispatcher built no client")
+	}
+	last := mgr.getClientLog[len(mgr.getClientLog)-1]
+	if last.Provider != "GOOGLEAI" || last.Model != "gemini-2.5-flash" {
+		t.Fatalf("worker built on %s/%s, want the refreshed GOOGLEAI/gemini-2.5-flash", last.Provider, last.Model)
+	}
+}

--- a/cli/agent/workers/worker_react.go
+++ b/cli/agent/workers/worker_react.go
@@ -174,6 +174,9 @@ func RunWorkerReAct(
 	// --- Failure tracking for reflection ---
 	consecutiveFailures := 0
 	blockedCmds := make(map[string]int)
+	// Empty completions (no text, no tool calls) tolerated before the
+	// worker fails loudly — see the guard after resolveToolCalls.
+	emptyTurns := 0
 
 	for turn := 0; turn < maxTurns; turn++ {
 		select {
@@ -208,7 +211,7 @@ func RunWorkerReAct(
 		history, _ = agent.ApplyMicrocompact(history, turn, mcCfg, logger)
 
 		// --- Call LLM (native or text mode) ---
-		responseText, nativeToolCalls, newHistory, err := callWorkerLLM(ctx, useNativeTools, toolAware, llmClient, history, toolDefs)
+		responseText, nativeToolCalls, stopReason, newHistory, err := callWorkerLLM(ctx, useNativeTools, toolAware, llmClient, history, toolDefs)
 		if err != nil {
 			return &AgentResult{
 				CallID:    callID,
@@ -225,10 +228,32 @@ func RunWorkerReAct(
 		allToolCalls = append(allToolCalls, parseErrRecords...)
 
 		if len(resolved) == 0 {
+			if strings.TrimSpace(responseText) == "" {
+				// An empty completion is NOT a final answer — see
+				// handleEmptyWorkerTurn for the recovery policy.
+				var retry bool
+				var emptyErr error
+				history, retry, emptyErr = handleEmptyWorkerTurn(history, emptyWorkerTurn{
+					stopReason: stopReason,
+					modelName:  llmClient.GetModelName(),
+					turn:       turn,
+					maxTurns:   maxTurns,
+					attempts:   &emptyTurns,
+					logger:     logger,
+				})
+				if emptyErr != nil {
+					return emptyWorkerResult(callID, finalOutput.String(), emptyErr, startTime, allToolCalls), emptyErr
+				}
+				if retry {
+					continue
+				}
+			}
 			// No tool calls — worker is done
 			finalOutput.WriteString(responseText)
 			break
 		}
+		// A productive turn resets the empty-completion tolerance.
+		emptyTurns = 0
 
 		// --- Pre-validate and classify ---
 		validated, classifyRecords := classifyToolCalls(resolved, allowed, blockedCmds, config)
@@ -409,14 +434,88 @@ func buildWorkerSystemPrompt(config WorkerReActConfig, useNativeTools bool, task
 	return systemPrompt
 }
 
+// maxEmptyWorkerTurns bounds how many consecutive empty completions a worker
+// nudges through before failing. Two covers the transient shapes (a
+// thinking-only turn, a hiccup) without letting a model that has genuinely
+// nothing to say burn the whole turn budget.
+const maxEmptyWorkerTurns = 2
+
+// workerEmptyTurnNudge is the model-facing recovery instruction folded into
+// the trailing user message after an empty completion.
+const workerEmptyTurnNudge = "[Your previous turn returned no text and no tool calls. " +
+	"Either produce your final answer for the delegated task now, or call a tool. " +
+	"An empty reply is not a valid completion.]"
+
+// emptyWorkerTurn carries what handleEmptyWorkerTurn needs to decide.
+type emptyWorkerTurn struct {
+	stopReason string
+	modelName  string
+	turn       int
+	maxTurns   int
+	attempts   *int // running count of consecutive empty completions
+	logger     *zap.Logger
+}
+
+// handleEmptyWorkerTurn applies the recovery policy for a completion with no
+// text and no tool calls. Providers return that shape with err == nil in
+// several legitimate cases (a thinking-only turn truncated at max_tokens,
+// content null, a model that emits nothing under a tool schema it dislikes);
+// treating it as "done" produced Status: OK with no output back at the
+// orchestrator, which then looped or absorbed the task itself.
+//
+// Returns the (possibly rewritten) history, whether the loop should retry,
+// and a terminal error when the worker must fail:
+//   - a truncated empty turn fails immediately with the stop reason — a
+//     retry on the same budget cannot help;
+//   - otherwise up to maxEmptyWorkerTurns consecutive empties are nudged:
+//     the empty assistant turn is dropped (strict providers reject empty
+//     text blocks) and the nudge is folded into the trailing user message
+//     so alternation is preserved;
+//   - past that, the worker fails naming the model that served the call.
+func handleEmptyWorkerTurn(history []models.Message, et emptyWorkerTurn) ([]models.Message, bool, error) {
+	if et.stopReason == "max_tokens" || et.stopReason == "length" {
+		return history, false, fmt.Errorf("turn %d: worker LLM (%s) returned no text and no tool calls: output truncated (stop_reason=%s)",
+			et.turn+1, et.modelName, et.stopReason)
+	}
+	*et.attempts++
+	if *et.attempts > maxEmptyWorkerTurns || et.turn >= et.maxTurns-1 {
+		return history, false, fmt.Errorf("worker LLM (%s) returned an empty response (no text, no tool calls) after %d attempt(s)",
+			et.modelName, *et.attempts)
+	}
+	history = appendInboxMessage(history[:len(history)-1], workerEmptyTurnNudge)
+	if et.logger != nil {
+		et.logger.Warn("worker returned an empty response — nudging",
+			zap.Int("turn", et.turn+1),
+			zap.Int("attempt", *et.attempts),
+			zap.String("model", et.modelName))
+	}
+	return history, true, nil
+}
+
+// emptyWorkerResult builds the failure result for an empty-completion exit so
+// both exit branches produce the same shape.
+func emptyWorkerResult(callID, output string, err error, startTime time.Time, calls []ToolCallRecord) *AgentResult {
+	return &AgentResult{
+		CallID:    callID,
+		Output:    output,
+		Error:     err,
+		Duration:  time.Since(startTime),
+		ToolCalls: calls,
+	}
+}
+
 // callWorkerLLM performs one LLM round trip in either native function-calling
 // mode or text mode, appends the assistant turn to history, and returns the
-// response text, any native tool calls, the updated history and an error.
-func callWorkerLLM(ctx context.Context, useNativeTools bool, toolAware client.ToolAwareClient, llmClient client.LLMClient, history []models.Message, toolDefs []models.ToolDefinition) (string, []models.ToolCall, []models.Message, error) {
+// response text, any native tool calls, the provider's stop reason (when it
+// reports one), the updated history and an error.
+func callWorkerLLM(ctx context.Context, useNativeTools bool, toolAware client.ToolAwareClient, llmClient client.LLMClient, history []models.Message, toolDefs []models.ToolDefinition) (string, []models.ToolCall, string, []models.Message, error) {
 	if useNativeTools {
 		llmResp, err := toolAware.SendPromptWithTools(ctx, "", history, toolDefs, 0)
 		if err != nil {
-			return "", nil, history, err
+			return "", nil, "", history, err
+		}
+		if llmResp == nil {
+			llmResp = &models.LLMResponse{}
 		}
 		responseText := llmResp.Content
 		nativeToolCalls := llmResp.ToolCalls
@@ -427,15 +526,19 @@ func callWorkerLLM(ctx context.Context, useNativeTools bool, toolAware client.To
 			Content:   responseText,
 			ToolCalls: nativeToolCalls,
 		})
-		return responseText, nativeToolCalls, history, nil
+		return responseText, nativeToolCalls, llmResp.StopReason, history, nil
 	}
 
 	responseText, err := llmClient.SendPrompt(ctx, "", history, 0)
 	if err != nil {
-		return "", nil, history, err
+		return "", nil, "", history, err
+	}
+	stopReason := ""
+	if src, ok := client.AsStopReasonAware(llmClient); ok {
+		stopReason = src.LastStopReason()
 	}
 	history = append(history, models.Message{Role: "assistant", Content: responseText})
-	return responseText, nil, history, nil
+	return responseText, nil, stopReason, history, nil
 }
 
 // executeToolCall runs a single (possibly blocked) tool call: it enforces the
@@ -649,8 +752,13 @@ func resolveToolCalls(useNativeTools bool, nativeToolCalls []models.ToolCall, re
 				pluginName: pluginName,
 			})
 		}
-	} else if !useNativeTools {
-		// XML/JSON parsing fallback
+	} else {
+		// XML/JSON parsing fallback — also taken in native mode when the
+		// provider returned zero structured calls, mirroring the
+		// orchestrator loop: a model that answers a native tool schema with
+		// a textual <tool_call> block must not have that block silently
+		// taken as its final answer (or, when the text is empty, as
+		// "nothing to do").
 		xmlToolCalls, _ := agent.ParseToolCalls(responseText)
 		for _, tc := range xmlToolCalls {
 			subcmd, args, parseErr := parseCoderToolCall(tc)

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -921,6 +921,34 @@ func (a *AgentMode) clientAndCtxForTurn(ctx context.Context) (llmclient.LLMClien
 	return turnClient, ctx
 }
 
+// effectiveRoute reports the provider and model that actually serve the
+// current turn: the AI's @model route override first, then the skill
+// frontmatter hint, then the session's own pair (with the same env/config
+// fallbacks initMultiAgent applies when the session provider is unset).
+// Every consumer that must follow a mid-task model switch — cost
+// attribution, the squad dispatcher, subagent delegation — reads this
+// instead of the frozen session fields.
+func (a *AgentMode) effectiveRoute() (provider, model string) {
+	hint := a.cli.agentRouteOverrideHandle()
+	if hint == "" {
+		hint = a.skillModelHint
+	}
+	if hint != "" {
+		resolution := a.cli.resolveSkillClient(hint)
+		if resolution.Provider != "" && resolution.Model != "" {
+			return resolution.Provider, resolution.Model
+		}
+	}
+	provider = a.cli.Provider
+	if provider == "" {
+		provider = os.Getenv("LLM_PROVIDER")
+	}
+	if provider == "" {
+		provider = config.Global.GetString("LLM_PROVIDER")
+	}
+	return provider, a.cli.Model
+}
+
 // Run inicia o modo agente com uma consulta do usuário, utilizando um loop de Raciocínio-Ação (ReAct).
 // Agora aceita systemPromptOverride para definir personas específicas (ex: Coder).
 func (a *AgentMode) Run(ctx context.Context, query string, additionalContext string, systemPromptOverride string) error {
@@ -2288,6 +2316,14 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 		if canUseNativeTools && len(nativeToolDefs) > 0 {
 			llmResp, err = toolAwareClient.SendPromptWithTools(turnCtx, "", turnHistory, nativeToolDefs, currentMaxTokens)
 			if a.cli.refreshClientOnAuthError(err) {
+				// The refresh rebuilt the session client; re-resolve the
+				// turn client so the retry runs on a fresh handle for the
+				// provider that actually served this turn (route override
+				// included) instead of the stale pre-refresh wrapper.
+				turnClient, turnCtx = a.clientAndCtxForTurn(ctx)
+				if tac, ok := llmclient.AsToolAware(turnClient); ok && tac.SupportsNativeTools() {
+					toolAwareClient = tac
+				}
 				llmResp, err = toolAwareClient.SendPromptWithTools(turnCtx, "", turnHistory, nativeToolDefs, currentMaxTokens)
 			}
 			if err == nil && llmResp != nil {
@@ -2297,6 +2333,7 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 		} else {
 			aiResponse, err = turnClient.SendPrompt(turnCtx, "", turnHistory, currentMaxTokens)
 			if a.cli.refreshClientOnAuthError(err) {
+				turnClient, turnCtx = a.clientAndCtxForTurn(ctx)
 				aiResponse, err = turnClient.SendPrompt(turnCtx, "", turnHistory, currentMaxTokens)
 			}
 		}
@@ -2312,17 +2349,7 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 				inputChars += len(m.Content)
 			}
 			turnUsage = llmclient.GetUsageOrEstimate(turnClient, inputChars, len(aiResponse))
-			effProvider := a.cli.Provider
-			effModel := a.cli.Model
-			hint := a.cli.agentRouteOverrideHandle()
-			if hint == "" {
-				hint = a.skillModelHint
-			}
-			if hint != "" {
-				resolution := a.cli.resolveSkillClient(hint)
-				effProvider = resolution.Provider
-				effModel = resolution.Model
-			}
+			effProvider, effModel := a.effectiveRoute()
 			a.cli.costTracker.RecordRealUsage(effProvider, effModel, turnUsage)
 			a.cli.maybeAnnounceBudget()
 		}
@@ -2501,7 +2528,9 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 		stopReason := ""
 		if llmResp != nil && llmResp.StopReason != "" {
 			stopReason = llmResp.StopReason
-		} else if src, ok := llmclient.AsStopReasonAware(a.cli.Client); ok {
+		} else if src, ok := llmclient.AsStopReasonAware(turnClient); ok {
+			// turnClient served this call; under a route override the
+			// session client's last stop reason belongs to another turn.
 			stopReason = src.LastStopReason()
 		}
 		if stopReason == "max_tokens" || stopReason == "length" {
@@ -2929,6 +2958,12 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 					a.policyAdapter.setStdinCh(a.stdinLines)
 					a.policyAdapter.setRestoreInput(a.reapplyStdinCbreak)
 				}
+				// Workers must follow the model that serves THIS turn. The
+				// dispatcher's pair was captured at Run() start, before the
+				// AI could take a @model route override mid-task; without
+				// this refresh every delegated worker kept talking to the
+				// model the orchestrator had just switched away from.
+				a.agentDispatcher.UpdateProviderModel(a.effectiveRoute())
 				agentResults := a.agentDispatcher.DispatchWithProgress(ctx, agentCalls, progressCh)
 				a.turnTimer.Stop()
 				// Clear the live progress display
@@ -3519,11 +3554,15 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 								toolOutput, execErr = a.handleAgentAsk(ctx, normalizedArgsStr)
 							} else if strings.EqualFold(strings.TrimSpace(toolName), "@coder") && isDelegateInvocation(normalizedArgsStr) {
 								nativeArgs, rawInner := extractDelegateArgs(normalizedArgsStr)
+								// turnClient, not a.cli.Client: the subagent must
+								// run on the model serving this turn (route
+								// override / skill hint included), not on the
+								// session client the orchestrator switched away from.
 								toolOutput, execErr = workers.RunDelegate(
 									ctx,
 									nativeArgs,
 									rawInner,
-									a.cli.Client,
+									turnClient,
 									nil, // no file lock manager at top level — subagent uses its own
 									nil, // no skills propagation for now
 									nil, // policy handled upstream already

--- a/cli/model_tool_adapter.go
+++ b/cli/model_tool_adapter.go
@@ -303,9 +303,19 @@ func (a *modelRoutingAdapter) Delegate(ctx context.Context, handle, prompt strin
 		maxTokens = 0
 	}
 
+	if resolution.Client == nil {
+		return "", errors.New(i18n.T("model.tool.delegate.failed", resolution.Provider+":"+resolution.Model))
+	}
 	answer, err := resolution.Client.SendPrompt(ctx, prompt, nil, maxTokens)
 	if err != nil {
 		return "", fmt.Errorf("%s: %w", i18n.T("model.tool.delegate.failed", resolution.Provider+":"+resolution.Model), err)
+	}
+	if strings.TrimSpace(answer) == "" {
+		// An empty completion must surface as a failure, not as a header
+		// with nothing under it — the calling model would otherwise take
+		// it as a legitimate (blank) answer.
+		return "", fmt.Errorf("%s: %s", i18n.T("model.tool.delegate.failed", resolution.Provider+":"+resolution.Model),
+			i18n.T("model.tool.delegate.empty"))
 	}
 
 	if cli.costTracker != nil {

--- a/cli/model_tool_adapter_test.go
+++ b/cli/model_tool_adapter_test.go
@@ -304,3 +304,30 @@ func TestModelToolEndToEndSwitch(t *testing.T) {
 		t.Fatalf("after reset turn client = %s, want the session model", turnClient.GetModelName())
 	}
 }
+
+// effectiveRoute is what the squad dispatcher and subagent delegation follow:
+// it must track the AI's @model override and fall back to the session pair.
+func TestEffectiveRouteFollowsModelOverride(t *testing.T) {
+	cliObj, _ := newRoutingTestCLI()
+	plugins.SetModelRoutingAdapter(&modelRoutingAdapter{cli: cliObj})
+	t.Cleanup(func() { plugins.SetModelRoutingAdapter(nil) })
+	p := plugins.NewBuiltinModelPlugin()
+	a := &AgentMode{cli: cliObj, logger: zap.NewNop()}
+	ctx := context.Background()
+
+	if prov, model := a.effectiveRoute(); prov != "CLAUDEAI" || model != "claude-sonnet-5" {
+		t.Fatalf("baseline route = %s/%s, want the session pair", prov, model)
+	}
+	if _, err := p.Execute(ctx, []string{`{"cmd":"use","args":{"model":"GOOGLEAI:gemini-2.5-flash"}}`}); err != nil {
+		t.Fatalf("@model use failed: %v", err)
+	}
+	if prov, model := a.effectiveRoute(); prov != "GOOGLEAI" || model != "gemini-2.5-flash" {
+		t.Fatalf("route after @model use = %s/%s, want GOOGLEAI/gemini-2.5-flash", prov, model)
+	}
+	if _, err := p.Execute(ctx, []string{`{"cmd":"reset"}`}); err != nil {
+		t.Fatalf("@model reset failed: %v", err)
+	}
+	if prov, model := a.effectiveRoute(); prov != "CLAUDEAI" || model != "claude-sonnet-5" {
+		t.Fatalf("route after reset = %s/%s, want the session pair", prov, model)
+	}
+}

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -3147,6 +3147,7 @@
   "model.tool.status.override": "Session model: %s. Active route override: %s (set by @model use).",
   "model.tool.status.no_override": "Session model: %s. No route override active.",
   "model.tool.delegate.failed": "delegated call to %s failed",
+  "model.tool.delegate.empty": "the model returned an empty response (no text)",
   "model.tool.delegate.header": "Answer delegated to %s:",
   "plugins.model.describe.use": "Routing task to %s",
   "plugins.model.describe.delegate": "Delegating subtask to %s",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -3147,6 +3147,7 @@
   "model.tool.status.override": "Session model: %s. Active route override: %s (set by @model use).",
   "model.tool.status.no_override": "Session model: %s. No route override active.",
   "model.tool.delegate.failed": "delegated call to %s failed",
+  "model.tool.delegate.empty": "the model returned an empty response (no text)",
   "model.tool.delegate.header": "Answer delegated to %s:",
   "plugins.model.describe.use": "Routing task to %s",
   "plugins.model.describe.delegate": "Delegating subtask to %s",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -3147,6 +3147,7 @@
   "model.tool.status.override": "Modelo da sessão: %s. Override de rota ativo: %s (definido por @model use).",
   "model.tool.status.no_override": "Modelo da sessão: %s. Nenhum override de rota ativo.",
   "model.tool.delegate.failed": "chamada delegada a %s falhou",
+  "model.tool.delegate.empty": "o modelo retornou uma resposta vazia (sem texto)",
   "model.tool.delegate.header": "Resposta delegada a %s:",
   "plugins.model.describe.use": "Roteando tarefa para %s",
   "plugins.model.describe.delegate": "Delegando sub-tarefa a %s",


### PR DESCRIPTION
## Summary

Reported: in `/coder`, after asking the agent to switch models mid-task (`@model use`), a `@delegate` task came back with an empty response from the provider and the loop treated it as done.

Root causes found and fixed:

- **Route override never reached workers.** `@model use` only affects the orchestrator's turn client. The squad dispatcher kept the provider/model captured at `Run()` start and the subagent delegate path received `a.cli.Client`. Now the dispatcher pair is refreshed from a single `effectiveRoute()` before every wave (mutex-guarded, read by worker goroutines) and `RunDelegate` gets `turnClient`.
- **Empty completion reported as success.** `RunWorkerReAct` took `""` with zero tool calls as the final answer; `FormatResults` rendered it `Status: OK` with no `Output:` and did not trigger the re-dispatch nudge. Now: up to two nudged retries, then a loud error naming the model; truncated empty turns (`max_tokens`/`length`) fail immediately with the stop reason; `Status: EMPTY` counts as failed; `@model delegate` rejects an empty answer.
- **Native mode swallowed XML tool calls.** The worker skipped the XML fallback when native returned zero calls; the orchestrator loop already falls back. Parity restored.
- **Stale client on auth-refresh retry** and stop reason read from the session client instead of the turn client: both re-resolve `turnClient`.

## Cross-impact checked

- `callWorkerLLM` is file-private; single caller updated.
- `UpdateProviderModel` callers: `initMultiAgent` (unchanged) and the new per-wave refresh.
- Cost attribution now uses `effectiveRoute()` with the same env/config fallbacks `initMultiAgent` applied; no change when no override is active.
- New i18n key `model.tool.delegate.empty` in en, en-US, pt-BR (parity floor passes locally).

## Verification

- Red proven against pre-fix `worker_react.go`: empty worker reported success; native mode ignored an XML tool call. Green after the fix.
- `go test ./...`: 107 packages ok · `golangci-lint --new-from-rev=main` clean · `scripts/qg/i18n-parity.sh` ok
- New tests: `cli/agent/workers/worker_empty_response_test.go` (nudge-then-succeed, persistent-empty fails, truncated fails immediately, XML fallback in native mode, EMPTY status + nudge, dispatcher honors refreshed pair) and `TestEffectiveRouteFollowsModelOverride`.
