### PR TITLE
feat(context): persist the token calibrator per state root and route every estimate through it

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -2423,7 +2423,7 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 			// Learn the real chars-per-token ratio for this provider/model
 			// from what was actually sent and what the API counted.
 			if turnUsage != nil && turnUsage.IsReal {
-				globalTokenCalibrator.Observe(effProvider, effModel, promptCharsOf(turnHistory), contextTokens(effProvider, effModel, turnUsage))
+				a.cli.calibrator().Observe(effProvider, effModel, promptCharsOf(turnHistory), contextTokens(effProvider, effModel, turnUsage))
 			}
 			a.cli.maybeAnnounceBudget()
 			a.cli.maybeAnnounceCacheMisses()
@@ -4153,7 +4153,7 @@ func (a *AgentMode) emitSessionSummary() {
 	}
 	if a.cli.compressionLayer != nil {
 		if s, _ := a.cli.compressionLayer.Stats(); s.SavedBytes() > 0 {
-			if savedTok := s.SavedBytes() / 4; savedTok > 0 {
+			if savedTok := a.cli.estimateTokens64(s.SavedBytes()); savedTok > 0 {
 				parts = append(parts, i18n.T("chat.envelope.compression_saved", formatTokenCount(savedTok)))
 			}
 		}

--- a/cli/chat_pipeline.go
+++ b/cli/chat_pipeline.go
@@ -975,7 +975,7 @@ func (cli *ChatCLI) telemetryParts(usage *models.UsageInfo, costUSD float64, inc
 		if s, _ := cli.compressionLayer.Stats(); s.SavedBytes() > cli.compressionSavedShown {
 			delta := s.SavedBytes() - cli.compressionSavedShown
 			cli.compressionSavedShown = s.SavedBytes()
-			if savedTok := delta / 4; savedTok > 0 {
+			if savedTok := cli.estimateTokens64(delta); savedTok > 0 {
 				parts = append(parts, i18n.T("chat.envelope.compression_saved", formatTokenCount(savedTok)))
 			}
 		}
@@ -1007,7 +1007,7 @@ func (cli *ChatCLI) projectedContextPct(window int) (float64, bool) {
 	if chars <= 0 {
 		return 0, false
 	}
-	tokens := globalTokenCalibrator.EstimateTokens(cli.Provider, cli.Model, chars)
+	tokens := cli.calibrator().EstimateTokens(cli.Provider, cli.Model, chars)
 	if tokens <= 0 {
 		return 0, false
 	}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -844,6 +844,7 @@ func NewChatCLI(ctx context.Context, manager manager.LLMManager, logger *zap.Log
 	homeDir, _ := os.UserHomeDir()
 	globalDir := filepath.Join(homeDir, ".chatcli")
 	cli.stateRoot = globalDir
+	cli.installTokenEstimator()
 	workspaceDir := detectProjectDir()
 	if workspaceDir == "" {
 		workspaceDir, _ = os.Getwd()
@@ -2125,6 +2126,9 @@ func (cli *ChatCLI) cleanup(ctx context.Context) {
 		cli.hubLocalClose()
 		cli.hubLocalClose = nil
 	}
+
+	// Learned token ratios outlive the process.
+	cli.calibrator().flushCalibration()
 
 	// Stop context watchers before the stores go away.
 	if cli.contextHandler != nil {

--- a/cli/cli_llm.go
+++ b/cli/cli_llm.go
@@ -553,11 +553,12 @@ func (cli *ChatCLI) switchProvider() {
 	cli.interactionState = StateSwitchingProvider
 }
 
+// getTokenEstimatorForCurrentLLM returns the estimator every file/context
+// budget uses: the learned chars-per-token ratio for the session's
+// provider/model (4.0 until the calibrator has a sample).
 func (cli *ChatCLI) getTokenEstimatorForCurrentLLM() func(string) int {
-	// Função padrão - estimativa conservadora
 	return func(text string) int {
-		// Aproximadamente 4 caracteres por token para a maioria dos modelos
-		return len(text) / 4
+		return cli.estimateTokens(len(text))
 	}
 }
 

--- a/cli/command_handler_metrics.go
+++ b/cli/command_handler_metrics.go
@@ -44,7 +44,7 @@ func (ch *CommandHandler) handleMetricsCommand() {
 	}
 	tokenUsed := 0
 	for _, msg := range c.history {
-		tokenUsed += len(msg.Content) / 4 // rough estimate: ~4 chars per token
+		tokenUsed += c.estimateTokens(len(msg.Content))
 	}
 	tokenPct := 0.0
 	if tokenLimit > 0 {

--- a/cli/compact_config.go
+++ b/cli/compact_config.go
@@ -138,6 +138,11 @@ func (cli *ChatCLI) compactConfig(provider, model string) CompactConfig {
 	if cli == nil {
 		return cfg
 	}
+	// The session's (tenant-scoped, persisted) calibrator wins over the
+	// process-wide default the constructor consulted.
+	if ratio, samples := cli.calibrator().CharsPerToken(provider, model); samples > 0 {
+		cfg.CharsPerTokenPrecise = ratio
+	}
 	if r := cli.autoCompact.get(); r > 0 {
 		cfg.BudgetRatio = r
 	}

--- a/cli/context_display.go
+++ b/cli/context_display.go
@@ -129,8 +129,7 @@ func (h *ContextHandler) handleShowAttached(sessionID string) error {
 
 	var totalTokens int64
 	for i, ctx := range contexts {
-		// Estimate tokens: ~4 chars per token (conservative)
-		estimatedTokens := ctx.TotalSize / 4
+		estimatedTokens := ctxmgr.EstimateTokens64(ctx.TotalSize)
 		totalTokens += estimatedTokens
 
 		fmt.Printf("\n%s %s\n",

--- a/cli/context_io.go
+++ b/cli/context_io.go
@@ -226,7 +226,7 @@ func (h *ContextHandler) printAttachFeedback(ctx *ctxmgr.FileContext, flags atta
 // attachment: the corpus stays out of the prompt, only the digest plus the
 // per-turn retrieved passages are paid for.
 func printKnowledgeAttachFeedback(ctx *ctxmgr.FileContext) {
-	digestTokens := int64(len(ctxmgr.BuildKnowledgeDigest(ctx, 0))) / 4
+	digestTokens := ctxmgr.EstimateTokens64(int64(len(ctxmgr.BuildKnowledgeDigest(ctx, 0))))
 	fmt.Printf("  %s %s\n",
 		colorize(i18n.T("context.io.label.attached"), ColorCyan),
 		i18n.T("context.io.knowledge_attached", ctx.FileCount, float64(ctx.TotalSize)/1024/1024))
@@ -270,7 +270,7 @@ func printWholeContextFeedback(ctx *ctxmgr.FileContext) {
 }
 
 func printTokenCostFeedback(ctx *ctxmgr.FileContext) {
-	estimatedTokens := ctx.TotalSize / 4
+	estimatedTokens := ctxmgr.EstimateTokens64(ctx.TotalSize)
 	fmt.Printf("  %s ~%s tokens/turno %s\n",
 		colorize(i18n.T("context.io.label.estimated_cost"), ColorGray),
 		formatTokenCount(estimatedTokens),

--- a/cli/context_status.go
+++ b/cli/context_status.go
@@ -103,7 +103,7 @@ func summarizeHistory(history []models.Message) historyStats {
 func (cli *ChatCLI) buildContextStatusReport(ctx context.Context) contextStatusReport {
 	r := contextStatusReport{Provider: cli.Provider, Model: cli.Model}
 	r.Window = catalog.GetContextWindow(cli.Provider, cli.Model)
-	r.CharsPerToken, r.CalibrationSamples = globalTokenCalibrator.CharsPerToken(cli.Provider, cli.Model)
+	r.CharsPerToken, r.CalibrationSamples = cli.calibrator().CharsPerToken(cli.Provider, cli.Model)
 	r.Prompt = cli.promptBreakdowns.latest()
 	r.History = summarizeHistory(cli.history)
 
@@ -137,7 +137,7 @@ func (cli *ChatCLI) buildContextStatusReport(ctx context.Context) contextStatusR
 	// calibration sample as a side effect.
 	if exact, ok := cli.calibrateExactWithTimeout(ctx); ok {
 		r.ExactHistoryTokens = exact
-		r.CharsPerToken, r.CalibrationSamples = globalTokenCalibrator.CharsPerToken(cli.Provider, cli.Model)
+		r.CharsPerToken, r.CalibrationSamples = cli.calibrator().CharsPerToken(cli.Provider, cli.Model)
 	}
 	if r.Window > 0 {
 		r.ProjectedPct = float64(r.TotalTokens) / float64(r.Window) * 100

--- a/cli/ctxmgr/chunker.go
+++ b/cli/ctxmgr/chunker.go
@@ -334,9 +334,8 @@ func (c *Chunker) estimateTokens(files []utils.FileInfo) int {
 }
 
 func (c *Chunker) estimateTokensForFile(file utils.FileInfo) int {
-	// Estimativa: ~4 caracteres por token
-	// Adicionar overhead para formatação (~20%)
-	baseTokens := len(file.Content) / 4
+	// Learned chars-per-token ratio, plus ~20% formatting overhead.
+	baseTokens := EstimateTokens(len(file.Content))
 	overhead := int(float64(baseTokens) * 0.2)
 	return baseTokens + overhead
 }

--- a/cli/ctxmgr/digest.go
+++ b/cli/ctxmgr/digest.go
@@ -160,9 +160,9 @@ func firstHeading(content string) string {
 	return ""
 }
 
-// approxTokens renders the standard 4-chars-per-token estimate with K/M units.
+// approxTokens renders the token estimate (learned ratio) with K/M units.
 func approxTokens(bytes int64) string {
-	t := bytes / 4
+	t := EstimateTokens64(bytes)
 	switch {
 	case t >= 1_000_000:
 		return fmt.Sprintf("%.1fM", float64(t)/1_000_000)

--- a/cli/ctxmgr/processor.go
+++ b/cli/ctxmgr/processor.go
@@ -196,7 +196,7 @@ func (p *Processor) EstimateTokenCount(files []utils.FileInfo) int {
 		totalChars += len(file.Content)
 	}
 
-	estimatedTokens := totalChars / 4
+	estimatedTokens := EstimateTokens(totalChars)
 
 	p.logger.Debug("Tokens estimados",
 		zap.Int("total_chars", totalChars),

--- a/cli/ctxmgr/token_estimate.go
+++ b/cli/ctxmgr/token_estimate.go
@@ -1,0 +1,59 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Token estimates inside the context manager (digests, chunker, validator,
+ * processor) read one chars-per-token source. The CLI points it at its
+ * calibrator so every estimate follows what the session's provider
+ * actually counts; without a source the historical 4.0 applies.
+ */
+package ctxmgr
+
+import "sync"
+
+const defaultCharsPerToken = 4.0
+
+var (
+	charsPerTokenMu     sync.RWMutex
+	charsPerTokenSource func() float64
+)
+
+// SetCharsPerTokenSource installs the live ratio source (nil restores the
+// default). The source is read on every estimate, never cached.
+func SetCharsPerTokenSource(src func() float64) {
+	charsPerTokenMu.Lock()
+	charsPerTokenSource = src
+	charsPerTokenMu.Unlock()
+}
+
+// CharsPerToken returns the current ratio (bounded to a sane band).
+func CharsPerToken() float64 {
+	charsPerTokenMu.RLock()
+	src := charsPerTokenSource
+	charsPerTokenMu.RUnlock()
+	if src == nil {
+		return defaultCharsPerToken
+	}
+	r := src()
+	if r < 1 || r > 16 {
+		return defaultCharsPerToken
+	}
+	return r
+}
+
+// EstimateTokens converts characters to tokens with the current ratio.
+func EstimateTokens(chars int) int {
+	if chars <= 0 {
+		return 0
+	}
+	return int(float64(chars)/CharsPerToken() + 0.5)
+}
+
+// EstimateTokens64 is EstimateTokens for byte sizes.
+func EstimateTokens64(chars int64) int64 {
+	if chars <= 0 {
+		return 0
+	}
+	return int64(float64(chars)/CharsPerToken() + 0.5)
+}

--- a/cli/ctxmgr/validator.go
+++ b/cli/ctxmgr/validator.go
@@ -189,7 +189,7 @@ func (v *Validator) ValidateContext(ctx *FileContext) *ValidationResult {
 		}
 
 		// Uso estimado de tokens
-		estimatedTokens := int(ctx.TotalSize / 4) // ~4 chars por token
+		estimatedTokens := int(EstimateTokens64(ctx.TotalSize))
 		if estimatedTokens > 50000 {
 			result.Warnings = append(result.Warnings,
 				fmt.Sprintf("uso estimado de ~%d tokens pode exceder limites de alguns modelos",

--- a/cli/tenant_scope.go
+++ b/cli/tenant_scope.go
@@ -147,6 +147,10 @@ func (cli *ChatCLI) applyStores(ts *tenantStores) {
 	cli.currentSessionName = ts.currentSessionName
 	cli.boundSessionSync = ts.boundSessionSync
 	cli.boundRemoteOnly = ts.boundRemoteOnly
+	if cli.stateRoot != ts.root {
+		// The outgoing root's learned ratios are written before the swap.
+		calibratorFor(cli.stateRoot).flushCalibration()
+	}
 	cli.stateRoot = ts.root
 	if cli.historyCompactor != nil {
 		cli.historyCompactor.SetCompressionLayer(ts.compressionLayer)

--- a/cli/token_accounting_test.go
+++ b/cli/token_accounting_test.go
@@ -40,7 +40,7 @@ func TestCalibrateExact_FeedsTheCalibratorFromTheProviderCount(t *testing.T) {
 	if !ok || n != 2000 || cc.calls != 1 {
 		t.Fatalf("exact count: n=%d ok=%v calls=%d", n, ok, cc.calls)
 	}
-	ratio, samples := globalTokenCalibrator.CharsPerToken("TESTPROV", "exact-model")
+	ratio, samples := cli.calibrator().CharsPerToken("TESTPROV", "exact-model")
 	if samples != 1 || ratio < 1.99 || ratio > 2.01 {
 		t.Fatalf("ratio must come from the exact count: %.2f (%d samples)", ratio, samples)
 	}
@@ -57,12 +57,12 @@ func TestCalibrateExact_FeedsTheCalibratorFromTheProviderCount(t *testing.T) {
 func TestObserveTokenCalibrationChars_UsesMeasuredChars(t *testing.T) {
 	cli := newTenantTestCLI(t)
 	cli.observeTokenCalibrationChars("TESTPROV", "chars-model", 3000, &models.UsageInfo{PromptTokens: 1000, IsReal: true})
-	ratio, samples := globalTokenCalibrator.CharsPerToken("TESTPROV", "chars-model")
+	ratio, samples := cli.calibrator().CharsPerToken("TESTPROV", "chars-model")
 	if samples != 1 || ratio < 2.99 || ratio > 3.01 {
 		t.Fatalf("ratio must use the measured chars: %.2f (%d)", ratio, samples)
 	}
 	cli.observeTokenCalibrationChars("TESTPROV", "chars-model", 0, &models.UsageInfo{PromptTokens: 1000, IsReal: true})
-	if _, samples := globalTokenCalibrator.CharsPerToken("TESTPROV", "chars-model"); samples != 1 {
+	if _, samples := cli.calibrator().CharsPerToken("TESTPROV", "chars-model"); samples != 1 {
 		t.Fatal("zero chars must be ignored")
 	}
 }

--- a/cli/token_calibration_store.go
+++ b/cli/token_calibration_store.go
@@ -1,0 +1,179 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Persistence and scoping of the token calibrator.
+ *
+ * A learned chars-per-token ratio is worth keeping: it takes several
+ * turns to converge and every new process started at 4.0 again. Ratios
+ * are saved to <state root>/calibration.json (atomic write, debounced)
+ * and loaded on first use. The state root is the tenant root when a
+ * gateway tenant is active, so tenants never share (or leak) ratios; the
+ * global root serves the REPL, the MCP server and one-shot runs.
+ */
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/diillson/chatcli/cli/ctxmgr"
+	"github.com/diillson/chatcli/utils"
+)
+
+// calibrationFileName is the per-root persistence file.
+const calibrationFileName = "calibration.json"
+
+// calibrationSaveDelay debounces writes: a burst of turns lands one write.
+const calibrationSaveDelay = 2 * time.Second
+
+// calibrationFile is the on-disk shape.
+type calibrationFile struct {
+	Version   int                `json:"version"`
+	UpdatedAt time.Time          `json:"updated_at"`
+	Ratios    map[string]float64 `json:"ratios"`
+	Samples   map[string]int     `json:"samples"`
+}
+
+var (
+	calibratorsMu     sync.Mutex
+	calibratorsByRoot = map[string]*tokenCalibrator{}
+)
+
+// calibratorFor returns the calibrator scoped to a state root, loading
+// its file on first use. An empty root is the process-wide calibrator.
+func calibratorFor(root string) *tokenCalibrator {
+	if root == "" {
+		return globalTokenCalibrator
+	}
+	calibratorsMu.Lock()
+	defer calibratorsMu.Unlock()
+	if c, ok := calibratorsByRoot[root]; ok {
+		return c
+	}
+	c := newTokenCalibrator()
+	c.path = filepath.Join(root, calibrationFileName)
+	c.load()
+	calibratorsByRoot[root] = c
+	return c
+}
+
+// calibrator returns this CLI's calibrator (tenant-scoped when a tenant
+// is active) and keeps the ctxmgr estimator pointed at it.
+func (cli *ChatCLI) calibrator() *tokenCalibrator {
+	if cli == nil {
+		return globalTokenCalibrator
+	}
+	return calibratorFor(cli.stateRoot)
+}
+
+// charsPerToken is the learned ratio for the session's provider/model.
+func (cli *ChatCLI) charsPerToken() float64 {
+	if cli == nil {
+		return defaultCharsPerToken
+	}
+	ratio, _ := cli.calibrator().CharsPerToken(cli.Provider, cli.Model)
+	return ratio
+}
+
+// estimateTokens converts characters to tokens with the learned ratio.
+func (cli *ChatCLI) estimateTokens(chars int) int {
+	if cli == nil {
+		return int(float64(chars)/defaultCharsPerToken + 0.5)
+	}
+	return cli.calibrator().EstimateTokens(cli.Provider, cli.Model, chars)
+}
+
+// estimateTokens64 is estimateTokens for byte sizes.
+func (cli *ChatCLI) estimateTokens64(chars int64) int64 {
+	if chars <= 0 {
+		return 0
+	}
+	if cli == nil {
+		return int64(float64(chars)/defaultCharsPerToken + 0.5)
+	}
+	return int64(float64(chars)/cli.charsPerToken() + 0.5)
+}
+
+// installTokenEstimator points the ctxmgr package (contexts, chunker,
+// validator, digests) at this CLI's live ratio, read lazily so a model
+// switch or a new sample is reflected without a sync point.
+func (cli *ChatCLI) installTokenEstimator() {
+	ctxmgr.SetCharsPerTokenSource(cli.charsPerToken)
+}
+
+// load reads the persisted ratios (missing or corrupt file = empty).
+func (c *tokenCalibrator) load() {
+	if c == nil || c.path == "" {
+		return
+	}
+	data, err := os.ReadFile(c.path) // #nosec G304 -- path under the state root
+	if err != nil {
+		return
+	}
+	var f calibrationFile
+	if err := json.Unmarshal(data, &f); err != nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for k, r := range f.Ratios {
+		if r >= calibrationMinRatio && r <= calibrationMaxRatio {
+			c.ratios[k] = r
+			c.samples[k] = f.Samples[k]
+		}
+	}
+}
+
+// scheduleSave debounces a write of the current ratios. Called with the
+// calibrator's lock held by Observe.
+func (c *tokenCalibrator) scheduleSave() {
+	if c == nil || c.path == "" {
+		return
+	}
+	if c.saveTimer != nil {
+		c.saveTimer.Stop()
+	}
+	c.saveTimer = time.AfterFunc(calibrationSaveDelay, c.save)
+}
+
+// save writes the ratios atomically; best-effort (a read-only home just
+// loses persistence, never a turn).
+func (c *tokenCalibrator) save() {
+	if c == nil || c.path == "" {
+		return
+	}
+	c.mu.RLock()
+	f := calibrationFile{Version: 1, UpdatedAt: time.Now(), Ratios: make(map[string]float64, len(c.ratios)), Samples: make(map[string]int, len(c.samples))}
+	for k, r := range c.ratios {
+		f.Ratios[k] = r
+		f.Samples[k] = c.samples[k]
+	}
+	c.mu.RUnlock()
+	data, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(c.path), 0o700); err != nil {
+		return
+	}
+	_ = utils.AtomicWriteFile(c.path, data, 0o600)
+}
+
+// flushCalibration writes pending ratios now (session end, tenant release).
+func (c *tokenCalibrator) flushCalibration() {
+	if c == nil || c.path == "" {
+		return
+	}
+	c.mu.Lock()
+	if c.saveTimer != nil {
+		c.saveTimer.Stop()
+		c.saveTimer = nil
+	}
+	c.mu.Unlock()
+	c.save()
+}

--- a/cli/token_calibration_store_test.go
+++ b/cli/token_calibration_store_test.go
@@ -1,0 +1,77 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/diillson/chatcli/cli/ctxmgr"
+	"github.com/diillson/chatcli/models"
+)
+
+func TestCalibrationPersistsPerRoot(t *testing.T) {
+	rootA, rootB := t.TempDir(), t.TempDir()
+	a := calibratorFor(rootA)
+	a.Observe("openai", "gpt-5.6-terra", 30_000, 10_000) // ratio 3.0
+	a.flushCalibration()
+	if _, err := os.Stat(filepath.Join(rootA, calibrationFileName)); err != nil {
+		t.Fatalf("calibration file must be written: %v", err)
+	}
+	// Another tenant root learns nothing from A.
+	if r, n := calibratorFor(rootB).CharsPerToken("openai", "gpt-5.6-terra"); n != 0 || r != defaultCharsPerToken {
+		t.Fatalf("tenant isolation: ratio=%v samples=%d", r, n)
+	}
+	// A fresh process (registry entry dropped) reloads A's ratio.
+	calibratorsMu.Lock()
+	delete(calibratorsByRoot, rootA)
+	calibratorsMu.Unlock()
+	if r, n := calibratorFor(rootA).CharsPerToken("openai", "gpt-5.6-terra"); n != 1 || r < 2.99 || r > 3.01 {
+		t.Fatalf("persisted ratio must reload: ratio=%v samples=%d", r, n)
+	}
+	// Corrupt file = empty calibrator, never an error.
+	rootC := t.TempDir()
+	_ = os.WriteFile(filepath.Join(rootC, calibrationFileName), []byte("{nope"), 0o600)
+	if _, n := calibratorFor(rootC).CharsPerToken("x", "y"); n != 0 {
+		t.Fatal("corrupt file must load as empty")
+	}
+	if calibratorFor("") != globalTokenCalibrator {
+		t.Fatal("empty root is the process-wide calibrator")
+	}
+}
+
+func TestEstimatorsFollowTheLearnedRatio(t *testing.T) {
+	cli := &ChatCLI{stateRoot: t.TempDir(), Provider: "openai", Model: "gpt-5.6-terra"}
+	cli.installTokenEstimator()
+	t.Cleanup(func() { ctxmgr.SetCharsPerTokenSource(nil) })
+	est := cli.getTokenEstimatorForCurrentLLM()
+	if est("abcdefgh") != 2 || ctxmgr.EstimateTokens(8) != 2 || cli.estimateTokens64(8) != 2 {
+		t.Fatal("default ratio is 4 chars per token")
+	}
+	cli.calibrator().Observe("openai", "gpt-5.6-terra", 20_000, 10_000) // 2.0
+	if est("abcdefgh") != 4 || ctxmgr.EstimateTokens(8) != 4 || ctxmgr.EstimateTokens64(8) != 4 || cli.estimateTokens64(8) != 4 {
+		t.Fatalf("estimators must follow the learned ratio: %d %d %d", est("abcdefgh"), ctxmgr.EstimateTokens(8), cli.estimateTokens64(8))
+	}
+	cfg := cli.compactConfig("openai", "gpt-5.6-terra")
+	if cfg.CharsPerTokenPrecise < 1.99 || cfg.CharsPerTokenPrecise > 2.01 {
+		t.Fatalf("compaction budget must use the session calibrator: %v", cfg.CharsPerTokenPrecise)
+	}
+	// A model switch is reflected lazily (no sync point).
+	cli.Model = "gpt-5.5"
+	if ctxmgr.EstimateTokens(8) != 2 {
+		t.Fatal("another model starts from the default again")
+	}
+	// The chat turn observer routes to the same scoped calibrator.
+	cli.observeTokenCalibrationChars("openai", "gpt-5.5", 60_000, &models.UsageInfo{PromptTokens: 10_000, IsReal: true})
+	if r, _ := cli.calibrator().CharsPerToken("openai", "gpt-5.5"); r < 5.99 || r > 6.01 {
+		t.Fatalf("observed ratio = %v", r)
+	}
+	ctxmgr.SetCharsPerTokenSource(func() float64 { return 99 })
+	if ctxmgr.CharsPerToken() != 4 {
+		t.Fatal("an out-of-band source falls back to the default")
+	}
+}

--- a/cli/token_calibrator.go
+++ b/cli/token_calibrator.go
@@ -47,6 +47,10 @@ type tokenCalibrator struct {
 	mu      sync.RWMutex
 	ratios  map[string]float64
 	samples map[string]int
+	// path is the persistence file ("" = memory only, the process-wide
+	// default); saveTimer debounces writes.
+	path      string
+	saveTimer *time.Timer
 }
 
 // globalTokenCalibrator is process-wide: the REPL, the gateway daemon and
@@ -81,6 +85,7 @@ func (c *tokenCalibrator) Observe(provider, model string, chars, tokens int) {
 		c.ratios[key] = ratio
 	}
 	c.samples[key]++
+	c.scheduleSave()
 }
 
 // CharsPerToken returns the learned ratio and how many samples produced it;
@@ -127,7 +132,7 @@ func (cli *ChatCLI) observeTokenCalibrationChars(provider, model string, chars i
 	if usage == nil || !usage.IsReal || chars <= 0 {
 		return
 	}
-	globalTokenCalibrator.Observe(provider, model, chars, contextTokens(provider, model, usage))
+	cli.calibrator().Observe(provider, model, chars, contextTokens(provider, model, usage))
 }
 
 // calibrateExactEvery paces exact calibration: one count_tokens call per
@@ -154,7 +159,7 @@ func (cli *ChatCLI) calibrateExact(ctx context.Context) (int, bool) {
 		}
 		return 0, false
 	}
-	globalTokenCalibrator.Observe(cli.Provider, cli.Model, promptCharsOf(cli.history), tokens)
+	cli.calibrator().Observe(cli.Provider, cli.Model, promptCharsOf(cli.history), tokens)
 	return tokens, true
 }
 


### PR DESCRIPTION
## Summary

Second context audit, P2 (G18): the token calibrator becomes durable and tenant-scoped, and no estimate in the CLI hardcodes 4 chars per token anymore.

- **Persistence.** Learned ratios are written to `<state root>/calibration.json` (atomic write, 2 s debounce, flushed at shutdown and when the gateway swaps tenants) and reloaded on first use. A corrupt or missing file loads as empty. Under the gateway the state root is the tenant root, so ratios never cross tenants; the REPL, MCP server and one-shot runs share the global root.
- **One source of truth.** `cli.estimateTokens`/`estimateTokens64` and a lazily read `ctxmgr.SetCharsPerTokenSource` replace the seven `chars/4` sites: the file-processing budget estimator, `/metrics`, `/context list` and attach feedback, the compression-savings footer in chat and agent, and the context manager's digest, chunker, validator and processor. The compaction budget also reads the session calibrator (the process default remains the constructor fallback for callers without a CLI).
- No new environment variable: the file lives under the existing state root.

## Tests

`cli/token_calibration_store_test.go`: write/reload per root, tenant isolation, corrupt file, estimators following a learned ratio (chat estimator, ctxmgr, int64, compaction config), model switch, out-of-band source fallback. Existing calibrator tests now read the scoped calibrator. Full suite, golangci-lint and the local gates are green.