### PR TITLE
feat(context): compaction hooks, verbatim-safe levels, summarizer accounting, 1h cache TTL on Bedrock/OpenRouter

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -2291,11 +2291,12 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 					renderer.Colorize("│", agent.ColorCyan),
 					renderer.Colorize(msg, agent.ColorGray))
 			})
+			a.cli.firePreCompact(ctx, compactTriggerAuto)
 			compacted, compactErr := a.cli.historyCompactor.Compact(ctx, a.cli.history, a.cli.Client, cfg)
 			a.cli.historyCompactor.SetStatusCallback(nil)
 			if compactErr == nil {
 				a.cli.history = compacted
-				a.cli.costTracker.NoteExpectedCacheRebuild()
+				a.cli.noteCompactionApplied(ctx, compactTriggerAuto)
 			} else if errors.Is(compactErr, context.Canceled) {
 				return compactErr
 			}
@@ -2567,9 +2568,20 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 					}
 				}
 
+				// Recovery drops whole messages without a summary: flush what
+				// the memory worker has not seen yet, tell the hooks, archive
+				// the dropped messages to CCR and account for the rebuild —
+				// the same guarantees as a planned compaction.
+				a.cli.flushMemoryBeforeCompaction(ctx)
+				a.cli.firePreCompact(ctx, compactTriggerRecovery)
 				recoveredHistory, recovered := contextRecovery.RecoverContextOverflow(a.cli.history)
 				if recovered {
+					if note := archiveDroppedMessages(a.cli.compressionLayer, a.cli.history, recoveredHistory); note != "" {
+						recoveredHistory = append(recoveredHistory, models.Message{Role: "user", Content: note})
+					}
 					a.cli.history = recoveredHistory
+					a.cli.costTracker.NoteExpectedCacheRebuild()
+					a.cli.firePostCompact(ctx, compactTriggerRecovery)
 
 					// Post-recovery hint for payload-related failures: without
 					// this, the model tends to re-read the same huge file that

--- a/cli/audit2_p1_test.go
+++ b/cli/audit2_p1_test.go
@@ -113,8 +113,8 @@ func TestSummaryPassesGate(t *testing.T) {
 	}{
 		{"", 100, false},
 		{"   ", 100, false},
-		{"SUMMARY", 200, true},                // tiny segment: tiny floor
-		{"SUMMARY", 100_000, false},           // huge segment: 7 chars is not a summary
+		{"SUMMARY", 200, true},      // tiny segment: tiny floor
+		{"SUMMARY", 100_000, false}, // huge segment: 7 chars is not a summary
 		{"I'm sorry, I cannot help with that " + long, 100_000, false},
 		{"Desculpe, não posso resumir " + long, 100_000, false},
 		{long, 100_000, true},

--- a/cli/audit2_p1_test.go
+++ b/cli/audit2_p1_test.go
@@ -1,0 +1,204 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/cli/compress"
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+// countingSummarizer returns a canned summary and counts calls.
+type countingSummarizer struct {
+	calls   int
+	summary string
+	usage   *models.UsageInfo
+}
+
+func (c *countingSummarizer) GetModelName() string { return "counting" }
+func (c *countingSummarizer) SendPrompt(context.Context, string, []models.Message, int) (string, error) {
+	c.calls++
+	return c.summary, nil
+}
+func (c *countingSummarizer) LastUsage() *models.UsageInfo { return c.usage }
+
+func verbatimFixture() []models.Message {
+	h := []models.Message{{Role: "system", Content: "charter"}}
+	for i := 0; i < 3; i++ {
+		h = append(h,
+			models.Message{Role: "user", Content: strings.Repeat("question detail ", 50)},
+			models.Message{Role: "assistant", Content: strings.Repeat("answer detail ", 50)},
+		)
+	}
+	h = append(h, models.Message{Role: "user", Content: "RECALLED ORIGINAL " + strings.Repeat("x", 300), Meta: &models.MessageMeta{PreserveVerbatim: true}})
+	h = append(h, models.Message{Role: "assistant", Content: strings.Repeat("more answer ", 50)})
+	for i := 0; i < 2; i++ {
+		h = append(h, models.Message{Role: "user", Content: "recent"})
+	}
+	return h
+}
+
+func hasVerbatim(h []models.Message) (int, bool) {
+	for i, m := range h {
+		if m.Meta != nil && m.Meta.PreserveVerbatim {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+func TestStructuredSummarize_KeepsPreserveVerbatimAfterSummary(t *testing.T) {
+	hc := NewHistoryCompactor(zap.NewNop())
+	cfg := CompactConfig{MinKeepRecent: 2}
+	got, err := hc.structuredSummarize(context.Background(), verbatimFixture(), &countingSummarizer{summary: strings.Repeat("## Summary\n- point ", 8)}, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	idx, ok := hasVerbatim(got)
+	if !ok {
+		t.Fatal("the PreserveVerbatim message must survive Level 2")
+	}
+	if got[idx-1].Meta == nil || !got[idx-1].Meta.IsSummary {
+		t.Fatalf("verbatim message must follow the summary, got index %d of %d", idx, len(got))
+	}
+	if got[idx-1].Meta.SummaryOf != 7 {
+		t.Fatalf("summary must cover the 7 compactable messages, got %d", got[idx-1].Meta.SummaryOf)
+	}
+}
+
+func TestEmergencyTruncate_KeepsVerbatimAndArchives(t *testing.T) {
+	layer := compress.NewLayer(compress.Config{Mode: compress.ModeLossyWithCCR, Store: compress.NewMemoryStore()})
+	hc := NewHistoryCompactor(zap.NewNop())
+	hc.SetCompressionLayer(layer)
+	got := hc.emergencyTruncate(verbatimFixture(), CompactConfig{MinKeepRecent: 2})
+	if _, ok := hasVerbatim(got); !ok {
+		t.Fatal("Level 3 must not drop a PreserveVerbatim message")
+	}
+	if !strings.Contains(got[1].Content, "@recall") {
+		t.Fatalf("Level 3 must archive what it drops to CCR: %q", got[1].Content)
+	}
+	if got[1].Meta.SummaryOf != 7 {
+		t.Fatalf("dropped count excludes the verbatim message: %d", got[1].Meta.SummaryOf)
+	}
+}
+
+func TestShrinkToBudget_SkipsVerbatim(t *testing.T) {
+	h := []models.Message{
+		{Role: "system", Content: "sys"},
+		{Role: "user", Content: strings.Repeat("v", 5000), Meta: &models.MessageMeta{PreserveVerbatim: true}},
+		{Role: "assistant", Content: strings.Repeat("a", 4000)},
+	}
+	got := shrinkToBudget(h, 6000, nil)
+	if len(got[1].Content) != 5000 {
+		t.Fatal("verbatim content must never be shrunk")
+	}
+	if len(got[2].Content) >= 4000 {
+		t.Fatal("the other message must absorb the cut")
+	}
+}
+
+func TestSummaryPassesGate(t *testing.T) {
+	long := strings.Repeat("## Files\n- a.go\n", 10)
+	cases := []struct {
+		resp string
+		seg  int
+		want bool
+	}{
+		{"", 100, false},
+		{"   ", 100, false},
+		{"SUMMARY", 200, true},                // tiny segment: tiny floor
+		{"SUMMARY", 100_000, false},           // huge segment: 7 chars is not a summary
+		{"I'm sorry, I cannot help with that " + long, 100_000, false},
+		{"Desculpe, não posso resumir " + long, 100_000, false},
+		{long, 100_000, true},
+	}
+	for _, c := range cases {
+		if got := summaryPassesGate(c.resp, c.seg); got != c.want {
+			t.Fatalf("gate(%q, %d) = %v, want %v", c.resp[:min(len(c.resp), 20)], c.seg, got, c.want)
+		}
+	}
+}
+
+func TestStructuredSummarize_QualityGateRetriesThenFails(t *testing.T) {
+	hc := NewHistoryCompactor(zap.NewNop())
+	s := &countingSummarizer{summary: "I'm sorry, I cannot summarize this conversation for you today."}
+	_, err := hc.structuredSummarize(context.Background(), summarizeFixtureHistory(2), s, CompactConfig{MinKeepRecent: 2})
+	if err == nil || s.calls != 2 {
+		t.Fatalf("a refusal must be retried once then rejected: err=%v calls=%d", err, s.calls)
+	}
+}
+
+func TestCompact_BacksOffLevel2WhenItDoesNotConverge(t *testing.T) {
+	hc := NewHistoryCompactor(zap.NewNop())
+	// The "summary" is as big as the segment: Level 2 can never fit the budget.
+	s := &countingSummarizer{summary: strings.Repeat("## Never converges\n- detail ", 400), usage: &models.UsageInfo{PromptTokens: 1000, CompletionTokens: 200}}
+	// MaxPayloadBytes caps the budget at 0.7×6000 chars: below the summary.
+	cfg := CompactConfig{Provider: "openai", Model: "gpt-5.6-terra", MinKeepRecent: 2, BudgetRatio: 0.5, CharsPerToken: 4, MaxPayloadBytes: 6000}
+	history := summarizeFixtureHistory(2)
+	for i := 0; i < 4; i++ {
+		history = append(history, models.Message{Role: "user", Content: strings.Repeat("filler ", 400)}, models.Message{Role: "assistant", Content: strings.Repeat("reply ", 400)})
+	}
+	out, err := hc.Compact(context.Background(), history, s, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rep := hc.LastReport()
+	if rep.Level != 3 || s.calls != 1 || rep.SummaryUsage == nil || rep.SummaryProvider != "openai" {
+		t.Fatalf("first run: level=%d calls=%d report=%+v", rep.Level, s.calls, rep)
+	}
+	// Next compactions skip the summarizer (back-off), then it comes back.
+	for i := 1; i <= l2BackoffTurns; i++ {
+		if _, err := hc.Compact(context.Background(), history, s, cfg); err != nil {
+			t.Fatal(err)
+		}
+		if s.calls != 1 || !hc.LastReport().Level2SkippedByBO {
+			t.Fatalf("run %d must skip Level 2: calls=%d report=%+v", i, s.calls, hc.LastReport())
+		}
+	}
+	if _, err := hc.Compact(context.Background(), history, s, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if s.calls != 2 {
+		t.Fatalf("after the back-off the summarizer must be tried again: calls=%d", s.calls)
+	}
+	_ = out
+}
+
+func TestRecordCompaction_CountsAndCosts(t *testing.T) {
+	ct := NewCostTracker()
+	ct.RecordCompaction(CompactReport{Level: 1})
+	ct.RecordCompaction(CompactReport{Level: 3, SummaryProvider: "openai", SummaryModel: "gpt-5.6-terra", SummaryUsage: &models.UsageInfo{PromptTokens: 100_000, CompletionTokens: 2_000, TotalTokens: 102_000}})
+	total, l3, cost := ct.CompactionStats()
+	if total != 2 || l3 != 1 || cost <= 0 {
+		t.Fatalf("stats = %d/%d/%f", total, l3, cost)
+	}
+	snap := ct.Snapshot()
+	if snap.Compactions != 2 || snap.CompactionsLevel3 != 1 || snap.CompactionCostUSD != cost {
+		t.Fatalf("snapshot = %+v", snap)
+	}
+	if snap.TotalCostUSD < cost {
+		t.Fatalf("the summarizer request joins the session total: total=%f compaction=%f", snap.TotalCostUSD, cost)
+	}
+	var nilTracker *CostTracker
+	nilTracker.RecordCompaction(CompactReport{Level: 2}) // must not panic
+}
+
+func TestArchiveDroppedMessages(t *testing.T) {
+	layer := compress.NewLayer(compress.Config{Mode: compress.ModeLossyWithCCR, Store: compress.NewMemoryStore()})
+	before := []models.Message{{Role: "system", Content: "sys"}, {Role: "user", Content: "keep"}, {Role: "assistant", Content: strings.Repeat("dropped ", 100)}, {Role: "user", Content: "keep"}}
+	after := []models.Message{{Role: "system", Content: "sys"}, {Role: "user", Content: "keep"}}
+	note := archiveDroppedMessages(layer, before, after)
+	if !strings.Contains(note, "@recall") {
+		t.Fatalf("dropped messages must be archived: %q", note)
+	}
+	if archiveDroppedMessages(layer, before, before) != "" || archiveDroppedMessages(nil, before, after) != "" {
+		t.Fatal("nothing dropped / no layer must yield no note")
+	}
+}

--- a/cli/cli_llm.go
+++ b/cli/cli_llm.go
@@ -205,11 +205,12 @@ func (cli *ChatCLI) compactHistoryIfNeeded(ctx context.Context) {
 		_ = os.Stdout.Sync()
 	})
 	cli.flushMemoryBeforeCompaction(ctx)
+	cli.firePreCompact(ctx, compactTriggerAuto)
 	compacted, err := cli.historyCompactor.Compact(ctx, cli.history, cli.Client, cfg)
 	cli.historyCompactor.SetStatusCallback(nil)
 	if err == nil {
 		cli.history = compacted
-		cli.costTracker.NoteExpectedCacheRebuild()
+		cli.noteCompactionApplied(ctx, compactTriggerAuto)
 	}
 }
 

--- a/cli/compact_command.go
+++ b/cli/compact_command.go
@@ -3,12 +3,10 @@ package cli
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
 	"github.com/diillson/chatcli/cli/compress"
-	"github.com/diillson/chatcli/cli/hooks"
 	"github.com/diillson/chatcli/i18n"
 	"github.com/diillson/chatcli/models"
 	"go.uber.org/zap"
@@ -30,20 +28,14 @@ func (cli *ChatCLI) handleCompactCommand(ctx context.Context, userInput string) 
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	// The pipeline's Level 2 summary can take minutes on a long history;
+	// the summarizer call carries its own bound (structuredSummarize), so
+	// the command only needs a generous outer one.
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Minute)
 	defer cancel()
 
 	if instruction == "" {
-		// Fire PreCompact hook
-		if cli.hookManager != nil {
-			wd, _ := os.Getwd()
-			cli.hookManager.Fire(ctx, hooks.HookEvent{
-				Type:       hooks.EventPreCompact,
-				Timestamp:  time.Now(),
-				SessionID:  cli.currentSessionName,
-				WorkingDir: wd,
-			})
-		}
+		cli.firePreCompact(ctx, compactTriggerManual)
 
 		// Automatic compaction
 		cfg := cli.compactConfig(cli.Provider, cli.Model)
@@ -64,24 +56,10 @@ func (cli *ChatCLI) handleCompactCommand(ctx context.Context, userInput string) 
 
 		before := len(cli.history)
 		cli.history = compacted
-		cli.costTracker.NoteExpectedCacheRebuild()
+		cli.noteCompactionApplied(ctx, compactTriggerManual)
 		after := len(cli.history)
 		fmt.Printf("  %s %s\n",
 			colorize("📦", ""), i18n.T("compact.success", before, after))
-
-		// Fire PostCompact hook
-		if cli.hookManager != nil {
-			wd, _ := os.Getwd()
-			// Detached: the async hook must outlive this command (and the
-			// 60s timeout ctx that defer-cancels on return), so we strip
-			// cancellation but keep inherited values.
-			cli.hookManager.FireAsync(context.WithoutCancel(ctx), hooks.HookEvent{
-				Type:       hooks.EventPostCompact,
-				Timestamp:  time.Now(),
-				SessionID:  cli.currentSessionName,
-				WorkingDir: wd,
-			})
-		}
 		return
 	}
 
@@ -118,7 +96,7 @@ func (cli *ChatCLI) guidedCompact(ctx context.Context, instruction string) {
 		return
 	}
 
-	middleMessages := cli.history[systemEnd:recentStart]
+	middleMessages, verbatim := splitVerbatim(cli.history[systemEnd:recentStart])
 	if len(middleMessages) < 2 {
 		fmt.Println(colorize("  "+i18n.T("compact.error.not_enough_middle"), ColorGray))
 		return
@@ -158,24 +136,43 @@ CONVERSATION TO COMPACT:
 		colorize(instruction, ColorCyan),
 	)
 
+	cli.firePreCompact(ctx, compactTriggerManual)
+
+	// Same route and bound as the automatic pipeline: the configured
+	// summarizer (CHATCLI_COMPACT_SUMMARIZER_*) when there is one, else the
+	// session client, with the summary's own 10-minute allowance.
+	cfg := cli.compactConfig(cli.Provider, cli.Model)
+	summarizer, usingSession := cli.Client, true
+	if cfg.SummarizerClient != nil {
+		summarizer, usingSession = cfg.SummarizerClient, false
+	}
+	summarizeCtx, cancelSummary := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancelSummary()
+
 	var response string
 	var err error
 	if ext := cli.externalSummarizer(); ext != nil {
-		response, err = ext.Compact(ctx, sb.String(), summarizerInputBudget(cli.compactConfig(cli.Provider, cli.Model)), instruction)
+		response, err = ext.Compact(summarizeCtx, sb.String(), summarizerInputBudget(cfg), instruction)
 		if err != nil {
 			cli.logger.Warn("context engine failed on guided compaction; using the session model", zap.Error(err))
 		}
 	}
 	if strings.TrimSpace(response) == "" {
-		response, err = cli.Client.SendPrompt(ctx, prompt, summaryHistory, 0)
+		response, err = summarizer.SendPrompt(summarizeCtx, prompt, summaryHistory, 0)
 		// Auto-retry on OAuth token expiration (401)
-		if cli.refreshClientOnAuthError(err) {
-			response, err = cli.Client.SendPrompt(ctx, prompt, summaryHistory, 0)
+		if usingSession && cli.refreshClientOnAuthError(err) {
+			summarizer = cli.Client
+			response, err = summarizer.SendPrompt(summarizeCtx, prompt, summaryHistory, 0)
 		}
 	}
 	if err != nil {
 		cli.logger.Warn("Guided compaction failed", zap.Error(err))
 		fmt.Println(colorize(fmt.Sprintf("  %s", i18n.T("compact.error.failed", err)), ColorYellow))
+		return
+	}
+	if !summaryPassesGate(response, sb.Len()) {
+		cli.logger.Warn("Guided compaction summary rejected by the quality gate", zap.Int("chars", len(strings.TrimSpace(response))))
+		fmt.Println(colorize("  "+i18n.T("compact.error.summary_rejected"), ColorYellow))
 		return
 	}
 
@@ -204,10 +201,17 @@ CONVERSATION TO COMPACT:
 			SummaryOf: len(middleMessages),
 		},
 	})
+	result = append(result, verbatim...)
 	result = append(result, cli.history[recentStart:]...)
 
 	cli.history = result
+	rep := CompactReport{Level: 2, SummaryUsage: summarizerUsage(cli.Client, cfg), SummaryProvider: cfg.SummarizerProvider, SummaryModel: cfg.SummarizerModel}
+	if rep.SummaryProvider == "" {
+		rep.SummaryProvider, rep.SummaryModel = cli.Provider, cli.Model
+	}
+	cli.costTracker.RecordCompaction(rep)
 	cli.costTracker.NoteExpectedCacheRebuild()
+	cli.firePostCompact(ctx, compactTriggerManual)
 	after := len(cli.history)
 
 	fmt.Printf("  %s %s (%s: %s)\n",

--- a/cli/compaction_hooks.go
+++ b/cli/compaction_hooks.go
@@ -1,0 +1,106 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * One seam for everything that surrounds a compaction, whichever loop
+ * runs it (chat, agent/coder, one-shot, /compact, overflow recovery):
+ * the PreCompact/PostCompact hooks with their trigger, the cost record,
+ * the cache-rebuild note. Keeping the call sites to two lines is what
+ * makes the four loops behave the same.
+ */
+package cli
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/diillson/chatcli/cli/compress"
+	"github.com/diillson/chatcli/cli/hooks"
+	"github.com/diillson/chatcli/models"
+)
+
+// Compaction triggers reported to hooks (CHATCLI_HOOK_TRIGGER).
+const (
+	compactTriggerAuto     = "auto"
+	compactTriggerManual   = "manual"
+	compactTriggerRecovery = "recovery"
+)
+
+// firePreCompact runs the PreCompact hooks synchronously (they may want to
+// snapshot the history before it changes).
+func (cli *ChatCLI) firePreCompact(ctx context.Context, trigger string) {
+	if cli == nil || cli.hookManager == nil {
+		return
+	}
+	cli.hookManager.Fire(ctx, cli.compactionEvent(hooks.EventPreCompact, trigger))
+}
+
+// firePostCompact runs the PostCompact hooks detached from the turn's
+// deadline (the turn must not wait on them).
+func (cli *ChatCLI) firePostCompact(ctx context.Context, trigger string) {
+	if cli == nil || cli.hookManager == nil {
+		return
+	}
+	cli.hookManager.FireAsync(context.WithoutCancel(ctx), cli.compactionEvent(hooks.EventPostCompact, trigger))
+}
+
+func (cli *ChatCLI) compactionEvent(typ hooks.EventType, trigger string) hooks.HookEvent {
+	wd, _ := os.Getwd()
+	return hooks.HookEvent{
+		Type:       typ,
+		Timestamp:  time.Now(),
+		SessionID:  cli.currentSessionName,
+		WorkingDir: wd,
+		Trigger:    trigger,
+	}
+}
+
+// noteCompactionApplied is the post-compaction bookkeeping shared by every
+// loop: cost record from the compactor's report, cache-rebuild note for
+// the cache telemetry, PostCompact hooks.
+func (cli *ChatCLI) noteCompactionApplied(ctx context.Context, trigger string) {
+	if cli == nil {
+		return
+	}
+	if cli.historyCompactor != nil {
+		cli.costTracker.RecordCompaction(cli.historyCompactor.LastReport())
+	}
+	cli.costTracker.NoteExpectedCacheRebuild()
+	cli.firePostCompact(ctx, trigger)
+}
+
+// archiveDroppedMessages archives to CCR the messages of before that are
+// absent from after (overflow recovery drops whole messages without a
+// summary). Returns the recall marker note, empty when nothing was
+// archived.
+func archiveDroppedMessages(layer *compress.Layer, before, after []models.Message) string {
+	if layer == nil || len(before) == 0 {
+		return ""
+	}
+	kept := make(map[string]int, len(after))
+	for _, m := range after {
+		kept[m.Role+"\x00"+m.Content]++
+	}
+	dropped := make([]models.Message, 0, len(before))
+	for _, m := range before {
+		key := m.Role + "\x00" + m.Content
+		if kept[key] > 0 {
+			kept[key]--
+			continue
+		}
+		if m.Role == "system" {
+			continue
+		}
+		dropped = append(dropped, m)
+	}
+	if len(dropped) == 0 {
+		return ""
+	}
+	key, ok := layer.Archive(renderMessagesForArchive(dropped))
+	if !ok {
+		return ""
+	}
+	return "[full transcript of the messages dropped by context recovery recoverable via @recall " + compress.FormatMarker(key) + "]"
+}

--- a/cli/cost_command.go
+++ b/cli/cost_command.go
@@ -263,6 +263,10 @@ func (cli *ChatCLI) renderCostSummary() {
 		fmt.Println(p + "    " + colorize(i18n.T("cost.cmd.cache_storage",
 			ct.cacheResources, fmt.Sprintf("$%.4f", ct.cacheStorageUSD)), ColorGray))
 	}
+	if ct.compactions > 0 {
+		fmt.Println(p + "    " + colorize(i18n.T("cost.cmd.compactions",
+			ct.compactions, ct.compactionsLevel3, fmt.Sprintf("$%.4f", ct.compactionCostUSD)), ColorGray))
+	}
 	// Session prompt-cache telemetry: hit share, misses, rebuilds ChatCLI
 	// itself caused (compaction), and whether the prefix is still warm.
 	if stats := ct.cacheStatsLocked(); stats.Reported() {

--- a/cli/cost_compaction.go
+++ b/cli/cost_compaction.go
@@ -1,0 +1,41 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Compaction accounting: how many times the history was compacted this
+ * session, how many landed in Level 3, and what the Level 2 summarizer
+ * cost. The summarizer's request is a real request on the session (or
+ * the configured summarizer) route, so its usage joins the totals like
+ * any turn; the compaction slice is kept apart so /cost can show it.
+ */
+package cli
+
+// RecordCompaction accounts one Compact run from its report.
+func (ct *CostTracker) RecordCompaction(rep CompactReport) {
+	if ct == nil || rep.Level == 0 {
+		return
+	}
+	var cost float64
+	if rep.SummaryUsage != nil {
+		cost = estimateTurnCostUSD(rep.SummaryProvider, rep.SummaryModel, rep.SummaryUsage)
+		ct.RecordRealUsage(rep.SummaryProvider, rep.SummaryModel, rep.SummaryUsage)
+	}
+	ct.mu.Lock()
+	ct.compactions++
+	if rep.Level == 3 {
+		ct.compactionsLevel3++
+	}
+	ct.compactionCostUSD += cost
+	ct.mu.Unlock()
+}
+
+// CompactionStats returns the session's compaction counters.
+func (ct *CostTracker) CompactionStats() (total, level3 int, costUSD float64) {
+	if ct == nil {
+		return 0, 0, 0
+	}
+	ct.mu.RLock()
+	defer ct.mu.RUnlock()
+	return ct.compactions, ct.compactionsLevel3, ct.compactionCostUSD
+}

--- a/cli/cost_tracker.go
+++ b/cli/cost_tracker.go
@@ -112,6 +112,9 @@ type SessionCostData struct {
 	CacheResources         int     `json:"cache_resources,omitempty"`
 	CacheStorageTokenHours float64 `json:"cache_storage_token_hours,omitempty"`
 	CacheStorageCostUSD    float64 `json:"cache_storage_cost_usd,omitempty"`
+	Compactions            int     `json:"compactions,omitempty"`
+	CompactionsLevel3      int     `json:"compactions_level3,omitempty"`
+	CompactionCostUSD      float64 `json:"compaction_cost_usd,omitempty"`
 }
 
 // CostTracker tracks token usage and estimated cost for the current session,
@@ -157,6 +160,9 @@ type CostTracker struct {
 	cacheResources         int
 	cacheStorageTokenHours float64
 	cacheStorageUSD        float64
+	compactions            int
+	compactionsLevel3      int
+	compactionCostUSD      float64
 
 	// Persistence write-through throttle.
 	lastSave time.Time
@@ -438,6 +444,9 @@ func (ct *CostTracker) snapshotLocked() SessionCostData {
 		CacheResources:         ct.cacheResources,
 		CacheStorageTokenHours: ct.cacheStorageTokenHours,
 		CacheStorageCostUSD:    ct.cacheStorageUSD,
+		Compactions:            ct.compactions,
+		CompactionsLevel3:      ct.compactionsLevel3,
+		CompactionCostUSD:      ct.compactionCostUSD,
 	}
 }
 
@@ -588,6 +597,9 @@ func (ct *CostTracker) RestoreSession(sessionID string) error {
 	ct.cacheResources = data.CacheResources
 	ct.cacheStorageTokenHours = data.CacheStorageTokenHours
 	ct.cacheStorageUSD = data.CacheStorageCostUSD
+	ct.compactions = data.Compactions
+	ct.compactionsLevel3 = data.CompactionsLevel3
+	ct.compactionCostUSD = data.CompactionCostUSD
 	ct.recomputeAggregates()
 	return nil
 }

--- a/cli/extension_compactor_test.go
+++ b/cli/extension_compactor_test.go
@@ -21,7 +21,7 @@ type summarizerStub struct{ calls int }
 func (s *summarizerStub) GetModelName() string { return "stub" }
 func (s *summarizerStub) SendPrompt(context.Context, string, []models.Message, int) (string, error) {
 	s.calls++
-	return "EMBEDDED SUMMARY", nil
+	return "EMBEDDED SUMMARY\n## Files Read\n- none of note\n## Current Task State\n- the user asked for a refactor of the parser and the assistant delivered it", nil
 }
 
 func compactableHistory() []models.Message {
@@ -48,7 +48,7 @@ func TestStructuredSummarize_ContextEngineReplacesAndFallsBack(t *testing.T) {
 		if budget <= 0 || instruction != "" {
 			t.Fatalf("budget=%d instruction=%q", budget, instruction)
 		}
-		return "ENGINE SUMMARY", nil
+		return "ENGINE SUMMARY\n## Files Read\n- none of note\n## Current Task State\n- the user asked for a refactor of the parser and the assistant delivered it", nil
 	})
 	out, err := hc.structuredSummarize(context.Background(), compactableHistory(), stub, cfg)
 	if err != nil {

--- a/cli/history_compactor.go
+++ b/cli/history_compactor.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -46,7 +47,47 @@ type HistoryCompactor struct {
 	compress *compress.Layer
 	statusMu sync.RWMutex
 	onStatus StatusCallback
+
+	// l2Backoff counts the compactions that skip Level 2: set when a
+	// summary did not bring the history under budget (the next turns would
+	// pay a summarizer call each to land in Level 3 anyway).
+	l2Backoff  int
+	lastReport CompactReport
 }
+
+// CompactReport describes the last Compact run: the level that produced
+// the result and what the Level 2 summarizer consumed (nil when no
+// summary was produced), so the caller can account for it.
+type CompactReport struct {
+	Level             int
+	SummaryUsage      *models.UsageInfo
+	SummaryProvider   string
+	SummaryModel      string
+	Level2SkippedByBO bool
+}
+
+// LastReport returns the report of the most recent Compact call.
+func (hc *HistoryCompactor) LastReport() CompactReport {
+	hc.statusMu.RLock()
+	defer hc.statusMu.RUnlock()
+	return hc.lastReport
+}
+
+func (hc *HistoryCompactor) setReport(rep CompactReport) {
+	hc.statusMu.Lock()
+	hc.lastReport = rep
+	hc.statusMu.Unlock()
+}
+
+// l2BackoffTurns is how many compactions skip Level 2 after a summary
+// failed to converge.
+const l2BackoffTurns = 2
+
+// minSummaryChars caps the quality floor for a Level 2 summary: the floor
+// scales with the segment (segment/40) up to this many characters, so a
+// one-line answer for a hundred-kilobyte segment is a refusal, a truncated
+// stream or an empty answer — not a summary — and must not replace it.
+const minSummaryChars = 80
 
 // CompactConfig holds parameters for a compaction operation.
 type CompactConfig struct {
@@ -317,12 +358,30 @@ func (hc *HistoryCompactor) Compact(
 		)
 		hc.emitStatus(CompactStageDone, i18n.T("compact.status.trim_sufficient",
 			FormatPayloadSize(before), FormatPayloadSize(current)))
+		hc.setReport(CompactReport{Level: 1})
 		return history, nil
 	}
 
 	// LEVEL 2: Structured summarization of old messages (requires LLM call)
-	hc.emitStatus(CompactStageSummarize, i18n.T("compact.status.summarize"))
-	summarized, err := hc.structuredSummarize(ctx, history, llmClient, cfg)
+	rep := CompactReport{Level: 2, SummaryProvider: cfg.SummarizerProvider, SummaryModel: cfg.SummarizerModel}
+	if rep.SummaryProvider == "" {
+		rep.SummaryProvider, rep.SummaryModel = cfg.Provider, cfg.Model
+	}
+	var (
+		summarized []models.Message
+		err        error
+	)
+	if hc.l2Backoff > 0 {
+		hc.l2Backoff--
+		rep.Level2SkippedByBO = true
+		err = errL2Backoff
+		hc.logger.Info("Level 2 skipped: back-off after a non-converging summary",
+			zap.Int("remaining", hc.l2Backoff))
+	} else {
+		hc.emitStatus(CompactStageSummarize, i18n.T("compact.status.summarize"))
+		summarized, err = hc.structuredSummarize(ctx, history, llmClient, cfg)
+		rep.SummaryUsage = summarizerUsage(llmClient, cfg)
+	}
 	if err != nil {
 		// A cancellation from the user should propagate, not silently fall
 		// through to emergency truncation — the user's own choice to abort
@@ -340,6 +399,7 @@ func (hc *HistoryCompactor) Compact(
 		history = summarized
 		current = totalChars(history)
 		if current <= budget {
+			hc.l2Backoff = 0
 			hc.logger.Info("Level 2 (structured summarization) sufficient",
 				zap.Int("before_chars", before),
 				zap.Int("after_chars", current),
@@ -348,8 +408,14 @@ func (hc *HistoryCompactor) Compact(
 			)
 			hc.emitStatus(CompactStageDone, i18n.T("compact.status.summarize_applied",
 				beforeMsgs, len(history), FormatPayloadSize(before), FormatPayloadSize(current)))
+			hc.setReport(rep)
 			return history, nil
 		}
+		// The summary alone did not fit: the next compactions go straight
+		// to Level 3 instead of paying a summarizer call per turn.
+		hc.l2Backoff = l2BackoffTurns
+		hc.logger.Warn("Level 2 did not converge; backing off the summarizer",
+			zap.Int("after_chars", current), zap.Int("budget_chars", budget), zap.Int("skip_turns", l2BackoffTurns))
 	}
 
 	// LEVEL 3: Emergency truncation (last resort)
@@ -370,8 +436,41 @@ func (hc *HistoryCompactor) Compact(
 		zap.Int("after_msgs", len(history)),
 	)
 	hc.emitStatus(CompactStageDone, i18n.T("compact.status.truncated", beforeMsgs, len(history)))
+	rep.Level = 3
+	hc.setReport(rep)
 
 	return history, nil
+}
+
+// errL2Backoff marks a Level 2 skipped by the back-off (not a failure).
+var errL2Backoff = errors.New("level 2 skipped by back-off")
+
+// summarizerUsage reads what the Level 2 call consumed from the client
+// that served it (the configured summarizer, else the session client).
+func summarizerUsage(llmClient client.LLMClient, cfg CompactConfig) *models.UsageInfo {
+	c := llmClient
+	if cfg.SummarizerClient != nil {
+		c = cfg.SummarizerClient
+	}
+	if ua, ok := c.(client.UsageAwareClient); ok && ua != nil {
+		return ua.LastUsage()
+	}
+	return nil
+}
+
+// splitVerbatim separates the messages flagged PreserveVerbatim from a
+// segment about to be summarized or dropped: they are re-appended after
+// the summary, in order, so the model keeps seeing exactly what it asked
+// to see in full.
+func splitVerbatim(segment []models.Message) (compactable, verbatim []models.Message) {
+	for _, m := range segment {
+		if m.Meta != nil && m.Meta.PreserveVerbatim {
+			verbatim = append(verbatim, m)
+			continue
+		}
+		compactable = append(compactable, m)
+	}
+	return compactable, verbatim
 }
 
 // structuredSummarize summarizes the "middle" block of messages using
@@ -399,7 +498,7 @@ func (hc *HistoryCompactor) structuredSummarize(
 		return history, nil
 	}
 
-	middleMessages := history[systemEnd:recentStart]
+	middleMessages, verbatim := splitVerbatim(history[systemEnd:recentStart])
 	if len(middleMessages) < 4 {
 		return history, nil
 	}
@@ -441,6 +540,21 @@ func (hc *HistoryCompactor) structuredSummarize(
 			return nil, fmt.Errorf("structured summarization LLM call failed: %w", err)
 		}
 	}
+	// Quality gate: a refusal, an empty or a truncated answer must never
+	// replace the segment. One retry, then the caller falls back to Level
+	// 3 (which archives the segment to CCR instead of losing it).
+	if !summaryPassesGate(response, len(segment)) {
+		hc.logger.Warn("Level 2 summary rejected by the quality gate; retrying once",
+			zap.Int("chars", len(strings.TrimSpace(response))))
+		hc.emitStatus(CompactStageSummarize, i18n.T("compact.status.summary_retry"))
+		response, err = summarizer.SendPrompt(summarizeCtx, prompt, summaryHistory, 0)
+		if err != nil {
+			return nil, fmt.Errorf("structured summarization retry failed: %w", err)
+		}
+		if !summaryPassesGate(response, len(segment)) {
+			return nil, errSummaryRejected
+		}
+	}
 
 	// Archive the FULL middle segment (untruncated, unlike the summarizer
 	// input above) before replacing it: level 1 (trim) and level 3
@@ -464,9 +578,36 @@ func (hc *HistoryCompactor) structuredSummarize(
 			SummaryOf: len(middleMessages),
 		},
 	})
+	result = append(result, verbatim...)
 	result = append(result, history[recentStart:]...)
 
 	return result, nil
+}
+
+// errSummaryRejected marks a summary that failed the quality gate twice.
+var errSummaryRejected = errors.New("summary rejected by the quality gate")
+
+// summaryPassesGate is the Level 2 quality gate: a length floor relative
+// to the summarized segment and no refusal/placeholder opening.
+func summaryPassesGate(response string, segmentChars int) bool {
+	text := strings.TrimSpace(response)
+	floor := segmentChars / 40
+	if floor > minSummaryChars {
+		floor = minSummaryChars
+	}
+	if text == "" || len(text) < floor {
+		return false
+	}
+	head := strings.ToLower(text)
+	if len(head) > 160 {
+		head = head[:160]
+	}
+	for _, refusal := range []string{"i'm sorry", "i am sorry", "i cannot", "i can't", "as an ai", "não posso", "desculpe"} {
+		if strings.HasPrefix(head, refusal) {
+			return false
+		}
+	}
+	return true
 }
 
 // Summarizer input sizing: the segment text may take this share of the
@@ -620,18 +761,32 @@ func (hc *HistoryCompactor) emergencyTruncate(history []models.Message, cfg Comp
 		return history
 	}
 
-	droppedCount := recentStart - systemEnd
+	dropped, verbatim := splitVerbatim(history[systemEnd:recentStart])
+	droppedCount := len(dropped)
+	if droppedCount == 0 {
+		return history
+	}
 
-	result := make([]models.Message, 0, systemEnd+1+keepRecent)
+	// Level 3 was the pipeline's lossy floor: archive what it drops so
+	// @recall can bring any of it back (best-effort, like Level 2).
+	recallNote := ""
+	if hc.compress != nil {
+		if key, ok := hc.compress.Archive(renderMessagesForArchive(dropped)); ok {
+			recallNote = " Full transcript of the removed messages recoverable via @recall " + compress.FormatMarker(key) + "."
+		}
+	}
+
+	result := make([]models.Message, 0, systemEnd+1+len(verbatim)+keepRecent)
 	result = append(result, history[:systemEnd]...)
 	result = append(result, models.Message{
 		Role:    "user",
-		Content: fmt.Sprintf("[CONTEXT TRUNCATED: %d messages removed due to context window limit. Recent context preserved below.]", droppedCount),
+		Content: fmt.Sprintf("[CONTEXT TRUNCATED: %d messages removed due to context window limit. Recent context preserved below.%s]", droppedCount, recallNote),
 		Meta: &models.MessageMeta{
 			IsSummary: true,
 			SummaryOf: droppedCount,
 		},
 	})
+	result = append(result, verbatim...)
 	result = append(result, history[recentStart:]...)
 
 	return result
@@ -670,7 +825,7 @@ func shrinkToBudget(history []models.Message, budget int, ccr *compress.Layer) [
 		// Pick the largest shrinkable (non-system, above-floor) message.
 		idx, maxLen := -1, floorChars
 		for i, msg := range result {
-			if msg.Role == "system" {
+			if msg.Role == "system" || (msg.Meta != nil && msg.Meta.PreserveVerbatim) {
 				continue
 			}
 			if len(msg.Content) > maxLen {

--- a/cli/history_compactor_archive_test.go
+++ b/cli/history_compactor_archive_test.go
@@ -20,7 +20,7 @@ type summarizerFake struct{}
 
 func (summarizerFake) GetModelName() string { return "fake" }
 func (summarizerFake) SendPrompt(_ context.Context, _ string, _ []models.Message, _ int) (string, error) {
-	return "## Files Read\n- none", nil
+	return "## Files Read\n- none of note\n## Current Task State\n- the user asked for a refactor of the parser and the assistant delivered it\n## Decisions\n- keep the lexer stateful", nil
 }
 
 func summarizeFixtureHistory(minKeepRecent int) []models.Message {

--- a/cli/hooks/manager.go
+++ b/cli/hooks/manager.go
@@ -196,6 +196,7 @@ func (m *Manager) executeCommandHook(ctx context.Context, hook HookConfig, event
 		"CHATCLI_HOOK_EVENT="+string(event.Type),
 		"CHATCLI_HOOK_TOOL="+event.ToolName,
 		"CHATCLI_HOOK_SESSION="+event.SessionID,
+		"CHATCLI_HOOK_TRIGGER="+event.Trigger,
 	)
 
 	err := cmd.Run()

--- a/cli/hooks/trigger_test.go
+++ b/cli/hooks/trigger_test.go
@@ -1,0 +1,24 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package hooks
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+func TestCommandHook_ReceivesTrigger(t *testing.T) {
+	m := NewManager(zap.NewNop())
+	res := m.executeCommandHook(context.Background(), HookConfig{Name: "t", Event: EventPreCompact, Type: HookTypeCommand, Command: "echo trigger=$CHATCLI_HOOK_TRIGGER; cat"},
+		HookEvent{Type: EventPreCompact, Trigger: "recovery", Timestamp: time.Now()}, 5*time.Second)
+	if res == nil || !strings.Contains(res.Output, "trigger=recovery") || !strings.Contains(res.Output, `"trigger":"recovery"`) {
+		t.Fatalf("trigger must reach env and JSON: %+v", res)
+	}
+}

--- a/cli/hooks/types.go
+++ b/cli/hooks/types.go
@@ -103,6 +103,10 @@ type HookEvent struct {
 	SessionID string `json:"sessionId,omitempty"`
 	// WorkingDir is the current working directory.
 	WorkingDir string `json:"workingDir,omitempty"`
+	// Trigger says what caused a compaction event: "auto" (window/payload
+	// pressure at a turn boundary), "manual" (/compact) or "recovery"
+	// (context-overflow recovery after a rejected request).
+	Trigger string `json:"trigger,omitempty"`
 }
 
 // HookResult is the result of a hook execution.

--- a/cli/oneshot_mode.go
+++ b/cli/oneshot_mode.go
@@ -244,9 +244,10 @@ func (cli *ChatCLI) RunOnce(ctx context.Context, input string, disableAnimation 
 		cli.historyCompactor.SetStatusCallback(func(stage CompactStage, msg string) {
 			fmt.Fprintf(os.Stderr, "  %s\n", msg)
 		})
+		cli.firePreCompact(ctx, compactTriggerAuto)
 		if compacted, compactErr := cli.historyCompactor.Compact(ctx, cli.history, activeClient, cfg); compactErr == nil {
 			cli.history = compacted
-			cli.costTracker.NoteExpectedCacheRebuild()
+			cli.noteCompactionApplied(ctx, compactTriggerAuto)
 		}
 		cli.historyCompactor.SetStatusCallback(nil)
 	}

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -2204,10 +2204,8 @@
   "llm.zai.jwt_cached": "Using cached ZAI JWT token",
   "llm.zai.jwt_invalid_key": "Invalid ZAI API key format for JWT (expected id.secret), using raw key",
   "llm.info.using_custom_base_url": "Using custom base URL for %s: %s",
-
   "cfg.route.unknown_section": "Unknown section: %s",
   "cfg.route.hint": "Sections: all, general, providers, agent, resilience, session, integrations, auth, security, server",
-
   "cfg.val.default": "(default)",
   "cfg.val.managed_tag": "(managed)",
   "cfg.val.managed_locked_tag": "(managed · locked)",
@@ -2243,11 +2241,9 @@
   "cfg.val.budget_ok": "OK",
   "cfg.val.budget_warning": "Warning",
   "cfg.val.budget_exceeded": "Exceeded",
-
   "cfg.panorama.title": "ChatCLI — Panorama",
   "cfg.panorama.drill_down": "Drill-down:",
   "cfg.panorama.sections_hint": "Sections: providers, agent, resilience, session, integrations, auth, security, server",
-
   "cfg.section.general.title": "General",
   "cfg.section.providers.title": "Providers",
   "cfg.section.agent.title": "Agent runtime",
@@ -2331,7 +2327,6 @@
   "cfg.hub.principal": "principal",
   "cfg.hub.conversation": "conversation",
   "cfg.section.server.title": "Server / operator",
-
   "cfg.sub.quality.refine": "── Self-Refine (#5)",
   "cfg.sub.quality.verify": "── Chain-of-Verification / CoVe (#6)",
   "cfg.sub.quality.reflexion": "── Reflexion (#3)",
@@ -2344,7 +2339,6 @@
   "cfg.kv.quality.vector_count": "Vector entries",
   "cfg.kv.quality.vector_state": "Vector index",
   "cfg.val.not_attached": "(not attached)",
-
   "complete.root.thinking": "Override extended thinking / reasoning_effort for the next turn (cross-provider)",
   "complete.root.plan": "Force Plan-and-Solve / ReWOO on the next /agent or /coder run",
   "complete.root.refine": "Toggle Self-Refine post-processing for the session (on|off|auto)",
@@ -2412,7 +2406,6 @@
   "thinking.state_auto": "thinking: auto (no override active)",
   "thinking.state_off": "thinking: explicitly off (override active)",
   "thinking.state_set": "thinking: %s (override active)",
-
   "cfg.sub.general.locale": "── Locale & version",
   "cfg.sub.general.logging": "── Logging",
   "cfg.sub.general.history": "── Command history",
@@ -2486,7 +2479,6 @@
   "cfg.sub.server.watcher": "── K8s watcher (server)",
   "cfg.sub.server.audit": "── Audit",
   "cfg.sub.server.operator": "── Operator / AIOps",
-
   "cfg.kv.provider": "Provider",
   "cfg.kv.model": "Model",
   "cfg.kv.model_client": "Model (client)",
@@ -2557,7 +2549,6 @@
   "cfg.kv.last_match": "Last match",
   "cfg.kv.dotenv_path": ".env file path",
   "cfg.kv.history_file": "History file",
-
   "cfg.msg.skip_server": "No server-mode env vars detected — skipping (CLI context).",
   "cfg.msg.server_hint": "This section is only meaningful when running `chatcli server` or the operator.",
   "cfg.msg.auth_hint": "Run /auth login <provider> to authenticate.",
@@ -2569,7 +2560,6 @@
   "cfg.msg.no_contexts_attached": "(none — /context attach <name>)",
   "cfg.msg.no_persona": "(none — /agent load <name>)",
   "cfg.msg.manager_not_init": "(manager not initialized)",
-
   "ws.cmd.usage_provider": "Usage: /websearch provider <searxng|duckduckgo|auto>",
   "ws.cmd.unknown_sub": "Unknown subcommand: %s",
   "ws.cmd.usage_hint": "Usage: /websearch [list|provider <name>|reset|status]",
@@ -2596,7 +2586,6 @@
   "ws.cmd.persist_hint": "To persist, add to your shell/.env:",
   "ws.cmd.persist_unset": "unset CHATCLI_WEBSEARCH_PROVIDER",
   "ws.cmd.persist_set": "export CHATCLI_WEBSEARCH_PROVIDER=%s",
-
   "complete.config.reload": "Reload .env and reconfigure providers (same as /reload)",
   "complete.config.all": "Full dump (all sections)",
   "complete.config.general": "dotenv, locale, logging, version check",
@@ -2611,7 +2600,6 @@
   "complete.config.quality": "Seven-pattern agent quality pipeline (Self-Refine, CoVe, Reflexion, Plan-First, HyDE, Reasoning)",
   "complete.config.root_desc": "Configuration panorama (sections: all, general, providers, agent, quality, resilience, session, integrations, auth, security, server)",
   "complete.config.status_alias": "Alias of /config — configuration panorama",
-
   "complete.thinking.auto": "Clear override — defer to skill hints + quality.reasoning auto-agents",
   "complete.thinking.off": "Force NO thinking / reasoning_effort for next turn",
   "complete.thinking.on": "Alias for /thinking high — enable high-tier reasoning next turn",
@@ -2622,25 +2610,21 @@
   "complete.thinking.budget_medium": "Tier closest to 4096 thinking tokens → medium",
   "complete.thinking.budget_high": "Tier closest to 8000 thinking tokens → high (default)",
   "complete.thinking.budget_max": "Tier closest to 16384 thinking tokens → max",
-
   "complete.refine.on": "Force Self-Refine ON for this session (overrides /config quality)",
   "complete.refine.off": "Force Self-Refine OFF for this session",
   "complete.refine.once": "Arm Self-Refine for the next turn only",
   "complete.refine.auto": "Clear session override — use /config quality setting",
   "complete.refine.clear": "Alias for auto — clear session override",
-
   "complete.verify.on": "Force Chain-of-Verification ON for this session",
   "complete.verify.off": "Force Chain-of-Verification OFF for this session",
   "complete.verify.once": "Arm CoVe for the next turn only",
   "complete.verify.auto": "Clear session override — use /config quality setting",
   "complete.verify.clear": "Alias for auto — clear session override",
-
   "complete.plan.hint": "Free-text task. Without args, arms plan-first flag for the next /agent or /coder run.",
   "complete.plan.agent": "Explicit: plan-first + agent mode (same as /plan <task>)",
   "complete.plan.coder": "Plan-first + coder mode (software engineer with tools)",
   "complete.plan.preview": "Dry-run: generate and render the plan without executing anything",
   "complete.plan.dry": "Alias of preview — dry-run without execution",
-
   "complete.reflect.hint": "Free-text lesson. Persists directly to memory.Fact (category=lesson, trigger=manual) without LLM call.",
   "complete.reflect.list": "Show pending reflexion queue + DLQ entries",
   "complete.reflect.failed": "List dead-letter entries (failed lessons needing review)",
@@ -2648,8 +2632,6 @@
   "complete.reflect.purge": "Permanently delete a DLQ entry by job ID (requires <id>)",
   "complete.reflect.drain": "Force replay of WAL-pending lessons from a previous session",
   "complete.reflect.id_placeholder": "Job ID from /reflect failed (16 hex chars)",
-
-
   "complete.websearch.root_desc": "Configure web search provider (list, provider, reset, status)",
   "complete.websearch.sub_status": "Show current provider + active fallback chain",
   "complete.websearch.sub_list": "List known providers and which are configured",
@@ -2660,7 +2642,6 @@
   "complete.websearch.prov_brave": "HTML scraping, independent index, no API key",
   "complete.websearch.prov_mojeek": "HTML scraping, independent index, no API key",
   "complete.websearch.prov_auto": "Auto: DuckDuckGo first, SearxNG as fallback if configured",
-
   "hooks.cmd.not_initialized": "Hooks not initialized.",
   "hooks.cmd.box_title": "HOOKS",
   "hooks.cmd.none_configured": "No hooks configured.",
@@ -2674,7 +2655,6 @@
   "hooks.cmd.total_summary": "%d hooks (%s%d active%s)",
   "hooks.cmd.suggest_list": "List all configured hooks",
   "hooks.cmd.suggest_reload": "Reload hooks from configuration files",
-
   "mcp.dynamic.server_not_connected": "MCP server %q is not connected",
   "mcp.proxy.not_enabled": "MCP client is not enabled in this ChatCLI instance",
   "mcp.proxy.tool_not_found": "MCP tool %q not found on any connected server",
@@ -2687,8 +2667,8 @@
   "tool.usage": "Run one with: chatcli tool <name> --flag value ...  (or a single JSON envelope). No LLM call is made.",
   "agent.policy.ask_denied": "ACTION DENIED BY THE USER (security policy): %s",
   "agent.policy.ask_denied_always": "ACTION PERMANENTLY BLOCKED BY THE USER (deny rule recorded): %s",
-  "agent.policy.ask_timeout": "ACTION BLOCKED \u2014 the permission request timed out with no user response (the client may not display approval dialogs): %s",
-  "agent.policy.ask_failed": "ACTION BLOCKED \u2014 the permission request failed before the user could answer (transport error or cancelled turn): %s",
+  "agent.policy.ask_timeout": "ACTION BLOCKED — the permission request timed out with no user response (the client may not display approval dialogs): %s",
+  "agent.policy.ask_failed": "ACTION BLOCKED — the permission request failed before the user could answer (transport error or cancelled turn): %s",
   "scheduler.wait.progress": "wait_until: job %s still %s — %v elapsed, giving up in %v",
   "acp.permission.allow_once": "Allow",
   "acp.permission.allow_always": "Always allow",
@@ -2784,7 +2764,6 @@
   "mcp.cmd.usage_logs": "Usage: /mcp logs <server-name>",
   "mcp.cmd.box_logs_title": "MCP LOGS — %s",
   "mcp.cmd.no_logs": "No log lines captured yet.",
-
   "wt.cmd.usage_create": "Usage: /worktree create <branch-name>",
   "wt.cmd.usage_remove": "Usage: /worktree remove <path-or-branch>",
   "wt.cmd.err_not_git_repo": "Error: not inside a git repository.",
@@ -2815,7 +2794,6 @@
   "wt.cmd.sugg_list": "List active worktrees",
   "wt.cmd.sugg_remove": "Remove a worktree",
   "wt.cmd.sugg_status": "Show current worktree info",
-
   "cost.cmd.not_initialized": "Cost tracker not initialized.",
   "cost.cmd.box_title": "Session cost",
   "cost.cmd.provider": "Provider",
@@ -2866,7 +2844,6 @@
   "cost.cmd.output_cost": "Output: ",
   "cost.cmd.cache_cost": "Cache:",
   "cost.cmd.pricing_unavailable": "Pricing not available for this model.",
-
   "chan.cmd.box_title": "MCP channels",
   "chan.cmd.box_title_filtered": "CHANNEL: %s",
   "chan.cmd.mcp_disabled": "MCP not enabled. Channels require MCP servers.",
@@ -2897,7 +2874,6 @@
   "chan.cmd.confirm_denied": "Confirm action #%d denied.",
   "chan.cmd.run_usage": "Usage: /channel run <seq>",
   "chan.cmd.run_bad_seq": "Invalid seq number.",
-
   "chan.banner.title": "MCP channel inbox",
   "chan.banner.unread": "%d new channel message(s) since last ack",
   "chan.cmd.clear_all_done": "Inbox fully purged: %d message(s) removed, %d pending notification(s) acknowledged, audit file truncated — nothing will replay on restart",
@@ -2915,12 +2891,10 @@
   "chan.cmd.suggest_clear": "Drain the inbox (empty ring + ack); --all also truncates the audit file",
   "chan.banner.hint_ack": "Hint: /channel ack to clear, /channel list for full inbox",
   "chan.banner.more": "… and %d more item(s) — /channel list to see everything",
-
   "chan.trigger.toast_header": "trigger fired (%s) — rule %s",
   "chan.trigger.toast_confirm_hint": "Run /channel confirm %d [yes|no] to resolve",
   "chan.trigger.toast_auto_hint": "Will run on next prompt cycle. Press Esc to abort once started.",
   "chan.trigger.auto_header": "AUTO-AGENT ▶ %s   (%s/%s)",
-
   "complete.root.exit": "Exit ChatCLI",
   "complete.root.quit": "Alias of /exit - Exit ChatCLI",
   "complete.root.switch": "Switch the LLM provider; followed by --model changes the model",
@@ -2974,7 +2948,6 @@
   "graph.cmd.rendered": "Rendered the knowledge graph:",
   "graph.cmd.error": "Could not render the graph: %s",
   "graph.tool.no_node": "No graph node found for %q.",
-
   "complete.generic.flag_mode": "Set file processing mode (full, summary, chunked, smart, knowledge)",
   "complete.generic.flag_model": "Switch the model (runtime) based on the current provider (gpt-5, grok-4, etc.)",
   "complete.generic.flag_max_tokens": "Set the max tokens for the next responses (0 for default)",
@@ -2984,7 +2957,6 @@
   "complete.generic.flag_ai": "Send the command output directly to the AI to analyze; for additional context type ( @command --ai <command> > <context>)",
   "complete.generic.option_for": "Option for %s",
   "complete.generic.values_suffix": "(values: %s)",
-
   "complete.skill.user_invocable_fallback": "user-invocable skill",
   "complete.skill.sub_search": "Search for skills across registries",
   "complete.skill.sub_install": "Install a skill from a registry",
@@ -3004,7 +2976,6 @@
   "complete.skill.sub_registry_disable": "Disable a registry",
   "complete.skill.flag_reset": "Remove preference (use default order)",
   "complete.skill.prefer_local": "Prefer local version",
-
   "complete.connect.token": "Server authentication token",
   "complete.connect.provider": "LLM provider (OPENAI, CLAUDEAI, GOOGLEAI, XAI, ZAI, MINIMAX, MOONSHOT, STACKSPOT, OLLAMA, COPILOT, GITHUB_MODELS, OPENROUTER)",
   "complete.connect.model": "LLM model (gpt-4, claude-3, etc.)",
@@ -3017,7 +2988,6 @@
   "complete.connect.realm": "StackSpot: Realm/Tenant",
   "complete.connect.agent_id": "StackSpot: Agent ID",
   "complete.connect.ollama_url": "Ollama: Server base URL (e.g. http://localhost:11434)",
-
   "complete.watch.flag_deployment": "K8s deployment to monitor (required)",
   "complete.watch.flag_namespace": "Deployment namespace (default: default)",
   "complete.watch.flag_interval": "Collection interval (e.g. 10s, 1m)",
@@ -3027,7 +2997,6 @@
   "complete.watch.sub_start": "Start K8s monitoring (e.g. /watch start --deployment myapp)",
   "complete.watch.sub_stop": "Stop K8s monitoring",
   "complete.watch.sub_status": "Show active watcher status",
-
   "complete.context.root_desc": "📦 Manage persistent contexts (create, attach, detach, list, show, inspect, etc)",
   "complete.context.sub_create": "Create a context from files/directories (use --mode, --description, --tags)",
   "complete.context.sub_update": "Update an existing context (use --mode, --description, --tags)",
@@ -3089,7 +3058,6 @@
   "complete.context.name_chunks_fmt": "%d chunks",
   "complete.context.name_files_fmt": "%d files",
   "complete.context.name_tags_fmt": "tags:%s",
-
   "complete.session.root_desc": "Manage sessions (new, save, list, load, delete)",
   "complete.session.sub_new": "Create new session (clears current history)",
   "complete.session.sub_save": "Save current session with a name",
@@ -3102,14 +3070,12 @@
   "complete.session.sub_detach": "Drop the named-session binding (stop write-through)",
   "complete.session.sub_status": "Show the active session binding",
   "complete.session.saved_session": "Saved session",
-
   "complete.plugin.sub_list": "List all installed plugins.",
   "complete.plugin.sub_install": "Install a new plugin from a Git repository.",
   "complete.plugin.sub_reload": "Force reload of all installed plugins.",
   "complete.plugin.sub_show": "Show details of a specific plugin.",
   "complete.plugin.sub_inspect": "Show debug information for a plugin.",
   "complete.plugin.sub_uninstall": "Remove an installed plugin.",
-
   "complete.agent.sub_list": "List available agents",
   "complete.agent.sub_load": "Load a specific agent",
   "complete.agent.sub_attach": "Attach multiple agents to the existing session",
@@ -3120,13 +3086,11 @@
   "complete.agent.sub_off": "Disable the current agent",
   "complete.agent.sub_help": "Help for the /agent command",
   "complete.agent.flag_full": "Show full agent details",
-
   "complete.switch.root_desc": "Switch the LLM provider; followed by --model changes the model",
   "complete.switch.flag_model": "Switch the model (runtime) based on the current provider",
   "complete.switch.flag_max_tokens": "Set max tokens for the next responses (0 for default)",
   "complete.switch.flag_realm": "Change the Realm/Tenant at runtime",
   "complete.switch.flag_agent_id": "Change the agent at runtime",
-
   "complete.auth.root_desc": "Manage OAuth credentials (status, login, logout)",
   "complete.auth.sub_status": "Show authentication status for all providers",
   "complete.auth.sub_login": "Authenticate with a provider (anthropic, openai-codex, github-copilot, github-models)",
@@ -3135,7 +3099,6 @@
   "complete.auth.provider_openai_codex": "OpenAI (GPT Plus / Codex)",
   "complete.auth.provider_github_copilot": "GitHub Copilot",
   "complete.auth.provider_github_models": "GitHub Models (GPT-4o, Llama, Mistral, DeepSeek...)",
-
   "skill.cmd.installs_suffix": "installs",
   "skill.cmd.by_author": "by",
   "skill.cmd.status_enabled": "enabled",
@@ -3147,14 +3110,12 @@
   "skill.cmd.err_timeout": "unavailable (timeout)",
   "skill.cmd.err_tls": "TLS certificate error",
   "skill.cmd.err_not_found": "API endpoint not found",
-
   "persona.cmd.skills_count": "[%d skills]",
   "persona.cmd.skills_label": "Skills",
   "persona.cmd.arg_name": "<name>",
   "persona.cmd.arg_task": "<task>",
   "persona.cmd.example_agent": "create an HTTP server",
   "persona.cmd.example_coder": "refactor the code",
-
   "mem.cmd.no_notes_found_for": "No notes found for",
   "mem.cmd.profile.title": "User Profile",
   "mem.cmd.profile.empty": "No profile data yet. Interact more and the system will learn about you.",
@@ -3350,13 +3311,11 @@
   "mem.cmd.suggest.cat_project": "Project details",
   "mem.cmd.suggest.cat_personal": "Personal information",
   "mem.cmd.suggest.cat_general": "General facts",
-
   "sw.cmd.skill_swap_provider": "skill requested %s/%s — swapping for this turn",
   "sw.cmd.stream_stalled": "[Stream stalled — partial response shown]",
   "sw.cmd.could_not_list_models": "Could not list models for %s: %v",
   "sw.cmd.no_models_found": "No models found for %s",
   "sw.cmd.available_models_header": "Available models for %s (%s):",
-
   "sess.cmd.invalid_one_shot_input": "invalid input for one-shot agent mode: %s",
   "sess.cmd.fork_error": "Fork error: %v",
   "sess.cmd.fork_unsaved": "(unsaved)",
@@ -3365,12 +3324,9 @@
   "sess.cmd.fork_to": "To:",
   "sess.cmd.fork_messages": "Messages:",
   "sess.cmd.fork_footer": "Now working on the fork. The original remains intact.",
-
   "ctx.cmd.init_manager_error": "failed to initialize context manager",
   "ctx.cmd.read_response_error": "failed to read response",
-
   "cmd.core.session_fork_usage": "Usage: /session fork <new-name>",
-
   "scheduler.disabled": "Scheduler disabled for this session (CHATCLI_SCHEDULER_ENABLED=false or init failed).",
   "scheduler.created": "Job %s created (%s).",
   "scheduler.wait_async": "Wait registered in background as job %s.",
@@ -3433,12 +3389,10 @@
   "scheduler.wait.usage_example_2": "Example: /wait --until \"k8s:pod/prod/api:Ready\" --async",
   "scheduler.wait.usage_flags": "Flags: --until --then --every --timeout --max-polls --on-timeout --async --name",
   "scheduler.jobs.usage_header": "Usage: /jobs <subcommand> [args]",
-
   "help.section.scheduler": "Scheduler — Scheduling & wait-until",
   "help.command.schedule": "Schedules a job to fire at a time or cron expression. Ex: /schedule bk --cron \"0 2 * * *\" --do \"/run backup\"",
   "help.command.wait": "Waits until a condition is satisfied and optionally runs an action. Ex: /wait --until http://x/health==200 --then \"/run tests\"",
   "help.command.jobs": "Manage scheduled jobs: list, show, tree, cancel, pause, resume, logs, history, daemon, gc.",
-
   "cfg.section.scheduler.title": "Scheduler (Chronos) — Scheduling & Wait-Until",
   "cfg.sub.sched.core": "Core",
   "cfg.sub.sched.budget": "Default Budget",
@@ -3451,7 +3405,6 @@
   "cfg.kv.scheduler_queue_depth": "Queue depth",
   "cfg.kv.scheduler_audit_path": "Audit log",
   "cfg.kv.scheduler_daemon": "Daemon",
-
   "sched.complete.help": "Show command examples and flags",
   "sched.status.pending": "Waiting for next fire window",
   "sched.status.blocked": "Blocked by dependencies",
@@ -3549,7 +3502,6 @@
   "sched.jobs.daemon.start": "(use the binary: chatcli daemon start)",
   "sched.jobs.daemon.stop": "(use the binary: chatcli daemon stop)",
   "sched.jobs.daemon.restart": "(use the binary: chatcli daemon stop && start)",
-
   "help.command.parked": "list parked agents (/parked prune | gc <dur>)",
   "help.command.park_note": "send a directive to the parked agent (delivered at resume)",
   "help.command.resume": "force-resume a parked agent: /resume <token>",
@@ -3584,7 +3536,6 @@
   "park.resolve.empty": "park: empty token (use /parked to list)",
   "park.resolve.not_found": "park: no snapshot matching %q (use /parked to list)",
   "park.resolve.ambiguous": "park: token prefix %q is ambiguous (matches: %s) — use a longer prefix",
-
   "sec.cmd.usage_header": "Usage: /config security {rules|allow|deny|forget|reload} [args]",
   "sec.cmd.usage_note_pattern": "Patterns use prefix match against \"<toolName> <args>\" (e.g. \"@coder exec kubectl get\"). Deny beats Allow.",
   "sec.cmd.usage_note_scope": "Changes persist to ~/.chatcli/coder_policy.json and take effect for /coder and the scheduler on the next fire.",
@@ -3715,10 +3666,8 @@
   "complete.configimage.reset": "Clear image overrides",
   "complete.configimage.val": "value",
   "agent.spinner.working": "working",
-
   "agent.summary.block_ok": "Block #%d completed",
   "agent.summary.block_failed": "Block #%d failed",
-
   "plugins.taskgraph.describe_generic": "Task graph operation",
   "plugins.taskgraph.describe_plan": "Validating and persisting a task graph plan",
   "plugins.taskgraph.describe_run": "Executing a task graph (parallel workers + independent review)",
@@ -3741,5 +3690,8 @@
   "complete.taskgraph.dash": "Open the live browser dashboard (animated DAG, evidence, cost)",
   "plugins.taskgraph.describe_dash": "Serving the task graph dashboard",
   "complete.taskgraph.prune": "Remove old runs (default 30d; \"all\" clears everything but the active run)",
-  "plugins.taskgraph.describe_prune": "Pruning old task graph runs"
+  "plugins.taskgraph.describe_prune": "Pruning old task graph runs",
+  "cost.cmd.compactions": "Compactions: %d (level 3: %d) · summarizer %s",
+  "compact.status.summary_retry": "⚠ Summary rejected by the quality gate — retrying once",
+  "compact.error.summary_rejected": "The summary failed the quality gate (too short or a refusal); history left untouched. Try again or rephrase the instruction."
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -2204,10 +2204,8 @@
   "llm.zai.jwt_cached": "Using cached ZAI JWT token",
   "llm.zai.jwt_invalid_key": "Invalid ZAI API key format for JWT (expected id.secret), using raw key",
   "llm.info.using_custom_base_url": "Using custom base URL for %s: %s",
-
   "cfg.route.unknown_section": "Unknown section: %s",
   "cfg.route.hint": "Sections: all, general, providers, agent, resilience, session, integrations, auth, security, server",
-
   "cfg.val.default": "(default)",
   "cfg.val.managed_tag": "(managed)",
   "cfg.val.managed_locked_tag": "(managed · locked)",
@@ -2243,11 +2241,9 @@
   "cfg.val.budget_ok": "OK",
   "cfg.val.budget_warning": "Warning",
   "cfg.val.budget_exceeded": "Exceeded",
-
   "cfg.panorama.title": "ChatCLI — Panorama",
   "cfg.panorama.drill_down": "Drill-down:",
   "cfg.panorama.sections_hint": "Sections: providers, agent, resilience, session, integrations, auth, security, server",
-
   "cfg.section.general.title": "General",
   "cfg.section.providers.title": "Providers",
   "cfg.section.agent.title": "Agent runtime",
@@ -2331,7 +2327,6 @@
   "cfg.hub.principal": "principal",
   "cfg.hub.conversation": "conversation",
   "cfg.section.server.title": "Server / operator",
-
   "cfg.sub.quality.refine": "── Self-Refine (#5)",
   "cfg.sub.quality.verify": "── Chain-of-Verification / CoVe (#6)",
   "cfg.sub.quality.reflexion": "── Reflexion (#3)",
@@ -2344,7 +2339,6 @@
   "cfg.kv.quality.vector_count": "Vector entries",
   "cfg.kv.quality.vector_state": "Vector index",
   "cfg.val.not_attached": "(not attached)",
-
   "complete.root.thinking": "Override extended thinking / reasoning_effort for the next turn (cross-provider)",
   "complete.root.plan": "Force Plan-and-Solve / ReWOO on the next /agent or /coder run",
   "complete.root.refine": "Toggle Self-Refine post-processing for the session (on|off|auto)",
@@ -2412,7 +2406,6 @@
   "thinking.state_auto": "thinking: auto (no override active)",
   "thinking.state_off": "thinking: explicitly off (override active)",
   "thinking.state_set": "thinking: %s (override active)",
-
   "cfg.sub.general.locale": "── Locale & version",
   "cfg.sub.general.logging": "── Logging",
   "cfg.sub.general.history": "── Command history",
@@ -2486,7 +2479,6 @@
   "cfg.sub.server.watcher": "── K8s watcher (server)",
   "cfg.sub.server.audit": "── Audit",
   "cfg.sub.server.operator": "── Operator / AIOps",
-
   "cfg.kv.provider": "Provider",
   "cfg.kv.model": "Model",
   "cfg.kv.model_client": "Model (client)",
@@ -2557,7 +2549,6 @@
   "cfg.kv.last_match": "Last match",
   "cfg.kv.dotenv_path": ".env file path",
   "cfg.kv.history_file": "History file",
-
   "cfg.msg.skip_server": "No server-mode env vars detected — skipping (CLI context).",
   "cfg.msg.server_hint": "This section is only meaningful when running `chatcli server` or the operator.",
   "cfg.msg.auth_hint": "Run /auth login <provider> to authenticate.",
@@ -2569,7 +2560,6 @@
   "cfg.msg.no_contexts_attached": "(none — /context attach <name>)",
   "cfg.msg.no_persona": "(none — /agent load <name>)",
   "cfg.msg.manager_not_init": "(manager not initialized)",
-
   "ws.cmd.usage_provider": "Usage: /websearch provider <searxng|duckduckgo|auto>",
   "ws.cmd.unknown_sub": "Unknown subcommand: %s",
   "ws.cmd.usage_hint": "Usage: /websearch [list|provider <name>|reset|status]",
@@ -2596,7 +2586,6 @@
   "ws.cmd.persist_hint": "To persist, add to your shell/.env:",
   "ws.cmd.persist_unset": "unset CHATCLI_WEBSEARCH_PROVIDER",
   "ws.cmd.persist_set": "export CHATCLI_WEBSEARCH_PROVIDER=%s",
-
   "complete.config.reload": "Reload .env and reconfigure providers (same as /reload)",
   "complete.config.all": "Full dump (all sections)",
   "complete.config.general": "dotenv, locale, logging, version check",
@@ -2611,7 +2600,6 @@
   "complete.config.quality": "Seven-pattern agent quality pipeline (Self-Refine, CoVe, Reflexion, Plan-First, HyDE, Reasoning)",
   "complete.config.root_desc": "Configuration panorama (sections: all, general, providers, agent, quality, resilience, session, integrations, auth, security, server)",
   "complete.config.status_alias": "Alias of /config — configuration panorama",
-
   "complete.thinking.auto": "Clear override — defer to skill hints + quality.reasoning auto-agents",
   "complete.thinking.off": "Force NO thinking / reasoning_effort for next turn",
   "complete.thinking.on": "Alias for /thinking high — enable high-tier reasoning next turn",
@@ -2622,25 +2610,21 @@
   "complete.thinking.budget_medium": "Tier closest to 4096 thinking tokens → medium",
   "complete.thinking.budget_high": "Tier closest to 8000 thinking tokens → high (default)",
   "complete.thinking.budget_max": "Tier closest to 16384 thinking tokens → max",
-
   "complete.refine.on": "Force Self-Refine ON for this session (overrides /config quality)",
   "complete.refine.off": "Force Self-Refine OFF for this session",
   "complete.refine.once": "Arm Self-Refine for the next turn only",
   "complete.refine.auto": "Clear session override — use /config quality setting",
   "complete.refine.clear": "Alias for auto — clear session override",
-
   "complete.verify.on": "Force Chain-of-Verification ON for this session",
   "complete.verify.off": "Force Chain-of-Verification OFF for this session",
   "complete.verify.once": "Arm CoVe for the next turn only",
   "complete.verify.auto": "Clear session override — use /config quality setting",
   "complete.verify.clear": "Alias for auto — clear session override",
-
   "complete.plan.hint": "Free-text task. Without args, arms plan-first flag for the next /agent or /coder run.",
   "complete.plan.agent": "Explicit: plan-first + agent mode (same as /plan <task>)",
   "complete.plan.coder": "Plan-first + coder mode (software engineer with tools)",
   "complete.plan.preview": "Dry-run: generate and render the plan without executing anything",
   "complete.plan.dry": "Alias of preview — dry-run without execution",
-
   "complete.reflect.hint": "Free-text lesson. Persists directly to memory.Fact (category=lesson, trigger=manual) without LLM call.",
   "complete.reflect.list": "Show pending reflexion queue + DLQ entries",
   "complete.reflect.failed": "List dead-letter entries (failed lessons needing review)",
@@ -2648,8 +2632,6 @@
   "complete.reflect.purge": "Permanently delete a DLQ entry by job ID (requires <id>)",
   "complete.reflect.drain": "Force replay of WAL-pending lessons from a previous session",
   "complete.reflect.id_placeholder": "Job ID from /reflect failed (16 hex chars)",
-
-
   "complete.websearch.root_desc": "Configure web search provider (list, provider, reset, status)",
   "complete.websearch.sub_status": "Show current provider + active fallback chain",
   "complete.websearch.sub_list": "List known providers and which are configured",
@@ -2660,7 +2642,6 @@
   "complete.websearch.prov_brave": "HTML scraping, independent index, no API key",
   "complete.websearch.prov_mojeek": "HTML scraping, independent index, no API key",
   "complete.websearch.prov_auto": "Auto: DuckDuckGo first, SearxNG as fallback if configured",
-
   "hooks.cmd.not_initialized": "Hooks not initialized.",
   "hooks.cmd.box_title": "HOOKS",
   "hooks.cmd.none_configured": "No hooks configured.",
@@ -2674,7 +2655,6 @@
   "hooks.cmd.total_summary": "%d hooks (%s%d active%s)",
   "hooks.cmd.suggest_list": "List all configured hooks",
   "hooks.cmd.suggest_reload": "Reload hooks from configuration files",
-
   "mcp.dynamic.server_not_connected": "MCP server %q is not connected",
   "mcp.proxy.not_enabled": "MCP client is not enabled in this ChatCLI instance",
   "mcp.proxy.tool_not_found": "MCP tool %q not found on any connected server",
@@ -2687,8 +2667,8 @@
   "tool.usage": "Run one with: chatcli tool <name> --flag value ...  (or a single JSON envelope). No LLM call is made.",
   "agent.policy.ask_denied": "ACTION DENIED BY THE USER (security policy): %s",
   "agent.policy.ask_denied_always": "ACTION PERMANENTLY BLOCKED BY THE USER (deny rule recorded): %s",
-  "agent.policy.ask_timeout": "ACTION BLOCKED \u2014 the permission request timed out with no user response (the client may not display approval dialogs): %s",
-  "agent.policy.ask_failed": "ACTION BLOCKED \u2014 the permission request failed before the user could answer (transport error or cancelled turn): %s",
+  "agent.policy.ask_timeout": "ACTION BLOCKED — the permission request timed out with no user response (the client may not display approval dialogs): %s",
+  "agent.policy.ask_failed": "ACTION BLOCKED — the permission request failed before the user could answer (transport error or cancelled turn): %s",
   "scheduler.wait.progress": "wait_until: job %s still %s — %v elapsed, giving up in %v",
   "acp.permission.allow_once": "Allow",
   "acp.permission.allow_always": "Always allow",
@@ -2784,7 +2764,6 @@
   "mcp.cmd.usage_logs": "Usage: /mcp logs <server-name>",
   "mcp.cmd.box_logs_title": "MCP LOGS — %s",
   "mcp.cmd.no_logs": "No log lines captured yet.",
-
   "wt.cmd.usage_create": "Usage: /worktree create <branch-name>",
   "wt.cmd.usage_remove": "Usage: /worktree remove <path-or-branch>",
   "wt.cmd.err_not_git_repo": "Error: not inside a git repository.",
@@ -2815,7 +2794,6 @@
   "wt.cmd.sugg_list": "List active worktrees",
   "wt.cmd.sugg_remove": "Remove a worktree",
   "wt.cmd.sugg_status": "Show current worktree info",
-
   "cost.cmd.not_initialized": "Cost tracker not initialized.",
   "cost.cmd.box_title": "Session cost",
   "cost.cmd.provider": "Provider",
@@ -2866,7 +2844,6 @@
   "cost.cmd.output_cost": "Output: ",
   "cost.cmd.cache_cost": "Cache:",
   "cost.cmd.pricing_unavailable": "Pricing not available for this model.",
-
   "chan.cmd.box_title": "MCP channels",
   "chan.cmd.box_title_filtered": "CHANNEL: %s",
   "chan.cmd.mcp_disabled": "MCP not enabled. Channels require MCP servers.",
@@ -2897,7 +2874,6 @@
   "chan.cmd.confirm_denied": "Confirm action #%d denied.",
   "chan.cmd.run_usage": "Usage: /channel run <seq>",
   "chan.cmd.run_bad_seq": "Invalid seq number.",
-
   "chan.banner.title": "MCP channel inbox",
   "chan.banner.unread": "%d new channel message(s) since last ack",
   "chan.cmd.clear_all_done": "Inbox fully purged: %d message(s) removed, %d pending notification(s) acknowledged, audit file truncated — nothing will replay on restart",
@@ -2915,12 +2891,10 @@
   "chan.cmd.suggest_clear": "Drain the inbox (empty ring + ack); --all also truncates the audit file",
   "chan.banner.hint_ack": "Hint: /channel ack to clear, /channel list for full inbox",
   "chan.banner.more": "… and %d more item(s) — /channel list to see everything",
-
   "chan.trigger.toast_header": "trigger fired (%s) — rule %s",
   "chan.trigger.toast_confirm_hint": "Run /channel confirm %d [yes|no] to resolve",
   "chan.trigger.toast_auto_hint": "Will run on next prompt cycle. Press Esc to abort once started.",
   "chan.trigger.auto_header": "AUTO-AGENT ▶ %s   (%s/%s)",
-
   "complete.root.exit": "Exit ChatCLI",
   "complete.root.quit": "Alias of /exit - Exit ChatCLI",
   "complete.root.switch": "Switch the LLM provider; followed by --model changes the model",
@@ -2974,7 +2948,6 @@
   "graph.cmd.rendered": "Rendered the knowledge graph:",
   "graph.cmd.error": "Could not render the graph: %s",
   "graph.tool.no_node": "No graph node found for %q.",
-
   "complete.generic.flag_mode": "Set file processing mode (full, summary, chunked, smart, knowledge)",
   "complete.generic.flag_model": "Switch the model (runtime) based on the current provider (gpt-5, grok-4, etc.)",
   "complete.generic.flag_max_tokens": "Set the max tokens for the next responses (0 for default)",
@@ -2984,7 +2957,6 @@
   "complete.generic.flag_ai": "Send the command output directly to the AI to analyze; for additional context type ( @command --ai <command> > <context>)",
   "complete.generic.option_for": "Option for %s",
   "complete.generic.values_suffix": "(values: %s)",
-
   "complete.skill.user_invocable_fallback": "user-invocable skill",
   "complete.skill.sub_search": "Search for skills across registries",
   "complete.skill.sub_install": "Install a skill from a registry",
@@ -3004,7 +2976,6 @@
   "complete.skill.sub_registry_disable": "Disable a registry",
   "complete.skill.flag_reset": "Remove preference (use default order)",
   "complete.skill.prefer_local": "Prefer local version",
-
   "complete.connect.token": "Server authentication token",
   "complete.connect.provider": "LLM provider (OPENAI, CLAUDEAI, GOOGLEAI, XAI, ZAI, MINIMAX, MOONSHOT, STACKSPOT, OLLAMA, COPILOT, GITHUB_MODELS, OPENROUTER)",
   "complete.connect.model": "LLM model (gpt-4, claude-3, etc.)",
@@ -3017,7 +2988,6 @@
   "complete.connect.realm": "StackSpot: Realm/Tenant",
   "complete.connect.agent_id": "StackSpot: Agent ID",
   "complete.connect.ollama_url": "Ollama: Server base URL (e.g. http://localhost:11434)",
-
   "complete.watch.flag_deployment": "K8s deployment to monitor (required)",
   "complete.watch.flag_namespace": "Deployment namespace (default: default)",
   "complete.watch.flag_interval": "Collection interval (e.g. 10s, 1m)",
@@ -3027,7 +2997,6 @@
   "complete.watch.sub_start": "Start K8s monitoring (e.g. /watch start --deployment myapp)",
   "complete.watch.sub_stop": "Stop K8s monitoring",
   "complete.watch.sub_status": "Show active watcher status",
-
   "complete.context.root_desc": "📦 Manage persistent contexts (create, attach, detach, list, show, inspect, etc)",
   "complete.context.sub_create": "Create a context from files/directories (use --mode, --description, --tags)",
   "complete.context.sub_update": "Update an existing context (use --mode, --description, --tags)",
@@ -3089,7 +3058,6 @@
   "complete.context.name_chunks_fmt": "%d chunks",
   "complete.context.name_files_fmt": "%d files",
   "complete.context.name_tags_fmt": "tags:%s",
-
   "complete.session.root_desc": "Manage sessions (new, save, list, load, delete)",
   "complete.session.sub_new": "Create new session (clears current history)",
   "complete.session.sub_save": "Save current session with a name",
@@ -3102,14 +3070,12 @@
   "complete.session.sub_detach": "Drop the named-session binding (stop write-through)",
   "complete.session.sub_status": "Show the active session binding",
   "complete.session.saved_session": "Saved session",
-
   "complete.plugin.sub_list": "List all installed plugins.",
   "complete.plugin.sub_install": "Install a new plugin from a Git repository.",
   "complete.plugin.sub_reload": "Force reload of all installed plugins.",
   "complete.plugin.sub_show": "Show details of a specific plugin.",
   "complete.plugin.sub_inspect": "Show debug information for a plugin.",
   "complete.plugin.sub_uninstall": "Remove an installed plugin.",
-
   "complete.agent.sub_list": "List available agents",
   "complete.agent.sub_load": "Load a specific agent",
   "complete.agent.sub_attach": "Attach multiple agents to the existing session",
@@ -3120,13 +3086,11 @@
   "complete.agent.sub_off": "Disable the current agent",
   "complete.agent.sub_help": "Help for the /agent command",
   "complete.agent.flag_full": "Show full agent details",
-
   "complete.switch.root_desc": "Switch the LLM provider; followed by --model changes the model",
   "complete.switch.flag_model": "Switch the model (runtime) based on the current provider",
   "complete.switch.flag_max_tokens": "Set max tokens for the next responses (0 for default)",
   "complete.switch.flag_realm": "Change the Realm/Tenant at runtime",
   "complete.switch.flag_agent_id": "Change the agent at runtime",
-
   "complete.auth.root_desc": "Manage OAuth credentials (status, login, logout)",
   "complete.auth.sub_status": "Show authentication status for all providers",
   "complete.auth.sub_login": "Authenticate with a provider (anthropic, openai-codex, github-copilot, github-models)",
@@ -3135,7 +3099,6 @@
   "complete.auth.provider_openai_codex": "OpenAI (GPT Plus / Codex)",
   "complete.auth.provider_github_copilot": "GitHub Copilot",
   "complete.auth.provider_github_models": "GitHub Models (GPT-4o, Llama, Mistral, DeepSeek...)",
-
   "skill.cmd.installs_suffix": "installs",
   "skill.cmd.by_author": "by",
   "skill.cmd.status_enabled": "enabled",
@@ -3147,14 +3110,12 @@
   "skill.cmd.err_timeout": "unavailable (timeout)",
   "skill.cmd.err_tls": "TLS certificate error",
   "skill.cmd.err_not_found": "API endpoint not found",
-
   "persona.cmd.skills_count": "[%d skills]",
   "persona.cmd.skills_label": "Skills",
   "persona.cmd.arg_name": "<name>",
   "persona.cmd.arg_task": "<task>",
   "persona.cmd.example_agent": "create an HTTP server",
   "persona.cmd.example_coder": "refactor the code",
-
   "mem.cmd.no_notes_found_for": "No notes found for",
   "mem.cmd.profile.title": "User Profile",
   "mem.cmd.profile.empty": "No profile data yet. Interact more and the system will learn about you.",
@@ -3350,13 +3311,11 @@
   "mem.cmd.suggest.cat_project": "Project details",
   "mem.cmd.suggest.cat_personal": "Personal information",
   "mem.cmd.suggest.cat_general": "General facts",
-
   "sw.cmd.skill_swap_provider": "skill requested %s/%s — swapping for this turn",
   "sw.cmd.stream_stalled": "[Stream stalled — partial response shown]",
   "sw.cmd.could_not_list_models": "Could not list models for %s: %v",
   "sw.cmd.no_models_found": "No models found for %s",
   "sw.cmd.available_models_header": "Available models for %s (%s):",
-
   "sess.cmd.invalid_one_shot_input": "invalid input for one-shot agent mode: %s",
   "sess.cmd.fork_error": "Fork error: %v",
   "sess.cmd.fork_unsaved": "(unsaved)",
@@ -3365,12 +3324,9 @@
   "sess.cmd.fork_to": "To:",
   "sess.cmd.fork_messages": "Messages:",
   "sess.cmd.fork_footer": "Now working on the fork. The original remains intact.",
-
   "ctx.cmd.init_manager_error": "failed to initialize context manager",
   "ctx.cmd.read_response_error": "failed to read response",
-
   "cmd.core.session_fork_usage": "Usage: /session fork <new-name>",
-
   "scheduler.disabled": "Scheduler disabled for this session (CHATCLI_SCHEDULER_ENABLED=false or init failed).",
   "scheduler.created": "Job %s created (%s).",
   "scheduler.wait_async": "Wait registered in background as job %s.",
@@ -3433,12 +3389,10 @@
   "scheduler.wait.usage_example_2": "Example: /wait --until \"k8s:pod/prod/api:Ready\" --async",
   "scheduler.wait.usage_flags": "Flags: --until --then --every --timeout --max-polls --on-timeout --async --name",
   "scheduler.jobs.usage_header": "Usage: /jobs <subcommand> [args]",
-
   "help.section.scheduler": "Scheduler — Scheduling & wait-until",
   "help.command.schedule": "Schedules a job to fire at a time or cron expression. Ex: /schedule bk --cron \"0 2 * * *\" --do \"/run backup\"",
   "help.command.wait": "Waits until a condition is satisfied and optionally runs an action. Ex: /wait --until http://x/health==200 --then \"/run tests\"",
   "help.command.jobs": "Manage scheduled jobs: list, show, tree, cancel, pause, resume, logs, history, daemon, gc.",
-
   "cfg.section.scheduler.title": "Scheduler (Chronos) — Scheduling & Wait-Until",
   "cfg.sub.sched.core": "Core",
   "cfg.sub.sched.budget": "Default Budget",
@@ -3451,7 +3405,6 @@
   "cfg.kv.scheduler_queue_depth": "Queue depth",
   "cfg.kv.scheduler_audit_path": "Audit log",
   "cfg.kv.scheduler_daemon": "Daemon",
-
   "sched.complete.help": "Show command examples and flags",
   "sched.status.pending": "Waiting for next fire window",
   "sched.status.blocked": "Blocked by dependencies",
@@ -3549,7 +3502,6 @@
   "sched.jobs.daemon.start": "(use the binary: chatcli daemon start)",
   "sched.jobs.daemon.stop": "(use the binary: chatcli daemon stop)",
   "sched.jobs.daemon.restart": "(use the binary: chatcli daemon stop && start)",
-
   "help.command.parked": "list parked agents (/parked prune | gc <dur>)",
   "help.command.park_note": "send a directive to the parked agent (delivered at resume)",
   "help.command.resume": "force-resume a parked agent: /resume <token>",
@@ -3584,7 +3536,6 @@
   "park.resolve.empty": "park: empty token (use /parked to list)",
   "park.resolve.not_found": "park: no snapshot matching %q (use /parked to list)",
   "park.resolve.ambiguous": "park: token prefix %q is ambiguous (matches: %s) — use a longer prefix",
-
   "sec.cmd.usage_header": "Usage: /config security {rules|allow|deny|forget|reload} [args]",
   "sec.cmd.usage_note_pattern": "Patterns use prefix match against \"<toolName> <args>\" (e.g. \"@coder exec kubectl get\"). Deny beats Allow.",
   "sec.cmd.usage_note_scope": "Changes persist to ~/.chatcli/coder_policy.json and take effect for /coder and the scheduler on the next fire.",
@@ -3715,10 +3666,8 @@
   "complete.configimage.reset": "Clear image overrides",
   "complete.configimage.val": "value",
   "agent.spinner.working": "working",
-
   "agent.summary.block_ok": "Block #%d completed",
   "agent.summary.block_failed": "Block #%d failed",
-
   "plugins.taskgraph.describe_generic": "Task graph operation",
   "plugins.taskgraph.describe_plan": "Validating and persisting a task graph plan",
   "plugins.taskgraph.describe_run": "Executing a task graph (parallel workers + independent review)",
@@ -3741,5 +3690,8 @@
   "complete.taskgraph.dash": "Open the live browser dashboard (animated DAG, evidence, cost)",
   "plugins.taskgraph.describe_dash": "Serving the task graph dashboard",
   "complete.taskgraph.prune": "Remove old runs (default 30d; \"all\" clears everything but the active run)",
-  "plugins.taskgraph.describe_prune": "Pruning old task graph runs"
+  "plugins.taskgraph.describe_prune": "Pruning old task graph runs",
+  "cost.cmd.compactions": "Compactions: %d (level 3: %d) · summarizer %s",
+  "compact.status.summary_retry": "⚠ Summary rejected by the quality gate — retrying once",
+  "compact.error.summary_rejected": "The summary failed the quality gate (too short or a refusal); history left untouched. Try again or rephrase the instruction."
 }

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -2204,10 +2204,8 @@
   "llm.zai.jwt_cached": "Usando token JWT ZAI em cache",
   "llm.zai.jwt_invalid_key": "Formato de chave ZAI inválido para JWT (esperado id.secret), usando chave direta",
   "llm.info.using_custom_base_url": "Usando URL base customizada para %s: %s",
-
   "cfg.route.unknown_section": "Seção desconhecida: %s",
   "cfg.route.hint": "Seções: all, general, providers, agent, resilience, session, integrations, auth, security, server",
-
   "cfg.val.default": "(padrão)",
   "cfg.val.managed_tag": "(gerenciado)",
   "cfg.val.managed_locked_tag": "(gerenciado · travado)",
@@ -2243,11 +2241,9 @@
   "cfg.val.budget_ok": "OK",
   "cfg.val.budget_warning": "Atenção",
   "cfg.val.budget_exceeded": "Excedido",
-
   "cfg.panorama.title": "ChatCLI — Panorama",
   "cfg.panorama.drill_down": "Detalhar:",
   "cfg.panorama.sections_hint": "Seções: providers, agent, resilience, session, integrations, auth, security, server",
-
   "cfg.section.general.title": "Geral",
   "cfg.section.providers.title": "Providers",
   "cfg.section.agent.title": "Runtime do agente",
@@ -2331,7 +2327,6 @@
   "cfg.hub.principal": "principal",
   "cfg.hub.conversation": "conversa",
   "cfg.section.server.title": "Server / operator",
-
   "cfg.sub.quality.refine": "── Self-Refine (#5)",
   "cfg.sub.quality.verify": "── Chain-of-Verification / CoVe (#6)",
   "cfg.sub.quality.reflexion": "── Reflexion (#3)",
@@ -2344,7 +2339,6 @@
   "cfg.kv.quality.vector_count": "Entradas vetoriais",
   "cfg.kv.quality.vector_state": "Índice vetorial",
   "cfg.val.not_attached": "(não anexado)",
-
   "complete.root.thinking": "Sobrescreve extended thinking / reasoning_effort para o próximo turno (cross-provider)",
   "complete.root.plan": "Força Plan-and-Solve / ReWOO no próximo /agent ou /coder",
   "complete.root.refine": "Alterna pós-processamento Self-Refine na sessão (on|off|auto)",
@@ -2412,7 +2406,6 @@
   "thinking.state_auto": "thinking: auto (sem override ativo)",
   "thinking.state_off": "thinking: explicitamente desligado (override ativo)",
   "thinking.state_set": "thinking: %s (override ativo)",
-
   "cfg.sub.general.locale": "── Locale & versão",
   "cfg.sub.general.logging": "── Logging",
   "cfg.sub.general.history": "── Histórico de comandos",
@@ -2486,7 +2479,6 @@
   "cfg.sub.server.watcher": "── K8s watcher (server)",
   "cfg.sub.server.audit": "── Auditoria",
   "cfg.sub.server.operator": "── Operator / AIOps",
-
   "cfg.kv.provider": "Provider",
   "cfg.kv.model": "Modelo",
   "cfg.kv.model_client": "Modelo (client)",
@@ -2557,7 +2549,6 @@
   "cfg.kv.last_match": "Último match",
   "cfg.kv.dotenv_path": "Caminho do .env",
   "cfg.kv.history_file": "Arquivo de histórico",
-
   "cfg.msg.skip_server": "Nenhuma env de server-mode detectada — pulando (contexto CLI).",
   "cfg.msg.server_hint": "Esta seção só faz sentido ao rodar `chatcli server` ou o operator.",
   "cfg.msg.auth_hint": "Rode /auth login <provider> para autenticar.",
@@ -2569,7 +2560,6 @@
   "cfg.msg.no_contexts_attached": "(nenhum — /context attach <name>)",
   "cfg.msg.no_persona": "(nenhuma — /agent load <name>)",
   "cfg.msg.manager_not_init": "(manager não inicializado)",
-
   "ws.cmd.usage_provider": "Uso: /websearch provider <searxng|duckduckgo|auto>",
   "ws.cmd.unknown_sub": "Subcomando desconhecido: %s",
   "ws.cmd.usage_hint": "Use: /websearch [list|provider <name>|reset|status]",
@@ -2596,7 +2586,6 @@
   "ws.cmd.persist_hint": "Para persistir, adicione ao seu shell/.env:",
   "ws.cmd.persist_unset": "unset CHATCLI_WEBSEARCH_PROVIDER",
   "ws.cmd.persist_set": "export CHATCLI_WEBSEARCH_PROVIDER=%s",
-
   "complete.config.reload": "Recarrega o .env e reconfigura os providers (igual ao /reload)",
   "complete.config.all": "Dump completo (todas as seções)",
   "complete.config.general": "dotenv, locale, logging, version check",
@@ -2611,7 +2600,6 @@
   "complete.config.quality": "Pipeline de qualidade dos sete padrões (Self-Refine, CoVe, Reflexion, Plan-First, HyDE, Reasoning)",
   "complete.config.root_desc": "Panorama da configuração (seções: all, general, providers, agent, quality, resilience, session, integrations, auth, security, server)",
   "complete.config.status_alias": "Alias de /config — panorama da configuração",
-
   "complete.thinking.auto": "Limpa override — usa skill hints + quality.reasoning auto-agents",
   "complete.thinking.off": "Força SEM thinking / reasoning_effort no próximo turno",
   "complete.thinking.on": "Alias de /thinking high — ativa reasoning tier high no próximo turno",
@@ -2622,25 +2610,21 @@
   "complete.thinking.budget_medium": "Tier mais próximo de 4096 tokens de thinking → medium",
   "complete.thinking.budget_high": "Tier mais próximo de 8000 tokens de thinking → high (default)",
   "complete.thinking.budget_max": "Tier mais próximo de 16384 tokens de thinking → max",
-
   "complete.refine.on": "Força Self-Refine LIGADO nesta sessão (sobrescreve /config quality)",
   "complete.refine.off": "Força Self-Refine DESLIGADO nesta sessão",
   "complete.refine.once": "Arma Self-Refine só para o próximo turno",
   "complete.refine.auto": "Limpa override de sessão — usa /config quality",
   "complete.refine.clear": "Alias de auto — limpa override de sessão",
-
   "complete.verify.on": "Força Chain-of-Verification LIGADO nesta sessão",
   "complete.verify.off": "Força Chain-of-Verification DESLIGADO nesta sessão",
   "complete.verify.once": "Arma CoVe só para o próximo turno",
   "complete.verify.auto": "Limpa override de sessão — usa /config quality",
   "complete.verify.clear": "Alias de auto — limpa override de sessão",
-
   "complete.plan.hint": "Task livre. Sem args, arma plan-first flag para o próximo /agent ou /coder.",
   "complete.plan.agent": "Explícito: plan-first + modo agent (igual a /plan <task>)",
   "complete.plan.coder": "Plan-first + modo coder (engenheiro de software com tools)",
   "complete.plan.preview": "Dry-run: gera e mostra o plano sem executar nada",
   "complete.plan.dry": "Alias de preview — dry-run sem execução",
-
   "complete.reflect.hint": "Lição livre. Persiste direto em memory.Fact (category=lesson, trigger=manual) sem chamada LLM.",
   "complete.reflect.list": "Mostra fila de reflexion pendente + entradas da DLQ",
   "complete.reflect.failed": "Lista entradas da dead-letter queue (lições falhas p/ revisão)",
@@ -2648,8 +2632,6 @@
   "complete.reflect.purge": "Remove permanentemente uma entrada da DLQ por job ID (requer <id>)",
   "complete.reflect.drain": "Força replay de lições pendentes no WAL de uma sessão anterior",
   "complete.reflect.id_placeholder": "Job ID vindo de /reflect failed (16 hex chars)",
-
-
   "complete.websearch.root_desc": "Configura provider de busca web (list, provider, reset, status)",
   "complete.websearch.sub_status": "Exibe provider atual + cadeia de fallback ativa",
   "complete.websearch.sub_list": "Lista providers conhecidos e quais estão configurados",
@@ -2660,7 +2642,6 @@
   "complete.websearch.prov_brave": "Scraping HTML, índice independente, sem API key",
   "complete.websearch.prov_mojeek": "Scraping HTML, índice independente, sem API key",
   "complete.websearch.prov_auto": "Auto: DuckDuckGo primeiro, SearxNG como fallback se configurado",
-
   "hooks.cmd.not_initialized": "Hooks não inicializado.",
   "hooks.cmd.box_title": "HOOKS",
   "hooks.cmd.none_configured": "Nenhum hook configurado.",
@@ -2674,7 +2655,6 @@
   "hooks.cmd.total_summary": "%d hooks (%s%d ativos%s)",
   "hooks.cmd.suggest_list": "Lista todos os hooks configurados",
   "hooks.cmd.suggest_reload": "Recarrega hooks dos arquivos de configuração",
-
   "mcp.dynamic.server_not_connected": "Servidor MCP %q não está conectado",
   "mcp.proxy.not_enabled": "O client MCP não está habilitado nesta instância do ChatCLI",
   "mcp.proxy.tool_not_found": "Tool MCP %q não encontrada em nenhum servidor conectado",
@@ -2784,7 +2764,6 @@
   "mcp.cmd.usage_logs": "Uso: /mcp logs <nome-do-servidor>",
   "mcp.cmd.box_logs_title": "LOGS MCP — %s",
   "mcp.cmd.no_logs": "Nenhuma linha de log capturada ainda.",
-
   "wt.cmd.usage_create": "Uso: /worktree create <branch-name>",
   "wt.cmd.usage_remove": "Uso: /worktree remove <path-or-branch>",
   "wt.cmd.err_not_git_repo": "Erro: não estamos em um repositório git.",
@@ -2815,7 +2794,6 @@
   "wt.cmd.sugg_list": "Lista worktrees ativos",
   "wt.cmd.sugg_remove": "Remove um worktree",
   "wt.cmd.sugg_status": "Mostra informações do worktree atual",
-
   "cost.cmd.not_initialized": "Cost tracker não inicializado.",
   "cost.cmd.box_title": "Custo da sessão",
   "cost.cmd.provider": "Provider",
@@ -2866,7 +2844,6 @@
   "cost.cmd.output_cost": "Saída:",
   "cost.cmd.cache_cost": "Cache:",
   "cost.cmd.pricing_unavailable": "Preço não disponível para este modelo.",
-
   "chan.cmd.box_title": "Channels MCP",
   "chan.cmd.box_title_filtered": "CHANNEL: %s",
   "chan.cmd.mcp_disabled": "MCP não habilitado. Channels requerem MCP servers.",
@@ -2897,7 +2874,6 @@
   "chan.cmd.confirm_denied": "Ação de confirmação #%d negada.",
   "chan.cmd.run_usage": "Uso: /channel run <seq>",
   "chan.cmd.run_bad_seq": "Número de seq inválido.",
-
   "chan.banner.title": "Inbox de channels MCP",
   "chan.banner.unread": "%d mensagem(ns) nova(s) de channel desde o último ack",
   "chan.cmd.clear_all_done": "Inbox totalmente expurgado: %d mensagem(ns) removida(s), %d notificação(ões) pendente(s) reconhecida(s), arquivo de auditoria truncado — nada será recarregado no restart",
@@ -2915,12 +2891,10 @@
   "chan.cmd.suggest_clear": "Drenar o inbox (esvazia ring + ack); --all também trunca o arquivo de auditoria",
   "chan.banner.hint_ack": "Dica: /channel ack pra limpar, /channel list pro inbox completo",
   "chan.banner.more": "… e mais %d item(ns) — /channel list para ver tudo",
-
   "chan.trigger.toast_header": "trigger acionado (%s) — regra %s",
   "chan.trigger.toast_confirm_hint": "Execute /channel confirm %d [yes|no] pra resolver",
   "chan.trigger.toast_auto_hint": "Será executado no próximo ciclo do prompt. Pressione Esc pra abortar.",
   "chan.trigger.auto_header": "AUTO-AGENT ▶ %s   (%s/%s)",
-
   "complete.root.exit": "Sair do ChatCLI",
   "complete.root.quit": "Alias de /exit - Sair do ChatCLI",
   "complete.root.switch": "Trocar o provedor de LLM, seguido por --model troca o modelo",
@@ -2974,7 +2948,6 @@
   "graph.cmd.rendered": "Grafo de conhecimento renderizado:",
   "graph.cmd.error": "Não foi possível renderizar o grafo: %s",
   "graph.tool.no_node": "Nenhum nó do grafo encontrado para %q.",
-
   "complete.generic.flag_mode": "Define o modo de processamento de arquivos (full, summary, chunked, smart, knowledge)",
   "complete.generic.flag_model": "Troque o modelo (Runtime) baseado no provedor atual (grpt-5, grok-4, etc.)",
   "complete.generic.flag_max_tokens": "Define o máximo de tokens para as próximas respostas (0 para padrão)",
@@ -2984,7 +2957,6 @@
   "complete.generic.flag_ai": "Envia a saída do comando direto para a IA analisar, para contexto adicional digite ( @command --ai <comando> > <contexto>)",
   "complete.generic.option_for": "Opção para %s",
   "complete.generic.values_suffix": "(valores: %s)",
-
   "complete.skill.user_invocable_fallback": "skill invocável pelo usuário",
   "complete.skill.sub_search": "Procura skills nos registries configurados",
   "complete.skill.sub_install": "Instala uma skill a partir de um registry",
@@ -3004,7 +2976,6 @@
   "complete.skill.sub_registry_disable": "Desabilita um registry",
   "complete.skill.flag_reset": "Remove a preferência (usa ordem padrão)",
   "complete.skill.prefer_local": "Preferir versão local",
-
   "complete.connect.token": "Token de autenticação do servidor",
   "complete.connect.provider": "Provedor LLM (OPENAI, CLAUDEAI, GOOGLEAI, XAI, ZAI, MINIMAX, MOONSHOT, STACKSPOT, OLLAMA, COPILOT, GITHUB_MODELS, OPENROUTER)",
   "complete.connect.model": "Modelo LLM (gpt-4, claude-3, etc.)",
@@ -3017,7 +2988,6 @@
   "complete.connect.realm": "StackSpot: Realm/Tenant",
   "complete.connect.agent_id": "StackSpot: Agent ID",
   "complete.connect.ollama_url": "Ollama: Base URL do servidor (ex: http://localhost:11434)",
-
   "complete.watch.flag_deployment": "Deployment K8s a monitorar (obrigatório)",
   "complete.watch.flag_namespace": "Namespace do deployment (padrão: default)",
   "complete.watch.flag_interval": "Intervalo de coleta (ex: 10s, 1m)",
@@ -3027,7 +2997,6 @@
   "complete.watch.sub_start": "Iniciar monitoramento K8s (ex: /watch start --deployment myapp)",
   "complete.watch.sub_stop": "Parar o monitoramento K8s",
   "complete.watch.sub_status": "Exibir status do watcher ativo",
-
   "complete.context.root_desc": "📦 Gerencia contextos persistentes (create, attach, detach, list, show, inspect, etc)",
   "complete.context.sub_create": "Criar contexto de arquivos/diretórios (use --mode, --description, --tags)",
   "complete.context.sub_update": "Atualizar contexto existente (use --mode, --description, --tags)",
@@ -3089,7 +3058,6 @@
   "complete.context.name_chunks_fmt": "%d chunks",
   "complete.context.name_files_fmt": "%d arquivos",
   "complete.context.name_tags_fmt": "tags:%s",
-
   "complete.session.root_desc": "Gerencia as sessões (new, save, list, load, delete)",
   "complete.session.sub_new": "Criar nova sessão (limpa histórico atual)",
   "complete.session.sub_save": "Salvar sessão atual com um nome",
@@ -3102,14 +3070,12 @@
   "complete.session.sub_detach": "Remover o vínculo com a sessão nomeada (parar write-through)",
   "complete.session.sub_status": "Mostrar o vínculo de sessão ativo",
   "complete.session.saved_session": "Sessão salva",
-
   "complete.plugin.sub_list": "Lista todos os plugins instalados.",
   "complete.plugin.sub_install": "Instala um novo plugin a partir de um repositório Git.",
   "complete.plugin.sub_reload": "Força o recarregamento de todos os plugins instalados.",
   "complete.plugin.sub_show": "Mostra detalhes de um plugin específico.",
   "complete.plugin.sub_inspect": "Mostra informações de depuração de um plugin.",
   "complete.plugin.sub_uninstall": "Remove um plugin instalado.",
-
   "complete.agent.sub_list": "Lista agentes disponíveis",
   "complete.agent.sub_load": "Carrega um agente específico",
   "complete.agent.sub_attach": "Adicionar múltiplo agente a sessão existente",
@@ -3120,13 +3086,11 @@
   "complete.agent.sub_off": "Desativa o agente atual",
   "complete.agent.sub_help": "Ajuda do comando /agent",
   "complete.agent.flag_full": "Mostra detalhes completos do agente",
-
   "complete.switch.root_desc": "Trocar o provedor de LLM, seguido por --model troca o modelo",
   "complete.switch.flag_model": "Troque o modelo (Runtime) baseado no provedor atual",
   "complete.switch.flag_max_tokens": "Define o máximo de tokens para as próximas respostas (0 para padrão)",
   "complete.switch.flag_realm": "Altera o Realm/Tenant em tempo de execução",
   "complete.switch.flag_agent_id": "Altera o agent em tempo de execução",
-
   "complete.auth.root_desc": "Gerencia credenciais OAuth (status, login, logout)",
   "complete.auth.sub_status": "Exibir status de autenticação de todos os provedores",
   "complete.auth.sub_login": "Autenticar com um provedor (anthropic, openai-codex, github-copilot, github-models)",
@@ -3135,7 +3099,6 @@
   "complete.auth.provider_openai_codex": "OpenAI (GPT Plus / Codex)",
   "complete.auth.provider_github_copilot": "GitHub Copilot",
   "complete.auth.provider_github_models": "GitHub Models (GPT-4o, Llama, Mistral, DeepSeek...)",
-
   "skill.cmd.installs_suffix": "instalações",
   "skill.cmd.by_author": "por",
   "skill.cmd.status_enabled": "ativado",
@@ -3147,14 +3110,12 @@
   "skill.cmd.err_timeout": "indisponível (timeout)",
   "skill.cmd.err_tls": "erro de certificado TLS",
   "skill.cmd.err_not_found": "endpoint da API não encontrado",
-
   "persona.cmd.skills_count": "[%d skills]",
   "persona.cmd.skills_label": "Skills",
   "persona.cmd.arg_name": "<nome>",
   "persona.cmd.arg_task": "<tarefa>",
   "persona.cmd.example_agent": "crie um servidor HTTP",
   "persona.cmd.example_coder": "refatore o código",
-
   "mem.cmd.no_notes_found_for": "Nenhuma nota encontrada para",
   "mem.cmd.profile.title": "Perfil do Usuário",
   "mem.cmd.profile.empty": "Nenhum dado de perfil ainda. Interaja mais e o sistema aprenderá sobre você.",
@@ -3350,13 +3311,11 @@
   "mem.cmd.suggest.cat_project": "Detalhes de projetos",
   "mem.cmd.suggest.cat_personal": "Informações pessoais",
   "mem.cmd.suggest.cat_general": "Fatos gerais",
-
   "sw.cmd.skill_swap_provider": "skill solicitou %s/%s — trocando para este turno",
   "sw.cmd.stream_stalled": "[Stream travou — resposta parcial exibida]",
   "sw.cmd.could_not_list_models": "Não foi possível listar modelos para %s: %v",
   "sw.cmd.no_models_found": "Nenhum modelo encontrado para %s",
   "sw.cmd.available_models_header": "Modelos disponíveis para %s (%s):",
-
   "sess.cmd.invalid_one_shot_input": "entrada inválida para o modo agente one-shot: %s",
   "sess.cmd.fork_error": "Erro ao fork: %v",
   "sess.cmd.fork_unsaved": "(não salva)",
@@ -3365,12 +3324,9 @@
   "sess.cmd.fork_to": "Para:",
   "sess.cmd.fork_messages": "Mensagens:",
   "sess.cmd.fork_footer": "Agora trabalhando no fork. O original permanece intacto.",
-
   "ctx.cmd.init_manager_error": "erro ao inicializar gerenciador de contextos",
   "ctx.cmd.read_response_error": "erro ao ler resposta",
-
   "cmd.core.session_fork_usage": "Uso: /session fork <novo-nome>",
-
   "scheduler.disabled": "Scheduler desabilitado nesta sessão (CHATCLI_SCHEDULER_ENABLED=false ou falha na inicialização).",
   "scheduler.created": "Job %s criado (%s).",
   "scheduler.wait_async": "Wait registrado em segundo plano como job %s.",
@@ -3433,12 +3389,10 @@
   "scheduler.wait.usage_example_2": "Ex: /wait --until \"k8s:pod/prod/api:Ready\" --async",
   "scheduler.wait.usage_flags": "Flags: --until --then --every --timeout --max-polls --on-timeout --async --name",
   "scheduler.jobs.usage_header": "Uso: /jobs <subcomando> [args]",
-
   "help.section.scheduler": "Scheduler — Agendamento & wait-until",
   "help.command.schedule": "Agenda um job para disparar no tempo (ou cron) definido. Ex: /schedule bk --cron \"0 2 * * *\" --do \"/run backup\"",
   "help.command.wait": "Espera até a condição ser satisfeita e opcionalmente executa uma ação. Ex: /wait --until http://x/health==200 --then \"/run tests\"",
   "help.command.jobs": "Gerencia agendamentos: list, show, tree, cancel, pause, resume, logs, history, daemon, gc.",
-
   "cfg.section.scheduler.title": "Scheduler (Chronos) — Agendamento & Wait-Until",
   "cfg.sub.sched.core": "Núcleo",
   "cfg.sub.sched.budget": "Budget Padrão",
@@ -3451,7 +3405,6 @@
   "cfg.kv.scheduler_queue_depth": "Fila (profundidade)",
   "cfg.kv.scheduler_audit_path": "Audit log",
   "cfg.kv.scheduler_daemon": "Daemon",
-
   "sched.complete.help": "Mostra os exemplos e flags do comando",
   "sched.status.pending": "Aguardando o próximo fire",
   "sched.status.blocked": "Bloqueado por dependências",
@@ -3549,7 +3502,6 @@
   "sched.jobs.daemon.start": "(use o binário: chatcli daemon start)",
   "sched.jobs.daemon.stop": "(use o binário: chatcli daemon stop)",
   "sched.jobs.daemon.restart": "(use o binário: chatcli daemon stop && start)",
-
   "help.command.parked": "lista agents estacionados (/parked prune | gc <dur>)",
   "help.command.park_note": "envia uma diretiva para o agent estacionado (entregue no resume)",
   "help.command.resume": "força resume de um agent estacionado: /resume <token>",
@@ -3584,7 +3536,6 @@
   "park.resolve.empty": "park: token vazio (use /parked para listar)",
   "park.resolve.not_found": "park: nenhum snapshot bate com %q (use /parked para listar)",
   "park.resolve.ambiguous": "park: prefixo %q ambíguo (bate com: %s) — use um prefixo mais longo",
-
   "sec.cmd.usage_header": "Uso: /config security {rules|allow|deny|forget|reload} [args]",
   "sec.cmd.usage_note_pattern": "Patterns usam prefix match sobre \"<toolName> <args>\" (ex: \"@coder exec kubectl get\"). Deny bate Allow.",
   "sec.cmd.usage_note_scope": "Mudanças persistem em ~/.chatcli/coder_policy.json e valem para /coder e para o scheduler no próximo fire.",
@@ -3715,10 +3666,8 @@
   "complete.configimage.reset": "Limpa os overrides de imagem",
   "complete.configimage.val": "valor",
   "agent.spinner.working": "processando",
-
   "agent.summary.block_ok": "Bloco #%d concluído",
   "agent.summary.block_failed": "Bloco #%d falhou",
-
   "plugins.taskgraph.describe_generic": "Operação no task graph",
   "plugins.taskgraph.describe_plan": "Validando e persistindo um plano de task graph",
   "plugins.taskgraph.describe_run": "Executando um task graph (workers paralelos + review independente)",
@@ -3741,5 +3690,8 @@
   "complete.taskgraph.dash": "Abre a dashboard live no browser (DAG animado, evidências, custo)",
   "plugins.taskgraph.describe_dash": "Servindo a dashboard do task graph",
   "complete.taskgraph.prune": "Remove runs antigas (default 30d; \"all\" limpa tudo menos a run ativa)",
-  "plugins.taskgraph.describe_prune": "Removendo runs antigas do task graph"
+  "plugins.taskgraph.describe_prune": "Removendo runs antigas do task graph",
+  "cost.cmd.compactions": "Compactações: %d (nível 3: %d) · sumarizador %s",
+  "compact.status.summary_retry": "⚠ Resumo rejeitado pelo gate de qualidade — tentando mais uma vez",
+  "compact.error.summary_rejected": "O resumo não passou no gate de qualidade (curto demais ou recusa); histórico mantido. Tente de novo ou reformule a instrução."
 }

--- a/llm/bedrock/bedrock_client.go
+++ b/llm/bedrock/bedrock_client.go
@@ -469,9 +469,11 @@ func (c *BedrockClient) sendPromptAnthropicModel(ctx context.Context, wireModel,
 
 	applyAnthropicThinkingForEffort(reqBody, wireModel, ctx)
 
-	// Rolling conversation breakpoint (5-minute marker: the InvokeModel wire
-	// keeps the provider default TTL). See client.MarkAnthropicHistoryBreakpoint.
-	client.MarkAnthropicHistoryBreakpoint(client.AnthropicMessages{Maps: messages}, client.AnthropicCacheMarkerWithTTL(false))
+	// Rolling conversation breakpoint. Bedrock accepts "ttl":"1h" in the
+	// cache_control object for Claude 4.5+ (docs.aws.amazon.com/bedrock/
+	// latest/userguide/prompt-caching.html), so the configured TTL applies
+	// there; older Claude keeps the 5-minute wire default.
+	client.MarkAnthropicHistoryBreakpoint(client.AnthropicMessages{Maps: messages}, client.AnthropicCacheMarkerWithTTL(supportsExtendedCacheTTL(wireModel)))
 	enforceCacheControlBudget(reqBody, anthropicMaxCacheBreakpoints)
 
 	payload, err := json.Marshal(reqBody)
@@ -599,6 +601,23 @@ func (c *BedrockClient) buildMessagesAndSystem(prompt string, history []models.M
 		return messages, strings.Join(plainSystemParts, "\n\n")
 	}
 	return messages, nil
+}
+
+// supportsExtendedCacheTTL reports whether Bedrock honors the 1-hour
+// cache TTL for the model: every Claude from the 4.5 generation on
+// (Sonnet/Opus 4.5+, Haiku 4.5, the 5.x line, Fable/Mythos). Claude 3.x
+// and non-Anthropic vendors keep the 5-minute default.
+func supportsExtendedCacheTTL(model string) bool {
+	m := strings.ToLower(model)
+	if !strings.Contains(m, "claude") {
+		return false
+	}
+	for _, old := range []string{"claude-3", "claude-v2", "claude-instant", "sonnet-4-20", "opus-4-20", "opus-4-1", "claude-sonnet-4-v", "claude-opus-4-v"} {
+		if strings.Contains(m, old) {
+			return false
+		}
+	}
+	return true
 }
 
 func supportsExtendedThinking(model string) bool {

--- a/llm/bedrock/cache_ttl_test.go
+++ b/llm/bedrock/cache_ttl_test.go
@@ -1,0 +1,69 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package bedrock
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+	bedrockruntimetypes "github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+	"github.com/diillson/chatcli/llm/client"
+	"go.uber.org/zap"
+)
+
+func TestSupportsExtendedCacheTTL_Gate(t *testing.T) {
+	yes := []string{"anthropic.claude-sonnet-4-6", "anthropic.claude-opus-4-8", "anthropic.claude-sonnet-5", "anthropic.claude-fable-5-1", "anthropic.claude-haiku-4-5-20251001-v1:0", "us.anthropic.claude-opus-4-5-20251101-v1:0"}
+	no := []string{"anthropic.claude-3-7-sonnet-20250219-v1:0", "anthropic.claude-3-5-sonnet-20241022-v2:0", "amazon.nova-pro-v1:0", "meta.llama4", "openai.gpt-5.6-terra"}
+	for _, m := range yes {
+		if !supportsExtendedCacheTTL(m) {
+			t.Fatalf("%s must support the 1h TTL", m)
+		}
+	}
+	for _, m := range no {
+		if supportsExtendedCacheTTL(m) {
+			t.Fatalf("%s must not get a 1h TTL", m)
+		}
+	}
+}
+
+func TestConverseCacheTTL_FollowsEnvAndModel(t *testing.T) {
+	t.Setenv(client.PromptCacheTTLEnv, "1h")
+	if converseCacheTTL("anthropic.claude-sonnet-5") != bedrockruntimetypes.CacheTTLOneHour {
+		t.Fatal("Claude 5 on Converse must carry the 1h ttl when configured")
+	}
+	if converseCacheTTL("amazon.nova-pro-v1:0") != "" {
+		t.Fatal("Nova keeps the wire default")
+	}
+	t.Setenv(client.PromptCacheTTLEnv, "5m")
+	if converseCacheTTL("anthropic.claude-sonnet-5") != "" {
+		t.Fatal("5m stays the wire default (no ttl field)")
+	}
+	sys := []bedrockruntimetypes.SystemContentBlock{&bedrockruntimetypes.SystemContentBlockMemberText{Value: "sys"}}
+	msgs := []bedrockruntimetypes.Message{{Role: bedrockruntimetypes.ConversationRoleUser, Content: []bedrockruntimetypes.ContentBlock{&bedrockruntimetypes.ContentBlockMemberText{Value: "hi"}}}}
+	sys, msgs = applyConverseCachePoints(sys, msgs, bedrockruntimetypes.CacheTTLOneHour)
+	cp, ok := sys[len(sys)-1].(*bedrockruntimetypes.SystemContentBlockMemberCachePoint)
+	if !ok || cp.Value.Ttl != bedrockruntimetypes.CacheTTLOneHour {
+		t.Fatalf("system cachePoint must carry the ttl: %#v", sys[len(sys)-1])
+	}
+	last := msgs[0].Content[len(msgs[0].Content)-1].(*bedrockruntimetypes.ContentBlockMemberCachePoint)
+	if last.Value.Ttl != bedrockruntimetypes.CacheTTLOneHour {
+		t.Fatal("message cachePoint must carry the ttl")
+	}
+}
+
+func TestCaptureConverseUsage_SplitsTheHourWriteShare(t *testing.T) {
+	c := &BedrockClient{logger: zap.NewNop()}
+	out := &bedrockruntime.ConverseOutput{Usage: &bedrockruntimetypes.TokenUsage{
+		InputTokens: aws.Int32(10), OutputTokens: aws.Int32(2), CacheWriteInputTokens: aws.Int32(500), CacheReadInputTokens: aws.Int32(100),
+		CacheDetails: []bedrockruntimetypes.CacheDetail{{InputTokens: aws.Int32(300), Ttl: bedrockruntimetypes.CacheTTLOneHour}, {InputTokens: aws.Int32(200), Ttl: bedrockruntimetypes.CacheTTLFiveMinutes}},
+	}}
+	c.captureConverseUsage(out)
+	u := c.LastUsage()
+	if u == nil || u.CacheCreationInputTokens != 500 || u.CacheCreation1hInputTokens != 300 || u.CacheReadInputTokens != 100 {
+		t.Fatalf("usage = %+v", u)
+	}
+}

--- a/llm/bedrock/converse_cachepoint_test.go
+++ b/llm/bedrock/converse_cachepoint_test.go
@@ -33,7 +33,7 @@ func TestApplyConverseCachePoints_SystemAndLastUser(t *testing.T) {
 		{Role: "user", Content: "second"},
 	}
 	messages, system := buildConverseMessages("second", history)
-	system, messages = applyConverseCachePoints(system, messages)
+	system, messages = applyConverseCachePoints(system, messages, "")
 
 	if len(system) != 2 {
 		t.Fatalf("expected text + cachePoint system blocks, got %d", len(system))

--- a/llm/bedrock/converse_family.go
+++ b/llm/bedrock/converse_family.go
@@ -50,7 +50,7 @@ func (c *BedrockClient) sendPromptConverse(ctx context.Context, prompt string, h
 		return "", fmt.Errorf("%s", i18n.T("llm.error.no_response", "Bedrock"))
 	}
 	if converseSupportsCachePoint(c.model) {
-		system, messages = applyConverseCachePoints(system, messages)
+		system, messages = applyConverseCachePoints(system, messages, converseCacheTTL(c.model))
 	}
 
 	input := &bedrockruntime.ConverseInput{
@@ -343,21 +343,34 @@ func converseSupportsCachePoint(model string) bool {
 	return strings.Contains(m, "amazon.nova") || strings.Contains(m, "anthropic.") || strings.Contains(m, "claude")
 }
 
+// converseCacheTTL returns the cachePoint ttl for the model: the configured
+// lifetime on Claude 4.5+ ("ttl":"1h" per the Bedrock prompt-caching
+// guide), empty (wire default, 5 minutes) for Nova and older Claude.
+func converseCacheTTL(model string) bedrockruntimetypes.CacheTTL {
+	if !supportsExtendedCacheTTL(model) || client.AnthropicCacheTTL() != "1h" {
+		return ""
+	}
+	return bedrockruntimetypes.CacheTTLOneHour
+}
+
 // applyConverseCachePoints is the Converse counterpart of the Anthropic
 // cache planner: one cachePoint after the system blocks (stable prefix) and
 // one at the end of the last user message (rolling conversation
 // breakpoint), so the next turn reads the whole prefix from cache instead
 // of re-tokenizing it at full price.
-func applyConverseCachePoints(system []bedrockruntimetypes.SystemContentBlock, messages []bedrockruntimetypes.Message) ([]bedrockruntimetypes.SystemContentBlock, []bedrockruntimetypes.Message) {
-	point := func() *bedrockruntimetypes.ContentBlockMemberCachePoint {
-		return &bedrockruntimetypes.ContentBlockMemberCachePoint{
-			Value: bedrockruntimetypes.CachePointBlock{Type: bedrockruntimetypes.CachePointTypeDefault},
+func applyConverseCachePoints(system []bedrockruntimetypes.SystemContentBlock, messages []bedrockruntimetypes.Message, ttl bedrockruntimetypes.CacheTTL) ([]bedrockruntimetypes.SystemContentBlock, []bedrockruntimetypes.Message) {
+	block := func() bedrockruntimetypes.CachePointBlock {
+		b := bedrockruntimetypes.CachePointBlock{Type: bedrockruntimetypes.CachePointTypeDefault}
+		if ttl != "" {
+			b.Ttl = ttl
 		}
+		return b
+	}
+	point := func() *bedrockruntimetypes.ContentBlockMemberCachePoint {
+		return &bedrockruntimetypes.ContentBlockMemberCachePoint{Value: block()}
 	}
 	if len(system) > 0 {
-		system = append(system, &bedrockruntimetypes.SystemContentBlockMemberCachePoint{
-			Value: bedrockruntimetypes.CachePointBlock{Type: bedrockruntimetypes.CachePointTypeDefault},
-		})
+		system = append(system, &bedrockruntimetypes.SystemContentBlockMemberCachePoint{Value: block()})
 	}
 	if n := len(messages); n > 0 && messages[n-1].Role == bedrockruntimetypes.ConversationRoleUser && len(messages[n-1].Content) > 0 {
 		messages[n-1].Content = append(messages[n-1].Content, point())

--- a/llm/bedrock/mantle.go
+++ b/llm/bedrock/mantle.go
@@ -202,8 +202,9 @@ func (c *BedrockClient) sendPromptAnthropicMantle(ctx context.Context, prompt st
 	}
 
 	applyAnthropicThinkingForEffort(reqBody, c.model, ctx)
-	// Rolling conversation breakpoint (5-minute marker on the Bedrock wire).
-	client.MarkAnthropicHistoryBreakpoint(client.AnthropicMessages{Maps: messages}, client.AnthropicCacheMarkerWithTTL(false))
+	// Rolling conversation breakpoint; the configured TTL applies on Claude
+	// 4.5+ (Bedrock accepts "ttl":"1h" in cache_control).
+	client.MarkAnthropicHistoryBreakpoint(client.AnthropicMessages{Maps: messages}, client.AnthropicCacheMarkerWithTTL(supportsExtendedCacheTTL(c.model)))
 	enforceCacheControlBudget(reqBody, anthropicMaxCacheBreakpoints)
 
 	payload, err := json.Marshal(reqBody)

--- a/llm/bedrock/usage.go
+++ b/llm/bedrock/usage.go
@@ -16,6 +16,7 @@ import (
 	"encoding/json"
 
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+	bedrockruntimetypes "github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
 	"github.com/diillson/chatcli/llm/client"
 	"github.com/diillson/chatcli/models"
 )
@@ -79,6 +80,13 @@ func (c *BedrockClient) captureConverseUsage(out *bedrockruntime.ConverseOutput)
 	}
 	if info.TotalTokens == 0 {
 		info.TotalTokens = info.PromptTokens + info.CompletionTokens
+	}
+	// The 1-hour share of the cache write is billed at 2x: cacheDetails
+	// splits the write by ttl (1h entries first).
+	for _, d := range out.Usage.CacheDetails {
+		if d.Ttl == bedrockruntimetypes.CacheTTLOneHour {
+			info.CacheCreation1hInputTokens += deref(d.InputTokens)
+		}
 	}
 	c.usage.StoreUsage(info)
 	if out.StopReason != "" {

--- a/llm/openrouter/openrouter_client.go
+++ b/llm/openrouter/openrouter_client.go
@@ -126,7 +126,7 @@ func (c *OpenRouterClient) buildMessages(prompt string, history []models.Message
 	}
 
 	if openRouterSupportsCacheControl(c.model) {
-		applyOpenRouterCacheControl(messages)
+		applyOpenRouterCacheControlMarker(messages, openRouterCacheMarker(c.model))
 	}
 	return messages
 }
@@ -146,7 +146,28 @@ func openRouterSupportsCacheControl(model string) bool {
 // cache_control, converting string content into the multipart shape the
 // marker requires. Tool messages are left alone.
 func applyOpenRouterCacheControl(messages []map[string]interface{}) {
-	marker := map[string]string{"type": "ephemeral"}
+	applyOpenRouterCacheControlMarker(messages, map[string]string{"type": "ephemeral"})
+}
+
+// openRouterCacheMarker is the cache_control value for a model: the
+// configured TTL on anthropic/ models (OpenRouter forwards "ttl":"1h");
+// google/ models keep the fixed 5-minute marker (openrouter.ai/docs/
+// features/prompt-caching).
+func openRouterCacheMarker(model string) map[string]string {
+	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(model)), "anthropic/") {
+		return client.AnthropicCacheMarker()
+	}
+	return map[string]string{"type": "ephemeral"}
+}
+
+// openRouterUsesPromptCacheKey reports whether the model routes through
+// OpenAI, where prompt_cache_key is the sticky-routing key OpenRouter
+// forwards for automatic caching.
+func openRouterUsesPromptCacheKey(model string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(model)), "openai/")
+}
+
+func applyOpenRouterCacheControlMarker(messages []map[string]interface{}, marker map[string]string) {
 	var mark func(msg map[string]interface{})
 	mark = func(msg map[string]interface{}) {
 		switch content := msg["content"].(type) {
@@ -294,6 +315,11 @@ func (c *OpenRouterClient) SendPrompt(ctx context.Context, prompt string, histor
 
 	messages := c.buildMessages(prompt, history)
 	payload := c.buildPayload(messages, effectiveMaxTokens)
+	if openRouterUsesPromptCacheKey(c.model) {
+		if key := client.PromptCacheKey(history); key != "" {
+			payload["prompt_cache_key"] = key
+		}
+	}
 
 	jsonValue, err := json.Marshal(payload)
 	if err != nil {

--- a/llm/openrouter/openrouter_client_test.go
+++ b/llm/openrouter/openrouter_client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"github.com/diillson/chatcli/llm/client"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -190,5 +191,18 @@ func TestBuildMessages_CacheControlOnRealWireContent(t *testing.T) {
 	pm := plain.buildMessages("second", history)
 	if raw, _ := json.Marshal(pm[0]["content"]); string(raw) != `"stable prefix"` {
 		t.Fatalf("openai/ must not receive markers, got %s", raw)
+	}
+}
+
+func TestOpenRouterCacheMarker_TTLOnlyForAnthropic(t *testing.T) {
+	t.Setenv(client.PromptCacheTTLEnv, "1h")
+	if m := openRouterCacheMarker("anthropic/claude-sonnet-5"); m["ttl"] != "1h" {
+		t.Fatalf("anthropic marker must carry the configured ttl: %v", m)
+	}
+	if m := openRouterCacheMarker("google/gemini-2.5-pro"); m["ttl"] != "" {
+		t.Fatalf("google marker is fixed at 5 minutes: %v", m)
+	}
+	if !openRouterUsesPromptCacheKey("openai/gpt-5.6-terra") || openRouterUsesPromptCacheKey("anthropic/claude-sonnet-5") {
+		t.Fatal("prompt_cache_key applies to openai/ models only")
 	}
 }


### PR DESCRIPTION
## Summary

Second context audit, P1 (G06, G09, G10, G11). Every change applies to the four loops (chat, agent/coder, one-shot, `/compact`) and to overflow recovery, with the same guarantees in each.

**G10 — compaction hooks everywhere.** `PreCompact`/`PostCompact` hooks fire on every compaction, not only on `/compact`. The event carries a `trigger` (`auto`, `manual`, `recovery`) in the JSON payload and in `CHATCLI_HOOK_TRIGGER`.

**G06 — nothing lost that the model asked to keep.** Level 2 and Level 3 re-append `PreserveVerbatim` messages after the summary/notice; content shrinking skips them. Level 3 now archives what it drops to CCR with a recall marker (it was the pipeline's lossy floor). Overflow recovery flushes memory first, archives the dropped messages and notes the cache rebuild. A quality gate rejects refusals and too-short summaries (floor relative to the segment) with one retry before the Level 3 fallback.

**G11 — compaction is accounted.** Compactions, Level 3 count and the summarizer's usage/cost are recorded in the cost tracker, persisted with the session and shown by `/cost`. The summarizer's request joins the session totals like any turn. When a summary does not bring the history under budget, the next two compactions skip the summarizer instead of paying a call per turn.

**Guided `/compact`** uses the configured summarizer route (`CHATCLI_COMPACT_SUMMARIZER_*`), a 10-minute allowance for the summary (the shared 60 s deadline cut long histories short) and the same quality gate.

**G09 — 1h cache TTL parity.** Bedrock sends `cachePoint.ttl=1h` (Converse `CachePointBlock.Ttl`, InvokeModel `cache_control.ttl`) for Claude 4.5+ when `CHATCLI_PROMPT_CACHE_TTL` resolves to 1h, and splits the 1h write share in usage. OpenRouter passes the ttl on `anthropic/` markers and `prompt_cache_key` for `openai/` models. OpenAI direct needs nothing: retention defaults to 24h (`prompt_cache_retention`) and GPT-5.6+ only accepts the fixed 30m option.

## Tests

- `cli/audit2_p1_test.go`: verbatim survival in L2/L3/shrink, quality gate table, retry-then-reject, back-off cycle, compaction cost record/snapshot, recovery archive.
- `cli/hooks/trigger_test.go`: trigger reaches env and JSON.
- `llm/bedrock/cache_ttl_test.go`, `llm/openrouter`: model gate, Converse ttl, 1h usage split, OpenRouter markers.
- Existing summarizer stubs updated to realistic summaries (the gate rejects a 7-character "summary" for a large segment by design).

`go test ./...`, golangci-lint, i18n parity, ai-smells, api-breaking, provider-parity, scope-budget: green locally.