### PR TITLE
feat(memory): vector-aware auto-recall with a relevance floor and session-persisted context attachments

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -1428,7 +1428,7 @@ func (a *AgentMode) buildWorkspaceBlocks(ctx context.Context, query string) (str
 	// text changes every turn, and placing it in the stable workspace block
 	// would poison the prompt cache for everything after it.
 	if mode == memModeIndex {
-		if ar := a.cli.memoryAutoRecallBlock(hints); ar != "" {
+		if ar := a.cli.memoryAutoRecallBlockCtx(ctx, hints, query); ar != "" {
 			if dynamicText == "" {
 				dynamicText = ar
 			} else {
@@ -1557,7 +1557,7 @@ func (a *AgentMode) expandFollowUpCommand(ctx context.Context, text string) stri
 // matched. The caller injects the result append-only as a user-role message
 // at the turn boundary, the same protocol-safety contract as the mid-loop
 // skill blocks (never between a tool_use and its tool_result).
-func (a *AgentMode) followUpRecallBlocks(userMsg string) string {
+func (a *AgentMode) followUpRecallBlocks(ctx context.Context, userMsg string) string {
 	userMsg = strings.TrimSpace(userMsg)
 	if userMsg == "" {
 		return ""
@@ -1565,7 +1565,11 @@ func (a *AgentMode) followUpRecallBlocks(userMsg string) string {
 	hints := memory.ExtractKeywords([]string{userMsg})
 	var parts []string
 	if loadMemoryMode() == memModeIndex {
-		if ar := a.cli.memoryAutoRecallBlock(hints); ar != "" {
+		// Bounded so the (optional) embedding call can never stall a turn.
+		recallCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		ar := a.cli.memoryAutoRecallBlockCtx(recallCtx, hints, userMsg)
+		cancel()
+		if ar != "" {
 			parts = append(parts, ar)
 		}
 	}
@@ -2114,7 +2118,7 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 			}
 			// Same trigger surface for proactive recall: a follow-up asking
 			// about past work re-ranks memory/sessions against ITS words.
-			if rb := a.followUpRecallBlocks(userMsg); rb != "" {
+			if rb := a.followUpRecallBlocks(ctx, userMsg); rb != "" {
 				a.cli.history = append(a.cli.history, models.Message{Role: "user", Content: rb})
 			}
 		}
@@ -4065,7 +4069,7 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 			}
 			// And proactive recall against the follow-up's own words — the
 			// system prompt's recall blocks froze at Run() time.
-			if rb := a.followUpRecallBlocks(userInput); rb != "" {
+			if rb := a.followUpRecallBlocks(ctx, userInput); rb != "" {
 				a.cli.history = append(a.cli.history, models.Message{Role: "user", Content: rb})
 			}
 			continue

--- a/cli/chat_pipeline.go
+++ b/cli/chat_pipeline.go
@@ -168,7 +168,7 @@ func (cli *ChatCLI) assembleChatSystemPrompt(
 	// meaningful in index mode (full mode already pushes the whole
 	// retrieval). Mirrors the agent/coder wiring; own env gate inside.
 	if cli.chatEffectiveMemoryMode() == memModeIndex {
-		if ar := cli.memoryAutoRecallBlock(hints); ar != "" {
+		if ar := cli.memoryAutoRecallBlockCtx(ctx, hints, userInput); ar != "" {
 			out.add("memory_recall", models.ContentBlock{Type: "text", Text: ar})
 		}
 	}

--- a/cli/cli_session.go
+++ b/cli/cli_session.go
@@ -176,22 +176,26 @@ func (cli *ChatCLI) handleLoadSession(ctx context.Context, name string) {
 			if choice == "remote" {
 				cli.restoreSessionData(remoteSD)
 				cli.currentSessionName = name
+				cli.applySessionAttachments(remoteSD, name)
 				cli.boundRemoteOnly = true
 				fmt.Println(i18n.T("session.load_success_remote", name))
 			} else {
 				cli.restoreSessionData(localSD)
 				cli.currentSessionName = name
+				cli.applySessionAttachments(localSD, name)
 				cli.boundRemoteOnly = false
 				fmt.Println(i18n.T("session.load_success", name))
 			}
 		case foundLocal:
 			cli.restoreSessionData(localSD)
 			cli.currentSessionName = name
+			cli.applySessionAttachments(localSD, name)
 			cli.boundRemoteOnly = false
 			fmt.Println(i18n.T("session.load_success", name))
 		case foundRemote:
 			cli.restoreSessionData(remoteSD)
 			cli.currentSessionName = name
+			cli.applySessionAttachments(remoteSD, name)
 			cli.boundRemoteOnly = true
 			fmt.Println(i18n.T("session.load_success_remote", name))
 		default:
@@ -207,6 +211,7 @@ func (cli *ChatCLI) handleLoadSession(ctx context.Context, name string) {
 	} else {
 		cli.restoreSessionData(sd)
 		cli.currentSessionName = name
+		cli.applySessionAttachments(sd, name)
 		cli.boundRemoteOnly = false
 		fmt.Println(kit.Notice(kit.LevelSuccess, i18n.T("session.load_success", name)))
 	}
@@ -225,6 +230,7 @@ func (cli *ChatCLI) buildSessionData() *SessionData {
 		Version:      2,
 		ChatHistory:  cli.history,
 		TranscriptID: cli.transcriptID(),
+		Attachments:  cli.sessionAttachments(),
 	}
 }
 

--- a/cli/cli_session_binding.go
+++ b/cli/cli_session_binding.go
@@ -174,5 +174,6 @@ func (cli *ChatCLI) refreshBoundSession() {
 		return
 	}
 	cli.restoreSessionData(sd)
+	cli.applySessionAttachments(sd, name)
 	cli.boundSessionSync = mt
 }

--- a/cli/ctxmgr/manager.go
+++ b/cli/ctxmgr/manager.go
@@ -8,6 +8,7 @@ package ctxmgr
 import (
 	"context"
 	"fmt"
+	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -82,6 +83,26 @@ func NewManager(logger *zap.Logger) (*Manager, error) {
 		logger.Warn("Erro ao carregar contextos do disco", zap.Error(err))
 	}
 
+	return manager, nil
+}
+
+// NewManagerWithBasePath is NewManager over an explicit storage directory —
+// for surfaces and tests that must not touch the user's ~/.chatcli.
+func NewManagerWithBasePath(basePath string, logger *zap.Logger) (*Manager, error) {
+	if err := os.MkdirAll(basePath, 0o700); err != nil {
+		return nil, fmt.Errorf("erro ao inicializar storage: %w", err)
+	}
+	manager := &Manager{
+		contexts:         make(map[string]*FileContext),
+		attachedContexts: make(map[string][]AttachedContext),
+		Storage:          &Storage{basePath: basePath, logger: logger},
+		validator:        NewValidator(logger),
+		processor:        NewProcessor(logger),
+		logger:           logger,
+	}
+	if err := manager.loadContexts(); err != nil {
+		logger.Warn("Erro ao carregar contextos do disco", zap.Error(err))
+	}
 	return manager, nil
 }
 
@@ -486,6 +507,27 @@ func (m *Manager) ListContexts(filter *ContextFilter) ([]*FileContext, error) {
 }
 
 // GetAttachedContexts retorna os contextos anexados a uma sessão
+// AttachedRecords returns copies of the attachment records (context id,
+// priority, selected chunks, retrieval mode) bound to sessionID — what a
+// saved session needs to re-attach the same contexts on load. Attach state
+// is otherwise process-local and was lost on every restart.
+func (m *Manager) AttachedRecords(sessionID string) []AttachedContext {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	src := m.attachedContexts[sessionID]
+	if len(src) == 0 {
+		return nil
+	}
+	out := make([]AttachedContext, len(src))
+	for i, a := range src {
+		out[i] = a
+		if len(a.SelectedChunks) > 0 {
+			out[i].SelectedChunks = append([]int(nil), a.SelectedChunks...)
+		}
+	}
+	return out
+}
+
 func (m *Manager) GetAttachedContexts(sessionID string) ([]*FileContext, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/cli/memory_autorecall.go
+++ b/cli/memory_autorecall.go
@@ -26,6 +26,7 @@
 package cli
 
 import (
+	"context"
 	"os"
 	"strings"
 
@@ -47,6 +48,16 @@ const (
 
 	// autoRecallRelatedMax caps how many graph neighbors the line names.
 	autoRecallRelatedMax = 3
+
+	// autoRecallMinLexical is the keyword-relevance floor for a fact found
+	// by keywords alone (computeRelevance scale): roughly a third of the
+	// turn's hints must hit the fact. Semantic hits are gated by the cosine
+	// floor instead.
+	autoRecallMinLexical = 0.34
+
+	// autoRecallMinQueryChars skips the embedding call for queries too
+	// short to carry meaning ("ok", "sim").
+	autoRecallMinQueryChars = 8
 )
 
 // autoRecallHeader is an English model-facing constant, like memoryRecallHint.
@@ -62,11 +73,29 @@ func memoryAutoRecallEnabled() bool {
 	return true
 }
 
-// memoryAutoRecallBlock ranks the fact index against the turn's hints and
-// renders the top matches as a compact block, or "" when there is nothing
-// relevant to say. Injected facts are marked accessed so reinforcement works
-// exactly as it does for full-mode retrieval.
+// memoryAutoRecallBlock is the context-free form kept for callers that have
+// no query text; it ranks by keywords only (see memoryAutoRecallBlockCtx).
 func (cli *ChatCLI) memoryAutoRecallBlock(hints []string) string {
+	return cli.memoryAutoRecallBlockCtx(context.Background(), hints, "")
+}
+
+// memoryAutoRecallBlockCtx ranks the fact index against the turn's hints —
+// and, when a vector index is wired, against the query's embedding — and
+// renders the top matches as a compact block, or "" when nothing clears the
+// relevance floor. Two changes from the original lexical-only nudge:
+//
+//   - the blended ranker (semantic + lexical + temporal) is used whenever
+//     vectors exist, so a paraphrase with zero keyword overlap can surface;
+//     keyless setups keep the lexical path unchanged;
+//   - a lexical floor (autoRecallMinLexical) and the cosine floor
+//     (MinCosineScore) gate candidates, so one incidental token no longer
+//     injects an unrelated fact into every turn.
+//
+// Injected facts are NOT marked accessed: reinforcing a fact merely for
+// being pushed was self-entrenching (a spuriously surfaced fact climbed its
+// own ranking). Access is reinforced when the model actually pulls detail
+// through the memory tool, as the pull path already does.
+func (cli *ChatCLI) memoryAutoRecallBlockCtx(ctx context.Context, hints []string, query string) string {
 	if !memoryAutoRecallEnabled() || cli.memoryStore == nil || len(hints) == 0 {
 		return ""
 	}
@@ -75,7 +104,24 @@ func (cli *ChatCLI) memoryAutoRecallBlock(hints []string) string {
 		return ""
 	}
 
-	facts := mgr.Facts.Search(hints)
+	cfg := mgr.GetConfig()
+	var semantic map[string]float64
+	if vectors := mgr.VectorIndex(); vectors != nil && vectors.Enabled() && len(strings.TrimSpace(query)) >= autoRecallMinQueryChars {
+		if vec, err := vectors.EmbedQuery(ctx, query); err == nil {
+			topK := cfg.VectorTopK
+			if topK <= 0 {
+				topK = 12
+			}
+			hits := vectors.SimilarFactsScored(vec, topK, cfg.MinCosineScore)
+			if len(hits) > 0 {
+				semantic = make(map[string]float64, len(hits))
+				for _, h := range hits {
+					semantic[h.ID] = h.Score
+				}
+			}
+		}
+	}
+	facts := mgr.Facts.SearchBlendedMin(hints, semantic, cfg.RankWeights, autoRecallMinLexical)
 	if len(facts) == 0 {
 		return ""
 	}
@@ -98,7 +144,6 @@ func (cli *ChatCLI) memoryAutoRecallBlock(hints []string) string {
 	if len(accessed) == 0 {
 		return ""
 	}
-	mgr.Facts.MarkAccessed(accessed)
 
 	// Graph expansion: one compact line naming what is structurally adjacent
 	// to the facts above, so the model knows there is MORE to pull before it

--- a/cli/memory_bootstrap_paths_test.go
+++ b/cli/memory_bootstrap_paths_test.go
@@ -105,14 +105,14 @@ func TestFollowUpRecallBlocks_RefiresRecallMidLoop(t *testing.T) {
 	}
 	a := &AgentMode{cli: cli}
 
-	block := a.followUpRecallBlocks("lembra do problema do kimi que resolvemos?")
+	block := a.followUpRecallBlocks(context.Background(), "lembra do problema do kimi que resolvemos?")
 	if !strings.Contains(block, "[MEMORY AUTO-RECALL]") {
 		t.Errorf("mid-loop follow-up must re-rank facts, got %q", block)
 	}
 	if !strings.Contains(block, "[SESSION RECALL]") {
 		t.Errorf("mid-loop follow-up must re-rank sessions, got %q", block)
 	}
-	if got := a.followUpRecallBlocks("   "); got != "" {
+	if got := a.followUpRecallBlocks(context.Background(), "   "); got != "" {
 		t.Errorf("blank follow-up must inject nothing, got %q", got)
 	}
 }

--- a/cli/session_attachments.go
+++ b/cli/session_attachments.go
@@ -1,0 +1,75 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * /context attach state persisted with the session. Attachments lived only
+ * in the process: a restart, a /session load on another surface or the
+ * gateway daemon picking up a bound session all lost every attached
+ * context. Saved sessions now carry the attachment records and loading one
+ * re-attaches them under the session's own key.
+ */
+package cli
+
+import (
+	"strings"
+
+	"github.com/diillson/chatcli/cli/ctxmgr"
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+// contextSessionKey is the key /context attach records are bound under —
+// the same derivation the chat and agent prompt builders use.
+func (cli *ChatCLI) contextSessionKey() string {
+	if cli.currentSessionName == "" {
+		return "default"
+	}
+	return cli.currentSessionName
+}
+
+// sessionAttachments snapshots the live attachment records for saving.
+func (cli *ChatCLI) sessionAttachments() []models.SessionAttachment {
+	if cli.contextHandler == nil || cli.contextHandler.manager == nil {
+		return nil
+	}
+	records := cli.contextHandler.manager.AttachedRecords(cli.contextSessionKey())
+	if len(records) == 0 {
+		return nil
+	}
+	out := make([]models.SessionAttachment, 0, len(records))
+	for _, r := range records {
+		out = append(out, models.SessionAttachment{
+			ContextID:      r.ContextID,
+			Priority:       r.Priority,
+			SelectedChunks: r.SelectedChunks,
+			RetrievalTopK:  r.RetrievalTopK,
+		})
+	}
+	return out
+}
+
+// applySessionAttachments re-attaches a loaded session's contexts under
+// key. Contexts already attached are left alone; contexts that no longer
+// exist are skipped with a log line — a stale record must never block the
+// load.
+func (cli *ChatCLI) applySessionAttachments(sd *models.SessionData, key string) {
+	if sd == nil || len(sd.Attachments) == 0 || cli.contextHandler == nil || cli.contextHandler.manager == nil {
+		return
+	}
+	mgr := cli.contextHandler.manager
+	for _, a := range sd.Attachments {
+		if strings.TrimSpace(a.ContextID) == "" {
+			continue
+		}
+		err := mgr.AttachContextWithOptions(key, a.ContextID, ctxmgr.AttachOptions{
+			Priority:       a.Priority,
+			SelectedChunks: a.SelectedChunks,
+			RetrievalTopK:  a.RetrievalTopK,
+		})
+		if err != nil && cli.logger != nil {
+			cli.logger.Debug("session attachment not restored",
+				zap.String("context", a.ContextID), zap.String("session", key), zap.Error(err))
+		}
+	}
+}

--- a/cli/session_attachments_test.go
+++ b/cli/session_attachments_test.go
@@ -1,0 +1,110 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/cli/ctxmgr"
+	"github.com/diillson/chatcli/cli/workspace"
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+func newAttachTestCLI(t *testing.T) (*ChatCLI, *ctxmgr.Manager, string) {
+	t.Helper()
+	mgr, err := ctxmgr.NewManagerWithBasePath(t.TempDir(), zap.NewNop())
+	if err != nil {
+		t.Fatalf("manager: %v", err)
+	}
+	src := filepath.Join(t.TempDir(), "notes.md")
+	if err := os.WriteFile(src, []byte("# Notes\nDeploy uses helm.\n"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	fc, err := mgr.CreateContext(context.Background(), "notes", "test", []string{src}, ctxmgr.ModeFull, nil, false)
+	if err != nil {
+		t.Fatalf("create context: %v", err)
+	}
+	cli := &ChatCLI{logger: zap.NewNop(), contextHandler: &ContextHandler{manager: mgr, logger: zap.NewNop()}}
+	return cli, mgr, fc.ID
+}
+
+func TestSessionAttachments_RoundTrip(t *testing.T) {
+	cli, mgr, id := newAttachTestCLI(t)
+	cli.currentSessionName = "work"
+	if err := mgr.AttachContextWithOptions("work", id, ctxmgr.AttachOptions{Priority: 2, RetrievalTopK: 6}); err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+
+	sd := cli.buildSessionData()
+	if len(sd.Attachments) != 1 || sd.Attachments[0].ContextID != id || sd.Attachments[0].RetrievalTopK != 6 || sd.Attachments[0].Priority != 2 {
+		t.Fatalf("attachments not captured: %+v", sd.Attachments)
+	}
+
+	// A fresh process (same store, nothing attached) loads the session.
+	fresh := &ChatCLI{logger: zap.NewNop(), contextHandler: &ContextHandler{manager: mgr, logger: zap.NewNop()}}
+	fresh.applySessionAttachments(sd, "resumed")
+	got := mgr.AttachedRecords("resumed")
+	if len(got) != 1 || got[0].ContextID != id || got[0].RetrievalTopK != 6 {
+		t.Fatalf("attachments not restored: %+v", got)
+	}
+	// Idempotent: applying again does not duplicate.
+	fresh.applySessionAttachments(sd, "resumed")
+	if n := len(mgr.AttachedRecords("resumed")); n != 1 {
+		t.Fatalf("re-apply duplicated attachments: %d", n)
+	}
+	// A stale record (deleted context) is skipped without failing.
+	stale := &models.SessionData{Attachments: []models.SessionAttachment{{ContextID: "ctx-gone"}}}
+	fresh.applySessionAttachments(stale, "resumed")
+	if n := len(mgr.AttachedRecords("resumed")); n != 1 {
+		t.Fatalf("stale record must be skipped: %d", n)
+	}
+	// No handler → nil-safe.
+	(&ChatCLI{}).applySessionAttachments(sd, "x")
+	if (&ChatCLI{}).sessionAttachments() != nil {
+		t.Fatal("no handler → no attachments")
+	}
+}
+
+// Auto-recall must ignore facts that match only an incidental token and
+// must not reinforce facts merely for being pushed.
+func TestMemoryAutoRecall_FloorAndNoReinforcement(t *testing.T) {
+	t.Setenv("CHATCLI_MEMORY_AUTORECALL", "")
+	store := workspace.NewMemoryStore(t.TempDir(), zap.NewNop())
+	cli := &ChatCLI{memoryStore: store, logger: zap.NewNop()}
+	mgr := store.Manager()
+	if mgr == nil || mgr.Facts == nil {
+		t.Skip("memory manager unavailable in this build")
+	}
+	if !mgr.Facts.AddFact("The deploy pipeline uses helm charts from the infra repo", "project", []string{"deploy", "helm"}) {
+		t.Fatal("add fact")
+	}
+
+	before := map[string]int{}
+	for _, f := range mgr.Facts.GetAll() {
+		before[f.ID] = f.AccessCount
+	}
+	strong := cli.memoryAutoRecallBlockCtx(context.Background(), []string{"deploy", "helm", "pipeline"}, "how does the deploy pipeline work")
+	if !strings.Contains(strong, "helm charts") {
+		t.Fatalf("strong match must be recalled, got %q", strong)
+	}
+	weak := cli.memoryAutoRecallBlockCtx(context.Background(), []string{"coffee", "office", "floor", "broken", "repo"}, "the coffee machine on the office floor is broken")
+	if weak != "" {
+		t.Fatalf("one incidental token must not recall the fact, got %q", weak)
+	}
+	for _, f := range mgr.Facts.GetAll() {
+		if f.AccessCount != before[f.ID] {
+			t.Fatalf("auto-recall injection must not reinforce access (before=%d after=%d)", before[f.ID], f.AccessCount)
+		}
+	}
+	if cli.memoryAutoRecallBlock(nil) != "" {
+		t.Fatal("no hints → no block")
+	}
+}

--- a/cli/worker_skill_context.go
+++ b/cli/worker_skill_context.go
@@ -25,6 +25,7 @@
 package cli
 
 import (
+	"context"
 	"strings"
 
 	"github.com/diillson/chatcli/pkg/persona"
@@ -41,7 +42,7 @@ const (
 // proactive recall block plus the trigger-matched skill block for one task.
 func (a *AgentMode) workerTaskContext(task string) string {
 	var parts []string
-	if rb := a.followUpRecallBlocks(task); strings.TrimSpace(rb) != "" {
+	if rb := a.followUpRecallBlocks(context.Background(), task); strings.TrimSpace(rb) != "" {
 		parts = append(parts, rb)
 	}
 	if sb := a.workerSkillBlock(task); strings.TrimSpace(sb) != "" {

--- a/cli/workspace/memory/facts.go
+++ b/cli/workspace/memory/facts.go
@@ -425,6 +425,24 @@ func (fi *FactIndex) Search(keywords []string) []*Fact {
 // are empty it falls back to all facts by temporal score, matching Search's
 // empty-query behavior.
 func (fi *FactIndex) SearchBlended(keywords []string, semantic map[string]float64, w RankWeights) []*Fact {
+	return fi.SearchBlendedMin(keywords, semantic, w, 0)
+}
+
+// reinforcedLexicalHit is the raw computeRelevance score (before keyword
+// normalization) that clears the lexical floor on its own: one content hit
+// (1.0) reinforced by a tag hit (0.5), or two content hits.
+const reinforcedLexicalHit = 1.5
+
+// SearchBlendedMin is SearchBlended with a lexical relevance floor for
+// facts found by keywords alone: the fact must either match at least
+// minLexical of the keywords (computeRelevance scale, 1.0 = every keyword
+// hit in the content) or carry a reinforced hit — a raw score of 1.5, i.e.
+// a content hit backed by a tag hit, or two content hits — so a long
+// natural-language query with one strong term still recalls its fact
+// while one incidental token cannot. Semantic hits are unaffected (the
+// vector floor is MinCosineScore, applied by the caller). A floor of 0
+// keeps every keyword hit, which is what the pull tool wants.
+func (fi *FactIndex) SearchBlendedMin(keywords []string, semantic map[string]float64, w RankWeights, minLexical float64) []*Fact {
 	fi.mu.RLock()
 	defer fi.mu.RUnlock()
 
@@ -435,9 +453,14 @@ func (fi *FactIndex) SearchBlended(keywords []string, semantic map[string]float6
 
 	if len(keywords) > 0 {
 		for _, f := range fi.facts {
-			if rel := fi.computeRelevance(f, keywords); rel > 0 {
-				cands[f.ID] = &candidate{fact: f, lexical: rel, temporal: fi.scoreOf(f, now)}
+			rel := fi.computeRelevance(f, keywords)
+			if rel <= 0 {
+				continue
 			}
+			if minLexical > 0 && rel < minLexical && rel*float64(len(keywords)) < reinforcedLexicalHit {
+				continue
+			}
+			cands[f.ID] = &candidate{fact: f, lexical: rel, temporal: fi.scoreOf(f, now)}
 		}
 	}
 

--- a/cli/workspace/memory/facts_test.go
+++ b/cli/workspace/memory/facts_test.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"go.uber.org/zap"
@@ -137,4 +138,44 @@ func containsStr(haystack, needle string) bool {
 				}
 				return false
 			})())
+}
+
+// A lexical floor drops facts that match only an incidental token while
+// keeping semantic hits and strong keyword matches.
+func TestSearchBlendedMin_LexicalFloor(t *testing.T) {
+	fi := NewFactIndex(t.TempDir(), DefaultConfig(), zap.NewNop())
+	if !fi.AddFact("The deploy pipeline uses helm charts from the infra repo", "project", []string{"deploy", "helm"}) {
+		t.Fatal("add fact")
+	}
+	if !fi.AddFact("Coffee machine on floor two is broken", "misc", nil) {
+		t.Fatal("add fact")
+	}
+	keywords := []string{"deploy", "helm", "pipeline", "two"}
+
+	all := fi.SearchBlended(keywords, nil, DefaultRankWeights())
+	if len(all) != 2 {
+		t.Fatalf("no floor must keep both keyword hits, got %d", len(all))
+	}
+	floored := fi.SearchBlendedMin(keywords, nil, DefaultRankWeights(), 0.34)
+	if len(floored) != 1 || !strings.Contains(floored[0].Content, "helm") {
+		t.Fatalf("floor must keep only the strong match, got %d: %+v", len(floored), floored)
+	}
+	// A semantic hit survives the lexical floor regardless of keywords.
+	var coffeeID string
+	for _, f := range fi.GetAll() {
+		if strings.Contains(f.Content, "Coffee") {
+			coffeeID = f.ID
+		}
+	}
+	sem := map[string]float64{coffeeID: 0.9}
+	withSem := fi.SearchBlendedMin([]string{"deploy"}, sem, DefaultRankWeights(), 0.34)
+	found := false
+	for _, f := range withSem {
+		if f.ID == coffeeID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("semantic hit must not be dropped by the lexical floor")
+	}
 }

--- a/models/models.go
+++ b/models/models.go
@@ -165,6 +165,18 @@ type SessionData struct {
 	// session keeps writing to the same file. Empty for sessions saved before
 	// journals existed or with the journal disabled.
 	TranscriptID string `json:"transcript_id,omitempty"`
+	// Attachments are the /context attach records active when the session
+	// was saved, so loading it re-attaches the same contexts (same chunks
+	// and retrieval mode). Attach state was process-local before.
+	Attachments []SessionAttachment `json:"attachments,omitempty"`
+}
+
+// SessionAttachment mirrors one /context attach record for persistence.
+type SessionAttachment struct {
+	ContextID      string `json:"context_id"`
+	Priority       int    `json:"priority,omitempty"`
+	SelectedChunks []int  `json:"selected_chunks,omitempty"`
+	RetrievalTopK  int    `json:"retrieval_top_k,omitempty"`
 }
 
 // UsageInfo represents token usage information returned by LLM APIs.


### PR DESCRIPTION
## Summary

P3b of the context audit: recall quality and attach persistence.

**Auto-recall quality** (`cli/memory_autorecall.go`, `cli/workspace/memory/facts.go`):
- New `SearchBlendedMin` (lexical floor): a fact found by keywords alone must match ~⅓ of the turn's hints **or** carry a reinforced hit (raw score ≥ 1.5: content hit + tag hit, or two content hits). One incidental token can no longer inject an unrelated fact into every turn; a long natural-language query with one strong term still recalls its fact. `SearchBlended` delegates with floor 0 (pull tool unchanged).
- The proactive block now uses the blended semantic + lexical + temporal ranker whenever a vector index is enabled (one query embedding per turn, skipped under 8 chars; cosine floor `MinCosineScore`). Keyless setups keep the lexical ranker.
- No reinforcement on push: injected facts are no longer `MarkAccessed` (self-entrenching); access is reinforced by the pull tool.
- `followUpRecallBlocks` takes `ctx` (bounded 10 s for the embedding call); callers updated.

**Session-persisted attachments** (`cli/session_attachments.go`):
- `SessionData.Attachments` (additive) captured on every save/write-through from `Manager.AttachedRecords`; `/session load|attach` and the write-through refresh re-attach under the session's own key after `currentSessionName` is set. Already-attached and deleted contexts are skipped.
- `ctxmgr.NewManagerWithBasePath` for surfaces/tests that must not touch `~/.chatcli`.

## Cross-impact checked

- `SearchBlended` behavior unchanged (floor 0); `Facts.Search` untouched.
- Existing `TestExtractKeywordsSeesCurrentInput` (5-token Portuguese query, 1 fact) passes through the reinforced-hit rule.
- `applySessionAttachments` runs after `currentSessionName = name` at all five load sites + the binding refresh, so records land under the key the prompt builders read.

## Verification

- `go test ./...` ok · `golangci-lint` clean (`cli`, `cli/workspace/memory`, `cli/ctxmgr`, `models`) · i18n parity ok · AI-smells clean
- New tests: lexical floor keeps strong/semantic hits and drops incidental ones; auto-recall floor + no reinforcement against a real memory store; attachment round-trip, idempotent re-apply, stale record skipped, nil-safety.
