### PR TITLE
feat(audit): record every LLM request on every surface in the audit trail

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -287,6 +287,10 @@ type ChatCLI struct {
 	// one. Session totals live in /config compression stats.
 	compressionSavedShown int64
 
+	// LLM request audit trail writer (llm_audit.go); nil when the audit
+	// path is not configured.
+	llmAudit *llmAuditWriter
+
 	// Latest assembled system-prompt breakdown (chat and agent paths write
 	// it, /context status reads it).
 	promptBreakdowns promptBreakdownStore
@@ -849,6 +853,7 @@ func NewChatCLI(ctx context.Context, manager manager.LLMManager, logger *zap.Log
 	// from environment config, and wire the @compress/@recall tools to it. The
 	// layer is also consulted by the agent/coder loop to compress tool output.
 	cli.initTranscriptJournal("")
+	cli.initLLMAudit("repl")
 	cli.compressionLayer = compress.NewLayerFromEnv(filepath.Join(homeDir, ".chatcli"))
 	if err := cli.compressionLayer.StoreFallback(); err != nil {
 		// The layer already degraded to a bounded in-memory store; surface the
@@ -2074,6 +2079,12 @@ func (cli *ChatCLI) cleanup(ctx context.Context) {
 	if cli.hubLocalClose != nil {
 		cli.hubLocalClose()
 		cli.hubLocalClose = nil
+	}
+
+	// Flush and detach the LLM request audit trail.
+	if cli.llmAudit != nil {
+		cli.llmAudit.close()
+		cli.llmAudit = nil
 	}
 
 	// Fire SessionEnd hook

--- a/cli/content_redactor.go
+++ b/cli/content_redactor.go
@@ -106,6 +106,7 @@ func redactSecretsWithMode(text string, mode contentRedactMode) string {
 	if mode == contentRedactOff || text == "" {
 		return text
 	}
+	original := text
 	redactor := envRedactorFor(mode)
 
 	// Layer 1: name-based KEY=VALUE redaction, line by line. Only lines
@@ -136,5 +137,9 @@ func redactSecretsWithMode(text string, mode contentRedactMode) string {
 	}
 
 	// Layer 2: value-shape scan over the whole text.
-	return utils.SanitizeSensitiveText(text)
+	out := utils.SanitizeSensitiveText(text)
+	if out != original {
+		redactionsTotal.Add(1)
+	}
+	return out
 }

--- a/cli/cost_tracker.go
+++ b/cli/cost_tracker.go
@@ -1309,3 +1309,11 @@ func cacheWrite1hCost(provider, model string, write5m float64) float64 {
 	}
 	return write5m
 }
+
+// sessionIDSnapshot returns the current cost-session id (reset by /cost
+// reset); the audit trail keys its lines by it.
+func (ct *CostTracker) sessionIDSnapshot() string {
+	ct.mu.RLock()
+	defer ct.mu.RUnlock()
+	return ct.sessionID
+}

--- a/cli/llm_audit.go
+++ b/cli/llm_audit.go
@@ -78,7 +78,7 @@ func (cli *ChatCLI) initLLMAudit(surface string) {
 		}
 		return
 	}
-	f, err := os.OpenFile(clean, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600) // #nosec G304 -- operator-configured absolute path
+	f, err := os.OpenFile(clean, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600) // #nosec G304 G703 -- operator-configured absolute path (env), cleaned and required absolute above
 	if err != nil {
 		if cli.logger != nil {
 			cli.logger.Error("failed to open audit log for LLM requests", zap.String("path", clean), zap.Error(err))

--- a/cli/llm_audit.go
+++ b/cli/llm_audit.go
@@ -1,0 +1,138 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * LLM request audit trail. The gRPC server already audited transport
+ * metadata; nothing recorded what the interactive surfaces sent to which
+ * provider. With CHATCLI_AUDIT_LOG_PATH set, every request on every
+ * surface now leaves a JSON line: when, which provider and model, how
+ * large the payload was, how much history and how many cache markers it
+ * carried, the outcome, the latency, the token usage the provider
+ * reported and the running count of secrets redacted from what the model
+ * received. Never the prompt content. The sink hangs off the observability
+ * chokepoint every adapter passes through, so a new provider is audited
+ * the day it ships.
+ */
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/diillson/chatcli/llm/client"
+	"go.uber.org/zap"
+)
+
+// AuditLogPathEnv is shared with the gRPC audit logger: one file, one
+// format, both surfaces.
+const AuditLogPathEnv = "CHATCLI_AUDIT_LOG_PATH"
+
+// redactionsTotal counts content rewrites the LLM-path redactor performed
+// in this process; reported on every audit line so an operator can tell a
+// session that carried secrets from one that did not.
+var redactionsTotal atomic.Int64
+
+// llmAuditEntry is one audit line.
+type llmAuditEntry struct {
+	Timestamp  string            `json:"timestamp"`
+	Kind       string            `json:"kind"` // "llm"
+	Phase      string            `json:"phase"`
+	Surface    string            `json:"surface,omitempty"`
+	Session    string            `json:"session,omitempty"`
+	Provider   string            `json:"provider"`
+	Model      string            `json:"model"`
+	Status     string            `json:"status,omitempty"`
+	DurationMS int64             `json:"duration_ms,omitempty"`
+	Redactions int64             `json:"redactions_total"`
+	Fields     map[string]string `json:"fields,omitempty"`
+}
+
+// llmAuditWriter appends entries to the audit file.
+type llmAuditWriter struct {
+	mu      sync.Mutex
+	f       *os.File
+	enc     *json.Encoder
+	surface string
+	session func() string
+	logger  *zap.Logger
+}
+
+// initLLMAudit installs the request auditor when the audit path is
+// configured. surface names the process role for the trail (repl, oneshot,
+// gateway, mcp, ...). Failures are logged and leave auditing off — the
+// trail must never block a session from starting.
+func (cli *ChatCLI) initLLMAudit(surface string) {
+	path := os.Getenv(AuditLogPathEnv)
+	if path == "" {
+		return
+	}
+	clean := filepath.Clean(path)
+	if !filepath.IsAbs(clean) {
+		if cli.logger != nil {
+			cli.logger.Error("audit log path must be absolute; LLM audit disabled", zap.String("path", path))
+		}
+		return
+	}
+	f, err := os.OpenFile(clean, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600) // #nosec G304 -- operator-configured absolute path
+	if err != nil {
+		if cli.logger != nil {
+			cli.logger.Error("failed to open audit log for LLM requests", zap.String("path", clean), zap.Error(err))
+		}
+		return
+	}
+	w := &llmAuditWriter{f: f, enc: json.NewEncoder(f), surface: surface, logger: cli.logger}
+	w.session = func() string {
+		if cli.costTracker == nil {
+			return ""
+		}
+		return cli.costTracker.sessionIDSnapshot()
+	}
+	cli.llmAudit = w
+	client.RegisterRequestAuditor(w.record)
+}
+
+// record is the RequestAuditor callback.
+func (w *llmAuditWriter) record(ev client.RequestAuditEvent) {
+	entry := llmAuditEntry{
+		Timestamp:  ev.Time.UTC().Format(time.RFC3339Nano),
+		Kind:       "llm",
+		Phase:      ev.Phase,
+		Surface:    w.surface,
+		Provider:   ev.Provider,
+		Model:      ev.Model,
+		Status:     ev.Status,
+		Redactions: redactionsTotal.Load(),
+		Fields:     ev.Fields,
+	}
+	if ev.Duration > 0 {
+		entry.DurationMS = ev.Duration.Milliseconds()
+	}
+	if w.session != nil {
+		entry.Session = w.session()
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if err := w.enc.Encode(entry); err != nil && w.logger != nil {
+		w.logger.Warn("audit log write failed", zap.Error(err))
+	}
+}
+
+// close detaches the sink and closes the file.
+func (w *llmAuditWriter) close() {
+	if w == nil {
+		return
+	}
+	client.RegisterRequestAuditor(nil)
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.f != nil {
+		_ = w.f.Sync()
+		_ = w.f.Close()
+		w.f = nil
+	}
+}

--- a/cli/llm_audit_test.go
+++ b/cli/llm_audit_test.go
@@ -1,0 +1,90 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/diillson/chatcli/llm/client"
+	"go.uber.org/zap"
+)
+
+func TestLLMAudit_WritesOneLinePerPhase(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	t.Setenv(AuditLogPathEnv, path)
+	t.Setenv("CHATCLI_ENV_REDACT_MODE", "")
+
+	cli := &ChatCLI{logger: zap.NewNop(), costTracker: NewCostTracker()}
+	cli.initLLMAudit("test")
+	if cli.llmAudit == nil {
+		t.Fatal("audit writer not installed")
+	}
+	t.Cleanup(cli.llmAudit.close)
+
+	before := redactionsTotal.Load()
+	_ = redactSecretsWithMode("OPENAI_API_KEY="+strings.Repeat("k", 24), contentRedactPermissive)
+	if redactionsTotal.Load() != before+1 {
+		t.Fatal("a rewrite must bump the redaction counter")
+	}
+	_ = redactSecretsWithMode("plain text", contentRedactPermissive)
+	if redactionsTotal.Load() != before+1 {
+		t.Fatal("an untouched text must not bump the counter")
+	}
+
+	client.LogRequestStart(zap.NewNop(), "CLAUDEAI", "claude-sonnet-5", zap.Int("payload_bytes", 4096), zap.Int("cache_markers", 3))
+	client.LogRequestFinish(zap.NewNop(), "CLAUDEAI", "claude-sonnet-5", "success", 120*time.Millisecond, zap.Int("prompt_tokens", 900))
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open audit: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	var lines []llmAuditEntry
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		var e llmAuditEntry
+		if err := json.Unmarshal(sc.Bytes(), &e); err != nil {
+			t.Fatalf("bad line %q: %v", sc.Text(), err)
+		}
+		lines = append(lines, e)
+	}
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 audit lines, got %d", len(lines))
+	}
+	send, recv := lines[0], lines[1]
+	if send.Kind != "llm" || send.Phase != "send" || send.Provider != "CLAUDEAI" || send.Surface != "test" ||
+		send.Fields["payload_bytes"] != "4096" || send.Fields["cache_markers"] != "3" || send.Session == "" {
+		t.Fatalf("send line = %+v", send)
+	}
+	if recv.Phase != "recv" || recv.Status != "success" || recv.DurationMS != 120 || recv.Fields["prompt_tokens"] != "900" ||
+		recv.Redactions < before+1 {
+		t.Fatalf("recv line = %+v", recv)
+	}
+	if strings.Contains(send.Timestamp, " ") || !strings.HasSuffix(send.Timestamp, "Z") {
+		t.Fatalf("timestamp must be RFC3339 UTC: %q", send.Timestamp)
+	}
+}
+
+func TestLLMAudit_RelativePathOrUnsetDisables(t *testing.T) {
+	t.Setenv(AuditLogPathEnv, "relative/audit.jsonl")
+	cli := &ChatCLI{logger: zap.NewNop()}
+	cli.initLLMAudit("test")
+	if cli.llmAudit != nil {
+		t.Fatal("relative path must not enable auditing")
+	}
+	t.Setenv(AuditLogPathEnv, "")
+	cli.initLLMAudit("test")
+	if cli.llmAudit != nil {
+		t.Fatal("unset path must not enable auditing")
+	}
+	cli.llmAudit.close() // nil-safe
+}

--- a/llm/client/audit.go
+++ b/llm/client/audit.go
@@ -1,0 +1,89 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Request audit sink. LogRequestStart/LogRequestFinish are the one
+ * chokepoint every provider adapter passes through, so a sink registered
+ * here sees every LLM request on every surface (REPL, one-shot, gateway,
+ * MCP/ACP server, workers) without touching the adapters. The sink
+ * receives the same structured fields the logs carry — provider, model,
+ * payload size, history length, cache markers, tokens, status, duration —
+ * and never the prompt content.
+ */
+package client
+
+import (
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// RequestAuditEvent is one send or receive observation.
+type RequestAuditEvent struct {
+	Time     time.Time
+	Phase    string // "send" | "recv"
+	Provider string
+	Model    string
+	Status   string        // recv only: success | error | canceled
+	Duration time.Duration // recv only
+	Fields   map[string]string
+}
+
+// RequestAuditor consumes audit events.
+type RequestAuditor func(RequestAuditEvent)
+
+var (
+	auditMu      sync.RWMutex
+	auditSink    RequestAuditor
+	auditEnabled bool
+)
+
+// RegisterRequestAuditor installs the sink (nil clears it).
+func RegisterRequestAuditor(fn RequestAuditor) {
+	auditMu.Lock()
+	auditSink = fn
+	auditEnabled = fn != nil
+	auditMu.Unlock()
+}
+
+func emitAudit(ev RequestAuditEvent) {
+	auditMu.RLock()
+	fn := auditSink
+	auditMu.RUnlock()
+	if fn != nil {
+		fn(ev)
+	}
+}
+
+// fieldsToStrings flattens zap fields into the string map audit lines
+// carry. Only scalar types are rendered; anything else is skipped rather
+// than dumped, so a stray object field can never leak content.
+func fieldsToStrings(fields []zap.Field) map[string]string {
+	if len(fields) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(fields))
+	for _, f := range fields {
+		switch f.Type {
+		case zapcore.StringType:
+			out[f.Key] = f.String
+		case zapcore.Int64Type, zapcore.Int32Type, zapcore.Int16Type, zapcore.Int8Type,
+			zapcore.Uint64Type, zapcore.Uint32Type, zapcore.Uint16Type, zapcore.Uint8Type:
+			out[f.Key] = formatInt(f.Integer)
+		case zapcore.BoolType:
+			if f.Integer == 1 {
+				out[f.Key] = "true"
+			} else {
+				out[f.Key] = "false"
+			}
+		case zapcore.DurationType:
+			out[f.Key] = time.Duration(f.Integer).String()
+		case zapcore.Float64Type:
+			out[f.Key] = formatFloatBits(f.Integer)
+		}
+	}
+	return out
+}

--- a/llm/client/audit_format.go
+++ b/llm/client/audit_format.go
@@ -1,0 +1,18 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package client
+
+import (
+	"math"
+	"strconv"
+)
+
+func formatInt(v int64) string { return strconv.FormatInt(v, 10) }
+
+// formatFloatBits renders a zap Float64 field (stored as IEEE bits).
+func formatFloatBits(bits int64) string {
+	return strconv.FormatFloat(math.Float64frombits(uint64(bits)), 'g', -1, 64) // #nosec G115 -- zap stores float64 fields as their raw IEEE-754 bit pattern in Integer; this is the documented inverse
+}

--- a/llm/client/audit_test.go
+++ b/llm/client/audit_test.go
@@ -1,0 +1,50 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package client
+
+import (
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+func TestRequestAuditor_ReceivesSendAndRecv(t *testing.T) {
+	var got []RequestAuditEvent
+	RegisterRequestAuditor(func(ev RequestAuditEvent) { got = append(got, ev) })
+	t.Cleanup(func() { RegisterRequestAuditor(nil) })
+
+	LogRequestStart(zap.NewNop(), "OPENAI", "gpt-5.6",
+		zap.Int("payload_bytes", 1234), zap.Int("history_len", 7), zap.Bool("stream", true),
+		zap.Duration("timeout", 3*time.Second), zap.Float64("temperature", 0.5), zap.Any("body", map[string]int{"x": 1}))
+	LogRequestFinish(nil, "OPENAI", "gpt-5.6", "success", 250*time.Millisecond, zap.String("stop", "end"))
+
+	if len(got) != 2 {
+		t.Fatalf("expected send+recv, got %d", len(got))
+	}
+	send := got[0]
+	if send.Phase != "send" || send.Provider != "OPENAI" || send.Model != "gpt-5.6" {
+		t.Fatalf("send = %+v", send)
+	}
+	if send.Fields["payload_bytes"] != "1234" || send.Fields["history_len"] != "7" || send.Fields["stream"] != "true" ||
+		send.Fields["timeout"] != "3s" || send.Fields["temperature"] != "0.5" {
+		t.Fatalf("fields = %v", send.Fields)
+	}
+	if _, leaked := send.Fields["body"]; leaked {
+		t.Fatal("non-scalar fields must never reach the audit trail")
+	}
+	recv := got[1]
+	if recv.Phase != "recv" || recv.Status != "success" || recv.Duration != 250*time.Millisecond || recv.Fields["stop"] != "end" {
+		t.Fatalf("recv = %+v", recv)
+	}
+
+	// Cleared sink: no panic, nothing recorded.
+	RegisterRequestAuditor(nil)
+	LogRequestStart(zap.NewNop(), "XAI", "grok-4.6")
+	if len(got) != 2 {
+		t.Fatal("events recorded after the sink was cleared")
+	}
+}

--- a/llm/client/observability.go
+++ b/llm/client/observability.go
@@ -25,12 +25,18 @@ import (
 // traceable without flipping the global logger to DEBUG.
 func LogRequestStart(logger *zap.Logger, provider, model string, fields ...zap.Field) {
 	if logger == nil {
+		if auditEnabled {
+			emitAudit(RequestAuditEvent{Time: time.Now(), Phase: "send", Provider: provider, Model: model, Fields: fieldsToStrings(fields)})
+		}
 		return
 	}
 	base := make([]zap.Field, 0, 2+len(fields))
 	base = append(base, zap.String("provider", provider), zap.String("model", model))
 	base = append(base, fields...)
 	logger.Info("llm: send", base...)
+	if auditEnabled {
+		emitAudit(RequestAuditEvent{Time: time.Now(), Phase: "send", Provider: provider, Model: model, Fields: fieldsToStrings(fields)})
+	}
 }
 
 // LogRequestFinish emits an INFO log paired with LogRequestStart when
@@ -41,6 +47,10 @@ func LogRequestStart(logger *zap.Logger, provider, model string, fields ...zap.F
 // and tail latencies without parsing free-form error text.
 func LogRequestFinish(logger *zap.Logger, provider, model, status string, duration time.Duration, fields ...zap.Field) {
 	if logger == nil {
+		if auditEnabled {
+			emitAudit(RequestAuditEvent{Time: time.Now(), Phase: "recv", Provider: provider, Model: model,
+				Status: status, Duration: duration, Fields: fieldsToStrings(fields)})
+		}
 		return
 	}
 	base := make([]zap.Field, 0, 4+len(fields))
@@ -52,6 +62,10 @@ func LogRequestFinish(logger *zap.Logger, provider, model, status string, durati
 	)
 	base = append(base, fields...)
 	logger.Info("llm: recv", base...)
+	if auditEnabled {
+		emitAudit(RequestAuditEvent{Time: time.Now(), Phase: "recv", Provider: provider, Model: model,
+			Status: status, Duration: duration, Fields: fieldsToStrings(fields)})
+	}
 }
 
 // CountAnthropicCacheMarkers walks an Anthropic-style request body and


### PR DESCRIPTION
## Summary

P4a of the context audit: content-level audit trail for every LLM request, on every surface and every provider.

- `client.RegisterRequestAuditor` hooks the existing `LogRequestStart`/`LogRequestFinish` chokepoint (used by all 15 provider adapters — 23 send / 55 finish call sites, no adapter changes). Structured fields are flattened to scalars only; non-scalar fields are dropped.
- `cli/llm_audit.go` writes JSONL (`kind: "llm"`, phase `send`/`recv`, surface, cost-session id, provider, model, status, `duration_ms`, `redactions_total`, fields such as `payload_bytes`, `history_len`, `cache_markers`, token usage) to `CHATCLI_AUDIT_LOG_PATH` — the same variable and file the gRPC audit logger uses. Absolute path required, `0600`, closed on cleanup.
- The LLM-path redactor now counts rewrites (`redactionsTotal`) so each line states how many secrets were masked in this process so far.

## Cross-impact checked

- Inert unless the path is set; the sink is a nil-checked global behind an enabled flag, so adapters pay one branch per request. Works with a nil logger too.
- No new environment variables.

## Verification

- `go test ./...`: 108 packages ok · `golangci-lint` clean (`cli`, `llm/client`) · i18n parity ok · AI-smells clean
- New tests: sink receives send/recv with flattened scalar fields and drops non-scalars; writer emits one RFC3339-UTC line per phase with session id and redaction counter; relative/unset path disables; nil-safe close.

Docs (chatcli.ai en+pt, security page "LLM request trail") are staged in the docs repo for after merge.
