### PR TITLE
feat(workspace): nested AGENTS.md hierarchy with imports, nested watch dirs and legacy source paths

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -863,6 +863,9 @@ func NewChatCLI(ctx context.Context, manager manager.LLMManager, logger *zap.Log
 	var bootstrapLoader *workspace.BootstrapLoader
 	if bootstrapEnabled {
 		bootstrapLoader = workspace.NewBootstrapLoader(workspaceDir, globalDir, logger)
+		if cwd, err := os.Getwd(); err == nil {
+			bootstrapLoader.SetWorkingDir(cwd)
+		}
 	} else {
 		bootstrapLoader = workspace.NewBootstrapLoader("", "", logger) // noop
 		logger.Info("Bootstrap disabled via CHATCLI_BOOTSTRAP_ENABLED=false")

--- a/cli/ctxmgr/refresh.go
+++ b/cli/ctxmgr/refresh.go
@@ -21,6 +21,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -178,7 +179,19 @@ func (m *Manager) RefreshContext(ctx context.Context, name string) (*FileContext
 		return nil, RefreshReport{}, fmt.Errorf("contexto '%s' não encontrado", name)
 	}
 	if len(fc.SourcePaths) == 0 {
-		return fc, RefreshReport{}, ErrNoSourcePaths
+		// Contexts saved before source paths were recorded: the files they
+		// hold still name where they came from. Adopt those paths (each
+		// file, not their directories — the original selection is what
+		// the context meant) and persist them so the next refresh and the
+		// watcher find them.
+		inferred := inferSourcePaths(fc)
+		if len(inferred) == 0 {
+			return fc, RefreshReport{}, ErrNoSourcePaths
+		}
+		fc.SourcePaths = inferred
+		if err := m.Storage.SaveContext(fc); err == nil {
+			m.logger.Info("context: source paths migrated from its files", zap.String("context", name), zap.Int("paths", len(inferred)))
+		}
 	}
 	files, knowledgeMeta, scanOpts, err := m.scanSources(ctx, fc.SourcePaths, fc.Mode)
 	if err != nil {
@@ -237,17 +250,51 @@ func (m *Manager) RefreshContext(ctx context.Context, name string) (*FileContext
 	return fc, rep, nil
 }
 
+// inferSourcePaths derives source paths for a legacy context from its
+// files: absolute paths that still exist (synthetic "#chunk" entries and
+// relative paths are skipped). Empty when nothing usable remains.
+func inferSourcePaths(fc *FileContext) []string {
+	if fc == nil {
+		return nil
+	}
+	seen := make(map[string]bool, len(fc.Files))
+	out := make([]string, 0, len(fc.Files))
+	for _, f := range fc.Files {
+		p := f.Path
+		if i := strings.Index(p, "#"); i >= 0 {
+			p = p[:i]
+		}
+		if p == "" || !filepath.IsAbs(p) || seen[p] {
+			continue
+		}
+		if info, err := os.Stat(p); err != nil || info.IsDir() {
+			continue
+		}
+		seen[p] = true
+		out = append(out, p)
+	}
+	return out
+}
+
 // ErrNoSourcePaths marks a context that predates source-path recording.
 var ErrNoSourcePaths = fmt.Errorf("context has no recorded source paths")
 
-// SourcePathsOf returns the recorded source paths of a context by name.
+// SourcePathsOf returns the recorded source paths of a context by name,
+// inferring (and persisting) them for a legacy context.
 func (m *Manager) SourcePathsOf(name string) ([]string, bool) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	for _, c := range m.contexts {
-		if c.Name == name {
-			return append([]string(nil), c.SourcePaths...), true
+		if c.Name != name {
+			continue
 		}
+		if len(c.SourcePaths) == 0 {
+			if inferred := inferSourcePaths(c); len(inferred) > 0 {
+				c.SourcePaths = inferred
+				_ = m.Storage.SaveContext(c)
+			}
+		}
+		return append([]string(nil), c.SourcePaths...), true
 	}
 	return nil, false
 }

--- a/cli/ctxmgr/refresh_legacy_test.go
+++ b/cli/ctxmgr/refresh_legacy_test.go
@@ -1,0 +1,65 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package ctxmgr
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/diillson/chatcli/utils"
+	"go.uber.org/zap"
+)
+
+func TestInferSourcePaths_FromExistingAbsoluteFiles(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.go")
+	if err := os.WriteFile(a, []byte("package a"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fc := &FileContext{Files: []utils.FileInfo{
+		{Path: a}, {Path: a + "#chunk-2"}, {Path: "relative.go"}, {Path: filepath.Join(dir, "gone.go")}, {Path: dir},
+	}}
+	got := inferSourcePaths(fc)
+	if len(got) != 1 || got[0] != a {
+		t.Fatalf("inferred = %v", got)
+	}
+	if inferSourcePaths(nil) != nil || len(inferSourcePaths(&FileContext{})) != 0 {
+		t.Fatal("nothing to infer")
+	}
+}
+
+func TestWatcher_AddsNestedDirsCreatedAtOnce(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.md"), []byte("hello"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	w := NewContextWatcher(nil, zap.NewNop(), nil)
+	if err := w.ensureStarted(); err != nil {
+		t.Skip("fsnotify unavailable:", err)
+	}
+	t.Cleanup(w.Close)
+	w.mu.Lock()
+	_ = w.watcher.Add(root)
+	w.byDir[root] = "ctx"
+	w.names["ctx"] = []string{root}
+	w.mu.Unlock()
+	nested := filepath.Join(root, "pkg", "sub", "deep")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	w.schedule(filepath.Join(root, "pkg")) // what the fsnotify loop would call for the Create event
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for _, d := range []string{filepath.Join(root, "pkg"), filepath.Join(root, "pkg", "sub"), nested} {
+		if w.byDir[d] != "ctx" {
+			t.Fatalf("nested dir %s must be watched: %v", d, w.byDir)
+		}
+	}
+	if t0 := w.timers["ctx"]; t0 == nil {
+		t.Fatal("a refresh must be scheduled")
+	}
+}

--- a/cli/ctxmgr/watch.go
+++ b/cli/ctxmgr/watch.go
@@ -192,9 +192,16 @@ func (w *ContextWatcher) schedule(path string) {
 		return
 	}
 	if info, err := os.Stat(path); err == nil && info.IsDir() && !utils.ShouldSkipDir(filepath.Base(path)) {
-		if err := w.watcher.Add(path); err == nil {
-			w.byDir[path] = name
-			w.names[name] = append(w.names[name], path)
+		// A created directory may already hold a subtree (mkdir -p, a
+		// checkout, an unpack): watch all of it, not just the top.
+		for _, d := range watchDirsFor([]string{path}) {
+			if _, already := w.byDir[d]; already {
+				continue
+			}
+			if err := w.watcher.Add(d); err == nil {
+				w.byDir[d] = name
+				w.names[name] = append(w.names[name], d)
+			}
 		}
 	}
 	if t := w.timers[name]; t != nil {

--- a/cli/workspace/bootstrap.go
+++ b/cli/workspace/bootstrap.go
@@ -25,6 +25,7 @@ var BootstrapFiles = []string{
 type BootstrapLoader struct {
 	workspaceDir string
 	globalDir    string // ~/.chatcli/
+	workingDir   string // end of the AGENTS.md hierarchy walk (cwd by default)
 	cache        map[string]cachedFile
 	mu           sync.RWMutex
 	logger       *zap.Logger
@@ -51,7 +52,17 @@ func (bl *BootstrapLoader) LoadBootstrapContent() string {
 	var parts []string
 
 	for _, filename := range BootstrapFiles {
-		content, ok := bl.LoadFile(filename)
+		var (
+			content string
+			ok      bool
+		)
+		if filename == "AGENTS.md" {
+			// Project root → cwd hierarchy (CHATCLI.md / CLAUDE.md as
+			// per-directory fallbacks), global file when the project has none.
+			content, ok = bl.loadInstructionHierarchy()
+		} else if content, ok = bl.LoadFile(filename); ok {
+			content = bl.expandImports(content, bl.dirOfLoaded(filename), 1, map[string]bool{})
+		}
 		if ok && strings.TrimSpace(content) != "" {
 			parts = append(parts, fmt.Sprintf("## %s\n\n%s", filename, content))
 		}
@@ -91,6 +102,14 @@ func (bl *BootstrapLoader) LoadFile(filename string) (string, bool) {
 	}
 
 	return "", false
+}
+
+// dirOfLoaded returns the directory LoadFile resolved filename from.
+func (bl *BootstrapLoader) dirOfLoaded(filename string) string {
+	if _, err := os.Stat(filepath.Join(bl.workspaceDir, filename)); err == nil {
+		return bl.workspaceDir
+	}
+	return bl.globalDir
 }
 
 // IsStale checks if any cached file has been modified on disk.

--- a/cli/workspace/instructions.go
+++ b/cli/workspace/instructions.go
@@ -1,0 +1,182 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Instruction-file hierarchy and @imports.
+ *
+ * AGENTS.md is read from every directory between the project root and
+ * the working directory, root first, so a package-level file refines the
+ * repository-level one (the Codex layout). A directory without AGENTS.md
+ * may carry CHATCLI.md or CLAUDE.md instead. Any instruction file can
+ * pull another in with a line of the form "@path/to/file.md" (Claude
+ * Code's import syntax) or "@import path", relative to the importing
+ * file, up to four hops and never twice. The assembled text is capped at
+ * 32 KiB, the same ceiling Codex applies to project docs.
+ */
+package workspace
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+const (
+	// InstructionDocMaxBytes caps the assembled instruction hierarchy.
+	InstructionDocMaxBytes = 32 * 1024
+	// importMaxHops bounds nested @imports.
+	importMaxHops = 4
+)
+
+// instructionFileNames are the per-directory candidates, in priority order.
+var instructionFileNames = []string{"AGENTS.md", "CHATCLI.md", "CLAUDE.md"}
+
+// importLine matches "@path/file.md", "@./file.md", "@~/file.md" or
+// "@import path" on a line of its own (Markdown files and plain text).
+var importLine = regexp.MustCompile(`^\s*@(?:import\s+)?([~./\\A-Za-z0-9_][^\s]*\.(?:md|mdx|txt|markdown))\s*$`)
+
+// SetWorkingDir records the directory the hierarchy walk ends at (the
+// process cwd by default); no-op when it is outside the workspace.
+func (bl *BootstrapLoader) SetWorkingDir(dir string) {
+	bl.mu.Lock()
+	defer bl.mu.Unlock()
+	bl.workingDir = dir
+}
+
+// instructionDirs returns workspaceDir and every directory below it down
+// to the working directory, root first.
+func (bl *BootstrapLoader) instructionDirs() []string {
+	if bl.workspaceDir == "" {
+		return nil
+	}
+	bl.mu.RLock()
+	cwd := bl.workingDir
+	bl.mu.RUnlock()
+	if cwd == "" {
+		cwd, _ = os.Getwd()
+	}
+	root := filepath.Clean(bl.workspaceDir)
+	dirs := []string{root}
+	if cwd == "" {
+		return dirs
+	}
+	cwd = filepath.Clean(cwd)
+	rel, err := filepath.Rel(root, cwd)
+	if err != nil || rel == "." || strings.HasPrefix(rel, "..") {
+		return dirs
+	}
+	cur := root
+	for _, part := range strings.Split(rel, string(filepath.Separator)) {
+		if part == "" {
+			continue
+		}
+		cur = filepath.Join(cur, part)
+		dirs = append(dirs, cur)
+	}
+	return dirs
+}
+
+// instructionFileIn returns the first instruction file present in dir.
+func (bl *BootstrapLoader) instructionFileIn(dir string) (string, string, bool) {
+	for _, name := range instructionFileNames {
+		p := filepath.Join(dir, name)
+		if content, ok := bl.loadWithCache(p); ok {
+			return p, content, true
+		}
+	}
+	return "", "", false
+}
+
+// loadInstructionHierarchy assembles the project instruction files (root
+// → cwd), falling back to the global AGENTS.md when the project has none.
+// Each file has its @imports expanded; the result is capped.
+func (bl *BootstrapLoader) loadInstructionHierarchy() (string, bool) {
+	parts := make([]string, 0, 4)
+	for _, dir := range bl.instructionDirs() {
+		path, content, ok := bl.instructionFileIn(dir)
+		if !ok {
+			continue
+		}
+		content = strings.TrimSpace(bl.expandImports(content, filepath.Dir(path), 1, map[string]bool{path: true}))
+		if content == "" {
+			continue
+		}
+		if dir != filepath.Clean(bl.workspaceDir) {
+			rel, _ := filepath.Rel(bl.workspaceDir, path)
+			content = "<!-- " + filepath.ToSlash(rel) + " -->\n" + content
+		}
+		parts = append(parts, content)
+	}
+	if len(parts) == 0 {
+		if bl.globalDir == "" {
+			return "", false
+		}
+		path, content, ok := bl.instructionFileIn(bl.globalDir)
+		if !ok {
+			return "", false
+		}
+		parts = append(parts, bl.expandImports(content, filepath.Dir(path), 1, map[string]bool{path: true}))
+	}
+	return capInstructionDoc(strings.Join(parts, "\n\n"), InstructionDocMaxBytes), true
+}
+
+// expandImports replaces import lines with the imported file's content,
+// resolved relative to baseDir (absolute and ~ paths accepted), nested up
+// to importMaxHops and never the same file twice. A missing or unreadable
+// target leaves the line untouched.
+func (bl *BootstrapLoader) expandImports(content, baseDir string, hop int, visited map[string]bool) string {
+	if hop > importMaxHops || !strings.Contains(content, "@") {
+		return content
+	}
+	lines := strings.Split(content, "\n")
+	out := make([]string, 0, len(lines))
+	inFence := false
+	for _, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "```") {
+			inFence = !inFence
+		}
+		m := importLine.FindStringSubmatch(line)
+		if inFence || m == nil {
+			out = append(out, line)
+			continue
+		}
+		target := m[1]
+		if strings.HasPrefix(target, "~/") {
+			if home, err := os.UserHomeDir(); err == nil {
+				target = filepath.Join(home, target[2:])
+			}
+		}
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(baseDir, target)
+		}
+		target = filepath.Clean(target)
+		if visited[target] {
+			out = append(out, line)
+			continue
+		}
+		imported, ok := bl.loadWithCache(target)
+		if !ok {
+			out = append(out, line)
+			continue
+		}
+		visited[target] = true
+		out = append(out, fmt.Sprintf("<!-- import %s -->", filepath.Base(target)))
+		out = append(out, bl.expandImports(imported, filepath.Dir(target), hop+1, visited))
+	}
+	return strings.Join(out, "\n")
+}
+
+// capInstructionDoc truncates at a line boundary with a visible note.
+func capInstructionDoc(doc string, limit int) string {
+	if len(doc) <= limit {
+		return doc
+	}
+	cut := limit
+	if i := strings.LastIndexByte(doc[:limit], '\n'); i > limit/2 {
+		cut = i
+	}
+	return doc[:cut] + fmt.Sprintf("\n\n<!-- instruction files truncated at %d KiB -->", limit/1024)
+}

--- a/cli/workspace/instructions_test.go
+++ b/cli/workspace/instructions_test.go
@@ -1,0 +1,125 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestInstructionHierarchy_RootToCwdWithFallbacks(t *testing.T) {
+	root := t.TempDir()
+	global := t.TempDir()
+	writeFile(t, filepath.Join(global, "AGENTS.md"), "GLOBAL RULES")
+	writeFile(t, filepath.Join(root, "AGENTS.md"), "ROOT RULES")
+	writeFile(t, filepath.Join(root, "services", "CLAUDE.md"), "SERVICE RULES (claude fallback)")
+	writeFile(t, filepath.Join(root, "services", "api", "CHATCLI.md"), "API RULES")
+	writeFile(t, filepath.Join(root, "services", "api", "CLAUDE.md"), "must not win over CHATCLI.md")
+	bl := NewBootstrapLoader(root, global, zap.NewNop())
+	bl.SetWorkingDir(filepath.Join(root, "services", "api", "handlers"))
+	out := bl.LoadBootstrapContent()
+	for _, want := range []string{"ROOT RULES", "SERVICE RULES", "API RULES", "<!-- services/CLAUDE.md -->", "<!-- services/api/CHATCLI.md -->"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "GLOBAL RULES") || strings.Contains(out, "must not win") {
+		t.Fatalf("project files must shadow the global one and CHATCLI.md must beat CLAUDE.md:\n%s", out)
+	}
+	if strings.Index(out, "ROOT RULES") > strings.Index(out, "API RULES") {
+		t.Fatal("root file must come first (least specific → most specific)")
+	}
+	// cwd outside the workspace: root only.
+	bl.SetWorkingDir(t.TempDir())
+	if out := bl.LoadBootstrapContent(); !strings.Contains(out, "ROOT RULES") || strings.Contains(out, "API RULES") {
+		t.Fatalf("cwd outside the workspace must yield the root file only:\n%s", out)
+	}
+	// No project file at all: the global one.
+	empty := t.TempDir()
+	bl2 := NewBootstrapLoader(empty, global, zap.NewNop())
+	if out := bl2.LoadBootstrapContent(); !strings.Contains(out, "GLOBAL RULES") {
+		t.Fatalf("global fallback:\n%s", out)
+	}
+}
+
+func TestExpandImports_HopsCyclesFencesAndMissing(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "AGENTS.md"), "TOP\n@docs/style.md\n@import docs/missing.md\n```\n@docs/style.md\n```\n@AGENTS.md")
+	writeFile(t, filepath.Join(root, "docs", "style.md"), "STYLE\n@deeper/one.md")
+	writeFile(t, filepath.Join(root, "docs", "deeper", "one.md"), "ONE\n@two.md")
+	writeFile(t, filepath.Join(root, "docs", "deeper", "two.md"), "TWO\n@three.md")
+	writeFile(t, filepath.Join(root, "docs", "deeper", "three.md"), "THREE\n@four.md")
+	writeFile(t, filepath.Join(root, "docs", "deeper", "four.md"), "FOUR (fifth hop, must not appear)")
+	bl := NewBootstrapLoader(root, "", zap.NewNop())
+	bl.SetWorkingDir(root)
+	out := bl.LoadBootstrapContent()
+	for _, want := range []string{"TOP", "STYLE", "ONE", "TWO", "THREE", "<!-- import style.md -->", "@import docs/missing.md"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "FOUR") {
+		t.Fatal("imports stop after four hops")
+	}
+	if strings.Count(out, "STYLE") != 1 {
+		t.Fatalf("the fenced @ line must stay literal and a file imports once:\n%s", out)
+	}
+	if strings.Count(out, "TOP") != 1 {
+		t.Fatal("a self-import must not recurse")
+	}
+	// Imported files participate in staleness.
+	if bl.IsStale() {
+		t.Fatal("fresh")
+	}
+	writeFile(t, filepath.Join(root, "docs", "style.md"), "STYLE v2")
+	stale := false
+	for i := 0; i < 20 && !stale; i++ {
+		// mtime granularity: bump until the stat differs
+		_ = os.Chtimes(filepath.Join(root, "docs", "style.md"), nowPlus(i), nowPlus(i))
+		stale = bl.IsStale()
+	}
+	if !stale {
+		t.Fatal("an edited imported file must mark the cache stale")
+	}
+}
+
+func TestCapInstructionDoc(t *testing.T) {
+	doc := strings.Repeat("line of instructions\n", 3000) // ~63 KiB
+	out := capInstructionDoc(doc, InstructionDocMaxBytes)
+	if len(out) > InstructionDocMaxBytes+128 || !strings.Contains(out, "truncated at 32 KiB") {
+		t.Fatalf("cap: len=%d", len(out))
+	}
+	if capInstructionDoc("short", InstructionDocMaxBytes) != "short" {
+		t.Fatal("under the cap: untouched")
+	}
+}
+
+func TestOtherBootstrapFilesExpandImports(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "SOUL.md"), "SOUL\n@persona/voice.md")
+	writeFile(t, filepath.Join(root, "persona", "voice.md"), "VOICE")
+	bl := NewBootstrapLoader(root, t.TempDir(), zap.NewNop())
+	if out := bl.LoadBootstrapContent(); !strings.Contains(out, "VOICE") {
+		t.Fatalf("SOUL.md imports:\n%s", out)
+	}
+}
+
+func nowPlus(i int) time.Time { return time.Now().Add(time.Duration(i+1) * time.Second) }


### PR DESCRIPTION
## Summary

Second context audit, P2 (G16, G17): instruction files reach parity with Codex/Claude Code layouts, and two refresh/watch gaps close.

**Instruction hierarchy.** `AGENTS.md` is read from every directory between the project root and the working directory, root first, so a package-level file refines the repository-level one. A directory without `AGENTS.md` may carry `CHATCLI.md` or `CLAUDE.md` (that order). Nested files are prefixed with a `<!-- path -->` comment; the assembled text is capped at 32 KiB at a line boundary with a visible note (Codex's project-doc ceiling). The global `~/.chatcli/AGENTS.md` applies only when the project has no instruction file.

**Imports.** Any bootstrap file can pull another in with `@path/to/file.md` or `@import path` on a line of its own, resolved relative to the importing file (absolute and `~` accepted), up to 4 hops, never the same file twice; a missing target leaves the line as written and fenced lines are ignored. Imported files are cached with the bootstrap files, so `IsStale` sees their edits.

**Watcher.** A created directory's whole subtree is registered (mkdir -p, checkouts, unpacks), not just the top.

**Legacy contexts.** A context saved before source paths were recorded adopts the absolute paths of the files it holds on its first `/context refresh` or `/context watch` and persists them; `/context update` still re-records explicitly.

The exported `NewBootstrapLoader` signature is unchanged; the working directory arrives through a new `SetWorkingDir`.

## Tests

`cli/workspace/instructions_test.go` (hierarchy order, fallbacks, cwd outside the workspace, global fallback, import hops/cycles/fences/missing/staleness, cap, imports from SOUL.md) and `cli/ctxmgr/refresh_legacy_test.go` (path inference, nested watch registration). Full suite, golangci-lint and the local gates are green.