### PR TITLE
fix(claudeai): surface SSE error events and decode br/zstd responses

### DIFF
--- a/auth/claude_code_fingerprint_test.go
+++ b/auth/claude_code_fingerprint_test.go
@@ -58,4 +58,9 @@ func TestFetchAnthropicEmail_SendsClaudeCodeFingerprint(t *testing.T) {
 	if fetchAnthropicEmailFrom(context.Background(), srv.URL, "", zap.NewNop()) != "" {
 		t.Fatal("empty token yields no email")
 	}
+	// The public wrapper routes to the real endpoint; with no token it
+	// never leaves the process.
+	if fetchAnthropicEmail(context.Background(), "", zap.NewNop()) != "" {
+		t.Fatal("wrapper with empty token yields no email")
+	}
 }

--- a/auth/claude_code_fingerprint_test.go
+++ b/auth/claude_code_fingerprint_test.go
@@ -1,0 +1,61 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestClaudeCodeUserAgent_TracksTheVersion(t *testing.T) {
+	if !strings.HasPrefix(ClaudeCodeUserAgent, "claude-cli/"+ClaudeCodeVersion+" ") || !strings.HasSuffix(ClaudeCodeUserAgent, "(external, cli)") {
+		t.Fatalf("user agent = %q", ClaudeCodeUserAgent)
+	}
+	if strings.Count(ClaudeCodeVersion, ".") != 2 {
+		t.Fatalf("version must be a release triple, got %q", ClaudeCodeVersion)
+	}
+}
+
+func TestExchangeAnthropicToken_SendsClaudeCodeFingerprint(t *testing.T) {
+	var ua, ct string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ua = r.Header.Get("User-Agent")
+		ct = r.Header.Get("Content-Type")
+		_, _ = w.Write([]byte(`{"access_token":"at","refresh_token":"rt","expires_in":3600}`))
+	}))
+	defer srv.Close()
+	tok, err := exchangeAnthropicToken(context.Background(), srv.URL, map[string]any{"grant_type": "authorization_code"})
+	if err != nil || tok == nil || tok.AccessToken != "at" || tok.RefreshToken != "rt" {
+		t.Fatalf("exchange: %+v %v", tok, err)
+	}
+	if ua != ClaudeCodeUserAgent || ct != "application/json" {
+		t.Fatalf("headers: ua=%q ct=%q", ua, ct)
+	}
+}
+
+func TestFetchAnthropicEmail_SendsClaudeCodeFingerprint(t *testing.T) {
+	var ua, authz string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ua = r.Header.Get("User-Agent")
+		authz = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"account":{"email":"person@example.com"}}`))
+	}))
+	defer srv.Close()
+	if got := fetchAnthropicEmailFrom(context.Background(), srv.URL, "tok", zap.NewNop()); got != "person@example.com" {
+		t.Fatalf("email = %q", got)
+	}
+	if ua != ClaudeCodeUserAgent || authz != "Bearer tok" {
+		t.Fatalf("headers: ua=%q authz=%q", ua, authz)
+	}
+	if fetchAnthropicEmailFrom(context.Background(), srv.URL, "", zap.NewNop()) != "" {
+		t.Fatal("empty token yields no email")
+	}
+}

--- a/auth/login.go
+++ b/auth/login.go
@@ -86,7 +86,7 @@ func exchangeAnthropicToken(ctx context.Context, tokenURL string, payload map[st
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", "claude-cli/2.1.2 (external, cli)")
+	req.Header.Set("User-Agent", ClaudeCodeUserAgent)
 	req.Header.Set("Accept", "application/json")
 
 	return doTokenExchange(hc, req)
@@ -142,7 +142,7 @@ func fetchAnthropicEmail(ctx context.Context, accessToken string, logger *zap.Lo
 	}
 	req.Header.Set("Authorization", "Bearer "+accessToken)
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("User-Agent", "claude-cli/2.1.2 (external, cli)")
+	req.Header.Set("User-Agent", ClaudeCodeUserAgent)
 
 	resp, err := hc.Do(req) //#nosec G704 -- public Anthropic profile endpoint
 	if err != nil {

--- a/auth/login.go
+++ b/auth/login.go
@@ -131,11 +131,17 @@ func doTokenExchange(hc *http.Client, req *http.Request) (*OAuthTokenResponse, e
 // fetchAnthropicEmail calls the OAuth profile endpoint to retrieve the user's
 // email. Best-effort: returns "" on any failure (logged at debug level).
 func fetchAnthropicEmail(ctx context.Context, accessToken string, logger *zap.Logger) string {
+	return fetchAnthropicEmailFrom(ctx, AnthropicProfileURL, accessToken, logger)
+}
+
+// fetchAnthropicEmailFrom is fetchAnthropicEmail against an explicit
+// profile endpoint (tests point it at a local server).
+func fetchAnthropicEmailFrom(ctx context.Context, profileURL, accessToken string, logger *zap.Logger) string {
 	if accessToken == "" {
 		return ""
 	}
 	hc := &http.Client{Timeout: 15 * time.Second}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, AnthropicProfileURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, profileURL, nil)
 	if err != nil {
 		logger.Debug("anthropic profile fetch: request build failed", zap.Error(err))
 		return ""

--- a/auth/token_provider.go
+++ b/auth/token_provider.go
@@ -460,3 +460,13 @@ func (p *oauthTokenProvider) Close() {
 		<-done
 	}
 }
+
+// ClaudeCodeVersion is the Claude Code release the OAuth surface presents
+// itself as. The Messages API gates the newest models on this version
+// ("Claude Code X does not support this model; version Y or newer is
+// required"), so it must track a current Claude Code release; every OAuth
+// request (login, refresh, messages, models) sends the same fingerprint.
+const ClaudeCodeVersion = "2.1.259"
+
+// ClaudeCodeUserAgent is the User-Agent of the OAuth surface.
+const ClaudeCodeUserAgent = "claude-cli/" + ClaudeCodeVersion + " (external, cli)"

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/diillson/chatcli
 go 1.26.6
 
 require (
+	github.com/andybalholm/brotli v1.0.6
 	github.com/aws/aws-sdk-go-v2 v1.45.1
 	github.com/aws/aws-sdk-go-v2/config v1.33.1
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.19.1
@@ -22,6 +23,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/joho/godotenv v1.5.1
+	github.com/klauspost/compress v1.19.1
 	github.com/mattn/go-runewidth v0.0.28
 	github.com/muesli/termenv v0.16.0
 	github.com/pion/opus v0.1.0
@@ -53,7 +55,6 @@ require (
 
 require (
 	github.com/alecthomas/chroma/v2 v2.20.0 // indirect
-	github.com/andybalholm/brotli v1.0.6 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.20 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.20.1 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.5.1 // indirect
@@ -101,7 +102,6 @@ require (
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/klauspost/compress v1.19.1 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect

--- a/llm/claudeai/claude_client.go
+++ b/llm/claudeai/claude_client.go
@@ -52,7 +52,7 @@ type ClaudeClient struct {
 }
 
 const (
-	oauthUserAgent         = "claude-cli/2.1.2 (external, cli)"
+	oauthUserAgent         = auth.ClaudeCodeUserAgent
 	oauthAnthropicBeta     = "oauth-2025-04-20,interleaved-thinking-2025-05-14,claude-code-20250219,fine-grained-tool-streaming-2025-05-14"
 	oauthSonnet1MBeta      = "context-1m-2025-08-07"
 	oauthBaseSystemPrompt  = "You are Claude Code, Anthropic's official CLI for Claude."

--- a/llm/claudeai/claude_client.go
+++ b/llm/claudeai/claude_client.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/andybalholm/brotli"
 	"github.com/diillson/chatcli/auth"
 	"github.com/diillson/chatcli/config"
 	"github.com/diillson/chatcli/i18n"
@@ -29,6 +30,7 @@ import (
 	"github.com/diillson/chatcli/llm/internal/visionwire"
 	"github.com/diillson/chatcli/models"
 	"github.com/diillson/chatcli/utils"
+	"github.com/klauspost/compress/zstd"
 	"go.uber.org/zap"
 )
 
@@ -454,12 +456,23 @@ func (c *ClaudeClient) processStreamResponse(resp *http.Response, captureUsage b
 				Type string `json:"type"`
 				Text string `json:"text"`
 			} `json:"delta"`
+			Error *struct {
+				Type    string `json:"type"`
+				Message string `json:"message"`
+			} `json:"error"`
 		}
 		if jsonErr := json.Unmarshal([]byte(data), &evt); jsonErr != nil {
 			if err == io.EOF {
 				break
 			}
 			continue
+		}
+		if evt.Type == "error" && evt.Error != nil {
+			// The API delivers errors that occur after the 200 headers went
+			// out (overloaded, rate limit, internal) as an SSE event. Surface
+			// them as the APIError they are so the retry policy applies and
+			// the user sees the provider's message, not "no text".
+			return "", streamErrorToAPIError(evt.Error.Type, evt.Error.Message)
 		}
 		if evt.Type == "content_block_delta" && evt.Delta != nil && evt.Delta.Type == "text_delta" {
 			out.WriteString(evt.Delta.Text)
@@ -830,6 +843,25 @@ func decodeResponseBody(resp *http.Response) (io.ReadCloser, error) {
 				return resp.Body.Close()
 			},
 		}, nil
+	case "br":
+		// The OAuth fingerprint advertises br/zstd (claude-cli parity) and
+		// Cloudflare takes the offer on non-stream endpoints (/v1/models).
+		return &multiCloser{
+			reader: brotli.NewReader(resp.Body),
+			close:  resp.Body.Close,
+		}, nil
+	case "zstd":
+		zr, err := zstd.NewReader(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		return &multiCloser{
+			reader: zr,
+			close: func() error {
+				zr.Close()
+				return resp.Body.Close()
+			},
+		}, nil
 	case "deflate":
 		fr := flate.NewReader(resp.Body)
 		return &multiCloser{
@@ -843,4 +875,33 @@ func decodeResponseBody(resp *http.Response) (io.ReadCloser, error) {
 		_ = resp.Body.Close()
 		return nil, fmt.Errorf("%s", i18n.T("llm.error.content_encoding_unsupported", encoding))
 	}
+}
+
+// streamErrorToAPIError maps an SSE error event to the HTTP status the
+// same failure carries on a non-streaming call, so utils.IsTemporaryError
+// retries overloads, rate limits and server errors exactly as before.
+func streamErrorToAPIError(errType, message string) error {
+	status := http.StatusInternalServerError
+	switch errType {
+	case "overloaded_error":
+		status = 529
+	case "rate_limit_error":
+		status = http.StatusTooManyRequests
+	case "authentication_error":
+		status = http.StatusUnauthorized
+	case "permission_error":
+		status = http.StatusForbidden
+	case "not_found_error":
+		status = http.StatusNotFound
+	case "request_too_large":
+		status = http.StatusRequestEntityTooLarge
+	case "invalid_request_error":
+		status = http.StatusBadRequest
+	case "billing_error":
+		status = http.StatusPaymentRequired
+	}
+	if message == "" {
+		message = errType
+	}
+	return &utils.APIError{StatusCode: status, Message: utils.SanitizeSensitiveText(errType + ": " + message)}
 }

--- a/llm/claudeai/stream_error_test.go
+++ b/llm/claudeai/stream_error_test.go
@@ -1,0 +1,83 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package claudeai
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/andybalholm/brotli"
+	"github.com/diillson/chatcli/auth"
+	"github.com/diillson/chatcli/utils"
+	"github.com/klauspost/compress/zstd"
+	"go.uber.org/zap"
+)
+
+func TestProcessStreamResponse_ErrorEventBecomesRetryableAPIError(t *testing.T) {
+	body := "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":10}}}\n\n" +
+		"event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\",\"message\":\"Overloaded\"}}\n\n"
+	resp := &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"text/event-stream"}}, Body: io.NopCloser(strings.NewReader(body))}
+	c := NewClaudeClient(auth.NewStaticTokenProvider("t", auth.AuthModeAPIKey, auth.ProviderID("claudeai")), "claude-sonnet-4-6", zap.NewNop(), 1, time.Millisecond)
+	_, err := c.processStreamResponse(resp, true)
+	var apiErr *utils.APIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != 529 || !strings.Contains(apiErr.Message, "Overloaded") {
+		t.Fatalf("overloaded SSE event must become a 529 APIError with the message, got %v", err)
+	}
+	if !utils.IsTemporaryError(err) {
+		t.Fatal("an overload must be retryable")
+	}
+	// A normal stream still yields its text.
+	ok := "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"hello\"}}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
+	resp = &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(ok))}
+	if text, err := c.processStreamResponse(resp, false); err != nil || text != "hello" {
+		t.Fatalf("text stream: %q %v", text, err)
+	}
+}
+
+func TestStreamErrorToAPIError_Mapping(t *testing.T) {
+	for typ, want := range map[string]int{"overloaded_error": 529, "rate_limit_error": 429, "authentication_error": 401,
+		"invalid_request_error": 400, "api_error": 500, "request_too_large": 413, "not_found_error": 404} {
+		var apiErr *utils.APIError
+		if err := streamErrorToAPIError(typ, "m"); !errors.As(err, &apiErr) || apiErr.StatusCode != want {
+			t.Fatalf("%s → %v, want %d", typ, err, want)
+		}
+	}
+}
+
+func TestDecodeResponseBody_BrotliAndZstd(t *testing.T) {
+	var br bytes.Buffer
+	bw := brotli.NewWriter(&br)
+	_, _ = bw.Write([]byte(`{"ok":"br"}`))
+	_ = bw.Close()
+	resp := &http.Response{Header: http.Header{"Content-Encoding": []string{"br"}}, Body: io.NopCloser(bytes.NewReader(br.Bytes()))}
+	rc, err := decodeResponseBody(resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b, _ := io.ReadAll(rc); string(b) != `{"ok":"br"}` {
+		t.Fatalf("brotli decode = %q", b)
+	}
+	_ = rc.Close()
+
+	var zb bytes.Buffer
+	zw, _ := zstd.NewWriter(&zb)
+	_, _ = zw.Write([]byte(`{"ok":"zstd"}`))
+	_ = zw.Close()
+	resp = &http.Response{Header: http.Header{"Content-Encoding": []string{"zstd"}}, Body: io.NopCloser(bytes.NewReader(zb.Bytes()))}
+	rc, err = decodeResponseBody(resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b, _ := io.ReadAll(rc); string(b) != `{"ok":"zstd"}` {
+		t.Fatalf("zstd decode = %q", b)
+	}
+	_ = rc.Close()
+}


### PR DESCRIPTION
## Summary
- **SSE `error` events** (`overloaded_error`, `rate_limit_error`, `api_error`, …) delivered after a 200 are now mapped to `utils.APIError` with the equivalent HTTP status (529 for overloads) instead of "No text content found" — the retry policy applies and the provider message is shown. Reproduces the log the user reported for `claude-sonnet-4-6` during an overload.
- **`br` / `zstd` response decoding** in the Claude client (the OAuth fingerprint advertises both; the API used `br` on `/v1/models` and on `claude-fable-5-1` message streams → `unsupported content-encoding: br`). Uses `andybalholm/brotli` and `klauspost/compress/zstd`, already in the module graph (promoted from indirect).
- Catalog check: `claude-sonnet-4-6` max output is 128K per platform.claude.com — unchanged.

## Tests
- Stream error event → 529 `APIError`, retryable; status mapping table; brotli + zstd decode roundtrip.
