### PR TITLE
fix(security): encrypt session stores at rest and redact secrets on the LLM path

### DIFF
--- a/cli/agent/park/snapshot.go
+++ b/cli/agent/park/snapshot.go
@@ -24,6 +24,7 @@ import (
 
 	llmclient "github.com/diillson/chatcli/llm/client"
 	"github.com/diillson/chatcli/models"
+	"github.com/diillson/chatcli/pkg/atrest"
 )
 
 // SchemaVersion bumps when the on-disk shape of Snapshot changes in a
@@ -167,6 +168,11 @@ func (s *Snapshot) Save() error {
 	if err != nil {
 		return fmt.Errorf("park: marshal snapshot: %w", err)
 	}
+	// The snapshot embeds the whole conversation history; it follows the
+	// same opt-in encryption at rest as saved sessions.
+	if data, err = atrest.Seal(data); err != nil {
+		return fmt.Errorf("park: encrypt snapshot: %w", err)
+	}
 
 	// #nosec G304 -- tmp path is built from s.Token which is validated
 	// against tokenRegexp ([a-zA-Z0-9._-]{8,128}) before reaching here;
@@ -232,6 +238,9 @@ func Load(token string) (*Snapshot, error) {
 			return nil, ErrSnapshotNotFound
 		}
 		return nil, fmt.Errorf("park: read: %w", err)
+	}
+	if data, err = atrest.Open(data); err != nil {
+		return nil, fmt.Errorf("park: decrypt: %w", err)
 	}
 	var s Snapshot
 	if err := json.Unmarshal(data, &s); err != nil {

--- a/cli/agent/park/snapshot_test.go
+++ b/cli/agent/park/snapshot_test.go
@@ -4,10 +4,12 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/diillson/chatcli/models"
+	"github.com/diillson/chatcli/pkg/atrest"
 )
 
 // withTempDir redirects the snapshot directory to a temp dir for the
@@ -187,5 +189,43 @@ func TestAsParkError(t *testing.T) {
 	_, ok = AsParkError(errors.New("boring"))
 	if ok {
 		t.Fatalf("AsParkError matched non-park error")
+	}
+}
+
+// Park snapshots embed the whole conversation; with CHATCLI_ENCRYPTION_KEY set
+// they must be sealed on disk and still round-trip through Load.
+func TestSnapshot_EncryptedAtRestWhenKeySet(t *testing.T) {
+	dir := withTempDir(t)
+	t.Setenv(atrest.EnvKey, "park-test-key")
+
+	s := &Snapshot{
+		Token:         NewToken(),
+		History:       []models.Message{{Role: "user", Content: "secret plan alpha-bravo"}},
+		OriginalQuery: "do the thing",
+	}
+	if err := s.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, s.Token+".json"))
+	if err != nil {
+		t.Fatalf("read raw: %v", err)
+	}
+	if !atrest.IsEncrypted(raw) {
+		t.Fatal("snapshot must be encrypted at rest when the key is set")
+	}
+	if strings.Contains(string(raw), "alpha-bravo") {
+		t.Fatal("plaintext leaked into the snapshot file")
+	}
+	got, err := Load(s.Token)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(got.History) != 1 || got.History[0].Content != "secret plan alpha-bravo" {
+		t.Fatalf("round trip mismatch: %+v", got.History)
+	}
+
+	t.Setenv(atrest.EnvKey, "")
+	if _, err := Load(s.Token); err == nil {
+		t.Fatal("loading an encrypted snapshot without the key must fail")
 	}
 }

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -3730,6 +3730,11 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 				// Errors are left verbatim so the model can debug them in full.
 				// CompressToolOutput is nil-safe and a no-op when disabled or
 				// below the size threshold.
+				// Secret redaction on the model's copy (CHATCLI_ENV_REDACT_MODE):
+				// name-based KEY=VALUE masking plus value-shape scan, applied to
+				// every tool output — file reads and plugin results included,
+				// not only exec — and to error text, which quotes inputs.
+				toolOutput = redactSecretsForLLM(toolOutput)
 				if execErr == nil && a.cli != nil {
 					toolOutput, _ = a.cli.compressionLayer.CompressToolOutput(tc.Name, toolOutput)
 				}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -852,8 +852,10 @@ func NewChatCLI(ctx context.Context, manager manager.LLMManager, logger *zap.Log
 	// Share the same compression engine with delegated sub-agents/workers so
 	// their tool output is compressed too, and identical content read by
 	// sibling agents dedupes against the one content-addressed CCR store.
+	// Workers share the same secret-redaction chokepoint as the
+	// orchestrator (redaction first, then reversible compression).
 	workers.RegisterToolOutputCompressor(func(toolName, output string) string {
-		out, _ := cli.compressionLayer.CompressToolOutput(toolName, output)
+		out, _ := cli.compressionLayer.CompressToolOutput(toolName, redactSecretsForLLM(output))
 		return out
 	})
 	// The reverse direction: workers get a recall tool over the same store,

--- a/cli/cli_commands.go
+++ b/cli/cli_commands.go
@@ -36,6 +36,11 @@ func (cli *ChatCLI) processSpecialCommands(ctx context.Context, userInput string
 	userInput, context, images := cli.processFileCommand(ctx, userInput)
 	additionalContext += context
 
+	// Everything assembled above (git/env/file context) is content the
+	// model receives without the user retyping it — same redaction
+	// chokepoint as agent tool outputs.
+	additionalContext = redactSecretsForLLM(additionalContext)
+
 	// Processar '>' como um operador para adicionar contexto
 	if idx := strings.Index(userInput, ">"); idx != -1 {
 		additionalContext += userInput[idx+1:] + "\n"

--- a/cli/config_env_defaults.go
+++ b/cli/config_env_defaults.go
@@ -269,7 +269,7 @@ var envDefaults = map[string]envDefault{
 	"CHATCLI_BLOCK_TMP_WRITES":       {Value: "false", IsBool: true, Source: "session_workspace.go:150"},
 	"CHATCLI_ALLOW_HTTP_PROVIDERS":   {Value: "false", IsBool: true, Source: "TLS posture"},
 	"CHATCLI_ALLOW_INSECURE":         {Value: "false", IsBool: true, Source: "TLS posture"},
-	"CHATCLI_ENV_REDACT_MODE":        {Value: "normal", Source: "env_redactor.go (strict|normal)"},
+	"CHATCLI_ENV_REDACT_MODE":        {Value: "permissive", Source: "content_redactor.go (off|permissive|strict)"},
 
 	// ─── Server mode ─────────────────────────────────────────────
 	"CHATCLI_GRPC_REFLECTION":   {Value: "false", IsBool: true, Source: "server.go"},

--- a/cli/content_redactor.go
+++ b/cli/content_redactor.go
@@ -1,0 +1,140 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Secret redaction on the LLM-facing path.
+ *
+ * Everything the model receives that did not come from the user's own
+ * keyboard — tool outputs in agent/coder mode, worker tool outputs, the
+ * conversation segment handed to the memory extractor, and the @file/@git
+ * context assembled in chat — passes through redactSecretsForLLM before it
+ * leaves the process. Two layers compose:
+ *
+ *   1. KEY=VALUE lines (env dumps, .env files, docker/compose configs,
+ *      CI logs) are judged by NAME through EnvRedactor — AWS_SECRET_ACCESS_KEY,
+ *      DATABASE_URL, anything ending in _TOKEN/_PASSWORD/_KEY — plus its
+ *      value heuristics (known prefixes, long hex).
+ *   2. Free text is scanned by utils.SanitizeSensitiveText for the value
+ *      shapes providers hand out (sk-…, ghp_…, AKIA…, JWTs, bearer headers,
+ *      credential fields in JSON).
+ *
+ * CHATCLI_ENV_REDACT_MODE selects the policy: "permissive" (default) applies
+ * both layers with the name denylist; "strict" additionally redacts every
+ * KEY=VALUE line whose name is not on the known-safe allowlist; "off"
+ * disables this chokepoint entirely (the pre-existing regex pass on exec
+ * output is untouched by this setting).
+ */
+package cli
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/diillson/chatcli/utils"
+)
+
+// contentRedactMode is the resolved CHATCLI_ENV_REDACT_MODE policy.
+type contentRedactMode string
+
+const (
+	contentRedactOff        contentRedactMode = "off"
+	contentRedactPermissive contentRedactMode = "permissive"
+	contentRedactStrict     contentRedactMode = "strict"
+)
+
+// contentRedactModeFromEnv parses CHATCLI_ENV_REDACT_MODE. Unknown values
+// (including the historical "normal"/"full" spellings) resolve to the
+// permissive default so a typo never silently disables redaction.
+func contentRedactModeFromEnv() contentRedactMode {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("CHATCLI_ENV_REDACT_MODE"))) {
+	case "off", "none", "disabled", "false", "0":
+		return contentRedactOff
+	case "strict":
+		return contentRedactStrict
+	default:
+		return contentRedactPermissive
+	}
+}
+
+// envAssignmentLine matches "KEY=VALUE" (optionally "export KEY=VALUE"),
+// the shape env dumps, .env files and compose/CI logs share. Group 1 keeps
+// the prefix and key verbatim so the redacted line stays parseable.
+var envAssignmentLine = regexp.MustCompile(`^(\s*(?:export\s+)?[A-Za-z_][A-Za-z0-9_]*\s*=)(.*)$`)
+
+// envRedactorPool caches one EnvRedactor per mode. The redactor's pattern
+// tables are built from the environment at construction; CHATCLI_REDACT_PATTERNS
+// is therefore read once per process, like every other boot-time table.
+var (
+	envRedactorMu   sync.Mutex
+	envRedactorByMd = map[contentRedactMode]*EnvRedactor{}
+)
+
+func envRedactorFor(mode contentRedactMode) *EnvRedactor {
+	envRedactorMu.Lock()
+	defer envRedactorMu.Unlock()
+	if r, ok := envRedactorByMd[mode]; ok {
+		return r
+	}
+	r := NewEnvRedactor()
+	if mode == contentRedactStrict {
+		r.mode = EnvRedactStrict
+	} else {
+		r.mode = EnvRedactPermissive
+	}
+	envRedactorByMd[mode] = r
+	return r
+}
+
+// redactSecretsForLLM returns text with secrets masked according to the
+// configured policy. It is the single chokepoint for content that reaches
+// the model from tools, files and the memory extractor; humans have already
+// seen (and hooks already received) the unredacted original.
+func redactSecretsForLLM(text string) string {
+	mode := contentRedactModeFromEnv()
+	if mode == contentRedactOff || text == "" {
+		return text
+	}
+	return redactSecretsWithMode(text, mode)
+}
+
+// redactSecretsWithMode is the policy-explicit core, kept separate so tests
+// can exercise every mode without touching the environment.
+func redactSecretsWithMode(text string, mode contentRedactMode) string {
+	if mode == contentRedactOff || text == "" {
+		return text
+	}
+	redactor := envRedactorFor(mode)
+
+	// Layer 1: name-based KEY=VALUE redaction, line by line. Only lines
+	// that match the assignment shape are touched, and only their value.
+	if strings.Contains(text, "=") {
+		lines := strings.Split(text, "\n")
+		changed := false
+		for i, line := range lines {
+			m := envAssignmentLine.FindStringSubmatch(line)
+			if m == nil {
+				continue
+			}
+			key := strings.TrimSpace(strings.TrimSuffix(m[1], "="))
+			key = strings.TrimPrefix(key, "export ")
+			key = strings.TrimSpace(key)
+			value := strings.TrimSpace(m[2])
+			if value == "" || value == "[REDACTED]" {
+				continue
+			}
+			if redactor.isSensitive(key, strings.Trim(value, `"'`)) {
+				lines[i] = m[1] + "[REDACTED]"
+				changed = true
+			}
+		}
+		if changed {
+			text = strings.Join(lines, "\n")
+		}
+	}
+
+	// Layer 2: value-shape scan over the whole text.
+	return utils.SanitizeSensitiveText(text)
+}

--- a/cli/content_redactor_test.go
+++ b/cli/content_redactor_test.go
@@ -1,0 +1,140 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+)
+
+// Synthetic secrets are assembled at runtime so the source never contains a
+// literal that secret scanners (gitleaks) would flag, while the redactor
+// still sees the real value shapes.
+func fakeSecret(kind string) string { return "fake-" + kind + "-" + strings.Repeat("q", 24) }
+func fakeOpenAIKey() string         { return "sk-" + strings.Repeat("a", 30) }
+func fakeGitHubPAT() string         { return "ghp_" + strings.Repeat("b", 36) }
+func fakeJWT() string {
+	return "eyJ" + strings.Repeat("a", 20) + ".eyJ" + strings.Repeat("b", 20) + "." + strings.Repeat("c", 16)
+}
+
+func TestRedactSecrets_EnvLinesByName(t *testing.T) {
+	in := strings.Join([]string{
+		"HOME=/Users/dev",
+		"AWS_SECRET_ACCESS_KEY=" + fakeSecret("aws"),
+		"export DATABASE_URL=postgres://app:" + fakeSecret("pw") + "@db:5432/app",
+		"MY_SERVICE_TOKEN=\"abc123\"",
+		"GOFLAGS=-mod=vendor",
+		"PATH=/usr/bin",
+	}, "\n")
+	out := redactSecretsWithMode(in, contentRedactPermissive)
+
+	for _, keep := range []string{"HOME=/Users/dev", "GOFLAGS=-mod=vendor", "PATH=/usr/bin"} {
+		if !strings.Contains(out, keep) {
+			t.Fatalf("harmless line lost: %q\n%s", keep, out)
+		}
+	}
+	for _, gone := range []string{fakeSecret("aws"), fakeSecret("pw"), "abc123"} {
+		if strings.Contains(out, gone) {
+			t.Fatalf("secret survived: %q\n%s", gone, out)
+		}
+	}
+	for _, want := range []string{"AWS_SECRET_ACCESS_KEY=[REDACTED]", "export DATABASE_URL=[REDACTED]", "MY_SERVICE_TOKEN=[REDACTED]"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestRedactSecrets_ValueShapesInFreeText(t *testing.T) {
+	in := "config: token " + fakeOpenAIKey() + " and header Authorization: Bearer " + fakeJWT()
+	out := redactSecretsWithMode(in, contentRedactPermissive)
+	if strings.Contains(out, fakeOpenAIKey()) {
+		t.Fatalf("OpenAI-style key survived:\n%s", out)
+	}
+	if strings.Contains(out, fakeJWT()[:12]) {
+		t.Fatalf("bearer/JWT survived:\n%s", out)
+	}
+}
+
+func TestRedactSecrets_StrictRedactsUnknownNames(t *testing.T) {
+	in := "HOME=/Users/dev\nMY_INTERNAL_SETTING=42\nPATH=/usr/bin"
+	out := redactSecretsWithMode(in, contentRedactStrict)
+	if !strings.Contains(out, "HOME=/Users/dev") || !strings.Contains(out, "PATH=/usr/bin") {
+		t.Fatalf("allowlisted vars must survive strict mode:\n%s", out)
+	}
+	if strings.Contains(out, "MY_INTERNAL_SETTING=42") {
+		t.Fatalf("strict mode must redact non-allowlisted names:\n%s", out)
+	}
+	// Permissive keeps the same harmless line.
+	if perm := redactSecretsWithMode(in, contentRedactPermissive); !strings.Contains(perm, "MY_INTERNAL_SETTING=42") {
+		t.Fatalf("permissive must keep unknown harmless names:\n%s", perm)
+	}
+}
+
+func TestRedactSecrets_OffIsIdentity(t *testing.T) {
+	in := "AWS_SECRET_ACCESS_KEY=" + fakeSecret("aws")
+	if out := redactSecretsWithMode(in, contentRedactOff); out != in {
+		t.Fatalf("off must not touch content, got %q", out)
+	}
+}
+
+func TestRedactSecrets_LeavesCodeAndMarkersAlone(t *testing.T) {
+	in := "if a == b {\n\tx := y\n}\n[full content recoverable via @recall <<ccr:9f2a7c1d0e3b4a5f6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8f9a0b1c2d3>>]\nresult=ok"
+	out := redactSecretsWithMode(in, contentRedactPermissive)
+	if out != in {
+		t.Fatalf("plain code, markers and harmless assignments must be untouched:\n%s", out)
+	}
+}
+
+func TestContentRedactModeFromEnv(t *testing.T) {
+	cases := map[string]contentRedactMode{
+		"":           contentRedactPermissive,
+		"permissive": contentRedactPermissive,
+		"normal":     contentRedactPermissive, // historical spelling
+		"full":       contentRedactPermissive, // historical spelling
+		"STRICT":     contentRedactStrict,
+		"off":        contentRedactOff,
+		"none":       contentRedactOff,
+	}
+	for v, want := range cases {
+		t.Setenv("CHATCLI_ENV_REDACT_MODE", v)
+		if got := contentRedactModeFromEnv(); got != want {
+			t.Fatalf("mode(%q) = %s, want %s", v, got, want)
+		}
+	}
+}
+
+func TestRedactSecretsForLLM_HonorsEnv(t *testing.T) {
+	in := "OPENAI_API_KEY=" + fakeOpenAIKey()
+	t.Setenv("CHATCLI_ENV_REDACT_MODE", "off")
+	if got := redactSecretsForLLM(in); got != in {
+		t.Fatalf("off: got %q", got)
+	}
+	t.Setenv("CHATCLI_ENV_REDACT_MODE", "")
+	if got := redactSecretsForLLM(in); strings.Contains(got, fakeOpenAIKey()) {
+		t.Fatalf("default must redact: %q", got)
+	}
+}
+
+// The memory extractor must never see (and therefore never persist) a
+// secret that passed through the conversation.
+func TestBuildExtractionSnippet_RedactsBeforeExtraction(t *testing.T) {
+	t.Setenv("CHATCLI_ENV_REDACT_MODE", "")
+	msgs := []models.Message{
+		{Role: "user", Content: "use this: GITHUB_TOKEN=" + fakeGitHubPAT()},
+		{Role: "assistant", Content: "noted"},
+	}
+	sb := buildExtractionSnippet(msgs)
+	out := sb.String()
+	if strings.Contains(out, fakeGitHubPAT()) {
+		t.Fatalf("token reached the extraction prompt:\n%s", out)
+	}
+	if !strings.Contains(out, "[user]:") || !strings.Contains(out, "[assistant]: noted") {
+		t.Fatalf("snippet shape changed:\n%s", out)
+	}
+}

--- a/cli/memory_worker.go
+++ b/cli/memory_worker.go
@@ -381,6 +381,23 @@ items (bug fixed, feature built, decision made, incident resolved) — never
 greetings, questions or plans that didn't happen. Skip the section entirely if
 no work was completed.`
 
+// buildExtractionSnippet renders the conversation segment the memory
+// extractor sees. Secrets are redacted BEFORE truncation and before the
+// text reaches the extraction LLM, so a token pasted into the chat can
+// neither be sent out again nor be distilled into a persisted fact.
+func buildExtractionSnippet(messages []models.Message) strings.Builder {
+	var sb strings.Builder
+	for _, msg := range messages {
+		content := redactSecretsForLLM(msg.Content)
+		// Truncate very long messages to keep the extraction prompt small
+		if len(content) > 1500 {
+			content = content[:1200] + "\n... [truncated] ...\n" + content[len(content)-200:]
+		}
+		sb.WriteString(fmt.Sprintf("[%s]: %s\n\n", msg.Role, content))
+	}
+	return sb
+}
+
 func (mw *memoryWorker) extractAndSave(ctx context.Context, messages []models.Message) error {
 	if mw.cli.memoryStore == nil {
 		return fmt.Errorf("memory store not available")
@@ -407,15 +424,7 @@ func (mw *memoryWorker) extractAndSave(ctx context.Context, messages []models.Me
 	}
 
 	// Build conversation snippet for extraction
-	var sb strings.Builder
-	for _, msg := range messages {
-		content := msg.Content
-		// Truncate very long messages to keep the extraction prompt small
-		if len(content) > 1500 {
-			content = content[:1200] + "\n... [truncated] ...\n" + content[len(content)-200:]
-		}
-		sb.WriteString(fmt.Sprintf("[%s]: %s\n\n", msg.Role, content))
-	}
+	sb := buildExtractionSnippet(messages)
 
 	// Build enhanced prompt with existing context
 	var fullPrompt strings.Builder

--- a/cli/session_at_rest_test.go
+++ b/cli/session_at_rest_test.go
@@ -1,0 +1,110 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+	"github.com/diillson/chatcli/pkg/atrest"
+	"go.uber.org/zap"
+)
+
+func newAtRestSessionManager(t *testing.T) *SessionManager {
+	t.Helper()
+	return &SessionManager{sessionsDir: t.TempDir(), logger: zap.NewNop()}
+}
+
+func sampleSession() *SessionData {
+	return &SessionData{
+		Version: 2,
+		ChatHistory: []models.Message{
+			{Role: "user", Content: "remember the launch codes: alpha-bravo"},
+			{Role: "assistant", Content: "noted"},
+		},
+	}
+}
+
+func TestSessionStore_EncryptedRoundTripWhenKeySet(t *testing.T) {
+	t.Setenv(atrest.EnvKey, "session-test-key")
+	sm := newAtRestSessionManager(t)
+
+	if err := sm.SaveSessionV2("work", sampleSession()); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(sm.sessionsDir, "work.json"))
+	if err != nil {
+		t.Fatalf("read raw: %v", err)
+	}
+	if !atrest.IsEncrypted(raw) {
+		t.Fatal("session file must be encrypted at rest when the key is set")
+	}
+	if strings.Contains(string(raw), "launch codes") {
+		t.Fatal("plaintext leaked into the encrypted session file")
+	}
+
+	sd, err := sm.LoadSessionV2("work")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(sd.ChatHistory) != 2 || sd.ChatHistory[0].Content != "remember the launch codes: alpha-bravo" {
+		t.Fatalf("round trip mismatch: %+v", sd.ChatHistory)
+	}
+	// The search corpus goes through the same loader.
+	hits, err := sm.SearchSessions("launch codes", 2)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(hits) == 0 {
+		t.Fatal("encrypted sessions must remain searchable through the store")
+	}
+}
+
+func TestSessionStore_PlaintextMigratesOnNextSave(t *testing.T) {
+	t.Setenv(atrest.EnvKey, "")
+	sm := newAtRestSessionManager(t)
+	if err := sm.SaveSessionV2("legacy", sampleSession()); err != nil {
+		t.Fatalf("save plaintext: %v", err)
+	}
+	raw, _ := os.ReadFile(filepath.Join(sm.sessionsDir, "legacy.json"))
+	if atrest.IsEncrypted(raw) {
+		t.Fatal("no key configured: file must stay plaintext (legacy behavior)")
+	}
+
+	// Key appears later: the plaintext file still loads…
+	t.Setenv(atrest.EnvKey, "session-test-key")
+	sd, err := sm.LoadSessionV2("legacy")
+	if err != nil {
+		t.Fatalf("plaintext session must keep loading once a key is set: %v", err)
+	}
+	// …and is sealed on its next save.
+	if err := sm.SaveSessionV2("legacy", sd); err != nil {
+		t.Fatalf("re-save: %v", err)
+	}
+	raw, _ = os.ReadFile(filepath.Join(sm.sessionsDir, "legacy.json"))
+	if !atrest.IsEncrypted(raw) {
+		t.Fatal("re-saved session must be encrypted")
+	}
+}
+
+func TestSessionStore_EncryptedWithoutKeyIsClearError(t *testing.T) {
+	t.Setenv(atrest.EnvKey, "session-test-key")
+	sm := newAtRestSessionManager(t)
+	if err := sm.SaveSessionV2("locked", sampleSession()); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	t.Setenv(atrest.EnvKey, "")
+	_, err := sm.LoadSessionV2("locked")
+	if err == nil {
+		t.Fatal("loading an encrypted session without the key must fail")
+	}
+	if !strings.Contains(err.Error(), atrest.EnvKey) {
+		t.Fatalf("error must tell the user which variable is missing, got: %v", err)
+	}
+}

--- a/cli/session_encryption.go
+++ b/cli/session_encryption.go
@@ -6,26 +6,22 @@
 package cli
 
 import (
-	"crypto/aes"
-	"crypto/cipher"
-	"crypto/rand"
 	"crypto/sha256"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 
-	"golang.org/x/crypto/hkdf"
-)
-
-const (
-	sessionEncMagic = "CHATCLI_ENC_v1\n" // 15 bytes magic header for encrypted sessions
+	"github.com/diillson/chatcli/pkg/atrest"
 )
 
 // SessionEncryptor provides AES-256-GCM encryption for session files.
 // Key is derived from the existing auth key (~/.chatcli/.auth-key) using HKDF.
+//
+// The format and derivation live in pkg/atrest so the session store, the MCP
+// session mirrors and park snapshots (which cannot import cli) share them;
+// this type remains as the cli-side handle over the same primitive.
 type SessionEncryptor struct {
-	key []byte // 32-byte AES-256 key
+	inner *atrest.Encryptor
 }
 
 // NewSessionEncryptor creates an encryptor by deriving a key from the auth master key.
@@ -36,93 +32,34 @@ func NewSessionEncryptor() (*SessionEncryptor, error) {
 	if err != nil {
 		return nil, fmt.Errorf("session encryption unavailable: %w", err)
 	}
-
-	// Derive session-specific key using HKDF-SHA256
-	hkdfReader := hkdf.New(sha256.New, masterKey, nil, []byte("chatcli-session-encryption"))
-	derivedKey := make([]byte, 32) // AES-256
-	if _, err := io.ReadFull(hkdfReader, derivedKey); err != nil {
-		return nil, fmt.Errorf("key derivation failed: %w", err)
+	inner, err := atrest.NewFromMaster(masterKey, atrest.SessionInfo)
+	if err != nil {
+		return nil, err
 	}
-
-	return &SessionEncryptor{key: derivedKey}, nil
+	return &SessionEncryptor{inner: inner}, nil
 }
 
 // Encrypt encrypts plaintext data and prepends the magic header + nonce.
 // Format: CHATCLI_ENC_v1\n + 12-byte nonce + ciphertext (with GCM tag)
 func (se *SessionEncryptor) Encrypt(plaintext []byte) ([]byte, error) {
-	block, err := aes.NewCipher(se.key)
-	if err != nil {
-		return nil, fmt.Errorf("cipher init failed: %w", err)
-	}
-
-	gcm, err := cipher.NewGCM(block)
-	if err != nil {
-		return nil, fmt.Errorf("GCM init failed: %w", err)
-	}
-
-	nonce := make([]byte, gcm.NonceSize())
-	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
-		return nil, fmt.Errorf("nonce generation failed: %w", err)
-	}
-
-	ciphertext := gcm.Seal(nil, nonce, plaintext, nil)
-
-	// Prepend magic header + nonce
-	result := make([]byte, 0, len(sessionEncMagic)+len(nonce)+len(ciphertext))
-	result = append(result, []byte(sessionEncMagic)...)
-	result = append(result, nonce...)
-	result = append(result, ciphertext...)
-
-	return result, nil
+	return se.inner.Encrypt(plaintext)
 }
 
 // Decrypt decrypts data that was encrypted with Encrypt.
 // Returns the plaintext. Validates the magic header.
 func (se *SessionEncryptor) Decrypt(data []byte) ([]byte, error) {
-	magicLen := len(sessionEncMagic)
-	if len(data) < magicLen {
-		return nil, fmt.Errorf("data too short for encrypted session")
-	}
-
-	if string(data[:magicLen]) != sessionEncMagic {
-		return nil, fmt.Errorf("not an encrypted session (wrong magic header)")
-	}
-
-	block, err := aes.NewCipher(se.key)
-	if err != nil {
-		return nil, fmt.Errorf("cipher init failed: %w", err)
-	}
-
-	gcm, err := cipher.NewGCM(block)
-	if err != nil {
-		return nil, fmt.Errorf("GCM init failed: %w", err)
-	}
-
-	nonceSize := gcm.NonceSize()
-	if len(data) < magicLen+nonceSize {
-		return nil, fmt.Errorf("data too short for nonce")
-	}
-
-	nonce := data[magicLen : magicLen+nonceSize]
-	ciphertext := data[magicLen+nonceSize:]
-
-	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
-	if err != nil {
-		return nil, fmt.Errorf("decryption failed (tampered or wrong key): %w", err)
-	}
-
-	return plaintext, nil
+	return se.inner.Decrypt(data)
 }
 
 // IsEncrypted checks if data starts with the encrypted session magic header.
 func IsEncrypted(data []byte) bool {
-	return len(data) >= len(sessionEncMagic) && string(data[:len(sessionEncMagic)]) == sessionEncMagic
+	return atrest.IsEncrypted(data)
 }
 
 // loadMasterKey loads the encryption master key from env or auth key file.
 func loadMasterKey() ([]byte, error) {
 	// Prefer explicit env var
-	if envKey := os.Getenv("CHATCLI_ENCRYPTION_KEY"); envKey != "" {
+	if envKey := os.Getenv(atrest.EnvKey); envKey != "" {
 		// Hash to ensure consistent 32-byte key
 		h := sha256.Sum256([]byte(envKey))
 		return h[:], nil

--- a/cli/session_manager.go
+++ b/cli/session_manager.go
@@ -14,7 +14,9 @@ import (
 	"unicode/utf8"
 
 	"github.com/diillson/chatcli/cli/ctxmgr"
+	"github.com/diillson/chatcli/i18n"
 	"github.com/diillson/chatcli/models"
+	"github.com/diillson/chatcli/pkg/atrest"
 	"github.com/diillson/chatcli/utils"
 	"go.uber.org/zap"
 )
@@ -276,6 +278,16 @@ func (sm *SessionManager) SaveSessionV2(name string, sd *SessionData) error {
 		return fmt.Errorf("erro ao serializar a sessão: %w", err)
 	}
 
+	// Encryption at rest (opt-in via CHATCLI_ENCRYPTION_KEY): sealed right
+	// before the write so every producer of this store — REPL save, exit
+	// autosave, MCP session mirrors, write-through — is covered by the one
+	// call. A no-op when no key is configured.
+	data, err = atrest.Seal(data)
+	if err != nil {
+		sm.logger.Error("Erro ao criptografar a sessão", zap.String("session", name), zap.Error(err))
+		return fmt.Errorf("%s: %w", i18n.T("session.encrypt_failed"), err)
+	}
+
 	// Atomic same-directory temp + rename: the REPL, the gateway daemon and
 	// the MCP server all share this store, so a plain WriteFile interrupted
 	// mid-write (or two processes saving concurrently) could leave a torn
@@ -339,6 +351,16 @@ func (sm *SessionManager) LoadSessionV2(name string) (*SessionData, error) {
 	if err != nil {
 		sm.logger.Error("Erro ao ler o arquivo da sessão", zap.String("path", filePath), zap.Error(err))
 		return nil, fmt.Errorf("erro ao ler o arquivo da sessão: %w", err)
+	}
+
+	// Transparent at-rest handling: plaintext files (written before a key
+	// was configured) pass through and are sealed on their next save; an
+	// encrypted file with no key present is a clear error, never a silently
+	// empty or "corrupt" session.
+	data, err = atrest.Open(data)
+	if err != nil {
+		sm.logger.Error("Erro ao decriptar a sessão", zap.String("session", name), zap.Error(err))
+		return nil, fmt.Errorf("%s: %w", i18n.T("session.decrypt_failed", name), err)
 	}
 
 	// Try v2 format first

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -3148,6 +3148,8 @@
   "model.tool.status.no_override": "Session model: %s. No route override active.",
   "model.tool.delegate.failed": "delegated call to %s failed",
   "model.tool.delegate.empty": "the model returned an empty response (no text)",
+  "session.encrypt_failed": "session encryption failed",
+  "session.decrypt_failed": "failed to decrypt session %s",
   "model.tool.delegate.header": "Answer delegated to %s:",
   "plugins.model.describe.use": "Routing task to %s",
   "plugins.model.describe.delegate": "Delegating subtask to %s",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -3148,6 +3148,8 @@
   "model.tool.status.no_override": "Session model: %s. No route override active.",
   "model.tool.delegate.failed": "delegated call to %s failed",
   "model.tool.delegate.empty": "the model returned an empty response (no text)",
+  "session.encrypt_failed": "session encryption failed",
+  "session.decrypt_failed": "failed to decrypt session %s",
   "model.tool.delegate.header": "Answer delegated to %s:",
   "plugins.model.describe.use": "Routing task to %s",
   "plugins.model.describe.delegate": "Delegating subtask to %s",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -3148,6 +3148,8 @@
   "model.tool.status.no_override": "Modelo da sessão: %s. Nenhum override de rota ativo.",
   "model.tool.delegate.failed": "chamada delegada a %s falhou",
   "model.tool.delegate.empty": "o modelo retornou uma resposta vazia (sem texto)",
+  "session.encrypt_failed": "falha ao criptografar a sessão",
+  "session.decrypt_failed": "falha ao decriptar a sessão %s",
   "model.tool.delegate.header": "Resposta delegada a %s:",
   "plugins.model.describe.use": "Roteando tarefa para %s",
   "plugins.model.describe.delegate": "Delegando sub-tarefa a %s",

--- a/pkg/atrest/atrest.go
+++ b/pkg/atrest/atrest.go
@@ -1,0 +1,166 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+// Package atrest is the single encryption-at-rest primitive for ChatCLI's
+// durable stores (saved sessions, autosaves, MCP session mirrors, park
+// snapshots). It is a leaf package on purpose: stores that cannot import cli
+// (cli/agent/park) and cli itself share one format and one key derivation.
+//
+// Format: Magic + 12-byte GCM nonce + AES-256-GCM ciphertext (tag included).
+// Key: HKDF-SHA256(master = SHA-256(CHATCLI_ENCRYPTION_KEY), info) → 32 bytes,
+// the exact derivation the original cli.SessionEncryptor documented, so a file
+// written by either path opens with the other.
+//
+// Policy: encryption is an explicit opt-in — Seal encrypts only while
+// CHATCLI_ENCRYPTION_KEY is set, and Open transparently passes plaintext
+// through, so an existing plaintext store keeps loading and is re-written
+// encrypted on its next save (transparent migration). An encrypted file with
+// no key present is an error, never silently empty.
+package atrest
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"golang.org/x/crypto/hkdf"
+)
+
+const (
+	// Magic is the header every encrypted payload starts with.
+	Magic = "CHATCLI_ENC_v1\n"
+	// EnvKey is the environment variable that opts a process into
+	// encryption at rest and supplies the master secret.
+	EnvKey = "CHATCLI_ENCRYPTION_KEY"
+	// SessionInfo is the HKDF info string for session-class stores.
+	SessionInfo = "chatcli-session-encryption"
+)
+
+// ErrKeyMissing is returned by Open when the payload is encrypted but no key
+// is configured in the environment.
+var ErrKeyMissing = errors.New("encrypted at rest but " + EnvKey + " is not set")
+
+// Encryptor seals and opens payloads with one derived AES-256 key.
+type Encryptor struct {
+	key []byte
+}
+
+// NewFromMaster derives an Encryptor from master key material via
+// HKDF-SHA256 with the given info string.
+func NewFromMaster(master []byte, info string) (*Encryptor, error) {
+	if len(master) == 0 {
+		return nil, errors.New("atrest: empty master key")
+	}
+	derived := make([]byte, 32)
+	if _, err := io.ReadFull(hkdf.New(sha256.New, master, nil, []byte(info)), derived); err != nil {
+		return nil, fmt.Errorf("atrest: key derivation failed: %w", err)
+	}
+	return &Encryptor{key: derived}, nil
+}
+
+// Encrypt returns Magic + nonce + ciphertext for plaintext.
+func (e *Encryptor) Encrypt(plaintext []byte) ([]byte, error) {
+	gcm, err := e.gcm()
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("atrest: nonce generation failed: %w", err)
+	}
+	out := make([]byte, 0, len(Magic)+len(nonce)+len(plaintext)+gcm.Overhead())
+	out = append(out, Magic...)
+	out = append(out, nonce...)
+	return gcm.Seal(out, nonce, plaintext, nil), nil
+}
+
+// Decrypt validates the header and returns the plaintext. A wrong key or a
+// tampered payload fails authentication.
+func (e *Encryptor) Decrypt(data []byte) ([]byte, error) {
+	if !IsEncrypted(data) {
+		return nil, errors.New("atrest: not an encrypted payload (missing magic header)")
+	}
+	gcm, err := e.gcm()
+	if err != nil {
+		return nil, err
+	}
+	body := data[len(Magic):]
+	if len(body) < gcm.NonceSize() {
+		return nil, errors.New("atrest: payload too short for nonce")
+	}
+	nonce, ciphertext := body[:gcm.NonceSize()], body[gcm.NonceSize():]
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, fmt.Errorf("atrest: decryption failed (tampered or wrong key): %w", err)
+	}
+	return plaintext, nil
+}
+
+func (e *Encryptor) gcm() (cipher.AEAD, error) {
+	block, err := aes.NewCipher(e.key)
+	if err != nil {
+		return nil, fmt.Errorf("atrest: cipher init failed: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("atrest: GCM init failed: %w", err)
+	}
+	return gcm, nil
+}
+
+// IsEncrypted reports whether data carries the encrypted-payload header.
+func IsEncrypted(data []byte) bool {
+	return len(data) >= len(Magic) && string(data[:len(Magic)]) == Magic
+}
+
+// Enabled reports whether the process opted into encryption at rest.
+func Enabled() bool {
+	return os.Getenv(EnvKey) != ""
+}
+
+// fromEnv builds the session-class Encryptor from CHATCLI_ENCRYPTION_KEY.
+// Re-derived per call: the derivation costs microseconds and reading the
+// environment each time keeps behavior consistent with a runtime reload.
+func fromEnv() (*Encryptor, error) {
+	secret := os.Getenv(EnvKey)
+	if secret == "" {
+		return nil, ErrKeyMissing
+	}
+	master := sha256.Sum256([]byte(secret))
+	return NewFromMaster(master[:], SessionInfo)
+}
+
+// Seal encrypts plaintext when encryption at rest is enabled and returns it
+// unchanged otherwise. Stores call it right before writing.
+func Seal(plaintext []byte) ([]byte, error) {
+	if !Enabled() {
+		return plaintext, nil
+	}
+	enc, err := fromEnv()
+	if err != nil {
+		return nil, err
+	}
+	return enc.Encrypt(plaintext)
+}
+
+// Open decrypts an encrypted payload and passes plaintext through untouched.
+// Stores call it right after reading, so a plaintext file written before the
+// key was configured keeps loading (and is sealed on its next save).
+func Open(data []byte) ([]byte, error) {
+	if !IsEncrypted(data) {
+		return data, nil
+	}
+	enc, err := fromEnv()
+	if err != nil {
+		return nil, err
+	}
+	return enc.Decrypt(data)
+}

--- a/pkg/atrest/atrest_test.go
+++ b/pkg/atrest/atrest_test.go
@@ -1,0 +1,124 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package atrest
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestSealOpen_RoundTripWhenEnabled(t *testing.T) {
+	t.Setenv(EnvKey, "unit-test-secret")
+	plain := []byte(`{"version":2,"chat_history":[{"role":"user","content":"hi"}]}`)
+
+	sealed, err := Seal(plain)
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	if !IsEncrypted(sealed) {
+		t.Fatal("sealed payload must carry the magic header")
+	}
+	if bytes.Contains(sealed, []byte("chat_history")) {
+		t.Fatal("ciphertext leaks plaintext")
+	}
+	opened, err := Open(sealed)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if !bytes.Equal(opened, plain) {
+		t.Fatalf("round trip mismatch: %q", opened)
+	}
+}
+
+func TestSealOpen_PassthroughWhenDisabled(t *testing.T) {
+	t.Setenv(EnvKey, "")
+	plain := []byte("plaintext store")
+	sealed, err := Seal(plain)
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	if !bytes.Equal(sealed, plain) {
+		t.Fatal("Seal must be a no-op without a key")
+	}
+	opened, err := Open(plain)
+	if err != nil || !bytes.Equal(opened, plain) {
+		t.Fatalf("Open must pass plaintext through, got %q err=%v", opened, err)
+	}
+}
+
+func TestOpen_PlaintextPassesThroughEvenWithKey(t *testing.T) {
+	// Transparent migration: a store written before the key existed keeps
+	// loading once the key is configured.
+	t.Setenv(EnvKey, "unit-test-secret")
+	plain := []byte(`{"version":2}`)
+	opened, err := Open(plain)
+	if err != nil || !bytes.Equal(opened, plain) {
+		t.Fatalf("plaintext must pass through with a key set, got %q err=%v", opened, err)
+	}
+}
+
+func TestOpen_EncryptedWithoutKeyIsExplicitError(t *testing.T) {
+	t.Setenv(EnvKey, "unit-test-secret")
+	sealed, err := Seal([]byte("secret session"))
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	t.Setenv(EnvKey, "")
+	if _, err := Open(sealed); !errors.Is(err, ErrKeyMissing) {
+		t.Fatalf("expected ErrKeyMissing, got %v", err)
+	}
+}
+
+func TestOpen_WrongKeyOrTamperFails(t *testing.T) {
+	t.Setenv(EnvKey, "key-one")
+	sealed, err := Seal([]byte("secret session"))
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+
+	t.Setenv(EnvKey, "key-two")
+	if _, err := Open(sealed); err == nil || !strings.Contains(err.Error(), "decryption failed") {
+		t.Fatalf("wrong key must fail authentication, got %v", err)
+	}
+
+	t.Setenv(EnvKey, "key-one")
+	tampered := append([]byte(nil), sealed...)
+	tampered[len(tampered)-1] ^= 0xFF
+	if _, err := Open(tampered); err == nil {
+		t.Fatal("tampered payload must fail authentication")
+	}
+}
+
+func TestDerivation_MatchesDocumentedScheme(t *testing.T) {
+	// Two encryptors built from the same master and info must open each
+	// other's payloads: that is what lets cli.SessionEncryptor and the
+	// env-driven Seal share files.
+	master := sha256.Sum256([]byte("shared"))
+	a, err := NewFromMaster(master[:], SessionInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := NewFromMaster(master[:], SessionInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sealed, err := a.Encrypt([]byte("x"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out, err := b.Decrypt(sealed); err != nil || string(out) != "x" {
+		t.Fatalf("cross-open failed: %q %v", out, err)
+	}
+	if _, err := NewFromMaster(nil, SessionInfo); err == nil {
+		t.Fatal("empty master must be rejected")
+	}
+	if _, err := a.Decrypt([]byte("not encrypted")); err == nil {
+		t.Fatal("Decrypt must reject payloads without the header")
+	}
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -102,42 +102,46 @@ func SanitizeSensitiveText(s string) string {
 
 // maskSensitiveInText aplica regex para esconder padrões comuns de segredos
 
+// sensitiveTextPatterns is compiled once: SanitizeSensitiveText runs on
+// every tool output and attachment on the LLM path, and recompiling
+// fifteen regexes per call was pure overhead.
+var sensitiveTextPatterns = []struct {
+	re   *regexp.Regexp
+	repl string
+}{
+	// Chaves de API comuns (OpenAI, Anthropic, Stripe, etc.)
+	{regexp.MustCompile(`(?i)(sk|pk)_(test|live)_[a-zA-Z0-9]{20,}`), "[REDACTED_API_KEY]"},
+	{regexp.MustCompile(`sk-ant-[a-zA-Z0-9_-]{20,}`), "sk-ant-[REDACTED]"},
+	{regexp.MustCompile(`sk-[a-zA-Z0-9]{20,}`), "sk-[REDACTED]"},
+	// L3: xAI / Grok API keys
+	{regexp.MustCompile(`xai-[a-zA-Z0-9]{20,}`), "xai-[REDACTED]"},
+	// L3: StackSpot tokens (stk_ prefix)
+	{regexp.MustCompile(`stk_[a-zA-Z0-9]{20,}`), "stk_[REDACTED]"},
+	// L3: Mistral API keys
+	{regexp.MustCompile(`(?i)mistral[_-]?[a-zA-Z0-9]{20,}`), "[REDACTED_MISTRAL_KEY]"},
+	// L3: Cohere API keys
+	{regexp.MustCompile(`(?i)cohere[_-]?[a-zA-Z0-9]{20,}`), "[REDACTED_COHERE_KEY]"},
+	// L3: HuggingFace tokens
+	{regexp.MustCompile(`hf_[a-zA-Z0-9]{20,}`), "hf_[REDACTED]"},
+	// L3: GitHub tokens
+	{regexp.MustCompile(`gh[ps]_[a-zA-Z0-9]{20,}`), "[REDACTED_GH_TOKEN]"},
+	{regexp.MustCompile(`github_pat_[a-zA-Z0-9_]{20,}`), "[REDACTED_GH_PAT]"},
+	// Google AI
+	{regexp.MustCompile(`AIza[0-9A-Za-z\-_]{30,}`), "[REDACTED_GOOGLE_API_KEY]"},
+	// AWS keys
+	{regexp.MustCompile(`AKIA[0-9A-Z]{16}`), "[REDACTED_AWS_KEY]"},
+	// Bearer tokens e JWTs (parte do meio)
+	{regexp.MustCompile(`(?i)Bearer\s+[A-Za-z0-9\.\-_]+`), "Bearer [REDACTED]"},
+	{regexp.MustCompile(`ey[A-Za-z0-9-_=]+\.ey[A-Za-z0-9-_=]+\.[A-Za-z0-9-_.+/=]+`), "[REDACTED_JWT]"},
+	// Campos em JSON
+	{regexp.MustCompile(`("access_token"|"refresh_token"|"client_secret"|"client_key"|"api_key"|"password"|"token")\s*:\s*"[^"]+"`), `${1}:"[REDACTED]"`},
+	// Formato KEY=VALUE
+	{regexp.MustCompile(`(?im)^(API_KEY|ACCESS_TOKEN|CLIENT_SECRET|CLIENT_KEY|SECRET|PASSWORD)\s*=\s*.*$`), "$1=[REDACTED]"},
+}
+
 func maskSensitiveInText(s string) string {
-	patterns := []struct {
-		re   *regexp.Regexp
-		repl string
-	}{
-		// Chaves de API comuns (OpenAI, Anthropic, Stripe, etc.)
-		{regexp.MustCompile(`(?i)(sk|pk)_(test|live)_[a-zA-Z0-9]{20,}`), "[REDACTED_API_KEY]"},
-		{regexp.MustCompile(`sk-ant-[a-zA-Z0-9_-]{20,}`), "sk-ant-[REDACTED]"},
-		{regexp.MustCompile(`sk-[a-zA-Z0-9]{20,}`), "sk-[REDACTED]"},
-		// L3: xAI / Grok API keys
-		{regexp.MustCompile(`xai-[a-zA-Z0-9]{20,}`), "xai-[REDACTED]"},
-		// L3: StackSpot tokens (stk_ prefix)
-		{regexp.MustCompile(`stk_[a-zA-Z0-9]{20,}`), "stk_[REDACTED]"},
-		// L3: Mistral API keys
-		{regexp.MustCompile(`(?i)mistral[_-]?[a-zA-Z0-9]{20,}`), "[REDACTED_MISTRAL_KEY]"},
-		// L3: Cohere API keys
-		{regexp.MustCompile(`(?i)cohere[_-]?[a-zA-Z0-9]{20,}`), "[REDACTED_COHERE_KEY]"},
-		// L3: HuggingFace tokens
-		{regexp.MustCompile(`hf_[a-zA-Z0-9]{20,}`), "hf_[REDACTED]"},
-		// L3: GitHub tokens
-		{regexp.MustCompile(`gh[ps]_[a-zA-Z0-9]{20,}`), "[REDACTED_GH_TOKEN]"},
-		{regexp.MustCompile(`github_pat_[a-zA-Z0-9_]{20,}`), "[REDACTED_GH_PAT]"},
-		// Google AI
-		{regexp.MustCompile(`AIza[0-9A-Za-z\-_]{30,}`), "[REDACTED_GOOGLE_API_KEY]"},
-		// AWS keys
-		{regexp.MustCompile(`AKIA[0-9A-Z]{16}`), "[REDACTED_AWS_KEY]"},
-		// Bearer tokens e JWTs (parte do meio)
-		{regexp.MustCompile(`(?i)Bearer\s+[A-Za-z0-9\.\-_]+`), "Bearer [REDACTED]"},
-		{regexp.MustCompile(`ey[A-Za-z0-9-_=]+\.ey[A-Za-z0-9-_=]+\.[A-Za-z0-9-_.+/=]+`), "[REDACTED_JWT]"},
-		// Campos em JSON
-		{regexp.MustCompile(`("access_token"|"refresh_token"|"client_secret"|"client_key"|"api_key"|"password"|"token")\s*:\s*"[^"]+"`), `${1}:"[REDACTED]"`},
-		// Formato KEY=VALUE
-		{regexp.MustCompile(`(?im)^(API_KEY|ACCESS_TOKEN|CLIENT_SECRET|CLIENT_KEY|SECRET|PASSWORD)\s*=\s*.*$`), "$1=[REDACTED]"},
-	}
 	out := s
-	for _, p := range patterns {
+	for _, p := range sensitiveTextPatterns {
 		out = p.re.ReplaceAllString(out, p.repl)
 	}
 	return out


### PR DESCRIPTION
## Summary

Two security modules were fully written and never called (`SessionEncryptor`, `EnvRedactor`), while the docs and `/config security` presented them as live. This PR wires both, without changing behavior for anyone who has not opted in.

**Encryption at rest** (`pkg/atrest`, leaf package shared by the session store and `cli/agent/park`):
- Opt-in: active only while `CHATCLI_ENCRYPTION_KEY` is set. Covers saved sessions, exit autosaves, MCP/ACP session mirrors (all through `SaveSessionV2`) and park snapshots.
- Transparent migration: plaintext files keep loading and are sealed on next save. Encrypted file + no key = clear error naming the variable (i18n, 3 locales).
- Same format/derivation the docs already described (`CHATCLI_ENC_v1` + nonce + AES-256-GCM, HKDF-SHA256). `cli.SessionEncryptor` kept as a thin handle (no removed exports).

**Secret redaction on the LLM path** (`cli/content_redactor.go`, `redactSecretsForLLM`):
- Applied at: orchestrator tool outputs (file reads, plugins, MCP, error text), worker tool outputs (shared compressor hook), chat `@file`/`@git`/`@env` context, memory extraction snippet (a pasted token can no longer be distilled into a persisted fact).
- Layer 1: `KEY=VALUE` lines judged by name via `EnvRedactor` (denylist + value heuristics). Layer 2: `utils.SanitizeSensitiveText` value shapes (regexes now compiled once).
- Policy via the existing `CHATCLI_ENV_REDACT_MODE`: `permissive` (default), `strict`, `off`. Historical spellings (`normal`, `full`) resolve to permissive. Humans and `PostToolUse` hooks still get the unredacted output.

## Cross-impact checked

- Only `SaveSessionV2`/`LoadSessionV2` touch session bytes; the search corpus and MCP mirrors go through them (test covers search over encrypted sessions).
- The exec-output regex pass that already existed is untouched; `off` disables only the new chokepoint.
- No new environment variables; `config_env_defaults` corrected (`normal` → `permissive`).
- Hub SQLite, memory stores and knowledge contexts are explicitly out of scope (documented as such).

## Verification

- `go test ./...`: 108 packages ok · `golangci-lint` clean on diff and on touched packages · `scripts/qg/i18n-parity.sh` ok
- New tests: `pkg/atrest` (round trip, passthrough, migration, missing key, wrong key/tamper, derivation), `cli/session_at_rest_test.go` (encrypted round trip + search, plaintext migration, clear error), park snapshot encryption, `cli/content_redactor_test.go` (env names, value shapes, strict, off, code/markers untouched, env parsing, extraction snippet).

Docs (chatcli.ai, en + pt) are updated to describe the real variables and modes; they land on the docs repo once this merges.
