### PR TITLE
fix(context): close the P0 gaps of the second context audit

### DIFF
--- a/cli/audit2_p0_test.go
+++ b/cli/audit2_p0_test.go
@@ -1,0 +1,126 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/diillson/chatcli/llm/client"
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+type usageAwareStub struct{ u *models.UsageInfo }
+
+func (s *usageAwareStub) GetModelName() string { return "stub" }
+func (s *usageAwareStub) SendPrompt(context.Context, string, []models.Message, int) (string, error) {
+	return "", nil
+}
+func (s *usageAwareStub) LastUsage() *models.UsageInfo { return s.u }
+
+func TestLLMAudit_SurfaceTenantAndTokensOnRecv(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	t.Setenv(AuditLogPathEnv, path)
+	cli := newTenantTestCLI(t)
+	cli.Client = &usageAwareStub{u: &models.UsageInfo{PromptTokens: 900, CompletionTokens: 40, CacheReadInputTokens: 600, CacheCreationInputTokens: 100, IsReal: true}}
+	cli.initLLMAudit("repl")
+	t.Cleanup(func() { cli.llmAudit.close() })
+	cli.SetAuditSurface("gateway")
+	client.LogRequestStart(zap.NewNop(), "CLAUDEAI", "claude-sonnet-5")
+	client.LogRequestFinish(zap.NewNop(), "CLAUDEAI", "claude-sonnet-5", "success", 50*time.Millisecond)
+	cli.llmAudit.close()
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	var entries []llmAuditEntry
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		var e llmAuditEntry
+		if err := json.Unmarshal(sc.Bytes(), &e); err != nil {
+			t.Fatal(err)
+		}
+		entries = append(entries, e)
+	}
+	if len(entries) != 2 || entries[0].Surface != "gateway" || entries[1].Surface != "gateway" {
+		t.Fatalf("surface must follow SetAuditSurface: %+v", entries)
+	}
+	recv := entries[1]
+	if recv.InputTokens != 900 || recv.OutputTokens != 40 || recv.CacheReadTokens != 600 || recv.CacheWriteTokens != 100 {
+		t.Fatalf("recv line must carry the provider usage: %+v", recv)
+	}
+	if entries[0].InputTokens != 0 {
+		t.Fatal("send lines carry no usage")
+	}
+}
+
+func TestExternalMemoryStore_RedactsSecrets(t *testing.T) {
+	cli := newTenantTestCLI(t)
+	f := &fakeToolCaller{answers: map[string]string{}, fail: map[string]bool{}}
+	cli.extToolCaller = f
+	t.Setenv(MemoryProviderEnv, "mcp:memsvc")
+	t.Setenv("CHATCLI_ENV_REDACT_MODE", "")
+	secret := "ghp_" + strings.Repeat("b", 36)
+	cli.externalMemoryStore(context.Background(), "s", []models.Message{{Role: "user", Content: "token is " + secret}})
+	waitCalls(t, f, "memsvc/memory_store", 1)
+	msgs, _ := f.args[0]["messages"].([]map[string]string)
+	if len(msgs) != 1 || strings.Contains(msgs[0]["content"], secret) {
+		t.Fatalf("secrets must be redacted before leaving the process: %v", f.args[0])
+	}
+}
+
+func TestEnterTenantChecked_RefusesWhenTheStoreSetCannotBeBuilt(t *testing.T) {
+	cli := newTenantTestCLI(t)
+	blocker := filepath.Join(t.TempDir(), "notadir")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cli.stateRoot = blocker // MkdirAll under a file fails
+	leave, err := cli.enterTenantChecked(context.Background(), "slack:x")
+	if err == nil || leave != nil {
+		t.Fatalf("a principal without a store set must be refused, got leave=%v err=%v", leave != nil, err)
+	}
+	if cli.activeTenant() != "" {
+		t.Fatal("the shared set must stay installed")
+	}
+}
+
+func TestRetentionPass_CoversTenantRoots(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", root)
+	t.Setenv("CHATCLI_SESSION_TTL", "1d")
+	cli := newTenantTestCLI(t)
+	cli.stateRoot = root
+	tenant := filepath.Join(root, "tenants", "slack_a-deadbeef")
+	costs := filepath.Join(tenant, "costs")
+	if err := os.MkdirAll(costs, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	old := filepath.Join(costs, "old-session.json")
+	if err := os.WriteFile(old, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	past := time.Now().Add(-72 * time.Hour)
+	if err := os.Chtimes(old, past, past); err != nil {
+		t.Fatal(err)
+	}
+	if roots := tenantRoots(root); len(roots) != 1 || roots[0] != tenant {
+		t.Fatalf("tenantRoots = %v", roots)
+	}
+	rep := cli.runRetentionPass()
+	if _, err := os.Stat(old); !os.IsNotExist(err) || rep.Costs < 1 {
+		t.Fatalf("stale tenant cost snapshot must be pruned: rep=%+v err=%v", rep, err)
+	}
+}

--- a/cli/extension_providers.go
+++ b/cli/extension_providers.go
@@ -158,7 +158,9 @@ func (cli *ChatCLI) externalMemoryStore(ctx context.Context, session string, msg
 		if strings.TrimSpace(m.Content) == "" {
 			continue
 		}
-		payload = append(payload, map[string]string{"role": m.Role, "content": m.Content})
+		// The same secret redaction the embedded extractor applies: an
+		// external provider never receives raw keys or tokens.
+		payload = append(payload, map[string]string{"role": m.Role, "content": redactSecretsForLLM(m.Content)})
 	}
 	if len(payload) == 0 {
 		return

--- a/cli/gateway_command.go
+++ b/cli/gateway_command.go
@@ -571,7 +571,14 @@ func (cli *ChatCLI) gatewayAgentFunc(sessions *hubSessions, transcriber transcri
 		// store set (sessions, memory, contexts, CCR, costs, transcript and
 		// live history) is installed for the turn and the shared set is
 		// restored afterwards. No-op for the shared principal.
-		if leave := cli.enterGatewayTenant(ctx, sessions, msg.Platform, msg.UserID); leave != nil {
+		leave, tenantErr := cli.enterGatewayTenant(ctx, sessions, msg.Platform, msg.UserID)
+		if tenantErr != nil {
+			// Isolation is a promise: a principal whose store set cannot be
+			// built is answered with an error, never served from the
+			// shared stores.
+			return i18n.T("gateway.tenant_unavailable"), nil
+		}
+		if leave != nil {
 			defer leave()
 		}
 

--- a/cli/llm_audit.go
+++ b/cli/llm_audit.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/diillson/chatcli/llm/client"
+	"github.com/diillson/chatcli/models"
 	"go.uber.org/zap"
 )
 
@@ -50,6 +51,15 @@ type llmAuditEntry struct {
 	DurationMS int64             `json:"duration_ms,omitempty"`
 	Redactions int64             `json:"redactions_total"`
 	Fields     map[string]string `json:"fields,omitempty"`
+
+	// Tenant is the gateway principal whose store set served the request
+	// ("" for the shared set); the token counts are the provider's own
+	// usage for the answered request (recv lines only).
+	Tenant           string `json:"tenant,omitempty"`
+	InputTokens      int    `json:"input_tokens,omitempty"`
+	OutputTokens     int    `json:"output_tokens,omitempty"`
+	CacheReadTokens  int    `json:"cache_read_tokens,omitempty"`
+	CacheWriteTokens int    `json:"cache_write_tokens,omitempty"`
 }
 
 // llmAuditWriter appends entries to the audit file.
@@ -59,6 +69,8 @@ type llmAuditWriter struct {
 	enc     *json.Encoder
 	surface string
 	session func() string
+	tenant  func() string
+	usage   func() *models.UsageInfo
 	logger  *zap.Logger
 }
 
@@ -92,17 +104,46 @@ func (cli *ChatCLI) initLLMAudit(surface string) {
 		}
 		return cli.costTracker.sessionIDSnapshot()
 	}
+	w.tenant = cli.activeTenant
+	w.usage = func() *models.UsageInfo {
+		if ua, ok := cli.Client.(client.UsageAwareClient); ok && cli.Client != nil {
+			return ua.LastUsage()
+		}
+		return nil
+	}
 	cli.llmAudit = w
 	client.RegisterRequestAuditor(w.record)
 }
 
+// setSurface renames the surface for entries from now on (the gateway,
+// ACP, tool and watch entrypoints share NewChatCLI with the REPL).
+func (w *llmAuditWriter) setSurface(surface string) {
+	if w == nil || surface == "" {
+		return
+	}
+	w.mu.Lock()
+	w.surface = surface
+	w.mu.Unlock()
+}
+
+// SetAuditSurface names the process role on every audit line from now on.
+func (cli *ChatCLI) SetAuditSurface(surface string) {
+	if cli == nil || cli.llmAudit == nil {
+		return
+	}
+	cli.llmAudit.setSurface(surface)
+}
+
 // record is the RequestAuditor callback.
 func (w *llmAuditWriter) record(ev client.RequestAuditEvent) {
+	w.mu.Lock()
+	surface := w.surface
+	w.mu.Unlock()
 	entry := llmAuditEntry{
 		Timestamp:  ev.Time.UTC().Format(time.RFC3339Nano),
 		Kind:       "llm",
 		Phase:      ev.Phase,
-		Surface:    w.surface,
+		Surface:    surface,
 		Provider:   ev.Provider,
 		Model:      ev.Model,
 		Status:     ev.Status,
@@ -114,6 +155,17 @@ func (w *llmAuditWriter) record(ev client.RequestAuditEvent) {
 	}
 	if w.session != nil {
 		entry.Session = w.session()
+	}
+	if w.tenant != nil {
+		entry.Tenant = w.tenant()
+	}
+	if ev.Phase == "recv" && ev.Status == "success" && w.usage != nil {
+		if u := w.usage(); u != nil {
+			entry.InputTokens = u.PromptTokens
+			entry.OutputTokens = u.CompletionTokens
+			entry.CacheReadTokens = u.CacheReadInputTokens
+			entry.CacheWriteTokens = u.CacheCreationInputTokens
+		}
 	}
 	w.mu.Lock()
 	defer w.mu.Unlock()

--- a/cli/oneshot_mode.go
+++ b/cli/oneshot_mode.go
@@ -48,6 +48,7 @@ func (cli *ChatCLI) HandleOneShotOrFatal(ctx context.Context, opts *Options) boo
 	if !opts.PromptFlagUsed && !HasStdin() {
 		return false
 	}
+	cli.SetAuditSurface("oneshot")
 
 	// Aplica overrides de provider/model
 	if err := cli.ApplyOverrides(ctx, cli.manager, opts.Provider, opts.Model); err != nil {

--- a/cli/retention.go
+++ b/cli/retention.go
@@ -14,6 +14,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -26,8 +27,9 @@ import (
 
 // retentionReport is what one boot pass removed.
 type retentionReport struct {
-	Parks int
-	Costs int
+	Transcripts int // tenant transcripts removed (the shared set prunes on open)
+	Parks       int
+	Costs       int
 }
 
 // runRetentionPass expires park snapshots and cost snapshots older than the
@@ -50,6 +52,13 @@ func (cli *ChatCLI) runRetentionPass() retentionReport {
 	}
 	if dir := costStoreDir(); dir != "" {
 		rep.Costs = pruneCostSnapshotsOlderThan(dir, cutoff)
+	}
+	// Tenant store sets (gateway isolation) follow the same policy.
+	if cli != nil && cli.stateRoot != "" {
+		for _, root := range tenantRoots(cli.stateRoot) {
+			rep.Costs += pruneCostSnapshotsOlderThan(filepath.Join(root, "costs"), cutoff)
+			rep.Transcripts += pruneTranscripts(filepath.Join(root, transcriptDirName), ttl)
+		}
 	}
 	if cli != nil && cli.logger != nil && (rep.Parks > 0 || rep.Costs > 0) {
 		cli.logger.Info("retention pass", zap.Int("parks_removed", rep.Parks), zap.Int("cost_snapshots_removed", rep.Costs))

--- a/cli/tenant_scope.go
+++ b/cli/tenant_scope.go
@@ -224,8 +224,16 @@ func (cli *ChatCLI) buildTenantStores(ctx context.Context, principal string) (*t
 // swaps the base set back. Nil for the shared principal (no-op). Callers
 // hold the gateway turn mutex, which is what makes the swap safe.
 func (cli *ChatCLI) enterTenant(ctx context.Context, principal string) func() {
+	leave, _ := cli.enterTenantChecked(ctx, principal)
+	return leave
+}
+
+// enterTenantChecked is enterTenant reporting why a principal could not
+// get its own store set. Callers that must not serve one tenant's turn
+// from the shared stores refuse the turn on error.
+func (cli *ChatCLI) enterTenantChecked(ctx context.Context, principal string) (func(), error) {
 	if principal == "" || principal == defaultHubPrincipal {
-		return nil
+		return nil, nil
 	}
 	if cli.tenants == nil {
 		cli.tenants = &tenantPool{max: gatewayMaxTenants(), items: map[string]*tenantStores{}}
@@ -241,9 +249,9 @@ func (cli *ChatCLI) enterTenant(ctx context.Context, principal string) func() {
 		built, err := cli.buildTenantStores(ctx, principal)
 		if err != nil {
 			if cli.logger != nil {
-				cli.logger.Error("tenant store set unavailable; serving from the shared stores", zap.String("principal", principal), zap.Error(err))
+				cli.logger.Error("tenant store set unavailable; refusing to serve from the shared stores", zap.String("principal", principal), zap.Error(err))
 			}
-			return nil
+			return nil, err
 		}
 		ts = built
 		ts.lastUsed = time.Now()
@@ -268,7 +276,7 @@ func (cli *ChatCLI) enterTenant(ctx context.Context, principal string) func() {
 		pool.active = ""
 		pool.mu.Unlock()
 		cli.applyStores(pool.base)
-	}
+	}, nil
 }
 
 // evictTenantsLocked releases least recently used sets beyond the cap.
@@ -300,11 +308,26 @@ func (cli *ChatCLI) evictTenantsLocked() {
 
 // enterGatewayTenant is the gateway hook: swaps the sender's store set in
 // when hub isolation is on and the sender is not the shared principal.
-func (cli *ChatCLI) enterGatewayTenant(ctx context.Context, sessions *hubSessions, platform, userID string) func() {
+func (cli *ChatCLI) enterGatewayTenant(ctx context.Context, sessions *hubSessions, platform, userID string) (func(), error) {
 	if sessions == nil || sessions.store == nil || !resolveHubIsolate(ctx, sessions.store) {
+		return nil, nil
+	}
+	return cli.enterTenantChecked(ctx, sessions.principalFor(ctx, platform, userID))
+}
+
+// tenantRoots lists the on-disk roots of every principal's store set.
+func tenantRoots(stateRoot string) []string {
+	entries, err := os.ReadDir(filepath.Join(stateRoot, "tenants"))
+	if err != nil {
 		return nil
 	}
-	return cli.enterTenant(ctx, sessions.principalFor(ctx, platform, userID))
+	var roots []string
+	for _, e := range entries {
+		if e.IsDir() {
+			roots = append(roots, filepath.Join(stateRoot, "tenants", e.Name()))
+		}
+	}
+	return roots
 }
 
 // activeTenant reports the principal whose store set is installed ("" for

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -197,6 +197,7 @@ func RunConnect(ctx context.Context, args []string, llmMgr manager.LLMManager, l
 	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("cmd.connect.init_failed"), err)
 	}
+	chatCLI.SetAuditSurface("remote")
 
 	// Override the LLM client with the remote client
 	chatCLI.Client = remoteClient

--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -38,6 +38,7 @@ func RunGateway(args []string, mgr manager.LLMManager, logger *zap.Logger) error
 	if err != nil {
 		return err
 	}
+	chatCLI.SetAuditSurface("gateway")
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()

--- a/cmd/rpcserve.go
+++ b/cmd/rpcserve.go
@@ -66,6 +66,7 @@ func runRPC(kind string, mgr manager.LLMManager, logger *zap.Logger) error {
 	if err != nil {
 		logger.Warn("rpcserve: ChatCLI init failed; agent/coder/tools disabled", zap.Error(err))
 	}
+	chatCLI.SetAuditSurface("acp")
 	if chatCLI != nil {
 		// stdin carries the JSON-RPC protocol: any interactive confirmation
 		// would consume protocol frames and hang the run. Unattended mode

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -297,6 +297,7 @@ func startColocatedGateway(llmMgr manager.LLMManager, srv *server.Server, logger
 		logger.Warn(i18n.T("cmd.server.gateway_init_failed"), zap.Error(err))
 		return nil
 	}
+	gwCLI.SetAuditSurface("gateway")
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		if err := gwCLI.RunGatewayWithBroker(ctx, broker); err != nil && ctx.Err() == nil {

--- a/cmd/tool.go
+++ b/cmd/tool.go
@@ -71,6 +71,7 @@ func RunTool(ctx context.Context, args []string, mgr manager.LLMManager, logger 
 	if err != nil {
 		return fmt.Errorf("chatcli init failed: %w", err)
 	}
+	chatCLI.SetAuditSurface("tool")
 	// One-shot, non-interactive: nothing may block reading stdin.
 	chatCLI.SetUnattended(true)
 	return runToolWith(ctx, chatCLI, args, os.Stdout)

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -144,6 +144,7 @@ func RunWatch(ctx context.Context, args []string, llmMgr manager.LLMManager, log
 	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("cmd.watch.init_failed"), err)
 	}
+	chatCLI.SetAuditSurface("watch")
 
 	if err := chatCLI.ApplyOverrides(ctx, llmMgr, opts.Provider, opts.Model); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("cmd.watch.override_failed"), err)

--- a/config/managed.go
+++ b/config/managed.go
@@ -61,11 +61,11 @@ var (
 	managedPresent bool
 )
 
-// ManagedConfigPath returns the managed file location for this process.
+// ManagedConfigPath returns the system managed file location for this
+// platform. CHATCLI_MANAGED_CONFIG names an ADDITIONAL file (see
+// ManagedConfigPaths); it can never replace the system file, so a shell
+// variable cannot switch off a locked policy.
 func ManagedConfigPath() string {
-	if p := strings.TrimSpace(os.Getenv(ManagedConfigEnv)); p != "" {
-		return p
-	}
 	if runtime.GOOS == "windows" {
 		base := os.Getenv("ProgramData")
 		if base == "" {
@@ -138,24 +138,81 @@ func unquote(v string) string {
 	return v
 }
 
-// ApplyManaged loads the managed file and applies it to the process
+// ManagedConfigPaths lists the managed files in precedence order: the
+// system file first, then the CHATCLI_MANAGED_CONFIG file when set. A
+// key the system file LOCKS cannot be redefined by the second file.
+func ManagedConfigPaths() []string {
+	paths := []string{ManagedConfigPath()}
+	if p := strings.TrimSpace(os.Getenv(ManagedConfigEnv)); p != "" && p != paths[0] {
+		paths = append(paths, p)
+	}
+	return paths
+}
+
+// mergeManagedFiles reads the given files in precedence order and merges
+// their entries: a later file may redefine unlocked keys and add new
+// ones, but never a key the FIRST (system) file locked. Missing files
+// are skipped; the returned error is the first read failure.
+func mergeManagedFiles(paths []string) []ManagedEntry {
+	merged, _, _, _ := mergeManagedFilesReport(paths)
+	return merged
+}
+
+func mergeManagedFilesReport(paths []string) (entries []ManagedEntry, read []string, present bool, err error) {
+	var merged []ManagedEntry
+	index := map[string]int{}
+	systemLocked := map[string]bool{}
+	for i, p := range paths {
+		data, rerr := os.ReadFile(p) // #nosec G304 -- fixed system path or operator-provided CHATCLI_MANAGED_CONFIG
+		if rerr != nil {
+			if !os.IsNotExist(rerr) && err == nil {
+				err = rerr
+			}
+			continue
+		}
+		read = append(read, p)
+		for _, e := range ParseManaged(string(data)) {
+			if i > 0 && systemLocked[e.Key] {
+				continue // the system policy is not overridable
+			}
+			if j, ok := index[e.Key]; ok {
+				merged[j] = e
+			} else {
+				index[e.Key] = len(merged)
+				merged = append(merged, e)
+			}
+			if i == 0 && e.Locked {
+				systemLocked[e.Key] = true
+			}
+		}
+	}
+	return merged, read, len(read) > 0, err
+}
+
+// loadManagedEntries merges the configured managed files (system first).
+func loadManagedEntries() (entries []ManagedEntry, present bool, path string, err error) {
+	entries, read, present, err := mergeManagedFilesReport(ManagedConfigPaths())
+	path = strings.Join(read, "; ")
+	if path == "" {
+		path = ManagedConfigPath()
+	}
+	return entries, present, path, err
+}
+
+// ApplyManaged loads the managed files and applies them to the process
 // environment: locked entries always, defaults only where the variable
 // is unset. Safe to call again (reload): locked values are re-asserted,
 // defaults re-filled. A missing file is not an error.
 func ApplyManaged() ManagedReport {
-	rep := ManagedReport{Path: ManagedConfigPath()}
-	data, err := os.ReadFile(rep.Path) // #nosec G304 -- fixed system path or operator-provided CHATCLI_MANAGED_CONFIG
-	if err != nil {
-		if !os.IsNotExist(err) {
-			rep.Err = err
-		}
+	entries, present, path, err := loadManagedEntries()
+	rep := ManagedReport{Path: path, Err: err}
+	if !present {
 		managedMu.Lock()
 		managedEntries, managedPath, managedPresent = nil, rep.Path, false
 		managedMu.Unlock()
 		return rep
 	}
 	rep.Present = true
-	entries := ParseManaged(string(data))
 	byKey := make(map[string]ManagedEntry, len(entries))
 	for _, e := range entries {
 		byKey[e.Key] = e

--- a/config/managed_test.go
+++ b/config/managed_test.go
@@ -95,13 +95,40 @@ func TestApplyManaged_MissingFileIsNotAnError(t *testing.T) {
 	}
 }
 
-func TestManagedConfigPath_EnvOverride(t *testing.T) {
+func TestManagedConfigPaths_EnvAddsASecondFileNeverReplacesTheSystemOne(t *testing.T) {
 	t.Setenv(ManagedConfigEnv, "/tmp/x.env")
-	if ManagedConfigPath() != "/tmp/x.env" {
-		t.Fatal("env override must win")
+	paths := ManagedConfigPaths()
+	if len(paths) != 2 || paths[0] != ManagedConfigPath() || paths[1] != "/tmp/x.env" {
+		t.Fatalf("paths = %v", paths)
 	}
 	t.Setenv(ManagedConfigEnv, "")
-	if p := ManagedConfigPath(); p == "" {
-		t.Fatal("a platform default must exist")
+	if p := ManagedConfigPaths(); len(p) != 1 || p[0] == "" {
+		t.Fatalf("a platform default must exist: %v", p)
+	}
+}
+
+func TestApplyManaged_SystemLockedKeysCannotBeOverriddenByTheEnvFile(t *testing.T) {
+	// The system file is a fixed path we cannot write in a test, so the
+	// merge logic is exercised directly: entries from a later file never
+	// redefine a key the first (system) file locked.
+	dir := t.TempDir()
+	sys := filepath.Join(dir, "system.env")
+	extra := filepath.Join(dir, "extra.env")
+	if err := os.WriteFile(sys, []byte("!CHATCLI_TEST_POLICY=locked\nCHATCLI_TEST_DEF=sys\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(extra, []byte("CHATCLI_TEST_POLICY=hijack\nCHATCLI_TEST_DEF=extra\nCHATCLI_TEST_NEW=1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	merged := mergeManagedFiles([]string{sys, extra})
+	got := map[string]ManagedEntry{}
+	for _, e := range merged {
+		got[e.Key] = e
+	}
+	if got["CHATCLI_TEST_POLICY"].Value != "locked" || !got["CHATCLI_TEST_POLICY"].Locked {
+		t.Fatalf("system lock must survive: %+v", got["CHATCLI_TEST_POLICY"])
+	}
+	if got["CHATCLI_TEST_DEF"].Value != "extra" || got["CHATCLI_TEST_NEW"].Value != "1" {
+		t.Fatalf("unlocked defaults may be redefined and new keys added: %+v", got)
 	}
 }

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -480,6 +480,7 @@
   "session.rpc.live_messages": "Live conversation: %d message(s).",
   "session.rpc.forked": "Forked to session '%s' — this session is now bound to it.",
   "gateway.session.unavailable": "Session management is unavailable right now (no session store or hub).",
+  "gateway.tenant_unavailable": "This chat could not get its own isolated store; the request was not processed. Ask the operator to check the gateway log.",
   "gateway.session.usage": "Session commands: /session attach <name> · /session detach · /session status · /session save <name> · /session list · /session new",
   "session.error_save": "Error saving session: %v",
   "session.save_success": "Session '%s' saved successfully.",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -480,6 +480,7 @@
   "session.rpc.live_messages": "Live conversation: %d message(s).",
   "session.rpc.forked": "Forked to session '%s' — this session is now bound to it.",
   "gateway.session.unavailable": "Session management is unavailable right now (no session store or hub).",
+  "gateway.tenant_unavailable": "This chat could not get its own isolated store; the request was not processed. Ask the operator to check the gateway log.",
   "gateway.session.usage": "Session commands: /session attach <name> · /session detach · /session status · /session save <name> · /session list · /session new",
   "session.error_save": "Error saving session: %v",
   "session.save_success": "Session '%s' saved successfully.",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -480,6 +480,7 @@
   "session.rpc.live_messages": "Conversa ativa: %d mensagem(ns).",
   "session.rpc.forked": "Fork criado em '%s' — esta sessão agora está vinculada a ela.",
   "gateway.session.unavailable": "Gestão de sessão indisponível no momento (sem store de sessões ou hub).",
+  "gateway.tenant_unavailable": "Este chat não conseguiu obter seu store isolado; a solicitação não foi processada. Peça ao operador para verificar o log do gateway.",
   "gateway.session.usage": "Comandos de sessão: /session attach <nome> · /session detach · /session status · /session save <nome> · /session list · /session new",
   "session.error_save": "Erro ao salvar sessão: %v",
   "session.save_success": "Sessão '%s' salva com sucesso.",

--- a/llm/claudeai/tool_usage_1h_test.go
+++ b/llm/claudeai/tool_usage_1h_test.go
@@ -1,0 +1,27 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package claudeai
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestParseClaudeToolResponse_CarriesTheHourCacheWriteShare(t *testing.T) {
+	body := `{"content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":2,"cache_creation_input_tokens":500,"cache_read_input_tokens":300,"cache_creation":{"ephemeral_1h_input_tokens":500,"ephemeral_5m_input_tokens":0}}}`
+	resp, err := parseClaudeToolResponse(body, zap.NewNop())
+	if err != nil || resp == nil || resp.Usage == nil {
+		t.Fatalf("parse: %v %+v", err, resp)
+	}
+	u := resp.Usage
+	if u.PromptTokens != 10 || u.CompletionTokens != 2 || u.CacheCreationInputTokens != 500 || u.CacheReadInputTokens != 300 || !u.IsReal {
+		t.Fatalf("usage = %+v", u)
+	}
+	if u.CacheCreation1hInputTokens != 500 {
+		t.Fatalf("the 1h write share must reach the cost tracker (2x rate), got %d", u.CacheCreation1hInputTokens)
+	}
+}

--- a/llm/claudeai/tool_use.go
+++ b/llm/claudeai/tool_use.go
@@ -372,21 +372,11 @@ func parseClaudeToolResponse(body string, logger *zap.Logger) (*models.LLMRespon
 	response.Content = strings.Join(textParts, "\n")
 
 	// Extract usage
-	if usage, ok := result["usage"].(map[string]interface{}); ok {
-		response.Usage = &models.UsageInfo{IsReal: true}
-		if it, ok := usage["input_tokens"].(float64); ok {
-			response.Usage.PromptTokens = int(it)
-		}
-		if ot, ok := usage["output_tokens"].(float64); ok {
-			response.Usage.CompletionTokens = int(ot)
-		}
-		if cc, ok := usage["cache_creation_input_tokens"].(float64); ok {
-			response.Usage.CacheCreationInputTokens = int(cc)
-		}
-		if cr, ok := usage["cache_read_input_tokens"].(float64); ok {
-			response.Usage.CacheReadInputTokens = int(cr)
-		}
-		response.Usage.TotalTokens = response.Usage.PromptTokens + response.Usage.CompletionTokens
+	if _, ok := result["usage"].(map[string]interface{}); ok {
+		// One parser for both surfaces: the 1-hour cache-write share
+		// (cache_creation.ephemeral_1h_input_tokens) is billed at 2x and
+		// was dropped here, under-pricing coder sessions on the hour TTL.
+		response.Usage = client.ParseAnthropicUsage(result)
 		// Store in global tracker so LastUsage() works
 		RecordClaudeUsage(response.Usage)
 	}

--- a/llm/devincli/devincli_client.go
+++ b/llm/devincli/devincli_client.go
@@ -272,6 +272,7 @@ func (c *Client) SendPrompt(ctx context.Context, prompt string, history []models
 	// re-count the previous turn's usage.
 	c.StoreUsage(nil)
 	start := time.Now()
+	client.LogRequestStart(c.logger, "DEVIN", c.model, zap.Int("history_len", len(history)), zap.Int("prompt_chars", len(prompt)))
 	c.logger.Info("llm: send",
 		zap.String("provider", "DEVIN"),
 		zap.String("model", c.model),
@@ -284,6 +285,7 @@ func (c *Client) SendPrompt(ctx context.Context, prompt string, history []models
 		return c.runOnce(ctx, flattened, timeout)
 	})
 	if err != nil {
+		client.LogRequestFinish(c.logger, "DEVIN", c.model, "error", time.Since(start))
 		c.logger.Error(i18n.T("llm.devincli.exec_failed"), zap.Error(err))
 		return "", err
 	}
@@ -295,6 +297,7 @@ func (c *Client) SendPrompt(ctx context.Context, prompt string, history []models
 		zap.Duration("duration", time.Since(start)),
 		zap.Int("response_chars", len(response)),
 	)
+	client.LogRequestFinish(c.logger, "DEVIN", c.model, "success", time.Since(start), zap.Int("response_chars", len(response)))
 	return response, nil
 }
 


### PR DESCRIPTION
## Summary (Audit II — G01…G05)
- **G01 cost**: `llm/claudeai/tool_use.go` parses usage via `client.ParseAnthropicUsage` → `cache_creation.ephemeral_1h_input_tokens` reaches the tracker (2× rate) on the coder path.
- **G02 audit**: `SetAuditSurface` per entrypoint (gateway, ACP, tool, watch, remote, one-shot); recv lines carry `tenant`, `input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_write_tokens`; Devin CLI now logs through `LogRequestStart/Finish`.
- **G03 security**: `memory_store` payloads go through `redactSecretsForLLM` before leaving the process.
- **G04 policy**: system `managed.env` always loads first; `CHATCLI_MANAGED_CONFIG` is an additional file that cannot redefine system-locked keys (`ManagedConfigPaths`, `mergeManagedFiles`).
- **G05 tenancy**: fail-closed — a principal whose store set cannot be built gets an error reply (`gateway.tenant_unavailable`, i18n ×3) instead of the shared stores; retention prunes cost snapshots and transcripts under every tenant root.

## Tests
- 1h share parse; audit surface/tenant/tokens; extension redaction; tenant refusal; tenant retention; managed merge precedence.
- `go test ./...`, golangci-lint, i18n parity, ai-smells, api-breaking clean locally.
