### PR TITLE
feat(gateway): per-principal store sets under hub isolation

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -291,6 +291,15 @@ type ChatCLI struct {
 	// path is not configured.
 	llmAudit *llmAuditWriter
 
+	// stateRoot is the directory the durable stores live under
+	// (~/.chatcli by default; a tenant root while a per-principal store set
+	// is active — see tenant_scope.go). bootstrapLoader and workspaceDir are
+	// kept so tenant store sets can rebuild the context builder.
+	stateRoot       string
+	bootstrapLoader *workspace.BootstrapLoader
+	workspaceDir    string
+	tenants         *tenantPool
+
 	// Latest assembled system-prompt breakdown (chat and agent paths write
 	// it, /context status reads it).
 	promptBreakdowns promptBreakdownStore
@@ -810,6 +819,7 @@ func NewChatCLI(ctx context.Context, manager manager.LLMManager, logger *zap.Log
 	// Initialize workspace context (bootstrap files + memory)
 	homeDir, _ := os.UserHomeDir()
 	globalDir := filepath.Join(homeDir, ".chatcli")
+	cli.stateRoot = globalDir
 	workspaceDir := detectProjectDir()
 	if workspaceDir == "" {
 		workspaceDir, _ = os.Getwd()
@@ -933,6 +943,8 @@ func NewChatCLI(ctx context.Context, manager manager.LLMManager, logger *zap.Log
 	// search past conversations.
 	plugins.SetSessionAdapter(&sessionPluginAdapter{cli: cli})
 	cli.contextBuilder = workspace.NewContextBuilder(bootstrapLoader, memStore, workspaceDir)
+	cli.bootstrapLoader = bootstrapLoader
+	cli.workspaceDir = workspaceDir
 
 	// Start background memory annotation worker
 	if memoryEnabled {

--- a/cli/config_env_defaults.go
+++ b/cli/config_env_defaults.go
@@ -178,12 +178,13 @@ var envDefaults = map[string]envDefault{
 	"CHATCLI_EMBED_DIMENSIONS": {Value: "(provider-default)", Source: "openai 1536, google 3072 (128-3072), titan-v2 1024 (256/512/1024), titan-v1 1536, cohere-v3 1024, cohere-v4 1536, nova-mme 3072 (256/384/1024/3072)"},
 
 	// ─── Cost / budget ───────────────────────────────────────────
-	"CHATCLI_SESSION_BUDGET_USD": {Value: "(no budget)", Source: "cost_tracker.go"},
-	"CHATCLI_BUDGET_WARNING_PCT": {Value: "0.80", Source: "cost_tracker.go"},
-	"CHATCLI_BUDGET_HARD_STOP":   {Value: "false", IsBool: true, Source: "cost_tracker.go (refuse turns once budget exceeded)"},
-	"CHATCLI_SESSION_TTL":        {Value: "90", Source: "session_manager.go (days)"},
-	"CHATCLI_SESSION_TRANSCRIPT": {Value: "true", IsBool: true, Source: "transcript_journal.go (append-only ~/.chatcli/transcripts/<id>.jsonl)"},
-	"CHATCLI_DISABLE_HISTORY":    {Value: "false", IsBool: true, Source: "history_manager.go"},
+	"CHATCLI_SESSION_BUDGET_USD":  {Value: "(no budget)", Source: "cost_tracker.go"},
+	"CHATCLI_BUDGET_WARNING_PCT":  {Value: "0.80", Source: "cost_tracker.go"},
+	"CHATCLI_BUDGET_HARD_STOP":    {Value: "false", IsBool: true, Source: "cost_tracker.go (refuse turns once budget exceeded)"},
+	"CHATCLI_SESSION_TTL":         {Value: "90", Source: "session_manager.go (days)"},
+	"CHATCLI_GATEWAY_MAX_TENANTS": {Value: "16", Source: "tenant_scope.go (resident per-principal store sets, hub isolation)"},
+	"CHATCLI_SESSION_TRANSCRIPT":  {Value: "true", IsBool: true, Source: "transcript_journal.go (append-only ~/.chatcli/transcripts/<id>.jsonl)"},
+	"CHATCLI_DISABLE_HISTORY":     {Value: "false", IsBool: true, Source: "history_manager.go"},
 
 	// ─── Memory / bootstrap ──────────────────────────────────────
 	"CHATCLI_MEMORY_ENABLED":    {Value: "true", IsBool: true, Source: "memory.go"},

--- a/cli/config_sections.go
+++ b/cli/config_sections.go
@@ -1486,6 +1486,11 @@ func (cli *ChatCLI) showConfigHub(ctx context.Context) {
 	kv(p, "bindings", presence(os.Getenv("CHATCLI_HUB_BINDINGS")))
 	kv(p, "db", envOr("CHATCLI_HUB_DB"))
 	kv(p, "CHATCLI_HUB_RUNS", envOr("CHATCLI_HUB_RUNS"))
+	maxTenants := strconv.Itoa(gatewayMaxTenants())
+	if strings.TrimSpace(os.Getenv(GatewayMaxTenantsEnv)) == "" {
+		maxTenants = defaultMarker + maxTenants
+	}
+	kv(p, GatewayMaxTenantsEnv, maxTenants)
 
 	fmt.Println(p)
 	if mutable {

--- a/cli/context_handler.go
+++ b/cli/context_handler.go
@@ -38,6 +38,16 @@ func NewContextHandler(logger *zap.Logger) (*ContextHandler, error) {
 	}, nil
 }
 
+// NewContextHandlerAt is NewContextHandler over an explicit contexts
+// directory (per-tenant store sets in the gateway, tests).
+func NewContextHandlerAt(basePath string, logger *zap.Logger) (*ContextHandler, error) {
+	manager, err := ctxmgr.NewManagerWithBasePath(basePath, logger)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ctx.cmd.init_manager_error"), err)
+	}
+	return &ContextHandler{manager: manager, logger: logger}, nil
+}
+
 // HandleContextCommand processa comandos /context
 func (h *ContextHandler) HandleContextCommand(ctx context.Context, sessionID, input string) error {
 	parts := strings.Fields(input)

--- a/cli/cost_tracker.go
+++ b/cli/cost_tracker.go
@@ -114,6 +114,10 @@ type SessionCostData struct {
 type CostTracker struct {
 	mu sync.RWMutex
 
+	// storeDir overrides the snapshot directory (per-tenant store sets);
+	// empty means the process default (costStoreDir).
+	storeDir string
+
 	sessionID    string
 	sessionName  string
 	sessionStart time.Time
@@ -153,7 +157,14 @@ type CostTracker struct {
 
 // NewCostTracker creates a new cost tracker with optional budget limit.
 func NewCostTracker() *CostTracker {
+	return NewCostTrackerAt("")
+}
+
+// NewCostTrackerAt is NewCostTracker persisting snapshots under dir
+// (empty = process default).
+func NewCostTrackerAt(dir string) *CostTracker {
 	ct := &CostTracker{
+		storeDir:     dir,
 		sessionID:    newCostSessionID(time.Now()),
 		sessionStart: time.Now(),
 		lastUpdate:   time.Now(),
@@ -497,7 +508,10 @@ func (ct *CostTracker) SaveSession() error {
 		return nil // nothing worth persisting
 	}
 
-	dir := costStoreDir()
+	dir := ct.storeDir
+	if dir == "" {
+		dir = costStoreDir()
+	}
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("create cost store dir: %w", err)
 	}

--- a/cli/gateway_command.go
+++ b/cli/gateway_command.go
@@ -567,6 +567,14 @@ func (cli *ChatCLI) gatewayAgentFunc(sessions *hubSessions, transcriber transcri
 			msg.Text = transcript
 		}
 
+		// Multi-tenant gateway: with hub isolation on, this sender's own
+		// store set (sessions, memory, contexts, CCR, costs, transcript and
+		// live history) is installed for the turn and the shared set is
+		// restored afterwards. No-op for the shared principal.
+		if leave := cli.enterGatewayTenant(ctx, sessions, msg.Platform, msg.UserID); leave != nil {
+			defer leave()
+		}
+
 		// Session control from the channel: "/session attach|detach|status|
 		// save|list|new" binds this sender's principal to a named saved
 		// session (cross-surface continuity with the REPL/MCP/ACP). Handled

--- a/cli/memory_flush.go
+++ b/cli/memory_flush.go
@@ -22,7 +22,7 @@ import (
 // unextractedSegment returns the live messages the memory worker has not
 // processed yet (system messages excluded — they carry no episodic content).
 func (cli *ChatCLI) unextractedSegment() []models.Message {
-	if cli == nil || cli.memWorker == nil || cli.memWorker.cli == nil || cli.memWorker.cli.memoryStore == nil {
+	if cli == nil || cli.memWorker == nil || cli.memWorker.store == nil {
 		return nil
 	}
 	start := cli.memWorker.lastProcessedIdx

--- a/cli/memory_worker.go
+++ b/cli/memory_worker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/diillson/chatcli/cli/workspace"
 	"os"
 	"strings"
 	"sync"
@@ -19,8 +20,15 @@ import (
 // memoryWorker runs in the background, periodically analyzing conversation
 // history and writing structured annotations to the MemoryStore.
 type memoryWorker struct {
-	cli              *ChatCLI
-	logger           *zap.Logger
+	cli    *ChatCLI
+	logger *zap.Logger
+	// store and history are bound at construction so a worker always
+	// distills into the store it was built for and reads the history it was
+	// built over — required once the gateway swaps per-tenant store sets on
+	// the shared ChatCLI (see tenant_scope.go): an extraction goroutine
+	// that fires after a tenant switch must not read another tenant's turn.
+	store            *workspace.MemoryStore
+	history          func() []models.Message
 	lastProcessedIdx int // index of last message processed for memory
 	mu               sync.Mutex
 	stopCh           chan struct{}
@@ -62,11 +70,19 @@ const (
 )
 
 func newMemoryWorker(cli *ChatCLI) *memoryWorker {
+	return newMemoryWorkerFor(cli, cli.memoryStore, defaultPendingDir(), func() []models.Message { return cli.history })
+}
+
+// newMemoryWorkerFor builds a worker over an explicit store, pending queue
+// directory and history source (per-tenant store sets in the gateway).
+func newMemoryWorkerFor(cli *ChatCLI, store *workspace.MemoryStore, pendingDir string, history func() []models.Message) *memoryWorker {
 	mw := &memoryWorker{
 		cli:        cli,
 		logger:     cli.logger,
+		store:      store,
+		history:    history,
 		stopCh:     make(chan struct{}),
-		pendingDir: defaultPendingDir(),
+		pendingDir: pendingDir,
 		coord:      newRunCoordinator(memoryCooldown, memoryMinNewMessages),
 	}
 	mw.lookupFallback = func(provider string) (client.LLMClient, error) {
@@ -98,7 +114,7 @@ func (mw *memoryWorker) stop() {
 // nudge is called after each LLM response to check if memory extraction should run.
 // It runs in a goroutine — non-blocking to the main flow.
 func (mw *memoryWorker) nudge(ctx context.Context) {
-	if mw.cli.memoryStore == nil {
+	if mw.store == nil {
 		return
 	}
 	// Don't queue multiple runs
@@ -116,7 +132,7 @@ func (mw *memoryWorker) nudge(ctx context.Context) {
 // right after its turn, so an async extraction could never finish — it only
 // enqueues, and the next session's worker drains the backlog.
 func (mw *memoryWorker) queueSegmentForNextSession(segment []models.Message) {
-	if mw.cli.memoryStore == nil || len(segment) == 0 {
+	if mw.store == nil || len(segment) == 0 {
 		return
 	}
 	if _, err := mw.persistPending(segment); err != nil {
@@ -131,7 +147,7 @@ func (mw *memoryWorker) queueSegmentForNextSession(segment []models.Message) {
 // RPC turn has already restored the previous history, so the live-delta gate
 // would never see these messages.
 func (mw *memoryWorker) nudgeSegment(ctx context.Context, segment []models.Message) {
-	if mw.cli.memoryStore == nil || len(segment) == 0 {
+	if mw.store == nil || len(segment) == 0 {
 		return
 	}
 	if _, err := mw.persistPending(segment); err != nil {
@@ -223,10 +239,10 @@ func (mw *memoryWorker) loop(ctx context.Context) {
 // when a digest is actually due, and its absence degrades to deterministic
 // condensation.
 func (mw *memoryWorker) runRollups(ctx context.Context) {
-	if mw.cli.memoryStore == nil {
+	if mw.store == nil {
 		return
 	}
-	mgr := mw.cli.memoryStore.Manager()
+	mgr := mw.store.Manager()
 
 	var sendPrompt func(ctx context.Context, prompt string) (string, error)
 	if llmClient := mw.cli.getClient(); llmClient != nil {
@@ -254,7 +270,7 @@ func (mw *memoryWorker) maybeExtract(ctx context.Context) {
 	// repaired/compacted (possibly SHORTER) slices mid-run, so re-reading it
 	// between the len check and the slice expression can panic on bounds.
 	// Every access below goes through this snapshot.
-	hist := mw.cli.history
+	hist := mw.history()
 	historyLen := len(hist)
 
 	mw.mu.Lock()
@@ -288,8 +304,8 @@ func (mw *memoryWorker) maybeExtract(ctx context.Context) {
 	)
 
 	// Record interaction event
-	if mw.cli.memoryStore != nil {
-		mw.cli.memoryStore.RecordInteraction(memory.InteractionEvent{
+	if mw.store != nil {
+		mw.store.RecordInteraction(memory.InteractionEvent{
 			Timestamp: time.Now(),
 			Feature:   mw.detectFeature(),
 		})
@@ -399,11 +415,11 @@ func buildExtractionSnippet(messages []models.Message) strings.Builder {
 }
 
 func (mw *memoryWorker) extractAndSave(ctx context.Context, messages []models.Message) error {
-	if mw.cli.memoryStore == nil {
+	if mw.store == nil {
 		return fmt.Errorf("memory store not available")
 	}
 
-	mgr := mw.cli.memoryStore.Manager()
+	mgr := mw.store.Manager()
 
 	// Self-evolution piggybacks on this same extraction pass (no extra LLM
 	// call): when enabled, the prompt asks for SKILL_CANDIDATES alongside the
@@ -475,7 +491,7 @@ func (mw *memoryWorker) extractAndSave(ctx context.Context, messages []models.Me
 	// Use enhanced processing that populates profile, topics, projects.
 	// A non-empty summary becomes a visible one-line notice so the user
 	// can tell the system actually learned something this turn.
-	summary := mw.cli.memoryStore.ProcessExtractionResult(response)
+	summary := mw.store.ProcessExtractionResult(response)
 	if !summary.IsEmpty() {
 		mw.cli.pushMemoryNotice(formatMemoryNotice(summary))
 	}
@@ -498,11 +514,11 @@ func (mw *memoryWorker) extractAndSave(ctx context.Context, messages []models.Me
 
 // maybeCompact checks if memory compaction should run and executes it.
 func (mw *memoryWorker) maybeCompact(ctx context.Context) {
-	if mw.cli.memoryStore == nil {
+	if mw.store == nil {
 		return
 	}
 
-	mgr := mw.cli.memoryStore.Manager()
+	mgr := mw.store.Manager()
 	if !mgr.NeedsCompaction() {
 		return
 	}
@@ -536,11 +552,11 @@ func (mw *memoryWorker) maybeCompact(ctx context.Context) {
 
 // cleanupDailyNotes removes old daily notes.
 func (mw *memoryWorker) cleanupDailyNotes() {
-	if mw.cli.memoryStore == nil {
+	if mw.store == nil {
 		return
 	}
 
-	mgr := mw.cli.memoryStore.Manager()
+	mgr := mw.store.Manager()
 	deleted, err := mgr.CleanupDailyNotes()
 	if err != nil {
 		mw.logger.Warn("Memory worker: daily cleanup failed", zap.Error(err))
@@ -552,13 +568,13 @@ func (mw *memoryWorker) cleanupDailyNotes() {
 // detectFeature detects the current mode for usage stats.
 func (mw *memoryWorker) detectFeature() string {
 	// Check recent messages for mode hints
-	histLen := len(mw.cli.history)
+	histLen := len(mw.history())
 	if histLen == 0 {
 		return "chat"
 	}
 
 	for i := histLen - 1; i >= 0 && i >= histLen-5; i-- {
-		content := mw.cli.history[i].Content
+		content := mw.history()[i].Content
 		if strings.Contains(content, "/agent") || strings.Contains(content, "agent mode") {
 			return "agent"
 		}

--- a/cli/memory_worker_segment_test.go
+++ b/cli/memory_worker_segment_test.go
@@ -80,7 +80,7 @@ func TestNudgeSegment_EmptyAndNoStoreAreNoops(t *testing.T) {
 		t.Fatalf("empty segment must not queue anything; got %d files", got)
 	}
 
-	mw.cli.memoryStore = nil
+	mw.store = nil // the worker owns its store handle (tenant sets swap it per principal)
 	mw.nudgeSegment(context.Background(), []models.Message{{Role: "user", Content: "x"}})
 	if got := len(mw.pendingFiles()); got != 0 {
 		t.Fatalf("no memory store must be a no-op; got %d files", got)

--- a/cli/session_manager.go
+++ b/cli/session_manager.go
@@ -46,12 +46,15 @@ func NewSessionManager(logger *zap.Logger) (*SessionManager, error) {
 	if err != nil {
 		return nil, fmt.Errorf("não foi possível obter o diretório home: %w", err)
 	}
+	return NewSessionManagerAt(filepath.Join(homeDir, ".chatcli", "sessions"), logger)
+}
 
-	sessionsDir := filepath.Join(homeDir, ".chatcli", "sessions")
+// NewSessionManagerAt is NewSessionManager over an explicit store directory
+// (per-tenant store sets in the gateway, tests).
+func NewSessionManagerAt(sessionsDir string, logger *zap.Logger) (*SessionManager, error) {
 	if err := os.MkdirAll(sessionsDir, 0o700); err != nil {
 		return nil, fmt.Errorf("não foi possível criar o diretório de sessões: %w", err)
 	}
-
 	return &SessionManager{
 		sessionsDir: sessionsDir,
 		logger:      logger,

--- a/cli/tenant_scope.go
+++ b/cli/tenant_scope.go
@@ -1,0 +1,314 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Per-principal store sets for the gateway daemon.
+ *
+ * The gateway serves every channel identity through one ChatCLI. With
+ * CHATCLI_HUB_ISOLATE=true the conversation hub already keeps one
+ * conversation per principal, but every durable store — saved sessions,
+ * long-term memory, knowledge contexts, the CCR archive, cost snapshots,
+ * the transcript journal — and the live history were shared: a /session
+ * list from one chat listed everyone's sessions, one user's facts surfaced
+ * in another's turns. A tenant store set is a complete replacement of those
+ * handles rooted at ~/.chatcli/tenants/<principal>; the gateway swaps it in
+ * under its turn mutex before a principal's turn and swaps the base set
+ * back after. Nothing changes for the single-user default: the swap only
+ * happens when isolation is on and the principal is not the shared one.
+ */
+package cli
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/diillson/chatcli/cli/agent/workers"
+	"github.com/diillson/chatcli/cli/compress"
+	"github.com/diillson/chatcli/cli/workspace"
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+// GatewayMaxTenantsEnv caps how many tenant store sets stay resident;
+// least recently used sets are released (their memory worker stopped)
+// past the cap and rebuilt from disk on the next turn.
+const GatewayMaxTenantsEnv = "CHATCLI_GATEWAY_MAX_TENANTS"
+
+const defaultGatewayMaxTenants = 16
+
+// tenantStores is one principal's complete store set plus its live
+// conversation state.
+type tenantStores struct {
+	principal string
+	root      string
+
+	sessionManager   *SessionManager
+	contextHandler   *ContextHandler
+	memoryStore      *workspace.MemoryStore
+	memWorker        *memoryWorker
+	compressionLayer *compress.Layer
+	costTracker      *CostTracker
+	transcript       *transcriptJournal
+	contextBuilder   *workspace.ContextBuilder
+
+	history            []models.Message
+	checkpoints        []conversationCheckpoint
+	currentSessionName string
+	boundSessionSync   time.Time
+	boundRemoteOnly    bool
+
+	graphWired bool
+	lastUsed   time.Time
+}
+
+// tenantPool keeps the resident store sets and the base (single-user) set.
+type tenantPool struct {
+	mu     sync.Mutex
+	max    int
+	base   *tenantStores
+	items  map[string]*tenantStores
+	active string
+}
+
+// gatewayMaxTenants reads the residency cap.
+func gatewayMaxTenants() int {
+	if v := strings.TrimSpace(os.Getenv(GatewayMaxTenantsEnv)); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultGatewayMaxTenants
+}
+
+// tenantRootFor derives the on-disk root for a principal: a readable,
+// filesystem-safe slug plus a short digest so distinct principals that
+// sanitize to the same slug never share a directory.
+func tenantRootFor(base, principal string) string {
+	slug := strings.ToLower(strings.TrimSpace(principal))
+	var b strings.Builder
+	for _, r := range slug {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '.', r == '-', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	safe := b.String()
+	if len(safe) > 48 {
+		safe = safe[:48]
+	}
+	sum := sha256.Sum256([]byte(principal))
+	return filepath.Join(base, "tenants", safe+"-"+hex.EncodeToString(sum[:4]))
+}
+
+// captureStores snapshots the ChatCLI's current store handles and live
+// conversation state into a set (used for the base set and on leave).
+func (cli *ChatCLI) captureStores(into *tenantStores) {
+	into.sessionManager = cli.sessionManager
+	into.contextHandler = cli.contextHandler
+	into.memoryStore = cli.memoryStore
+	into.memWorker = cli.memWorker
+	into.compressionLayer = cli.compressionLayer
+	into.costTracker = cli.costTracker
+	into.transcript = cli.transcript
+	into.contextBuilder = cli.contextBuilder
+	into.history = cli.history
+	into.checkpoints = cli.checkpoints
+	into.currentSessionName = cli.currentSessionName
+	into.boundSessionSync = cli.boundSessionSync
+	into.boundRemoteOnly = cli.boundRemoteOnly
+	into.root = cli.stateRoot
+}
+
+// applyStores installs a set on the ChatCLI and re-registers the process
+// globals that bind a store handle at registration time (the CCR recaller
+// and squad compression layer); the adapters that read cli fields at call
+// time need nothing.
+func (cli *ChatCLI) applyStores(ts *tenantStores) {
+	cli.sessionManager = ts.sessionManager
+	cli.contextHandler = ts.contextHandler
+	cli.memoryStore = ts.memoryStore
+	cli.memWorker = ts.memWorker
+	cli.compressionLayer = ts.compressionLayer
+	cli.costTracker = ts.costTracker
+	cli.transcript = ts.transcript
+	cli.contextBuilder = ts.contextBuilder
+	cli.history = ts.history
+	cli.checkpoints = ts.checkpoints
+	cli.currentSessionName = ts.currentSessionName
+	cli.boundSessionSync = ts.boundSessionSync
+	cli.boundRemoteOnly = ts.boundRemoteOnly
+	cli.stateRoot = ts.root
+	if cli.historyCompactor != nil {
+		cli.historyCompactor.SetCompressionLayer(ts.compressionLayer)
+	}
+	if ts.compressionLayer != nil {
+		workers.RegisterCCRRecaller(ts.compressionLayer.Recall)
+		workers.RegisterSquadCompressionLayer(ts.compressionLayer)
+	}
+	if ts.memoryStore != nil && !ts.graphWired {
+		cli.wireMemoryGraph()
+		ts.graphWired = true
+	}
+}
+
+// buildTenantStores creates a principal's store set from disk.
+func (cli *ChatCLI) buildTenantStores(ctx context.Context, principal string) (*tenantStores, error) {
+	root := tenantRootFor(cli.stateRoot, principal)
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return nil, err
+	}
+	ts := &tenantStores{principal: principal, root: root, graphWired: false}
+
+	sm, err := NewSessionManagerAt(filepath.Join(root, "sessions"), cli.logger)
+	if err != nil {
+		return nil, err
+	}
+	ts.sessionManager = sm
+
+	ch, err := NewContextHandlerAt(filepath.Join(root, "contexts"), cli.logger)
+	if err != nil {
+		return nil, err
+	}
+	ch.GetManager().AttachEmbeddingProvider(cli.hydeProviderForSession())
+	ts.contextHandler = ch
+
+	if cli.memoryStore != nil { // memory enabled for the process
+		ms := workspace.NewMemoryStore(root, cli.logger)
+		ms.SetWorkspaceDir(cli.workspaceDir)
+		ts.memoryStore = ms
+		pool := cli.tenants
+		ts.memWorker = newMemoryWorkerFor(cli, ms, filepath.Join(root, "memory", "pending"), func() []models.Message {
+			pool.mu.Lock()
+			active := pool.active == principal
+			pool.mu.Unlock()
+			if active {
+				return cli.history
+			}
+			return ts.history
+		})
+		ts.memWorker.start(ctx)
+	}
+
+	layer := compress.NewLayerFromEnv(root)
+	if err := layer.StoreFallback(); err != nil && cli.logger != nil {
+		cli.logger.Warn("tenant CCR store unavailable; using bounded in-memory store", zap.String("principal", principal), zap.Error(err))
+	}
+	ts.compressionLayer = layer
+	ts.costTracker = NewCostTrackerAt(filepath.Join(root, "costs"))
+	if transcriptEnabled() {
+		dir := filepath.Join(root, transcriptDirName)
+		if err := os.MkdirAll(dir, 0o700); err == nil {
+			if j, err := openTranscriptJournal(dir, newTranscriptID(time.Now())); err == nil {
+				ts.transcript = j
+			}
+		}
+	}
+	ts.contextBuilder = workspace.NewContextBuilder(cli.bootstrapLoader, ts.memoryStore, cli.workspaceDir)
+	ts.history = make([]models.Message, 0)
+	return ts, nil
+}
+
+// enterTenant swaps principal's store set in and returns the function that
+// swaps the base set back. Nil for the shared principal (no-op). Callers
+// hold the gateway turn mutex, which is what makes the swap safe.
+func (cli *ChatCLI) enterTenant(ctx context.Context, principal string) func() {
+	if principal == "" || principal == defaultHubPrincipal {
+		return nil
+	}
+	if cli.tenants == nil {
+		cli.tenants = &tenantPool{max: gatewayMaxTenants(), items: map[string]*tenantStores{}}
+		base := &tenantStores{principal: defaultHubPrincipal}
+		cli.captureStores(base)
+		cli.tenants.base = base
+	}
+	pool := cli.tenants
+	pool.mu.Lock()
+	ts, ok := pool.items[principal]
+	pool.mu.Unlock()
+	if !ok {
+		built, err := cli.buildTenantStores(ctx, principal)
+		if err != nil {
+			if cli.logger != nil {
+				cli.logger.Error("tenant store set unavailable; serving from the shared stores", zap.String("principal", principal), zap.Error(err))
+			}
+			return nil
+		}
+		ts = built
+		ts.lastUsed = time.Now()
+		pool.mu.Lock()
+		pool.items[principal] = ts
+		pool.active = principal // protects the newcomer from its own eviction pass
+		cli.evictTenantsLocked()
+		pool.mu.Unlock()
+	}
+	// Save the base set's live state (the REPL may be sharing this process)
+	// and install the tenant.
+	cli.captureStores(pool.base)
+	pool.mu.Lock()
+	pool.active = principal
+	pool.mu.Unlock()
+	ts.lastUsed = time.Now()
+	cli.applyStores(ts)
+	return func() {
+		cli.captureStores(ts)
+		ts.root = tenantRootFor(pool.base.root, principal)
+		pool.mu.Lock()
+		pool.active = ""
+		pool.mu.Unlock()
+		cli.applyStores(pool.base)
+	}
+}
+
+// evictTenantsLocked releases least recently used sets beyond the cap.
+// Caller holds pool.mu. The active set is never released.
+func (cli *ChatCLI) evictTenantsLocked() {
+	pool := cli.tenants
+	for len(pool.items) > pool.max {
+		var oldest *tenantStores
+		for _, ts := range pool.items {
+			if ts.principal == pool.active {
+				continue
+			}
+			if oldest == nil || ts.lastUsed.Before(oldest.lastUsed) {
+				oldest = ts
+			}
+		}
+		if oldest == nil {
+			return
+		}
+		if oldest.memWorker != nil {
+			oldest.memWorker.stop()
+		}
+		delete(pool.items, oldest.principal)
+	}
+}
+
+// enterGatewayTenant is the gateway hook: swaps the sender's store set in
+// when hub isolation is on and the sender is not the shared principal.
+func (cli *ChatCLI) enterGatewayTenant(ctx context.Context, sessions *hubSessions, platform, userID string) func() {
+	if sessions == nil || sessions.store == nil || !resolveHubIsolate(ctx, sessions.store) {
+		return nil
+	}
+	return cli.enterTenant(ctx, sessions.principalFor(ctx, platform, userID))
+}
+
+// activeTenant reports the principal whose store set is installed ("" for
+// the base set).
+func (cli *ChatCLI) activeTenant() string {
+	if cli == nil || cli.tenants == nil {
+		return ""
+	}
+	cli.tenants.mu.Lock()
+	defer cli.tenants.mu.Unlock()
+	return cli.tenants.active
+}

--- a/cli/tenant_scope_test.go
+++ b/cli/tenant_scope_test.go
@@ -1,0 +1,122 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+func TestTenantRootFor_SafeAndDistinct(t *testing.T) {
+	a := tenantRootFor("/base", "telegram:12345")
+	b := tenantRootFor("/base", "telegram/12345")
+	if a == b {
+		t.Fatal("principals that sanitize alike must still get distinct roots")
+	}
+	if !strings.HasPrefix(a, filepath.Join("/base", "tenants", "telegram_12345-")) {
+		t.Fatalf("root = %s", a)
+	}
+	if strings.ContainsAny(filepath.Base(a), ":/\\ ") {
+		t.Fatalf("unsafe characters in %s", a)
+	}
+	long := tenantRootFor("/base", strings.Repeat("x", 200))
+	if len(filepath.Base(long)) > 48+1+8 {
+		t.Fatalf("slug not capped: %s", filepath.Base(long))
+	}
+}
+
+func newTenantTestCLI(t *testing.T) *ChatCLI {
+	t.Helper()
+	root := t.TempDir()
+	t.Setenv("HOME", root)
+	t.Setenv(GatewayMaxTenantsEnv, "")
+	t.Setenv("CHATCLI_SESSION_TRANSCRIPT", "false")
+	sm, err := NewSessionManagerAt(filepath.Join(root, "sessions"), zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &ChatCLI{
+		logger:           zap.NewNop(),
+		stateRoot:        root,
+		sessionManager:   sm,
+		historyCompactor: NewHistoryCompactor(zap.NewNop()),
+		costTracker:      NewCostTracker(),
+		history:          []models.Message{{Role: "user", Content: "base turn"}},
+	}
+}
+
+func TestEnterTenant_SwapsStoresAndRestoresBase(t *testing.T) {
+	cli := newTenantTestCLI(t)
+	baseSM := cli.sessionManager
+	ctx := context.Background()
+
+	if leave := cli.enterTenant(ctx, defaultHubPrincipal); leave != nil {
+		t.Fatal("shared principal must be a no-op")
+	}
+	leave := cli.enterTenant(ctx, "telegram:42")
+	if leave == nil {
+		t.Fatal("tenant must be entered")
+	}
+	if cli.sessionManager == baseSM || !strings.Contains(cli.sessionManager.sessionsDir, filepath.Join("tenants", "telegram_42-")) {
+		t.Fatalf("tenant session store not installed: %s", cli.sessionManager.sessionsDir)
+	}
+	if len(cli.history) != 0 || cli.activeTenant() != "telegram:42" {
+		t.Fatalf("tenant must start with its own empty history, got %d (active=%q)", len(cli.history), cli.activeTenant())
+	}
+	if cli.contextHandler == nil || cli.costTracker == baseTracker(t, cli) {
+		t.Fatal("tenant contexts/costs not installed")
+	}
+	cli.history = append(cli.history, models.Message{Role: "user", Content: "tenant turn"})
+	leave()
+
+	if cli.sessionManager != baseSM || cli.activeTenant() != "" {
+		t.Fatal("base stores must be restored on leave")
+	}
+	if len(cli.history) != 1 || cli.history[0].Content != "base turn" {
+		t.Fatalf("base history must be restored, got %+v", cli.history)
+	}
+
+	// Re-entering resumes the tenant's own conversation.
+	leave = cli.enterTenant(ctx, "telegram:42")
+	if len(cli.history) != 1 || cli.history[0].Content != "tenant turn" {
+		t.Fatalf("tenant history must persist across turns, got %+v", cli.history)
+	}
+	leave()
+}
+
+// baseTracker returns the pool's base cost tracker (nil when no pool).
+func baseTracker(t *testing.T, cli *ChatCLI) *CostTracker {
+	t.Helper()
+	if cli.tenants == nil || cli.tenants.base == nil {
+		return nil
+	}
+	return cli.tenants.base.costTracker
+}
+
+func TestEnterTenant_EvictsLeastRecentlyUsed(t *testing.T) {
+	cli := newTenantTestCLI(t)
+	t.Setenv(GatewayMaxTenantsEnv, "1")
+	ctx := context.Background()
+	cli.enterTenant(ctx, "slack:a")()
+	cli.enterTenant(ctx, "slack:b")()
+	if n := len(cli.tenants.items); n != 1 {
+		t.Fatalf("cap 1 must keep one resident set, got %d", n)
+	}
+	if _, ok := cli.tenants.items["slack:b"]; !ok {
+		t.Fatal("the most recent tenant must survive eviction")
+	}
+	// Evicted tenants are rebuilt from disk on return — its root exists.
+	leave := cli.enterTenant(ctx, "slack:a")
+	if !strings.Contains(cli.sessionManager.sessionsDir, "slack_a-") {
+		t.Fatalf("rebuilt tenant store = %s", cli.sessionManager.sessionsDir)
+	}
+	leave()
+}

--- a/cli/transcript_journal.go
+++ b/cli/transcript_journal.go
@@ -278,6 +278,19 @@ func transcriptTTL() time.Duration {
 	return sessionTTLDuration()
 }
 
+// transcriptDirForRoot resolves the journal directory under the active
+// state root (per-tenant store sets rebase it), defaulting to ~/.chatcli.
+func (cli *ChatCLI) transcriptDirForRoot() (string, error) {
+	if cli != nil && cli.stateRoot != "" {
+		dir := filepath.Join(cli.stateRoot, transcriptDirName)
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return "", err
+		}
+		return dir, nil
+	}
+	return transcriptDir()
+}
+
 // --- ChatCLI wiring ---
 
 // initTranscriptJournal opens the session journal at boot (or adopts an
@@ -286,7 +299,7 @@ func (cli *ChatCLI) initTranscriptJournal(id string) {
 	if !transcriptEnabled() {
 		return
 	}
-	dir, err := transcriptDir()
+	dir, err := cli.transcriptDirForRoot()
 	if err != nil {
 		if cli.logger != nil {
 			cli.logger.Warn("transcript journal unavailable", zap.Error(err))


### PR DESCRIPTION
## Summary
- With `CHATCLI_HUB_ISOLATE=true`, the gateway gives each channel principal its **own store set** (sessions, long-term memory, knowledge contexts, CCR archive, cost snapshots, transcript journal, live history) under `~/.chatcli/tenants/<principal>/`, swapped in under the gateway turn mutex and restored after the turn.
- Memory worker decoupled from the ChatCLI handles: it owns its store and history source (`newMemoryWorkerFor`), so each tenant extracts into its own memory.
- LRU residency cap `CHATCLI_GATEWAY_MAX_TENANTS` (default 16): evicted sets stop their memory worker and are rebuilt from disk on the next turn. Shown in `/config hub`, registered in env defaults.
- Store constructors gain rooted variants (`NewSessionManagerAt`, `NewContextHandlerAt`, `NewCostTrackerAt`, `ctxmgr.NewManagerWithBasePath`); the existing constructors delegate to them, byte-identical behavior.

## Non-degradation
- Single-user default: no tenant pool is ever created; `enterGatewayTenant` returns nil unless isolation is on **and** the sender is not the shared principal.
- The REPL sharing the process keeps its state: the base set's live history/checkpoints are captured before each tenant swap and restored on leave.
- Park snapshots, squad board and scheduler stay process-wide (documented).

## Tests
- `tenant_scope_test.go`: safe/distinct roots, swap + restore + per-tenant history persistence, LRU eviction + rebuild from disk.
- `go test ./...`, golangci-lint, i18n parity and ai-smells clean locally.
