### PR TITLE
feat(session): append-only transcript journal and memory flush before compaction

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -952,6 +952,8 @@ func (a *AgentMode) effectiveRoute() (provider, model string) {
 // Run inicia o modo agente com uma consulta do usuário, utilizando um loop de Raciocínio-Ação (ReAct).
 // Agora aceita systemPromptOverride para definir personas específicas (ex: Coder).
 func (a *AgentMode) Run(ctx context.Context, query string, additionalContext string, systemPromptOverride string) error {
+	// The journal must hold whatever the loop produced, however it exits.
+	defer a.cli.syncTranscript()
 	// Reentrancy guard. AgentMode is not safe to Run concurrently on the
 	// same instance — see runInflight comment in the struct. We CAS so
 	// that any caller stepping on an in-flight Run gets a clean error
@@ -2159,6 +2161,10 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 		// Microcompact (Level 0): cheap, progressive compaction of OLD tool
 		// results in history. Pure Go, no LLM call. Often keeps us below
 		// budget so the expensive summarization path is never triggered.
+		// Journal the previous turn's messages (tool results included) BEFORE
+		// this turn's rewrites can stub them — durability against a hard
+		// kill mid-run.
+		a.cli.syncTranscript()
 		mcCfg := agent.DefaultMicrocompactConfig()
 		// Route dropped bytes through CCR so every microcompacted tool
 		// result stays recoverable via @recall instead of being lost.
@@ -2231,6 +2237,7 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 					agent.ColorYellow))
 		}
 		if a.cli.historyCompactor.NeedsCompaction(a.cli.history, cfg) {
+			a.cli.flushMemoryBeforeCompaction(ctx)
 			// Emit live status during compaction so the terminal is never
 			// silent. Without this, Level 2 (LLM summarization) can block
 			// for 30-90s with zero feedback — users assume a freeze.

--- a/cli/chat_pipeline.go
+++ b/cli/chat_pipeline.go
@@ -774,6 +774,7 @@ func (cli *ChatCLI) handleChatTurnResult(
 	// the active named session so other surfaces can pick the thread up.
 	cli.mirrorHubTurn(ctx, userMessage.Content, aiResponse)
 	cli.persistBoundSession()
+	cli.syncTranscript()
 
 	usage := client.GetUsageOrEstimate(activeClient, len(userInput+additionalContext), len(aiResponse))
 	// Skip the record when the chat-ask/knowledge exception already booked

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -290,6 +290,9 @@ type ChatCLI struct {
 	// Latest assembled system-prompt breakdown (chat and agent paths write
 	// it, /context status reads it).
 	promptBreakdowns promptBreakdownStore
+	// Append-only transcript journal (transcript_journal.go): the durable
+	// full record behind the compacted in-memory window.
+	transcript *transcriptJournal
 
 	// Session language-server pool behind the @lsp tool. Created lazily on
 	// the first @lsp call (starting gopls for sessions that never navigate
@@ -839,6 +842,7 @@ func NewChatCLI(ctx context.Context, manager manager.LLMManager, logger *zap.Log
 	// Build the content-aware compression layer (CCR store under ~/.chatcli/ccr)
 	// from environment config, and wire the @compress/@recall tools to it. The
 	// layer is also consulted by the agent/coder loop to compress tool output.
+	cli.initTranscriptJournal("")
 	cli.compressionLayer = compress.NewLayerFromEnv(filepath.Join(homeDir, ".chatcli"))
 	if err := cli.compressionLayer.StoreFallback(); err != nil {
 		// The layer already degraded to a bounded in-memory store; surface the

--- a/cli/cli_llm.go
+++ b/cli/cli_llm.go
@@ -195,6 +195,7 @@ func (cli *ChatCLI) compactHistoryIfNeeded(ctx context.Context) {
 		fmt.Printf("\r\033[K  %s\n", msg)
 		_ = os.Stdout.Sync()
 	})
+	cli.flushMemoryBeforeCompaction(ctx)
 	compacted, err := cli.historyCompactor.Compact(ctx, cli.history, cli.Client, cfg)
 	cli.historyCompactor.SetStatusCallback(nil)
 	if err == nil {

--- a/cli/cli_session.go
+++ b/cli/cli_session.go
@@ -222,14 +222,16 @@ func (cli *ChatCLI) clearAllHistories() {
 // Uses ChatHistory field to store the unified history for backwards compatibility.
 func (cli *ChatCLI) buildSessionData() *SessionData {
 	return &SessionData{
-		Version:     2,
-		ChatHistory: cli.history,
+		Version:      2,
+		ChatHistory:  cli.history,
+		TranscriptID: cli.transcriptID(),
 	}
 }
 
 // restoreSessionData restores history from a SessionData.
 // Merges legacy separate histories into the unified history for backwards compatibility.
 func (cli *ChatCLI) restoreSessionData(sd *SessionData) {
+	cli.adoptTranscript(sd.TranscriptID)
 	cli.history = sd.ChatHistory
 	if cli.history == nil {
 		cli.history = make([]models.Message, 0)

--- a/cli/compact_command.go
+++ b/cli/compact_command.go
@@ -54,6 +54,7 @@ func (cli *ChatCLI) handleCompactCommand(ctx context.Context, userInput string) 
 		cli.historyCompactor.SetStatusCallback(func(stage CompactStage, msg string) {
 			fmt.Printf("  %s %s\n", colorize("│", ColorCyan), colorize(msg, ColorGray))
 		})
+		cli.flushMemoryBeforeCompaction(ctx)
 		compacted, err := cli.historyCompactor.Compact(ctx, cli.history, cli.Client, cfg)
 		cli.historyCompactor.SetStatusCallback(nil)
 		if err != nil {
@@ -171,6 +172,7 @@ CONVERSATION TO COMPACT:
 		return
 	}
 
+	cli.flushMemoryBeforeCompaction(ctx)
 	// Archive the FULL middle segment before replacing it, exactly as the
 	// automatic pipeline does: guided compaction was the last irreversible
 	// cut in the codebase. Best-effort — a disabled CCR layer keeps the

--- a/cli/config_env_defaults.go
+++ b/cli/config_env_defaults.go
@@ -181,6 +181,7 @@ var envDefaults = map[string]envDefault{
 	"CHATCLI_BUDGET_WARNING_PCT": {Value: "0.80", Source: "cost_tracker.go"},
 	"CHATCLI_BUDGET_HARD_STOP":   {Value: "false", IsBool: true, Source: "cost_tracker.go (refuse turns once budget exceeded)"},
 	"CHATCLI_SESSION_TTL":        {Value: "90", Source: "session_manager.go (days)"},
+	"CHATCLI_SESSION_TRANSCRIPT": {Value: "true", IsBool: true, Source: "transcript_journal.go (append-only ~/.chatcli/transcripts/<id>.jsonl)"},
 	"CHATCLI_DISABLE_HISTORY":    {Value: "false", IsBool: true, Source: "history_manager.go"},
 
 	// ─── Memory / bootstrap ──────────────────────────────────────

--- a/cli/config_sections.go
+++ b/cli/config_sections.go
@@ -877,6 +877,14 @@ func (cli *ChatCLI) showConfigSession() {
 	if bound := cli.boundSessionName(); bound != "" {
 		kv(p, i18n.T("cfg.kv.session_bound"), bound)
 	}
+	trVal := i18n.T("cfg.val.disabled")
+	if id := cli.transcriptID(); id != "" {
+		trVal = id
+	}
+	if os.Getenv(TranscriptEnv) == "" {
+		trVal = defaultMarker + trVal
+	}
+	kv(p, TranscriptEnv, trVal)
 	keepVal := fmt.Sprintf("%d", sessionAutosaveKeep())
 	if os.Getenv("CHATCLI_SESSION_AUTOSAVE_KEEP") == "" {
 		keepVal = defaultMarker + keepVal

--- a/cli/memory_flush.go
+++ b/cli/memory_flush.go
@@ -1,0 +1,66 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Memory flush before compaction. The memory worker extracts facts from the
+ * live history a couple of turns behind the conversation; compaction
+ * replaces the middle of that history with a summary, so anything the
+ * worker had not reached yet was distilled from a summary at best and lost
+ * at worst. Every compaction site now hands the not-yet-extracted segment
+ * to the worker's durable queue first, so the original messages reach
+ * long-term memory verbatim regardless of what the summary keeps.
+ */
+package cli
+
+import (
+	"context"
+
+	"github.com/diillson/chatcli/models"
+)
+
+// unextractedSegment returns the live messages the memory worker has not
+// processed yet (system messages excluded — they carry no episodic content).
+func (cli *ChatCLI) unextractedSegment() []models.Message {
+	if cli == nil || cli.memWorker == nil || cli.memWorker.cli == nil || cli.memWorker.cli.memoryStore == nil {
+		return nil
+	}
+	start := cli.memWorker.lastProcessedIdx
+	if start < 0 || start >= len(cli.history) {
+		return nil
+	}
+	seg := make([]models.Message, 0, len(cli.history)-start)
+	for _, m := range cli.history[start:] {
+		if m.Role == "system" {
+			continue
+		}
+		seg = append(seg, m)
+	}
+	if len(seg) < 2 {
+		return nil // a lone user turn carries nothing to distill
+	}
+	return seg
+}
+
+// flushMemoryBeforeCompaction queues the unextracted segment on the memory
+// worker's WAL and triggers an extraction pass, then marks the segment as
+// processed so the live-delta gate does not double-extract it.
+func (cli *ChatCLI) flushMemoryBeforeCompaction(ctx context.Context) {
+	seg := cli.unextractedSegment()
+	if seg == nil {
+		return
+	}
+	cli.memWorker.nudgeSegment(ctx, seg)
+	cli.memWorker.lastProcessedIdx = len(cli.history)
+}
+
+// queueMemoryBeforeCompaction is the one-shot variant: the process exits
+// right after its turn, so the segment is only queued for the next session.
+func (cli *ChatCLI) queueMemoryBeforeCompaction() {
+	seg := cli.unextractedSegment()
+	if seg == nil {
+		return
+	}
+	cli.memWorker.queueSegmentForNextSession(seg)
+	cli.memWorker.lastProcessedIdx = len(cli.history)
+}

--- a/cli/oneshot_mode.go
+++ b/cli/oneshot_mode.go
@@ -239,6 +239,7 @@ func (cli *ChatCLI) RunOnce(ctx context.Context, input string, disableAnimation 
 	// be piped into other tools).
 	cfg := DefaultCompactConfig(cli.Provider, cli.Model)
 	if cli.historyCompactor.NeedsCompaction(cli.history, cfg) {
+		cli.queueMemoryBeforeCompaction()
 		cli.historyCompactor.SetStatusCallback(func(stage CompactStage, msg string) {
 			fmt.Fprintf(os.Stderr, "  %s\n", msg)
 		})

--- a/cli/transcript_journal.go
+++ b/cli/transcript_journal.go
@@ -1,0 +1,349 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Append-only transcript journal.
+ *
+ * Saved sessions persist the in-memory window as it stands — after
+ * compaction the original messages exist only as CCR keys with a 7-day TTL,
+ * and a hard kill mid-turn lost everything since the last turn boundary.
+ * The journal is the durable record: every message is appended once, the
+ * first time it appears at the tail of the live history, and a history
+ * rewrite (compaction, guided /compact, microcompact stubs) is recorded as
+ * an event instead of being lost. Synced at turn boundaries and after each
+ * agent tool batch, each line fsynced, sealed line by line when encryption
+ * at rest is enabled. Journals follow the machine-session TTL.
+ */
+package cli
+
+import (
+	"bufio"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/diillson/chatcli/models"
+	"github.com/diillson/chatcli/pkg/atrest"
+	"go.uber.org/zap"
+)
+
+const (
+	// TranscriptEnv disables the journal when set to false.
+	TranscriptEnv = "CHATCLI_SESSION_TRANSCRIPT"
+	// transcriptDirName is the store under ~/.chatcli.
+	transcriptDirName = "transcripts"
+	// sealedLinePrefix marks a journal line encrypted at rest.
+	sealedLinePrefix = "enc:"
+)
+
+// transcriptEvent is one journal line.
+type transcriptEvent struct {
+	TS      time.Time       `json:"ts"`
+	Kind    string          `json:"kind"` // "msg" | "rewrite"
+	Message *models.Message `json:"message,omitempty"`
+	Before  int             `json:"before,omitempty"` // rewrite: messages before
+	After   int             `json:"after,omitempty"`  // rewrite: messages after
+}
+
+// transcriptJournal appends the live history to one file per session.
+type transcriptJournal struct {
+	mu        sync.Mutex
+	id        string
+	path      string
+	lastCount int
+	lastHash  string          // hash of the last journaled message
+	seen      map[string]bool // hashes journaled so far (rewrite dedup)
+	disabled  bool
+}
+
+// transcriptEnabled honors CHATCLI_SESSION_TRANSCRIPT (default on).
+func transcriptEnabled() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv(TranscriptEnv)))
+	return !(v == "false" || v == "0" || v == "off" || v == "no")
+}
+
+// newTranscriptID mints a sortable, collision-safe journal id.
+func newTranscriptID(now time.Time) string {
+	var b [4]byte
+	_, _ = rand.Read(b[:])
+	return "tr-" + now.Format("20060102-150405") + "-" + hex.EncodeToString(b[:])
+}
+
+// transcriptDir returns the journal directory, creating it.
+func transcriptDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(home, ".chatcli", transcriptDirName)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+// openTranscriptJournal binds a journal to id under dir. An existing file
+// (a resumed session) is scanned so already-journaled messages are not
+// appended again.
+func openTranscriptJournal(dir, id string) (*transcriptJournal, error) {
+	if id == "" || id != filepath.Base(id) {
+		return nil, fmt.Errorf("transcript: invalid id %q", id)
+	}
+	j := &transcriptJournal{id: id, path: filepath.Join(dir, id+".jsonl"), seen: map[string]bool{}}
+	msgs, err := readTranscript(j.path)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+	for _, m := range msgs {
+		h := messageHash(m)
+		j.seen[h] = true
+		j.lastHash = h
+	}
+	j.lastCount = 0 // the live history is re-synced from scratch by hash
+	return j, nil
+}
+
+// messageHash identifies a message by role, content and tool id.
+func messageHash(m models.Message) string {
+	h := sha256.New()
+	h.Write([]byte(m.Role))
+	h.Write([]byte{0})
+	h.Write([]byte(m.Content))
+	h.Write([]byte{0})
+	h.Write([]byte(m.ToolCallID))
+	h.Write([]byte{0})
+	h.Write([]byte(strconv.Itoa(len(m.ToolCalls))))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// Sync appends every message that has not been journaled yet. When the
+// history no longer extends the journaled prefix (a rewrite), a rewrite
+// event is recorded and only genuinely new messages are appended.
+func (j *transcriptJournal) Sync(history []models.Message) error {
+	if j == nil || j.disabled {
+		return nil
+	}
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	extends := len(history) >= j.lastCount && j.lastCount > 0 && messageHash(history[j.lastCount-1]) == j.lastHash
+	var events []transcriptEvent
+	now := time.Now()
+	if !extends && j.lastCount > 0 {
+		events = append(events, transcriptEvent{TS: now, Kind: "rewrite", Before: j.lastCount, After: len(history)})
+	}
+	start := 0
+	if extends {
+		start = j.lastCount
+	}
+	for i := start; i < len(history); i++ {
+		h := messageHash(history[i])
+		if j.seen[h] {
+			continue
+		}
+		m := history[i]
+		events = append(events, transcriptEvent{TS: now, Kind: "msg", Message: &m})
+		j.seen[h] = true
+	}
+	if len(events) > 0 {
+		if err := j.appendEvents(events); err != nil {
+			return err
+		}
+	}
+	j.lastCount = len(history)
+	if len(history) > 0 {
+		j.lastHash = messageHash(history[len(history)-1])
+	} else {
+		j.lastHash = ""
+	}
+	return nil
+}
+
+// appendEvents writes events as JSON lines (sealed when encryption at rest
+// is on) and fsyncs.
+func (j *transcriptJournal) appendEvents(events []transcriptEvent) error {
+	f, err := os.OpenFile(j.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600) // #nosec G304 -- path built from a validated id under ~/.chatcli/transcripts
+	if err != nil {
+		return err
+	}
+	w := bufio.NewWriter(f)
+	for _, ev := range events {
+		line, err := json.Marshal(ev)
+		if err != nil {
+			_ = f.Close()
+			return err
+		}
+		if atrest.Enabled() {
+			sealed, err := atrest.Seal(line)
+			if err != nil {
+				_ = f.Close()
+				return err
+			}
+			line = []byte(sealedLinePrefix + base64.StdEncoding.EncodeToString(sealed))
+		}
+		if _, err := w.Write(append(line, '\n')); err != nil {
+			_ = f.Close()
+			return err
+		}
+	}
+	if err := w.Flush(); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+// readTranscript returns every journaled message in order (rewrite events
+// are skipped: the journal is the full record, not the compacted view).
+func readTranscript(path string) ([]models.Message, error) {
+	f, err := os.Open(path) // #nosec G304 -- journal path under ~/.chatcli/transcripts
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	var out []models.Message
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 1024*1024), 64*1024*1024)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		if strings.HasPrefix(string(line), sealedLinePrefix) {
+			raw, err := base64.StdEncoding.DecodeString(string(line[len(sealedLinePrefix):]))
+			if err != nil {
+				return nil, fmt.Errorf("transcript: corrupt sealed line: %w", err)
+			}
+			if line, err = atrest.Open(raw); err != nil {
+				return nil, err
+			}
+		}
+		var ev transcriptEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			return nil, fmt.Errorf("transcript: corrupt line: %w", err)
+		}
+		if ev.Kind == "msg" && ev.Message != nil {
+			out = append(out, *ev.Message)
+		}
+	}
+	return out, sc.Err()
+}
+
+// pruneTranscripts removes journals whose last write is older than ttl.
+// Zero ttl keeps everything. Returns how many were removed.
+func pruneTranscripts(dir string, ttl time.Duration) int {
+	if ttl <= 0 {
+		return 0
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0
+	}
+	cutoff := time.Now().Add(-ttl)
+	removed := 0
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil || info.ModTime().After(cutoff) {
+			continue
+		}
+		if os.Remove(filepath.Join(dir, e.Name())) == nil {
+			removed++
+		}
+	}
+	return removed
+}
+
+// transcriptTTL mirrors the machine-session policy (CHATCLI_SESSION_TTL in
+// days, 90 by default, 0 disables expiry).
+func transcriptTTL() time.Duration {
+	days := 90
+	if v := os.Getenv("CHATCLI_SESSION_TTL"); v != "" {
+		if n, err := strconv.Atoi(strings.TrimSuffix(v, "d")); err == nil {
+			if n == 0 {
+				return 0
+			}
+			if n > 0 {
+				days = n
+			}
+		}
+	}
+	return time.Duration(days) * 24 * time.Hour
+}
+
+// --- ChatCLI wiring ---
+
+// initTranscriptJournal opens the session journal at boot (or adopts an
+// existing id when a saved session that carries one is loaded).
+func (cli *ChatCLI) initTranscriptJournal(id string) {
+	if !transcriptEnabled() {
+		return
+	}
+	dir, err := transcriptDir()
+	if err != nil {
+		if cli.logger != nil {
+			cli.logger.Warn("transcript journal unavailable", zap.Error(err))
+		}
+		return
+	}
+	if id == "" {
+		id = newTranscriptID(time.Now())
+	}
+	j, err := openTranscriptJournal(dir, id)
+	if err != nil {
+		if cli.logger != nil {
+			cli.logger.Warn("transcript journal could not be opened", zap.Error(err))
+		}
+		return
+	}
+	cli.transcript = j
+	if removed := pruneTranscripts(dir, transcriptTTL()); removed > 0 && cli.logger != nil {
+		cli.logger.Info("expired transcript journals pruned", zap.Int("removed", removed))
+	}
+}
+
+// syncTranscript journals whatever the live history gained since the last
+// call. Errors are logged, never surfaced: the journal must not break a turn.
+func (cli *ChatCLI) syncTranscript() {
+	if cli == nil || cli.transcript == nil {
+		return
+	}
+	if err := cli.transcript.Sync(cli.history); err != nil && cli.logger != nil {
+		cli.logger.Warn("transcript journal append failed", zap.Error(err))
+	}
+}
+
+// transcriptID returns the active journal id ("" when disabled).
+func (cli *ChatCLI) transcriptID() string {
+	if cli == nil || cli.transcript == nil {
+		return ""
+	}
+	return cli.transcript.id
+}
+
+// adoptTranscript switches the journal to the id a loaded session carries,
+// so its record keeps growing in the same file across resumes. A session
+// without an id keeps the current journal.
+func (cli *ChatCLI) adoptTranscript(id string) {
+	if id == "" || (cli.transcript != nil && cli.transcript.id == id) {
+		return
+	}
+	cli.initTranscriptJournal(id)
+}

--- a/cli/transcript_journal_test.go
+++ b/cli/transcript_journal_test.go
@@ -1,0 +1,265 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/diillson/chatcli/cli/workspace"
+	"github.com/diillson/chatcli/models"
+	"github.com/diillson/chatcli/pkg/atrest"
+	"go.uber.org/zap"
+)
+
+func TestTranscriptJournal_AppendsOnceAndRecordsRewrites(t *testing.T) {
+	t.Setenv(atrest.EnvKey, "")
+	dir := t.TempDir()
+	j, err := openTranscriptJournal(dir, "tr-test")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	h := []models.Message{
+		{Role: "system", Content: "sys"},
+		{Role: "user", Content: "u1"},
+		{Role: "assistant", Content: "a1"},
+	}
+	if err := j.Sync(h); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	// Same history again: nothing new appended.
+	if err := j.Sync(h); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	h = append(h, models.Message{Role: "tool", Content: "bytes", ToolCallID: "t1"})
+	if err := j.Sync(h); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	msgs, err := readTranscript(j.path)
+	if err != nil || len(msgs) != 4 {
+		t.Fatalf("journal = %d msgs err=%v", len(msgs), err)
+	}
+
+	// Compaction rewrote the middle: a rewrite event plus only the NEW
+	// summary message are appended; kept messages are not duplicated.
+	compacted := []models.Message{
+		h[0],
+		{Role: "user", Content: "[STRUCTURED SUMMARY]", Meta: &models.MessageMeta{IsSummary: true}},
+		h[3],
+	}
+	if err := j.Sync(compacted); err != nil {
+		t.Fatalf("sync after rewrite: %v", err)
+	}
+	msgs, _ = readTranscript(j.path)
+	if len(msgs) != 5 || msgs[4].Content != "[STRUCTURED SUMMARY]" {
+		t.Fatalf("after rewrite journal = %d msgs, last=%q", len(msgs), msgs[len(msgs)-1].Content)
+	}
+	raw, _ := os.ReadFile(j.path)
+	if !strings.Contains(string(raw), `"kind":"rewrite"`) {
+		t.Fatal("rewrite event missing from the journal")
+	}
+	// The original u1/a1 are still in the record even though the window lost them.
+	if msgs[1].Content != "u1" || msgs[2].Content != "a1" {
+		t.Fatal("pre-compaction messages must stay in the journal")
+	}
+}
+
+func TestTranscriptJournal_ResumeDoesNotDuplicate(t *testing.T) {
+	t.Setenv(atrest.EnvKey, "")
+	dir := t.TempDir()
+	j, _ := openTranscriptJournal(dir, "tr-resume")
+	h := []models.Message{{Role: "user", Content: "u1"}, {Role: "assistant", Content: "a1"}}
+	_ = j.Sync(h)
+
+	// A new process adopts the same id and syncs the same history.
+	j2, err := openTranscriptJournal(dir, "tr-resume")
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	h = append(h, models.Message{Role: "user", Content: "u2"})
+	if err := j2.Sync(h); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	msgs, _ := readTranscript(j2.path)
+	if len(msgs) != 3 {
+		t.Fatalf("resume must not duplicate journaled messages, got %d", len(msgs))
+	}
+}
+
+func TestTranscriptJournal_SealedLinesWhenEncryptionEnabled(t *testing.T) {
+	t.Setenv(atrest.EnvKey, "journal-key")
+	dir := t.TempDir()
+	j, _ := openTranscriptJournal(dir, "tr-sealed")
+	if err := j.Sync([]models.Message{{Role: "user", Content: "launch codes alpha"}}); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	raw, _ := os.ReadFile(j.path)
+	if strings.Contains(string(raw), "launch codes") || !strings.HasPrefix(string(raw), sealedLinePrefix) {
+		t.Fatalf("journal line must be sealed: %q", raw)
+	}
+	msgs, err := readTranscript(j.path)
+	if err != nil || len(msgs) != 1 || msgs[0].Content != "launch codes alpha" {
+		t.Fatalf("sealed journal must read back: %v %+v", err, msgs)
+	}
+	t.Setenv(atrest.EnvKey, "")
+	if _, err := readTranscript(j.path); err == nil {
+		t.Fatal("sealed journal must not open without the key")
+	}
+}
+
+func TestTranscriptJournal_InvalidIDAndPrune(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := openTranscriptJournal(dir, "../escape"); err == nil {
+		t.Fatal("path-traversal id must be rejected")
+	}
+	old := filepath.Join(dir, "tr-old.jsonl")
+	_ = os.WriteFile(old, []byte("{}\n"), 0o600)
+	stale := time.Now().Add(-100 * 24 * time.Hour)
+	_ = os.Chtimes(old, stale, stale)
+	fresh := filepath.Join(dir, "tr-new.jsonl")
+	_ = os.WriteFile(fresh, []byte("{}\n"), 0o600)
+	if n := pruneTranscripts(dir, 90*24*time.Hour); n != 1 {
+		t.Fatalf("prune removed %d, want 1", n)
+	}
+	if _, err := os.Stat(fresh); err != nil {
+		t.Fatal("fresh journal must survive")
+	}
+	if n := pruneTranscripts(dir, 0); n != 0 {
+		t.Fatal("zero ttl must keep everything")
+	}
+	t.Setenv(TranscriptEnv, "false")
+	if transcriptEnabled() {
+		t.Fatal("env kill switch not honored")
+	}
+	t.Setenv(TranscriptEnv, "")
+	if !transcriptEnabled() {
+		t.Fatal("default must be enabled")
+	}
+}
+
+func TestMemoryFlush_NilSafe(t *testing.T) {
+	cli := &ChatCLI{}
+	cli.flushMemoryBeforeCompaction(nil) //nolint:staticcheck // nil ctx is the point: no worker, no work
+	cli.queueMemoryBeforeCompaction()
+	if seg := cli.unextractedSegment(); seg != nil {
+		t.Fatalf("no worker → no segment, got %d", len(seg))
+	}
+}
+
+func TestInitTranscriptJournal_LifecycleUnderTempHome(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(atrest.EnvKey, "")
+	t.Setenv(TranscriptEnv, "")
+	t.Setenv("CHATCLI_SESSION_TTL", "")
+
+	cli := &ChatCLI{logger: zapNop()}
+	cli.initTranscriptJournal("")
+	if cli.transcriptID() == "" || !strings.HasPrefix(cli.transcriptID(), "tr-") {
+		t.Fatalf("journal not opened at boot: %q", cli.transcriptID())
+	}
+	cli.history = []models.Message{{Role: "user", Content: "u1"}, {Role: "assistant", Content: "a1"}}
+	cli.syncTranscript()
+	dir, _ := transcriptDir()
+	msgs, err := readTranscript(filepath.Join(dir, cli.transcriptID()+".jsonl"))
+	if err != nil || len(msgs) != 2 {
+		t.Fatalf("synced journal = %d msgs err=%v", len(msgs), err)
+	}
+
+	// A loaded session that carries its own id switches the journal.
+	first := cli.transcriptID()
+	cli.adoptTranscript("tr-20260903-000000-cafe0000")
+	if cli.transcriptID() == first {
+		t.Fatal("adoptTranscript must switch to the session's journal")
+	}
+	cli.adoptTranscript("") // empty id keeps the current journal
+	if cli.transcriptID() != "tr-20260903-000000-cafe0000" {
+		t.Fatal("empty id must keep the current journal")
+	}
+	cli.adoptTranscript("../escape")
+	if cli.transcriptID() != "tr-20260903-000000-cafe0000" {
+		t.Fatal("invalid id must not replace the journal")
+	}
+
+	// Session data round-trips the id; restore adopts it.
+	sd := cli.buildSessionData()
+	if sd.TranscriptID != cli.transcriptID() {
+		t.Fatalf("session data id = %q", sd.TranscriptID)
+	}
+	other := &ChatCLI{logger: zapNop()}
+	other.restoreSessionData(sd)
+	if other.transcriptID() != sd.TranscriptID {
+		t.Fatalf("restore must adopt the session journal, got %q", other.transcriptID())
+	}
+
+	// Disabled by env: no journal, sync is a no-op.
+	t.Setenv(TranscriptEnv, "false")
+	off := &ChatCLI{logger: zapNop()}
+	off.initTranscriptJournal("")
+	if off.transcriptID() != "" {
+		t.Fatal("journal must stay closed when disabled")
+	}
+	off.syncTranscript()
+}
+
+func TestTranscriptTTL(t *testing.T) {
+	t.Setenv("CHATCLI_SESSION_TTL", "")
+	if got := transcriptTTL(); got != 90*24*time.Hour {
+		t.Fatalf("default ttl = %s", got)
+	}
+	t.Setenv("CHATCLI_SESSION_TTL", "7d")
+	if got := transcriptTTL(); got != 7*24*time.Hour {
+		t.Fatalf("7d ttl = %s", got)
+	}
+	t.Setenv("CHATCLI_SESSION_TTL", "0")
+	if got := transcriptTTL(); got != 0 {
+		t.Fatalf("0 must disable expiry, got %s", got)
+	}
+	t.Setenv("CHATCLI_SESSION_TTL", "garbage")
+	if got := transcriptTTL(); got != 90*24*time.Hour {
+		t.Fatalf("garbage must keep the default, got %s", got)
+	}
+}
+
+func TestMemoryFlush_QueuesUnextractedSegment(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	store := workspace.NewMemoryStore(t.TempDir(), zapNop())
+	cli := &ChatCLI{logger: zapNop(), memoryStore: store}
+	cli.memWorker = newMemoryWorker(cli)
+	cli.history = []models.Message{
+		{Role: "system", Content: "sys"},
+		{Role: "user", Content: "u1"},
+		{Role: "assistant", Content: "a1"},
+		{Role: "user", Content: "u2"},
+		{Role: "assistant", Content: "a2"},
+	}
+	cli.memWorker.lastProcessedIdx = 3 // u1/a1 already extracted
+	seg := cli.unextractedSegment()
+	if len(seg) != 2 || seg[0].Content != "u2" {
+		t.Fatalf("segment = %+v", seg)
+	}
+	cli.queueMemoryBeforeCompaction()
+	if cli.memWorker.lastProcessedIdx != len(cli.history) {
+		t.Fatalf("watermark not advanced: %d", cli.memWorker.lastProcessedIdx)
+	}
+	if files := cli.memWorker.pendingFiles(); len(files) != 1 {
+		t.Fatalf("segment must be queued on the WAL, got %d files", len(files))
+	}
+	// Nothing left → nothing queued again.
+	cli.queueMemoryBeforeCompaction()
+	if files := cli.memWorker.pendingFiles(); len(files) != 1 {
+		t.Fatalf("empty segment must not enqueue, got %d files", len(files))
+	}
+	// A lone trailing user turn is not worth distilling.
+	cli.history = append(cli.history, models.Message{Role: "user", Content: "u3"})
+	if seg := cli.unextractedSegment(); seg != nil {
+		t.Fatalf("single user turn must not form a segment: %+v", seg)
+	}
+}
+
+func zapNop() *zap.Logger { return zap.NewNop() }

--- a/models/models.go
+++ b/models/models.go
@@ -160,6 +160,11 @@ type SessionData struct {
 	AgentHistory []Message `json:"agent_history,omitempty"`
 	CoderHistory []Message `json:"coder_history,omitempty"`
 	SharedMemory []Message `json:"shared_memory,omitempty"`
+	// TranscriptID names the append-only transcript journal this session's
+	// full record lives in (~/.chatcli/transcripts/<id>.jsonl), so a resumed
+	// session keeps writing to the same file. Empty for sessions saved before
+	// journals existed or with the journal disabled.
+	TranscriptID string `json:"transcript_id,omitempty"`
 }
 
 // UsageInfo represents token usage information returned by LLM APIs.


### PR DESCRIPTION
## Summary

P3a of the context audit: the durable full record every leading CLI keeps, plus a memory flush so compaction never loses unextracted facts.

**Transcript journal** (`cli/transcript_journal.go`):
- `~/.chatcli/transcripts/<id>.jsonl`, append-only, fsync per write. Every message appended once (hash-deduped) at: chat turn end, start of every agent/coder turn (previous turn's tool results reach disk before any rewrite stubs them), and agent run exit (deferred, any path).
- History rewrites (auto-compact, `/compact`, microcompact, skill aging, read dedup) → `rewrite` event; only new messages appended, no duplication. Resume reopens by id without re-appending.
- `SessionData.TranscriptID` (additive) so `/session load|attach` keep the same journal.
- Sealed line by line with the at-rest key when `CHATCLI_ENCRYPTION_KEY` is set (reader refuses without the key). Prune with the machine-session TTL (`CHATCLI_SESSION_TTL`). `CHATCLI_SESSION_TRANSCRIPT=false` disables; `/config session` shows the id; registered in `config_env_defaults`.

**Memory flush before compaction** (`cli/memory_flush.go`): every compaction site (chat auto, agent/coder auto, `/compact` auto + guided, one-shot) hands the not-yet-extracted segment (`memWorker.lastProcessedIdx` onward, system messages excluded) to the worker's WAL queue first — `nudgeSegment` on interactive surfaces, `queueSegmentForNextSession` on one-shot — and marks it processed.

## Cross-impact checked

- Journal failures are logged, never surfaced: a turn cannot fail because of the journal.
- The journal is an additive write path; session files, CCR and park snapshots are unchanged.
- Rebased on #1443 (context inspector) — the `ChatCLI` field block merged cleanly.

## Verification

- `go test ./...`: 108 packages ok · `golangci-lint` clean (`cli`, `models`) · i18n parity ok · AI-smells clean
- New tests: append-once + rewrite event + no duplication, resume without duplicates, sealed lines round-trip and refusal without key, invalid id rejection, TTL prune, env kill switch, nil-safe flush.
