### PR TITLE
feat(telemetry): OpenTelemetry metrics export over OTLP/HTTP and a provider-side context engine

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -41,6 +41,7 @@ import (
 	"github.com/diillson/chatcli/cli/paste"
 	"github.com/diillson/chatcli/cli/plugins"
 	"github.com/diillson/chatcli/cli/scheduler"
+	"github.com/diillson/chatcli/cli/telemetry"
 	"github.com/diillson/chatcli/cli/workspace"
 	"github.com/diillson/chatcli/client/remote"
 	"github.com/diillson/chatcli/i18n"
@@ -353,7 +354,9 @@ type ChatCLI struct {
 	// lastRecallTrace is what the last auto-recall injected and why (/memory why).
 	recallTraceMu   sync.Mutex
 	lastRecallTrace *memoryRecallTrace
-	lastEscTime     time.Time // for Esc+Esc double-press detection
+	// otlp is the OpenTelemetry metrics exporter (nil unless OTEL_* is set).
+	otlp        *telemetry.Exporter
+	lastEscTime time.Time // for Esc+Esc double-press detection
 
 	// Background memory annotation worker
 	memWorker        *memoryWorker
@@ -898,6 +901,7 @@ func NewChatCLI(ctx context.Context, manager manager.LLMManager, logger *zap.Log
 	// layer is also consulted by the agent/coder loop to compress tool output.
 	cli.initTranscriptJournal("")
 	cli.initLLMAudit("repl")
+	cli.initTelemetry(ctx, "repl")
 	cli.initCacheResourceCosting()
 	// GPT models count tokens locally: warm the vocabulary in the
 	// background so the first exact count is ready by the first turn.
@@ -2136,9 +2140,11 @@ func (cli *ChatCLI) cleanup(ctx context.Context) {
 		cli.hubLocalClose = nil
 	}
 
-	// Learned token ratios and today's spend outlive the process.
+	// Learned token ratios and today's spend outlive the process; the last
+	// metrics snapshot leaves with them.
 	cli.calibrator().flushCalibration()
 	cli.costTracker.FlushDailySpend()
+	cli.shutdownTelemetry(ctx)
 
 	// Stop context watchers before the stores go away.
 	if cli.contextHandler != nil {

--- a/cli/config_env_defaults.go
+++ b/cli/config_env_defaults.go
@@ -184,14 +184,20 @@ var envDefaults = map[string]envDefault{
 	"CHATCLI_EMBED_DIMENSIONS":    {Value: "(provider-default)", Source: "openai 1536, google 3072 (128-3072), titan-v2 1024 (256/512/1024), titan-v1 1536, cohere-v3 1024, cohere-v4 1536, nova-mme 3072 (256/384/1024/3072)"},
 
 	// ─── Cost / budget ───────────────────────────────────────────
-	"CHATCLI_SESSION_BUDGET_USD":  {Value: "(no budget)", Source: "cost_tracker.go"},
-	"CHATCLI_DAILY_BUDGET_USD":    {Value: "(no budget)", Source: "cli/cost_daily.go (spend across every session of the calendar day under the store dir — per tenant on the gateway; shares CHATCLI_BUDGET_WARNING_PCT and CHATCLI_BUDGET_HARD_STOP)"},
-	"CHATCLI_BUDGET_WARNING_PCT":  {Value: "0.80", Source: "cost_tracker.go"},
-	"CHATCLI_BUDGET_HARD_STOP":    {Value: "false", IsBool: true, Source: "cost_tracker.go (refuse turns once budget exceeded)"},
-	"CHATCLI_SESSION_TTL":         {Value: "90", Source: "session_manager.go (days)"},
-	"CHATCLI_GATEWAY_MAX_TENANTS": {Value: "16", Source: "tenant_scope.go (resident per-principal store sets, hub isolation)"},
-	"CHATCLI_SESSION_TRANSCRIPT":  {Value: "true", IsBool: true, Source: "transcript_journal.go (append-only ~/.chatcli/transcripts/<id>.jsonl)"},
-	"CHATCLI_DISABLE_HISTORY":     {Value: "false", IsBool: true, Source: "history_manager.go"},
+	"CHATCLI_SESSION_BUDGET_USD":          {Value: "(no budget)", Source: "cost_tracker.go"},
+	"CHATCLI_DAILY_BUDGET_USD":            {Value: "(no budget)", Source: "cli/cost_daily.go (spend across every session of the calendar day under the store dir — per tenant on the gateway; shares CHATCLI_BUDGET_WARNING_PCT and CHATCLI_BUDGET_HARD_STOP)"},
+	"OTEL_EXPORTER_OTLP_ENDPOINT":         {Value: "(off)", Source: "cli/telemetry/otlp.go (OpenTelemetry standard; base URL, metrics go to <base>/v1/metrics over OTLP/HTTP JSON)"},
+	"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": {Value: "(derived)", Source: "cli/telemetry/otlp.go (OpenTelemetry standard; full metrics URL, wins over the base endpoint)"},
+	"OTEL_EXPORTER_OTLP_HEADERS":          {Value: "", Source: "cli/telemetry/otlp.go (OpenTelemetry standard; k=v,k2=v2, values URL-encoded)"},
+	"OTEL_SERVICE_NAME":                   {Value: "chatcli", Source: "cli/telemetry/otlp.go (OpenTelemetry standard)"},
+	"OTEL_METRIC_EXPORT_INTERVAL":         {Value: "60000", Source: "cli/telemetry/otlp.go (OpenTelemetry standard; milliseconds, minimum 1000)"},
+	"OTEL_RESOURCE_ATTRIBUTES":            {Value: "", Source: "cli/telemetry/otlp.go (OpenTelemetry standard; k=v,k2=v2 merged into the resource)"},
+	"CHATCLI_BUDGET_WARNING_PCT":          {Value: "0.80", Source: "cost_tracker.go"},
+	"CHATCLI_BUDGET_HARD_STOP":            {Value: "false", IsBool: true, Source: "cost_tracker.go (refuse turns once budget exceeded)"},
+	"CHATCLI_SESSION_TTL":                 {Value: "90", Source: "session_manager.go (days)"},
+	"CHATCLI_GATEWAY_MAX_TENANTS":         {Value: "16", Source: "tenant_scope.go (resident per-principal store sets, hub isolation)"},
+	"CHATCLI_SESSION_TRANSCRIPT":          {Value: "true", IsBool: true, Source: "transcript_journal.go (append-only ~/.chatcli/transcripts/<id>.jsonl)"},
+	"CHATCLI_DISABLE_HISTORY":             {Value: "false", IsBool: true, Source: "history_manager.go"},
 
 	// ─── Memory / bootstrap ──────────────────────────────────────
 	"CHATCLI_MEMORY_ENABLED":    {Value: "true", IsBool: true, Source: "memory.go"},

--- a/cli/config_sections.go
+++ b/cli/config_sections.go
@@ -1467,6 +1467,10 @@ func (cli *ChatCLI) showConfigServer() {
 	kv(p, "CHATCLI_AUDIT_LOG_PATH", envOr("CHATCLI_AUDIT_LOG_PATH"))
 
 	fmt.Println(p)
+	subheader(p, "cfg.sub.server.otel")
+	cli.renderTelemetryStatus(p)
+
+	fmt.Println(p)
 	subheader(p, "cfg.sub.server.operator")
 	kv(p, "CHATCLI_AIOPS_PORT", envOr("CHATCLI_AIOPS_PORT"))
 	kv(p, "CHATCLI_OPERATOR_DEV_MODE", envBool("CHATCLI_OPERATOR_DEV_MODE"))

--- a/cli/llm_audit.go
+++ b/cli/llm_audit.go
@@ -142,7 +142,11 @@ func (w *llmAuditWriter) setSurface(surface string) {
 
 // SetAuditSurface names the process role on every audit line from now on.
 func (cli *ChatCLI) SetAuditSurface(surface string) {
-	if cli == nil || cli.llmAudit == nil {
+	if cli == nil {
+		return
+	}
+	cli.telemetrySurface(surface)
+	if cli.llmAudit == nil {
 		return
 	}
 	cli.llmAudit.setSurface(surface)

--- a/cli/telemetry/otlp.go
+++ b/cli/telemetry/otlp.go
@@ -1,0 +1,383 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * OpenTelemetry metrics export over OTLP/HTTP (JSON encoding), with no
+ * SDK dependency: the exporter renders the standard ExportMetricsService
+ * request by hand and pushes cumulative counters on an interval. It is
+ * configured only through the OpenTelemetry environment contract
+ * (OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
+ * OTEL_EXPORTER_OTLP_HEADERS, OTEL_SERVICE_NAME, OTEL_METRIC_EXPORT_INTERVAL,
+ * OTEL_RESOURCE_ATTRIBUTES), so a collector already wired for other
+ * services receives ChatCLI's tokens, cache, compaction, embedding and
+ * cost counters without ChatCLI-specific settings. Off unless an
+ * endpoint is set.
+ */
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Standard OpenTelemetry environment variables honored by the exporter.
+const (
+	EnvEndpoint        = "OTEL_EXPORTER_OTLP_ENDPOINT"
+	EnvMetricsEndpoint = "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"
+	EnvHeaders         = "OTEL_EXPORTER_OTLP_HEADERS"
+	EnvServiceName     = "OTEL_SERVICE_NAME"
+	EnvExportInterval  = "OTEL_METRIC_EXPORT_INTERVAL" // milliseconds
+	EnvResourceAttrs   = "OTEL_RESOURCE_ATTRIBUTES"
+
+	defaultServiceName = "chatcli"
+	defaultInterval    = 60 * time.Second
+	scopeName          = "github.com/diillson/chatcli"
+	pushTimeout        = 10 * time.Second
+)
+
+// Point is one cumulative counter value with its attributes.
+type Point struct {
+	Value float64
+	Attrs map[string]string
+}
+
+// Metric is one cumulative sum metric.
+type Metric struct {
+	Name   string
+	Unit   string
+	Points []Point
+}
+
+// Source produces the current cumulative metrics on every export.
+type Source func() []Metric
+
+// Exporter pushes metrics to an OTLP/HTTP endpoint on an interval.
+type Exporter struct {
+	endpoint string
+	headers  map[string]string
+	resource map[string]string
+	interval time.Duration
+	client   *http.Client
+	source   Source
+	start    time.Time
+
+	mu      sync.Mutex
+	cancel  context.CancelFunc
+	done    chan struct{}
+	lastErr error
+	pushes  int
+	logf    func(format string, args ...interface{})
+}
+
+// Enabled reports whether an OTLP endpoint is configured.
+func Enabled() bool {
+	return MetricsEndpoint() != ""
+}
+
+// MetricsEndpoint resolves the metrics URL per the OTLP spec: the
+// signal-specific variable as is, else the base endpoint + /v1/metrics.
+func MetricsEndpoint() string {
+	if v := strings.TrimSpace(os.Getenv(EnvMetricsEndpoint)); v != "" {
+		return v
+	}
+	base := strings.TrimSpace(os.Getenv(EnvEndpoint))
+	if base == "" {
+		return ""
+	}
+	return strings.TrimRight(base, "/") + "/v1/metrics"
+}
+
+// NewFromEnv builds the exporter from the OTEL_* environment; nil when
+// no endpoint is configured. extraResource attributes (surface, tenant)
+// are merged over OTEL_RESOURCE_ATTRIBUTES.
+func NewFromEnv(source Source, extraResource map[string]string) *Exporter {
+	endpoint := MetricsEndpoint()
+	if endpoint == "" || source == nil {
+		return nil
+	}
+	e := &Exporter{
+		endpoint: endpoint,
+		headers:  parseHeaders(os.Getenv(EnvHeaders)),
+		resource: map[string]string{"service.name": defaultServiceName},
+		interval: defaultInterval,
+		client:   &http.Client{Timeout: pushTimeout},
+		source:   source,
+		start:    time.Now(),
+	}
+	for k, v := range parseKV(os.Getenv(EnvResourceAttrs)) {
+		e.resource[k] = v
+	}
+	if name := strings.TrimSpace(os.Getenv(EnvServiceName)); name != "" {
+		e.resource["service.name"] = name
+	}
+	for k, v := range extraResource {
+		if v != "" {
+			e.resource[k] = v
+		}
+	}
+	if ms, err := strconv.Atoi(strings.TrimSpace(os.Getenv(EnvExportInterval))); err == nil && ms >= 1000 {
+		e.interval = time.Duration(ms) * time.Millisecond
+	}
+	return e
+}
+
+// SetLogger installs a debug logger for push failures (optional).
+func (e *Exporter) SetLogger(logf func(format string, args ...interface{})) {
+	if e == nil {
+		return
+	}
+	e.mu.Lock()
+	e.logf = logf
+	e.mu.Unlock()
+}
+
+// SetResource updates one resource attribute (surface, tenant) for later pushes.
+func (e *Exporter) SetResource(key, value string) {
+	if e == nil || key == "" {
+		return
+	}
+	e.mu.Lock()
+	if value == "" {
+		delete(e.resource, key)
+	} else {
+		e.resource[key] = value
+	}
+	e.mu.Unlock()
+}
+
+// Start runs the export loop until Stop (or ctx ends); idempotent.
+func (e *Exporter) Start(ctx context.Context) {
+	if e == nil {
+		return
+	}
+	e.mu.Lock()
+	if e.cancel != nil {
+		e.mu.Unlock()
+		return
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	e.cancel = cancel
+	e.done = make(chan struct{})
+	e.mu.Unlock()
+	go e.loop(ctx)
+}
+
+// Stop stops the loop and pushes a final snapshot bounded by ctx.
+func (e *Exporter) Stop(ctx context.Context) {
+	if e == nil {
+		return
+	}
+	e.mu.Lock()
+	cancel, done := e.cancel, e.done
+	e.cancel = nil
+	e.mu.Unlock()
+	if cancel == nil {
+		return
+	}
+	cancel()
+	<-done
+	pushCtx, c := context.WithTimeout(ctx, pushTimeout)
+	defer c()
+	_ = e.Push(pushCtx)
+}
+
+func (e *Exporter) loop(ctx context.Context) {
+	defer close(e.done)
+	t := time.NewTicker(e.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if err := e.Push(ctx); err != nil {
+				e.mu.Lock()
+				logf := e.logf
+				e.mu.Unlock()
+				if logf != nil {
+					logf("otlp metrics push failed: %v", err)
+				}
+			}
+		}
+	}
+}
+
+// Push renders and sends one ExportMetricsServiceRequest now.
+func (e *Exporter) Push(ctx context.Context) error {
+	if e == nil {
+		return nil
+	}
+	body, err := e.render(e.source(), time.Now())
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	e.mu.Lock()
+	for k, v := range e.headers {
+		req.Header.Set(k, v)
+	}
+	e.mu.Unlock()
+	resp, err := e.client.Do(req)
+	if err != nil {
+		e.note(err)
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		err = fmt.Errorf("otlp endpoint returned HTTP %d", resp.StatusCode)
+		e.note(err)
+		return err
+	}
+	e.note(nil)
+	return nil
+}
+
+func (e *Exporter) note(err error) {
+	e.mu.Lock()
+	e.lastErr = err
+	if err == nil {
+		e.pushes++
+	}
+	e.mu.Unlock()
+}
+
+// Status reports pushes so far and the last error ("" when healthy).
+func (e *Exporter) Status() (endpoint string, pushes int, lastErr string) {
+	if e == nil {
+		return "", 0, ""
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.lastErr != nil {
+		lastErr = e.lastErr.Error()
+	}
+	return e.endpoint, e.pushes, lastErr
+}
+
+// ---- OTLP/JSON rendering (metrics.proto JSON mapping) ----
+
+type otlpKeyValue struct {
+	Key   string       `json:"key"`
+	Value otlpAnyValue `json:"value"`
+}
+
+type otlpAnyValue struct {
+	StringValue string `json:"stringValue"`
+}
+
+type otlpDataPoint struct {
+	Attributes        []otlpKeyValue `json:"attributes,omitempty"`
+	StartTimeUnixNano string         `json:"startTimeUnixNano"`
+	TimeUnixNano      string         `json:"timeUnixNano"`
+	AsDouble          float64        `json:"asDouble"`
+}
+
+type otlpSum struct {
+	DataPoints             []otlpDataPoint `json:"dataPoints"`
+	AggregationTemporality int             `json:"aggregationTemporality"` // 2 = CUMULATIVE
+	IsMonotonic            bool            `json:"isMonotonic"`
+}
+
+type otlpMetric struct {
+	Name string  `json:"name"`
+	Unit string  `json:"unit,omitempty"`
+	Sum  otlpSum `json:"sum"`
+}
+
+type otlpScope struct {
+	Name string `json:"name"`
+}
+
+type otlpScopeMetrics struct {
+	Scope   otlpScope    `json:"scope"`
+	Metrics []otlpMetric `json:"metrics"`
+}
+
+type otlpResource struct {
+	Attributes []otlpKeyValue `json:"attributes"`
+}
+
+type otlpResourceMetrics struct {
+	Resource     otlpResource       `json:"resource"`
+	ScopeMetrics []otlpScopeMetrics `json:"scopeMetrics"`
+}
+
+type otlpExportRequest struct {
+	ResourceMetrics []otlpResourceMetrics `json:"resourceMetrics"`
+}
+
+func (e *Exporter) render(metrics []Metric, now time.Time) ([]byte, error) {
+	e.mu.Lock()
+	res := sortedKV(e.resource)
+	e.mu.Unlock()
+	startNano := strconv.FormatInt(e.start.UnixNano(), 10)
+	nowNano := strconv.FormatInt(now.UnixNano(), 10)
+	out := make([]otlpMetric, 0, len(metrics))
+	for _, m := range metrics {
+		if m.Name == "" || len(m.Points) == 0 {
+			continue
+		}
+		pts := make([]otlpDataPoint, 0, len(m.Points))
+		for _, p := range m.Points {
+			pts = append(pts, otlpDataPoint{Attributes: sortedKV(p.Attrs), StartTimeUnixNano: startNano, TimeUnixNano: nowNano, AsDouble: p.Value})
+		}
+		out = append(out, otlpMetric{Name: m.Name, Unit: m.Unit, Sum: otlpSum{DataPoints: pts, AggregationTemporality: 2, IsMonotonic: true}})
+	}
+	req := otlpExportRequest{ResourceMetrics: []otlpResourceMetrics{{
+		Resource:     otlpResource{Attributes: res},
+		ScopeMetrics: []otlpScopeMetrics{{Scope: otlpScope{Name: scopeName}, Metrics: out}},
+	}}}
+	return json.Marshal(req)
+}
+
+func sortedKV(m map[string]string) []otlpKeyValue {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]otlpKeyValue, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, otlpKeyValue{Key: k, Value: otlpAnyValue{StringValue: m[k]}})
+	}
+	return out
+}
+
+// parseHeaders parses OTEL_EXPORTER_OTLP_HEADERS ("k=v,k2=v2", values
+// URL-encoded per the spec).
+func parseHeaders(raw string) map[string]string {
+	out := parseKV(raw)
+	for k, v := range out {
+		if dec, err := url.QueryUnescape(v); err == nil {
+			out[k] = dec
+		}
+	}
+	return out
+}
+
+func parseKV(raw string) map[string]string {
+	out := map[string]string{}
+	for _, pair := range strings.Split(raw, ",") {
+		k, v, ok := strings.Cut(pair, "=")
+		k, v = strings.TrimSpace(k), strings.TrimSpace(v)
+		if ok && k != "" {
+			out[k] = v
+		}
+	}
+	return out
+}

--- a/cli/telemetry/otlp_test.go
+++ b/cli/telemetry/otlp_test.go
@@ -1,0 +1,123 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+)
+
+func TestExporter_PushesOTLPJSONWithResourceAndHeaders(t *testing.T) {
+	var mu sync.Mutex
+	var bodies [][]byte
+	var auth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		bodies = append(bodies, b)
+		auth = r.Header.Get("Authorization")
+		mu.Unlock()
+		if r.URL.Path != "/v1/metrics" || r.Header.Get("Content-Type") != "application/json" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	t.Setenv(EnvEndpoint, srv.URL)
+	t.Setenv(EnvMetricsEndpoint, "")
+	t.Setenv(EnvHeaders, "Authorization=Bearer%20abc,x-team=ctx")
+	t.Setenv(EnvServiceName, "chatcli-test")
+	t.Setenv(EnvResourceAttrs, "deployment.environment=staging")
+	t.Setenv(EnvExportInterval, "1000")
+	source := func() []Metric {
+		return []Metric{{Name: "chatcli.llm.tokens", Unit: "{token}", Points: []Point{{Value: 42, Attrs: map[string]string{"kind": "input", "provider": "openai"}}}}, {Name: "empty"}}
+	}
+	exp := NewFromEnv(source, map[string]string{"chatcli.surface": "repl", "chatcli.tenant": ""})
+	if exp == nil {
+		t.Fatal("endpoint configured → exporter")
+	}
+	if err := exp.Push(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	exp.SetResource("chatcli.tenant", "acme")
+	exp.Start(context.Background())
+	exp.Start(context.Background()) // idempotent
+	exp.Stop(context.Background())  // final push
+	mu.Lock()
+	defer mu.Unlock()
+	if len(bodies) < 2 || auth != "Bearer abc" {
+		t.Fatalf("pushes=%d auth=%q", len(bodies), auth)
+	}
+	var req otlpExportRequest
+	if err := json.Unmarshal(bodies[len(bodies)-1], &req); err != nil {
+		t.Fatal(err)
+	}
+	rm := req.ResourceMetrics[0]
+	attrs := map[string]string{}
+	for _, kv := range rm.Resource.Attributes {
+		attrs[kv.Key] = kv.Value.StringValue
+	}
+	if attrs["service.name"] != "chatcli-test" || attrs["deployment.environment"] != "staging" || attrs["chatcli.surface"] != "repl" || attrs["chatcli.tenant"] != "acme" {
+		t.Fatalf("resource = %v", attrs)
+	}
+	metrics := rm.ScopeMetrics[0].Metrics
+	if len(metrics) != 1 || metrics[0].Name != "chatcli.llm.tokens" || metrics[0].Sum.AggregationTemporality != 2 || !metrics[0].Sum.IsMonotonic {
+		t.Fatalf("metrics = %+v", metrics)
+	}
+	dp := metrics[0].Sum.DataPoints[0]
+	if dp.AsDouble != 42 || dp.StartTimeUnixNano == "" || dp.TimeUnixNano == "" || len(dp.Attributes) != 2 {
+		t.Fatalf("datapoint = %+v", dp)
+	}
+	if ep, pushes, lastErr := exp.Status(); ep != srv.URL+"/v1/metrics" || pushes < 2 || lastErr != "" {
+		t.Fatalf("status = %s %d %q", ep, pushes, lastErr)
+	}
+}
+
+func TestExporter_EnvResolutionAndFailures(t *testing.T) {
+	t.Setenv(EnvEndpoint, "")
+	t.Setenv(EnvMetricsEndpoint, "")
+	if Enabled() || NewFromEnv(func() []Metric { return nil }, nil) != nil {
+		t.Fatal("no endpoint → disabled")
+	}
+	t.Setenv(EnvMetricsEndpoint, "http://collector:4318/custom/metrics")
+	t.Setenv(EnvEndpoint, "http://ignored:4318/")
+	if MetricsEndpoint() != "http://collector:4318/custom/metrics" {
+		t.Fatal("the signal-specific endpoint wins")
+	}
+	t.Setenv(EnvMetricsEndpoint, "")
+	if MetricsEndpoint() != "http://ignored:4318/v1/metrics" {
+		t.Fatal("base endpoint + /v1/metrics")
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusInternalServerError) }))
+	defer srv.Close()
+	t.Setenv(EnvEndpoint, srv.URL)
+	t.Setenv(EnvExportInterval, "10") // below the floor → default
+	exp := NewFromEnv(func() []Metric { return nil }, nil)
+	if exp.interval != defaultInterval {
+		t.Fatal("interval floor")
+	}
+	if err := exp.Push(context.Background()); err == nil {
+		t.Fatal("HTTP 500 must be an error")
+	}
+	if _, _, lastErr := exp.Status(); lastErr == "" {
+		t.Fatal("status must carry the last error")
+	}
+	var nilExp *Exporter
+	nilExp.Start(context.Background())
+	nilExp.Stop(context.Background())
+	if err := nilExp.Push(context.Background()); err != nil {
+		t.Fatal("nil exporter is a no-op")
+	}
+	if h := parseHeaders("a=1, b=x%2Fy ,bad"); h["a"] != "1" || h["b"] != "x/y" || len(h) != 2 {
+		t.Fatalf("headers = %v", h)
+	}
+}

--- a/cli/telemetry_wiring.go
+++ b/cli/telemetry_wiring.go
@@ -1,0 +1,134 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Wires the OTLP metrics exporter to the session's cost tracker: the
+ * cumulative token, cache, compaction, embedding and cost counters every
+ * surface already keeps become OpenTelemetry sums, labeled by surface and
+ * tenant. Configured purely through the OTEL_* environment.
+ */
+package cli
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/diillson/chatcli/cli/telemetry"
+	"go.uber.org/zap"
+)
+
+// initTelemetry starts the OTLP exporter when an endpoint is configured.
+func (cli *ChatCLI) initTelemetry(ctx context.Context, surface string) {
+	if cli == nil || !telemetry.Enabled() {
+		return
+	}
+	exp := telemetry.NewFromEnv(cli.telemetryMetrics, map[string]string{"chatcli.surface": surface})
+	if exp == nil {
+		return
+	}
+	if cli.logger != nil {
+		logger := cli.logger
+		exp.SetLogger(func(format string, args ...interface{}) { logger.Sugar().Debugf(format, args...) })
+	}
+	cli.otlp = exp
+	// The loop outlives any request: bound by process shutdown, not by
+	// the constructor's context.
+	exp.Start(context.WithoutCancel(ctx))
+	if cli.logger != nil {
+		endpoint, _, _ := exp.Status()
+		cli.logger.Info("OpenTelemetry metrics export enabled", zap.String("endpoint", endpoint))
+	}
+}
+
+// telemetryMetrics renders the cost tracker as cumulative OTLP sums.
+func (cli *ChatCLI) telemetryMetrics() []telemetry.Metric {
+	ct := cli.costTracker
+	if ct == nil {
+		return nil
+	}
+	snap := ct.Snapshot()
+	tokens := telemetry.Metric{Name: "chatcli.llm.tokens", Unit: "{token}"}
+	cost := telemetry.Metric{Name: "chatcli.llm.cost", Unit: "USD"}
+	for _, rec := range snap.ModelUsage {
+		if rec == nil {
+			continue
+		}
+		base := map[string]string{"provider": rec.Provider, "model": rec.Model}
+		for kind, n := range map[string]int64{
+			"input": rec.PromptTokens, "output": rec.CompletionTokens,
+			"cache_read": rec.CacheReadTokens, "cache_write": rec.CacheCreationTokens, "reasoning": rec.ReasoningTokens,
+		} {
+			if n <= 0 {
+				continue
+			}
+			attrs := map[string]string{"kind": kind}
+			for k, v := range base {
+				attrs[k] = v
+			}
+			tokens.Points = append(tokens.Points, telemetry.Point{Value: float64(n), Attrs: attrs})
+		}
+		cost.Points = append(cost.Points, telemetry.Point{Value: rec.TotalCostUSD, Attrs: base})
+	}
+	out := []telemetry.Metric{tokens, cost}
+	if snap.Compactions > 0 {
+		out = append(out, telemetry.Metric{Name: "chatcli.context.compactions", Unit: "{compaction}", Points: []telemetry.Point{
+			{Value: float64(snap.Compactions - snap.CompactionsLevel3), Attrs: map[string]string{"level": "summary"}},
+			{Value: float64(snap.CompactionsLevel3), Attrs: map[string]string{"level": "truncation"}},
+		}})
+		out = append(out, telemetry.Metric{Name: "chatcli.context.compaction_cost", Unit: "USD", Points: []telemetry.Point{{Value: snap.CompactionCostUSD}}})
+	}
+	if stats := ct.CacheStats(); stats.Requests > 0 {
+		out = append(out, telemetry.Metric{Name: "chatcli.cache.requests", Unit: "{request}", Points: []telemetry.Point{
+			{Value: float64(stats.Requests), Attrs: map[string]string{"outcome": "total"}},
+			{Value: float64(stats.Misses), Attrs: map[string]string{"outcome": "miss"}},
+			{Value: float64(stats.Rebuilds), Attrs: map[string]string{"outcome": "expected_rebuild"}},
+		}})
+	}
+	if snap.CacheResources > 0 {
+		out = append(out, telemetry.Metric{Name: "chatcli.cache.storage_cost", Unit: "USD", Points: []telemetry.Point{{Value: snap.CacheStorageCostUSD}}})
+	}
+	out = append(out, telemetry.Metric{Name: "chatcli.session.cost", Unit: "USD", Points: []telemetry.Point{{Value: snap.TotalCostUSD, Attrs: map[string]string{"session": snap.SessionID}}}})
+	return out
+}
+
+// telemetrySurface relabels the exporter's surface resource attribute.
+func (cli *ChatCLI) telemetrySurface(surface string) {
+	if cli == nil || cli.otlp == nil {
+		return
+	}
+	cli.otlp.SetResource("chatcli.surface", surface)
+}
+
+// telemetryTenant relabels the exporter's tenant resource attribute.
+func (cli *ChatCLI) telemetryTenant(principal string) {
+	if cli == nil || cli.otlp == nil {
+		return
+	}
+	cli.otlp.SetResource("chatcli.tenant", principal)
+}
+
+// shutdownTelemetry pushes a final snapshot and stops the loop.
+func (cli *ChatCLI) shutdownTelemetry(ctx context.Context) {
+	if cli == nil || cli.otlp == nil {
+		return
+	}
+	cli.otlp.Stop(ctx)
+	cli.otlp = nil
+}
+
+// renderTelemetryStatus prints the /config rows of the exporter.
+func (cli *ChatCLI) renderTelemetryStatus(p string) {
+	kv(p, telemetry.EnvEndpoint, envOr(telemetry.EnvEndpoint))
+	kv(p, telemetry.EnvMetricsEndpoint, envOr(telemetry.EnvMetricsEndpoint))
+	kv(p, telemetry.EnvServiceName, envOr(telemetry.EnvServiceName))
+	kv(p, telemetry.EnvExportInterval, envOr(telemetry.EnvExportInterval))
+	if cli != nil && cli.otlp != nil {
+		endpoint, pushes, lastErr := cli.otlp.Status()
+		state := strconv.Itoa(pushes) + " push(es) → " + endpoint
+		if lastErr != "" {
+			state += " · " + lastErr
+		}
+		kv(p, "OTLP", state)
+	}
+}

--- a/cli/telemetry_wiring_test.go
+++ b/cli/telemetry_wiring_test.go
@@ -1,0 +1,39 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+)
+
+func TestTelemetryMetrics_RenderTheCostTracker(t *testing.T) {
+	cli := &ChatCLI{costTracker: NewCostTracker()}
+	cli.costTracker.RecordRealUsage("openai", "gpt-5.6-terra", &models.UsageInfo{PromptTokens: 1000, CompletionTokens: 100, CacheReadInputTokens: 200, TotalTokens: 1100, IsReal: true})
+	cli.costTracker.RecordCompaction(CompactReport{Level: 3})
+	names := map[string]int{}
+	for _, m := range cli.telemetryMetrics() {
+		names[m.Name] = len(m.Points)
+	}
+	if names["chatcli.llm.tokens"] != 3 || names["chatcli.llm.cost"] != 1 || names["chatcli.context.compactions"] != 2 || names["chatcli.session.cost"] != 1 {
+		t.Fatalf("metrics = %v", names)
+	}
+	if (&ChatCLI{}).telemetryMetrics() != nil {
+		t.Fatal("no tracker → nothing")
+	}
+	// No endpoint: init is a no-op; surface/tenant/shutdown never panic.
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "")
+	cli.initTelemetry(context.Background(), "repl")
+	if cli.otlp != nil {
+		t.Fatal("exporter must stay off without an endpoint")
+	}
+	cli.SetAuditSurface("gateway")
+	cli.telemetryTenant("acme")
+	cli.shutdownTelemetry(context.Background())
+}

--- a/cli/tenant_scope.go
+++ b/cli/tenant_scope.go
@@ -155,6 +155,7 @@ func (cli *ChatCLI) applyStores(ts *tenantStores) {
 	}
 	cli.stateRoot = ts.root
 	cli.applyTenantPaths()
+	cli.telemetryTenant(ts.principal)
 	if cli.historyCompactor != nil {
 		cli.historyCompactor.SetCompressionLayer(ts.compressionLayer)
 	}

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -1355,7 +1355,7 @@
   "auth.logout.success": "Logout ok",
   "auth.error.unknown_subcommand": "Unknown subcommand. Use: status | login | logout",
   "memory.error.not_available": "Memory system not available.",
-  "memory.usage": "Usage: /memory [today|yesterday|week|longterm|list|load <date>|profile|profile set <k>=<v>|remember [cat] <fact>|forget <substr>|facts|topics|projects|stats|timeline [q]|compact|<YYYY-MM-DD>]",
+  "memory.usage": "Usage: /memory [today|yesterday|week|longterm|list|load <date>|profile|profile set <k>=<v>|remember [cat] <fact>|forget <substr>|facts|topics|projects|stats|timeline [q]|compact|export [path]|import <path>|recall <query>|why|<YYYY-MM-DD>]",
   "memory.no_notes_for": "No notes found for",
   "memory.notes_for": "Memory notes for",
   "memory.no_notes_week": "No notes in the last 7 days.",
@@ -3536,7 +3536,7 @@
   "park.resolve.empty": "park: empty token (use /parked to list)",
   "park.resolve.not_found": "park: no snapshot matching %q (use /parked to list)",
   "park.resolve.ambiguous": "park: token prefix %q is ambiguous (matches: %s) — use a longer prefix",
-  "sec.cmd.usage_header": "Usage: /config security {rules|allow|deny|forget|reload|reseal|verify-audit [path]} [args]",
+  "sec.cmd.usage_header": "Usage: /config security {rules|allow|deny|forget|reload} [args]",
   "sec.cmd.usage_note_pattern": "Patterns use prefix match against \"<toolName> <args>\" (e.g. \"@coder exec kubectl get\"). Deny beats Allow.",
   "sec.cmd.usage_note_scope": "Changes persist to ~/.chatcli/coder_policy.json and take effect for /coder and the scheduler on the next fire.",
   "sec.cmd.unknown_sub": "Unknown /config security subcommand: %s",
@@ -3751,5 +3751,6 @@
   "cfg.sub.sec.atrest": "Encryption at rest",
   "cfg.kv.sec.atrest_key": "Key fingerprint",
   "cfg.kv.sec.atrest_covers": "Covers",
-  "cfg.kv.sec.atrest_covers_list": "sessions, transcripts, park snapshots, long-term memory (JSON stores), knowledge contexts, CCR archive, cost snapshots, memory exports"
+  "cfg.kv.sec.atrest_covers_list": "sessions, transcripts, park snapshots, long-term memory (JSON stores), knowledge contexts, CCR archive, cost snapshots, memory exports",
+  "cfg.sub.server.otel": "OpenTelemetry export"
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1355,7 +1355,7 @@
   "auth.logout.success": "Logout ok",
   "auth.error.unknown_subcommand": "Unknown subcommand. Use: status | login | logout",
   "memory.error.not_available": "Memory system not available.",
-  "memory.usage": "Usage: /memory [today|yesterday|week|longterm|list|load <date>|profile|profile set <k>=<v>|remember [cat] <fact>|forget <substr>|facts|topics|projects|stats|timeline [q]|compact|<YYYY-MM-DD>]",
+  "memory.usage": "Usage: /memory [today|yesterday|week|longterm|list|load <date>|profile|profile set <k>=<v>|remember [cat] <fact>|forget <substr>|facts|topics|projects|stats|timeline [q]|compact|export [path]|import <path>|recall <query>|why|<YYYY-MM-DD>]",
   "memory.no_notes_for": "No notes found for",
   "memory.notes_for": "Memory notes for",
   "memory.no_notes_week": "No notes in the last 7 days.",
@@ -3536,7 +3536,7 @@
   "park.resolve.empty": "park: empty token (use /parked to list)",
   "park.resolve.not_found": "park: no snapshot matching %q (use /parked to list)",
   "park.resolve.ambiguous": "park: token prefix %q is ambiguous (matches: %s) — use a longer prefix",
-  "sec.cmd.usage_header": "Usage: /config security {rules|allow|deny|forget|reload|reseal|verify-audit [path]} [args]",
+  "sec.cmd.usage_header": "Usage: /config security {rules|allow|deny|forget|reload} [args]",
   "sec.cmd.usage_note_pattern": "Patterns use prefix match against \"<toolName> <args>\" (e.g. \"@coder exec kubectl get\"). Deny beats Allow.",
   "sec.cmd.usage_note_scope": "Changes persist to ~/.chatcli/coder_policy.json and take effect for /coder and the scheduler on the next fire.",
   "sec.cmd.unknown_sub": "Unknown /config security subcommand: %s",
@@ -3751,5 +3751,6 @@
   "cfg.sub.sec.atrest": "Encryption at rest",
   "cfg.kv.sec.atrest_key": "Key fingerprint",
   "cfg.kv.sec.atrest_covers": "Covers",
-  "cfg.kv.sec.atrest_covers_list": "sessions, transcripts, park snapshots, long-term memory (JSON stores), knowledge contexts, CCR archive, cost snapshots, memory exports"
+  "cfg.kv.sec.atrest_covers_list": "sessions, transcripts, park snapshots, long-term memory (JSON stores), knowledge contexts, CCR archive, cost snapshots, memory exports",
+  "cfg.sub.server.otel": "OpenTelemetry export"
 }

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -1355,7 +1355,7 @@
   "auth.logout.success": "Logout realizado",
   "auth.error.unknown_subcommand": "Subcomando desconhecido. Use: status | login | logout",
   "memory.error.not_available": "Sistema de memória não disponível.",
-  "memory.usage": "Uso: /memory [today|yesterday|week|longterm|list|load <data>|profile|profile set <k>=<v>|remember [cat] <fato>|forget <trecho>|facts|topics|projects|stats|timeline [q]|compact|<AAAA-MM-DD>]",
+  "memory.usage": "Uso: /memory [today|yesterday|week|longterm|list|load <data>|profile|profile set <k>=<v>|remember [cat] <fato>|forget <trecho>|facts|topics|projects|stats|timeline [q]|compact|export [caminho]|import <caminho>|recall <consulta>|why|<YYYY-MM-DD>]",
   "memory.no_notes_for": "Nenhuma nota encontrada para",
   "memory.notes_for": "Notas de memória para",
   "memory.no_notes_week": "Nenhuma nota nos últimos 7 dias.",
@@ -3536,7 +3536,7 @@
   "park.resolve.empty": "park: token vazio (use /parked para listar)",
   "park.resolve.not_found": "park: nenhum snapshot bate com %q (use /parked para listar)",
   "park.resolve.ambiguous": "park: prefixo %q ambíguo (bate com: %s) — use um prefixo mais longo",
-  "sec.cmd.usage_header": "Uso: /config security {rules|allow|deny|forget|reload|reseal|verify-audit [caminho]} [args]",
+  "sec.cmd.usage_header": "Uso: /config security {rules|allow|deny|forget|reload} [args]",
   "sec.cmd.usage_note_pattern": "Patterns usam prefix match sobre \"<toolName> <args>\" (ex: \"@coder exec kubectl get\"). Deny bate Allow.",
   "sec.cmd.usage_note_scope": "Mudanças persistem em ~/.chatcli/coder_policy.json e valem para /coder e para o scheduler no próximo fire.",
   "sec.cmd.unknown_sub": "Subcomando de /config security desconhecido: %s",
@@ -3751,5 +3751,6 @@
   "cfg.sub.sec.atrest": "Criptografia em repouso",
   "cfg.kv.sec.atrest_key": "Fingerprint da chave",
   "cfg.kv.sec.atrest_covers": "Cobre",
-  "cfg.kv.sec.atrest_covers_list": "sessões, transcripts, park snapshots, memória de longo prazo (stores JSON), contextos de conhecimento, arquivo CCR, snapshots de custo, exportações de memória"
+  "cfg.kv.sec.atrest_covers_list": "sessões, transcripts, park snapshots, memória de longo prazo (stores JSON), contextos de conhecimento, arquivo CCR, snapshots de custo, exportações de memória",
+  "cfg.sub.server.otel": "Exportação OpenTelemetry"
 }

--- a/llm/claudeai/claude_client.go
+++ b/llm/claudeai/claude_client.go
@@ -685,16 +685,24 @@ func (c *ClaudeClient) applyAuthHeaders(req *http.Request, token string) {
 // requires on the Messages API. Only when the TTL is configured — the
 // default 5-minute cache needs no flag.
 func applyExtendedCacheTTLBeta(req *http.Request) {
-	if client.AnthropicCacheTTL() != "1h" {
-		return
+	if client.AnthropicCacheTTL() == "1h" {
+		addAnthropicBeta(req, client.ExtendedCacheTTLBeta)
 	}
+	if client.ProviderContextEngine() {
+		addAnthropicBeta(req, client.ContextManagementBeta)
+	}
+}
+
+// addAnthropicBeta appends one beta flag to the anthropic-beta header
+// without duplicating it.
+func addAnthropicBeta(req *http.Request, beta string) {
 	if existing := req.Header.Get("anthropic-beta"); existing != "" {
-		if !strings.Contains(existing, client.ExtendedCacheTTLBeta) {
-			req.Header.Set("anthropic-beta", existing+","+client.ExtendedCacheTTLBeta)
+		if !strings.Contains(existing, beta) {
+			req.Header.Set("anthropic-beta", existing+","+beta)
 		}
 		return
 	}
-	req.Header.Set("anthropic-beta", client.ExtendedCacheTTLBeta)
+	req.Header.Set("anthropic-beta", beta)
 }
 
 func oauthTextBlock(text string) map[string]interface{} {
@@ -720,6 +728,9 @@ func applyOAuthHeaders(req *http.Request, token string) {
 	}
 	if client.AnthropicCacheTTL() == "1h" {
 		betas = betas + "," + client.ExtendedCacheTTLBeta
+	}
+	if client.ProviderContextEngine() {
+		betas = betas + "," + client.ContextManagementBeta
 	}
 	req.Header.Set("anthropic-beta", betas)
 	req.Header.Set("anthropic-version", "2023-06-01")

--- a/llm/claudeai/context_engine_wire_test.go
+++ b/llm/claudeai/context_engine_wire_test.go
@@ -1,0 +1,84 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package claudeai
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/auth"
+	llmclient "github.com/diillson/chatcli/llm/client"
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+func captureToolRequest(t *testing.T) (map[string]interface{}, http.Header) {
+	t.Helper()
+	var body map[string]interface{}
+	var headers http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		headers = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":5,"output_tokens":1},"context_management":{"applied_edits":[{"type":"clear_tool_uses_20250919","cleared_tool_uses":3,"cleared_input_tokens":12000}]}}`))
+	}))
+	defer server.Close()
+	c := NewClaudeClient(auth.NewStaticTokenProvider("sk-test", auth.AuthModeAPIKey, auth.ProviderAnthropic), "claude-sonnet-5", zap.NewNop(), 1, 0)
+	c.apiURL = server.URL
+	tools := []models.ToolDefinition{{Type: "function", Function: models.ToolFunctionDef{Name: "read_file", Description: "read", Parameters: map[string]interface{}{"type": "object"}}}}
+	resp, err := c.SendPromptWithTools(context.Background(), "go", []models.Message{{Role: "user", Content: "go"}}, tools, 100)
+	if err != nil || resp == nil {
+		t.Fatalf("SendPromptWithTools: %v", err)
+	}
+	return body, headers
+}
+
+func TestProviderContextEngine_AddsContextManagementAndBeta(t *testing.T) {
+	t.Setenv(llmclient.ContextEngineEnv, "provider")
+	t.Setenv(llmclient.PromptCacheTTLEnv, "1h")
+	body, headers := captureToolRequest(t)
+	cm, ok := body["context_management"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("context_management missing: %v", body)
+	}
+	edits, _ := cm["edits"].([]interface{})
+	if len(edits) != 1 || edits[0].(map[string]interface{})["type"] != "clear_tool_uses_20250919" {
+		t.Fatalf("edits = %v", edits)
+	}
+	beta := headers.Get("anthropic-beta")
+	if !strings.Contains(beta, llmclient.ContextManagementBeta) || !strings.Contains(beta, llmclient.ExtendedCacheTTLBeta) {
+		t.Fatalf("beta header = %q", beta)
+	}
+	// OAuth path carries the beta too.
+	req, _ := http.NewRequest(http.MethodPost, "http://x", nil)
+	applyOAuthHeaders(req, "tok")
+	if !strings.Contains(req.Header.Get("anthropic-beta"), llmclient.ContextManagementBeta) {
+		t.Fatalf("oauth beta header = %q", req.Header.Get("anthropic-beta"))
+	}
+	// Adding the same beta twice does not duplicate it.
+	addAnthropicBeta(req, llmclient.ContextManagementBeta)
+	if strings.Count(req.Header.Get("anthropic-beta"), llmclient.ContextManagementBeta) != 1 {
+		t.Fatal("beta must not be duplicated")
+	}
+}
+
+func TestProviderContextEngine_OffByDefault(t *testing.T) {
+	t.Setenv(llmclient.ContextEngineEnv, "")
+	t.Setenv(llmclient.PromptCacheTTLEnv, "")
+	body, headers := captureToolRequest(t)
+	if _, ok := body["context_management"]; ok {
+		t.Fatal("context_management must be absent when the engine is builtin")
+	}
+	if strings.Contains(headers.Get("anthropic-beta"), llmclient.ContextManagementBeta) {
+		t.Fatal("beta must be absent when the engine is builtin")
+	}
+}

--- a/llm/claudeai/tool_use.go
+++ b/llm/claudeai/tool_use.go
@@ -88,6 +88,11 @@ func (c *ClaudeClient) SendPromptWithTools(ctx context.Context, prompt string, h
 	if len(toolDefs) > 0 {
 		reqBody["tools"] = toolDefs
 	}
+	// Provider context engine: let Anthropic clear stale tool results
+	// server-side (context editing beta) on top of the local compaction.
+	if cm := client.AnthropicContextManagement(); cm != nil && len(toolDefs) > 0 {
+		reqBody["context_management"] = cm
+	}
 
 	// Skill effort hint → thinking (tool-use path). Opus 4.7+ uses adaptive,
 	// older models use budgeted extended thinking — see applyThinkingForEffort.
@@ -370,6 +375,13 @@ func parseClaudeToolResponse(body string, logger *zap.Logger) (*models.LLMRespon
 	}
 
 	response.Content = strings.Join(textParts, "\n")
+
+	// Server-side context edits applied by the provider context engine.
+	if cm, ok := result["context_management"].(map[string]interface{}); ok {
+		if edits, ok := cm["applied_edits"].([]interface{}); ok && len(edits) > 0 && logger != nil {
+			logger.Info("anthropic context editing applied", zap.Int("edits", len(edits)))
+		}
+	}
 
 	// Extract usage
 	if _, ok := result["usage"].(map[string]interface{}); ok {

--- a/llm/client/cache_prefix.go
+++ b/llm/client/cache_prefix.go
@@ -25,6 +25,38 @@ import (
 	"sync/atomic"
 )
 
+// ContextEngineEnv selects the context engine (cli reads builtin|mcp:<server>|
+// provider); "provider" asks the model's own server-side context editing
+// (Anthropic context management) to drop stale tool results before they
+// are billed, in addition to ChatCLI's local compaction.
+const ContextEngineEnv = "CHATCLI_CONTEXT_ENGINE"
+
+// ContextManagementBeta is the Anthropic beta that enables context editing.
+const ContextManagementBeta = "context-management-2025-06-27"
+
+// ProviderContextEngine reports whether CHATCLI_CONTEXT_ENGINE=provider.
+func ProviderContextEngine() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv(ContextEngineEnv)), "provider")
+}
+
+// AnthropicContextManagement returns the context_management request block
+// for the provider context engine: clear the oldest tool results once the
+// prompt passes 100K input tokens, keeping the five most recent tool uses
+// and freeing at least 20K tokens per edit. Nil when the engine is off.
+func AnthropicContextManagement() map[string]interface{} {
+	if !ProviderContextEngine() {
+		return nil
+	}
+	return map[string]interface{}{
+		"edits": []map[string]interface{}{{
+			"type":           "clear_tool_uses_20250919",
+			"trigger":        map[string]interface{}{"type": "input_tokens", "value": 100000},
+			"keep":           map[string]interface{}{"type": "tool_uses", "value": 5},
+			"clear_at_least": map[string]interface{}{"type": "input_tokens", "value": 20000},
+		}},
+	}
+}
+
 // PromptCacheTTLEnv selects the Anthropic cache lifetime: "5m" (default) or
 // "1h". The hour keeps the prefix warm through longer idle gaps at a higher
 // write rate (2x input instead of 1.25x), so it pays off for sessions that

--- a/llm/client/cache_prefix.go
+++ b/llm/client/cache_prefix.go
@@ -39,22 +39,40 @@ func ProviderContextEngine() bool {
 	return strings.EqualFold(strings.TrimSpace(os.Getenv(ContextEngineEnv)), "provider")
 }
 
+// ContextThreshold is a typed amount in an Anthropic context edit
+// ("input_tokens" or "tool_uses" with a value).
+type ContextThreshold struct {
+	Type  string `json:"type"`
+	Value int    `json:"value"`
+}
+
+// ContextEdit is one Anthropic context-editing strategy.
+type ContextEdit struct {
+	Type         string            `json:"type"`
+	Trigger      *ContextThreshold `json:"trigger,omitempty"`
+	Keep         *ContextThreshold `json:"keep,omitempty"`
+	ClearAtLeast *ContextThreshold `json:"clear_at_least,omitempty"`
+}
+
+// ContextManagement is the context_management request block.
+type ContextManagement struct {
+	Edits []ContextEdit `json:"edits"`
+}
+
 // AnthropicContextManagement returns the context_management request block
 // for the provider context engine: clear the oldest tool results once the
 // prompt passes 100K input tokens, keeping the five most recent tool uses
 // and freeing at least 20K tokens per edit. Nil when the engine is off.
-func AnthropicContextManagement() map[string]interface{} {
+func AnthropicContextManagement() *ContextManagement {
 	if !ProviderContextEngine() {
 		return nil
 	}
-	return map[string]interface{}{
-		"edits": []map[string]interface{}{{
-			"type":           "clear_tool_uses_20250919",
-			"trigger":        map[string]interface{}{"type": "input_tokens", "value": 100000},
-			"keep":           map[string]interface{}{"type": "tool_uses", "value": 5},
-			"clear_at_least": map[string]interface{}{"type": "input_tokens", "value": 20000},
-		}},
-	}
+	return &ContextManagement{Edits: []ContextEdit{{
+		Type:         "clear_tool_uses_20250919",
+		Trigger:      &ContextThreshold{Type: "input_tokens", Value: 100000},
+		Keep:         &ContextThreshold{Type: "tool_uses", Value: 5},
+		ClearAtLeast: &ContextThreshold{Type: "input_tokens", Value: 20000},
+	}}}
 }
 
 // PromptCacheTTLEnv selects the Anthropic cache lifetime: "5m" (default) or

--- a/llm/client/context_engine_test.go
+++ b/llm/client/context_engine_test.go
@@ -1,0 +1,30 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package client
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestAnthropicContextManagement_OnlyForProviderEngine(t *testing.T) {
+	t.Setenv(ContextEngineEnv, "mcp:engine")
+	if AnthropicContextManagement() != nil || ProviderContextEngine() {
+		t.Fatal("only the provider value enables server-side editing")
+	}
+	t.Setenv(ContextEngineEnv, " Provider ")
+	cm := AnthropicContextManagement()
+	if cm == nil || !ProviderContextEngine() {
+		t.Fatal("provider engine must be on")
+	}
+	raw, _ := json.Marshal(cm)
+	for _, want := range []string{`"edits":[{"type":"clear_tool_uses_20250919"`, `"trigger":{"type":"input_tokens","value":100000}`, `"keep":{"type":"tool_uses","value":5}`, `"clear_at_least":{"type":"input_tokens","value":20000}`} {
+		if !strings.Contains(string(raw), want) {
+			t.Fatalf("wire shape missing %s: %s", want, raw)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Second context audit, P3 (G21): observability parity and the optional server-side context engine.

**OpenTelemetry export.** `cli/telemetry` renders the standard `ExportMetricsServiceRequest` by hand and pushes it over OTLP/HTTP (JSON encoding) — no SDK, no new dependency. It is configured exclusively through the OpenTelemetry environment contract (`OTEL_EXPORTER_OTLP_ENDPOINT` / `_METRICS_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_SERVICE_NAME`, `OTEL_METRIC_EXPORT_INTERVAL`, `OTEL_RESOURCE_ATTRIBUTES`), so a collector already wired for other services receives ChatCLI without ChatCLI-specific settings; off unless an endpoint is set. Every surface (REPL, one-shot, gateway, MCP/ACP, gRPC server) pushes cumulative sums on the interval and once more at shutdown: `chatcli.llm.tokens` (kind/provider/model), `chatcli.llm.cost`, `chatcli.context.compactions` + `compaction_cost`, `chatcli.cache.requests` + `storage_cost`, `chatcli.session.cost`; the resource carries `service.name`, `chatcli.surface` (follows `SetAuditSurface`) and `chatcli.tenant` (follows the gateway swap). `/config server` shows endpoint, push count and last error.

**Provider context engine.** `CHATCLI_CONTEXT_ENGINE=provider` (the existing selector gains a value) adds Anthropic's server-side context editing on tool-loop requests: the `context-management-2025-06-27` beta on both API-key and OAuth paths and a `context_management` block with one `clear_tool_uses_20250919` edit (trigger 100 K input tokens, keep 5 tool uses, clear at least 20 K). Applied edits reported by the API are logged. The local pipeline, CCR archive and `/rewind compact` are unchanged, so the provider edits only remove what is already recoverable. Other providers ignore the value (no documented equivalent).

Env registered in `config_env_defaults` and `/config server`; i18n (en, en-US, pt-BR).

## Tests

`cli/telemetry/otlp_test.go` (OTLP JSON shape, resource merge, headers, start/stop idempotence, endpoint resolution, interval floor, failure status) and `cli/telemetry_wiring_test.go` (metrics rendered from the cost tracker, no-endpoint no-op). Full suite, golangci-lint (contextcheck included) and the local gates are green.