### PR TITLE
fix(memory): lock sealed stores read-only when the key is missing, keep daily notes plain, seal and redact the pending queue

### DIFF
--- a/cli/config_security_atrest.go
+++ b/cli/config_security_atrest.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/diillson/chatcli/cli/workspace/memory"
 	"github.com/diillson/chatcli/i18n"
 	"github.com/diillson/chatcli/pkg/atrest"
 )
@@ -146,4 +147,11 @@ func (cli *ChatCLI) renderAtRestStatus(p string) {
 	}
 	kv(p, atrest.EnvPreviousKeys, fmt.Sprintf("%d", previous))
 	kv(p, i18n.T("cfg.kv.sec.atrest_covers"), i18n.T("cfg.kv.sec.atrest_covers_list"))
+	if locked := memory.LockedStores(); len(locked) > 0 {
+		names := make([]string, 0, len(locked))
+		for _, l := range locked {
+			names = append(names, l.Store)
+		}
+		kv(p, i18n.T("cfg.kv.sec.atrest_locked"), colorize(i18n.T("cfg.val.sec.atrest_locked", strings.Join(names, ", ")), ColorRed))
+	}
 }

--- a/cli/memory_command.go
+++ b/cli/memory_command.go
@@ -437,6 +437,9 @@ func (cli *ChatCLI) showMemoryStats() {
 
 	fmt.Println()
 	fmt.Println(colorize("  "+i18n.T("mem.cmd.stats.title"), ColorCyan+ColorBold))
+	for _, l := range memory.LockedStores() {
+		fmt.Println(colorize("  "+i18n.T("mem.cmd.stats.locked_store", l.Store, l.Path, l.Reason), ColorRed))
+	}
 	fmt.Println(colorize("  ─────────────────────────────────────────", ColorGray))
 
 	fmt.Printf("  %s  %d\n", colorize(i18n.T("mem.cmd.stats.facts_stored"), ColorYellow), mgr.Facts.Count())

--- a/cli/memory_pending.go
+++ b/cli/memory_pending.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/diillson/chatcli/pkg/atrest"
 	"os"
 	"path/filepath"
 	"sort"
@@ -132,8 +133,19 @@ func (mw *memoryWorker) persistPending(messages []models.Message) (string, error
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return "", err
 	}
-	data, err := json.Marshal(pendingSegment{CreatedAt: time.Now(), Messages: messages})
+	// The queue holds raw conversation on disk until extraction runs:
+	// redact secrets first (extraction redacts again, harmlessly) and seal
+	// when encryption at rest is on, exactly like every other store.
+	redacted := make([]models.Message, len(messages))
+	for i, m := range messages {
+		redacted[i] = m
+		redacted[i].Content = redactSecretsForLLM(m.Content)
+	}
+	data, err := json.Marshal(pendingSegment{CreatedAt: time.Now(), Messages: redacted})
 	if err != nil {
+		return "", err
+	}
+	if data, err = atrest.Seal(data); err != nil {
 		return "", err
 	}
 	// Zero-padded so lexicographic file order is chronological order.
@@ -183,6 +195,9 @@ func (mw *memoryWorker) drainPending(ctx context.Context) int {
 			break
 		}
 		data, err := os.ReadFile(path) // #nosec G304 -- our own queue dir under ~/.chatcli
+		if err == nil {
+			data, err = atrest.Open(data)
+		}
 		if err != nil {
 			continue
 		}

--- a/cli/memory_pending_test.go
+++ b/cli/memory_pending_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/diillson/chatcli/cli/workspace"
 	"github.com/diillson/chatcli/llm/client"
 	"github.com/diillson/chatcli/models"
+	"github.com/diillson/chatcli/pkg/atrest"
 	"go.uber.org/zap"
 )
 
@@ -189,5 +190,33 @@ func TestPersistPending_EnforcesCap(t *testing.T) {
 	}
 	if got := len(mw.pendingFiles()); got > pendingMaxFiles {
 		t.Fatalf("pending files = %d, want <= %d", got, pendingMaxFiles)
+	}
+}
+
+func TestPersistPending_RedactsAndSealsAtRest(t *testing.T) {
+	t.Setenv("CHATCLI_ENCRYPTION_KEY", "wal-key")
+	active := &scriptedClient{name: "claude", response: "NOTHING_NEW"}
+	mw := newResilienceWorker(t, active)
+	segment := []models.Message{{Role: "user", Content: "token is sk-abcdefghijklmnopqrstuvwxyz1234567890ABCD and the deploy freeze ends friday"}}
+	path, err := mw.persistPending(segment)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := os.ReadFile(path)
+	if !atrest.IsEncrypted(raw) {
+		t.Fatal("the pending queue must be sealed when the key is set")
+	}
+	plain, err := atrest.Open(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(plain), "sk-abcdefghijklmnopqrstuvwxyz1234567890ABCD") {
+		t.Fatal("secrets must be redacted before the segment reaches disk")
+	}
+	if !strings.Contains(string(plain), "deploy freeze") {
+		t.Fatal("the conversation itself must survive")
+	}
+	if got := mw.drainPending(context.Background()); got != 1 {
+		t.Fatalf("sealed segments must drain: %d", got)
 	}
 }

--- a/cli/workspace/memory/compactor.go
+++ b/cli/workspace/memory/compactor.go
@@ -26,6 +26,7 @@ const compactorStateFile = "compactor_state.json"
 
 // Compactor handles LLM-based memory consolidation and cleanup.
 type Compactor struct {
+	latch  storeLatch // read-only once a sealed file could not be opened
 	facts  *FactIndex
 	daily  *DailyNoteStore
 	config Config
@@ -58,7 +59,7 @@ func NewCompactor(facts *FactIndex, daily *DailyNoteStore, config Config, memDir
 // leaves the zero value — the worst case is one extra compaction check.
 func (c *Compactor) loadState() {
 	data, err := readStoreFile(filepath.Join(c.memDir, compactorStateFile))
-	if err != nil {
+	if c.latch.lockIfSealed(err, c.logger, "compactor") || err != nil {
 		return
 	}
 	var s compactorState

--- a/cli/workspace/memory/daily.go
+++ b/cli/workspace/memory/daily.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/diillson/chatcli/utils"
 	"go.uber.org/zap"
 )
 
@@ -48,7 +49,9 @@ func (d *DailyNoteStore) WriteDailyNote(entry string) error {
 	}
 	ts := time.Now().Format("15:04")
 	next := append(existing, []byte(fmt.Sprintf("\n## %s\n\n%s\n", ts, entry))...)
-	if err := atomicWriteFile(path, next, 0o600); err != nil {
+	// Daily notes are human-editable Markdown by contract (never sealed):
+	// the plain atomic writer, not the sealing one.
+	if err := utils.AtomicWriteFile(path, next, 0o600); err != nil {
 		return fmt.Errorf("writing daily note: %w", err)
 	}
 	return nil

--- a/cli/workspace/memory/episodes.go
+++ b/cli/workspace/memory/episodes.go
@@ -50,6 +50,7 @@ type Episode struct {
 // EpisodeStore manages the append-only episodic timeline with JSON
 // persistence shared across processes.
 type EpisodeStore struct {
+	latch    storeLatch // read-only once a sealed file could not be opened
 	mu       sync.RWMutex
 	episodes map[string]*Episode // keyed by ID
 	path     string
@@ -254,6 +255,9 @@ func mergeRefs(a, b []string) []string {
 
 func (es *EpisodeStore) load() {
 	data, err := readStoreFile(es.path)
+	if es.latch.lockIfSealed(err, es.logger, "episodes") {
+		return
+	}
 	if err != nil {
 		if !os.IsNotExist(err) {
 			es.logger.Debug("failed to load episode store", zap.Error(err))
@@ -289,6 +293,9 @@ func (es *EpisodeStore) load() {
 // union: adopt every episode the other process appended, keep ours, and only
 // then apply the cap. Caller must hold the write lock.
 func (es *EpisodeStore) persistLocked() {
+	if es.latch.locked() {
+		return // sealed file we cannot read: never overwrite it
+	}
 	es.mergeFromDiskLocked()
 
 	episodes := make([]*Episode, 0, len(es.episodes))
@@ -313,6 +320,9 @@ func (es *EpisodeStore) persistLocked() {
 // untouched. Caller must hold the write lock.
 func (es *EpisodeStore) mergeFromDiskLocked() {
 	data, err := readStoreFile(es.path)
+	if es.latch.lockIfSealed(err, es.logger, "episodes") {
+		return
+	}
 	if err == nil {
 		var onDisk []*Episode
 		if json.Unmarshal(data, &onDisk) == nil {

--- a/cli/workspace/memory/facts.go
+++ b/cli/workspace/memory/facts.go
@@ -26,6 +26,7 @@ import (
 // and applies tombstones (facts explicitly forgotten by either process)
 // before rewriting the file. See mergeFromDiskLocked.
 type FactIndex struct {
+	latch storeLatch // read-only once a sealed file could not be opened
 	// rev counts mutations; dfCache is the token document-frequency table
 	// for that revision (IDF weights in computeRelevance).
 	rev, dfRev, dfCount int
@@ -968,6 +969,9 @@ func (fi *FactIndex) pruneLowestLocked(n int) {
 
 func (fi *FactIndex) load() {
 	data, err := readStoreFile(fi.path)
+	if fi.latch.lockIfSealed(err, fi.logger, "facts") {
+		return
+	}
 	if err != nil {
 		if !os.IsNotExist(err) {
 			fi.logger.Debug("failed to load fact index", zap.Error(err))
@@ -1041,6 +1045,9 @@ func legacyConfidence(accessCount int) float64 {
 
 func (fi *FactIndex) persistLocked() {
 	fi.rev++
+	if fi.latch.locked() {
+		return // sealed file we cannot read: never overwrite it
+	}
 	// Reconcile with the shared file first: adopt facts the other process
 	// persisted and honor tombstones from either side, so a rewrite never
 	// erases the other process's learning.
@@ -1092,7 +1099,7 @@ func (fi *FactIndex) mergeFromDiskLocked() {
 	}
 
 	data, err := readStoreFile(fi.path)
-	if err != nil {
+	if fi.latch.lockIfSealed(err, fi.logger, "facts") || err != nil {
 		return
 	}
 	var onDisk []*Fact
@@ -1187,7 +1194,7 @@ func (fi *FactIndex) recordTombstonesLocked(ids ...string) {
 // process may have recorded deletions since our last read).
 func (fi *FactIndex) loadTombstonesLocked() {
 	data, err := readStoreFile(fi.tombstonePath)
-	if err != nil {
+	if fi.latch.lockIfSealed(err, fi.logger, "facts") || err != nil {
 		return
 	}
 	var onDisk map[string]time.Time

--- a/cli/workspace/memory/graph_cache.go
+++ b/cli/workspace/memory/graph_cache.go
@@ -57,6 +57,7 @@ type graphFile struct {
 // GraphCache owns the cached graph snapshot and its persistence. Inert (all
 // methods no-ops returning nil) until SetSource attaches a builder.
 type GraphCache struct {
+	latch       storeLatch // read-only once a sealed file could not be opened
 	mu          sync.Mutex // guards rebuild + fingerprint bookkeeping
 	snap        atomic.Pointer[knowledge.Graph]
 	dirty       atomic.Bool
@@ -126,7 +127,7 @@ func (gc *GraphCache) SetSource(build func() *knowledge.Graph, fingerprint func(
 // the graph is re-derivable, so there is nothing to preserve.
 func (gc *GraphCache) loadPersisted(currentFP string) (*knowledge.Graph, bool) {
 	data, err := readStoreFile(gc.path)
-	if err != nil {
+	if gc.latch.lockIfSealed(err, gc.logger, "graph") || err != nil {
 		return nil, false // missing is the common first-boot case
 	}
 	discard := func(reason string) {
@@ -244,6 +245,9 @@ func (gc *GraphCache) checkFingerprintTTL() {
 // a skipped write is harmless (the next rebuild persists again) and the
 // atomic rename keeps readers from ever seeing a partial file.
 func (gc *GraphCache) persistAsync(g *knowledge.Graph, fp string) {
+	if gc.latch.locked() {
+		return // sealed cache we cannot read: never overwrite it
+	}
 	if !gc.persistInFlight.CompareAndSwap(false, true) {
 		return
 	}

--- a/cli/workspace/memory/merge_stores.go
+++ b/cli/workspace/memory/merge_stores.go
@@ -24,8 +24,8 @@ import (
 // mergeFromDiskLocked adopts topics the other process recorded and keeps
 // the stronger signal for topics both know.
 func (tt *TopicTracker) mergeFromDiskLocked() {
-	data, err := os.ReadFile(tt.path)
-	if err != nil {
+	data, err := readStoreFile(tt.path)
+	if tt.latch.lockIfSealed(err, tt.logger, "topics") || err != nil {
 		return
 	}
 	var onDisk []Topic
@@ -64,8 +64,8 @@ func (tt *TopicTracker) mergeFromDiskLocked() {
 // project both know, the more recently active record's scalars win and the
 // lists and metadata are unioned.
 func (pt *ProjectTracker) mergeFromDiskLocked() {
-	data, err := os.ReadFile(pt.path)
-	if err != nil {
+	data, err := readStoreFile(pt.path)
+	if pt.latch.lockIfSealed(err, pt.logger, "projects") || err != nil {
 		return
 	}
 	var onDisk []Project
@@ -129,8 +129,8 @@ func (ps *UserProfileStore) mergeFromDiskLocked() {
 	if err != nil || !info.ModTime().After(ps.loadedAt) {
 		return
 	}
-	data, err := os.ReadFile(ps.path)
-	if err != nil {
+	data, err := readStoreFile(ps.path)
+	if ps.latch.lockIfSealed(err, ps.logger, "profile") || err != nil {
 		return
 	}
 	var d UserProfile

--- a/cli/workspace/memory/patterns.go
+++ b/cli/workspace/memory/patterns.go
@@ -13,6 +13,7 @@ import (
 
 // PatternDetector tracks usage patterns, common errors, and skill evolution.
 type PatternDetector struct {
+	latch  storeLatch // read-only once a sealed file could not be opened
 	stats  UsageStats
 	mu     sync.RWMutex
 	path   string
@@ -299,7 +300,7 @@ func formatStat(format string, args ...interface{}) string {
 
 func (pd *PatternDetector) load() {
 	data, err := readStoreFile(pd.path)
-	if err != nil {
+	if pd.latch.lockIfSealed(err, pd.logger, "patterns") || err != nil {
 		return
 	}
 	var s UsageStats
@@ -324,6 +325,9 @@ func (pd *PatternDetector) load() {
 }
 
 func (pd *PatternDetector) persist() {
+	if pd.latch.locked() {
+		return
+	}
 	data, err := json.MarshalIndent(pd.stats, "", "  ")
 	if err != nil {
 		return

--- a/cli/workspace/memory/persist.go
+++ b/cli/workspace/memory/persist.go
@@ -18,12 +18,17 @@
 package memory
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"sort"
+	"sync"
 	"time"
 
 	"github.com/diillson/chatcli/pkg/atrest"
 	"github.com/diillson/chatcli/utils"
+	"go.uber.org/zap"
 )
 
 // atomicWriteFile writes data to path via a same-directory temp file, fsync
@@ -39,12 +44,110 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 
 // readStoreFile reads a store file and opens it when it is sealed
 // (encryption at rest, CHATCLI_ENCRYPTION_KEY). Plaintext passes through.
+// A sealed file that cannot be opened (key unset, wrong, or retired without
+// CHATCLI_ENCRYPTION_KEY_PREVIOUS) returns a *SealedStoreError so the store
+// LOCKS instead of starting empty and overwriting the user's memory.
 func readStoreFile(path string) ([]byte, error) {
 	data, err := os.ReadFile(path) // #nosec G304 -- fixed store filename under the memory dir
 	if err != nil {
 		return nil, err
 	}
-	return atrest.Open(data)
+	if atrest.IsEncrypted(data) {
+		plain, oerr := atrest.Open(data)
+		if oerr != nil {
+			return nil, &SealedStoreError{Path: path, Err: oerr}
+		}
+		return plain, nil
+	}
+	return data, nil
+}
+
+// SealedStoreError marks a sealed store file this process cannot open.
+type SealedStoreError struct {
+	Path string
+	Err  error
+}
+
+func (e *SealedStoreError) Error() string {
+	return "memory store sealed and unreadable (" + filepath.Base(e.Path) + "): " + e.Err.Error()
+}
+
+func (e *SealedStoreError) Unwrap() error { return e.Err }
+
+// storeLatch is the read-only latch every substore carries: once a sealed
+// file could not be opened, the store keeps whatever is in memory but
+// refuses every persist, so the sealed bytes on disk survive a process
+// without the key. Sessions already fail loudly in that case; memory used
+// to load empty (debug log only) and overwrite the file on the first fact.
+type storeLatch struct {
+	mu     sync.Mutex
+	reason string
+	path   string
+}
+
+// lockIfSealed latches the store when err is a sealed-store error and
+// returns whether it did.
+func (l *storeLatch) lockIfSealed(err error, logger *zap.Logger, store string) bool {
+	var se *SealedStoreError
+	if !errors.As(err, &se) {
+		return false
+	}
+	l.mu.Lock()
+	first := l.reason == ""
+	l.reason = se.Err.Error()
+	l.path = se.Path
+	l.mu.Unlock()
+	registerLockedStore(store, se.Path, se.Err.Error())
+	if first && logger != nil {
+		logger.Error("memory store is sealed and cannot be opened; store LOCKED read-only to protect it (set "+atrest.EnvKey+" or "+atrest.EnvPreviousKeys+")",
+			zap.String("store", store), zap.String("path", se.Path), zap.Error(se.Err))
+	}
+	return true
+}
+
+// locked reports whether persists must be refused.
+func (l *storeLatch) locked() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.reason != ""
+}
+
+var (
+	lockedStoresMu sync.Mutex
+	lockedStores   = map[string]LockedStore{}
+)
+
+// LockedStore describes one latched store for the UI.
+type LockedStore struct {
+	Store  string
+	Path   string
+	Reason string
+}
+
+func registerLockedStore(store, path, reason string) {
+	lockedStoresMu.Lock()
+	lockedStores[path] = LockedStore{Store: store, Path: path, Reason: reason}
+	lockedStoresMu.Unlock()
+}
+
+// LockedStores lists the stores latched read-only in this process, sorted
+// by path (empty when every store opened).
+func LockedStores() []LockedStore {
+	lockedStoresMu.Lock()
+	defer lockedStoresMu.Unlock()
+	out := make([]LockedStore, 0, len(lockedStores))
+	for _, l := range lockedStores {
+		out = append(out, l)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
+	return out
+}
+
+// resetLockedStoresForTest clears the registry (tests only).
+func resetLockedStoresForTest() {
+	lockedStoresMu.Lock()
+	lockedStores = map[string]LockedStore{}
+	lockedStoresMu.Unlock()
 }
 
 // quarantineCorrupt moves an unparseable store file aside as

--- a/cli/workspace/memory/profile.go
+++ b/cli/workspace/memory/profile.go
@@ -12,6 +12,7 @@ import (
 
 // UserProfileStore manages the user profile on disk.
 type UserProfileStore struct {
+	latch   storeLatch // read-only once a sealed file could not be opened
 	profile UserProfile
 	mu      sync.RWMutex
 	path    string
@@ -638,7 +639,7 @@ func sortedKeys[V any](m map[string]V) []string {
 
 func (ps *UserProfileStore) load() {
 	data, err := readStoreFile(ps.path)
-	if err != nil {
+	if ps.latch.lockIfSealed(err, ps.logger, "profile") || err != nil {
 		return
 	}
 	var p UserProfile
@@ -672,6 +673,9 @@ func (ps *UserProfileStore) load() {
 }
 
 func (ps *UserProfileStore) persist() {
+	if ps.latch.locked() {
+		return // sealed file we cannot read: never overwrite it
+	}
 	ps.mergeFromDiskLocked()
 	data, err := json.MarshalIndent(ps.profile, "", "  ")
 	if err != nil {

--- a/cli/workspace/memory/projects.go
+++ b/cli/workspace/memory/projects.go
@@ -12,6 +12,7 @@ import (
 
 // ProjectTracker tracks active projects with context.
 type ProjectTracker struct {
+	latch    storeLatch // read-only once a sealed file could not be opened
 	projects map[string]*Project
 	mu       sync.RWMutex
 	path     string
@@ -214,7 +215,7 @@ func stringSliceEqual(a, b []string) bool {
 
 func (pt *ProjectTracker) load() {
 	data, err := readStoreFile(pt.path)
-	if err != nil {
+	if pt.latch.lockIfSealed(err, pt.logger, "projects") || err != nil {
 		return
 	}
 	var projects []Project
@@ -235,6 +236,9 @@ func (pt *ProjectTracker) load() {
 }
 
 func (pt *ProjectTracker) persist() {
+	if pt.latch.locked() {
+		return // sealed file we cannot read: never overwrite it
+	}
 	pt.mergeFromDiskLocked()
 	projects := make([]Project, 0, len(pt.projects))
 	for _, p := range pt.projects {

--- a/cli/workspace/memory/sealed_latch_test.go
+++ b/cli/workspace/memory/sealed_latch_test.go
@@ -1,0 +1,145 @@
+/*
+ * ChatCLI - Long-term memory tests: sealed-store read-only latch.
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package memory
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/pkg/atrest"
+	"go.uber.org/zap"
+)
+
+func readAll(t *testing.T, dir string) map[string][]byte {
+	t.Helper()
+	out := map[string][]byte{}
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		b, _ := os.ReadFile(filepath.Join(dir, e.Name()))
+		out[e.Name()] = b
+	}
+	return out
+}
+
+func TestSealedStores_LockReadOnlyWithoutTheKey(t *testing.T) {
+	resetLockedStoresForTest()
+	dir := t.TempDir()
+	t.Setenv(atrest.EnvKey, "key-A")
+	m := NewManager(dir, DefaultConfig(), zap.NewNop())
+	m.Facts.AddFact("the deploy freeze ends on friday", "project", nil)
+	m.Episodes.Add(Episode{Summary: "fixed the parser", Project: "app"})
+	m.Topics.RecordWithSummary(map[string]string{"parser": "rewrote the lexer"})
+	m.Projects.Upsert(map[string]string{"name": "app", "project_status": "active"})
+	m.Profile.Update(map[string]string{"name": "Dev"})
+	m.Patterns.RecordSessionStart()
+	before := readAll(t, dir)
+	if len(before) < 5 {
+		t.Fatalf("expected sealed stores on disk, got %v", before)
+	}
+	for name, b := range before {
+		if strings.HasSuffix(name, ".json") && !atrest.IsEncrypted(b) {
+			t.Fatalf("%s must be sealed", name)
+		}
+	}
+
+	for _, key := range []string{"", "key-B"} {
+		resetLockedStoresForTest()
+		t.Setenv(atrest.EnvKey, key)
+		m2 := NewManager(dir, DefaultConfig(), zap.NewNop())
+		if m2.Facts.Count() != 0 {
+			t.Fatal("unreadable store loads empty in memory")
+		}
+		// Every write path is a no-op while locked.
+		m2.Facts.AddFact("a new fact that must not be written", "general", nil)
+		m2.Episodes.Add(Episode{Summary: "new episode", Project: "x"})
+		m2.Topics.RecordWithSummary(map[string]string{"cache": "new"})
+		m2.Projects.Upsert(map[string]string{"name": "site", "project_status": "active"})
+		m2.Profile.Update(map[string]string{"role": "SRE"})
+		m2.Patterns.RecordSessionStart()
+		after := readAll(t, dir)
+		for name, b := range before {
+			if !bytes.Equal(b, after[name]) {
+				t.Fatalf("key %q: sealed %s was overwritten", key, name)
+			}
+		}
+		locked := LockedStores()
+		if len(locked) < 5 {
+			t.Fatalf("key %q: locked stores must be reported, got %v", key, locked)
+		}
+	}
+
+	// With the retired key listed, everything opens and writes resume.
+	resetLockedStoresForTest()
+	t.Setenv(atrest.EnvKey, "key-B")
+	t.Setenv(atrest.EnvPreviousKeys, "key-A")
+	m3 := NewManager(dir, DefaultConfig(), zap.NewNop())
+	if m3.Facts.Count() != 1 || len(LockedStores()) != 0 {
+		t.Fatalf("retired key must unlock: facts=%d locked=%v", m3.Facts.Count(), LockedStores())
+	}
+	m3.Facts.AddFact("second fact", "general", nil)
+	if m3.Facts.Count() != 2 {
+		t.Fatal("writes must resume once the store opens")
+	}
+	// A fresh install (no files) is writable — the latch is about sealed
+	// files only.
+	resetLockedStoresForTest()
+	t.Setenv(atrest.EnvKey, "")
+	t.Setenv(atrest.EnvPreviousKeys, "")
+	fresh := NewManager(t.TempDir(), DefaultConfig(), zap.NewNop())
+	fresh.Facts.AddFact("first fact ever", "general", nil)
+	if fresh.Facts.Count() != 1 || len(LockedStores()) != 0 {
+		t.Fatal("fresh install must be writable")
+	}
+}
+
+func TestDailyNotes_StayPlainMarkdownWithTheKey(t *testing.T) {
+	t.Setenv(atrest.EnvKey, "daily-key")
+	d := NewDailyNoteStore(t.TempDir(), zap.NewNop())
+	if err := d.WriteDailyNote("first"); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.WriteDailyNote("second"); err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := os.ReadFile(d.TodayNotePath())
+	if atrest.IsEncrypted(raw) || !strings.Contains(string(raw), "first") || !strings.Contains(string(raw), "second") {
+		t.Fatalf("daily notes must stay readable Markdown: %q", raw)
+	}
+	notes := d.GetRecentDailyNotes(1)
+	if len(notes) != 1 || !strings.Contains(notes[0].Content, "second") {
+		t.Fatal("readers must see both entries")
+	}
+}
+
+func TestMultiProcessMerge_WorksOnSealedStores(t *testing.T) {
+	resetLockedStoresForTest()
+	t.Setenv(atrest.EnvKey, "merge-key")
+	dir := t.TempDir()
+	a := NewTopicTracker(dir, zap.NewNop())
+	b := NewTopicTracker(dir, zap.NewNop())
+	a.RecordWithSummary(map[string]string{"parser": "from A"})
+	b.RecordWithSummary(map[string]string{"cache": "from B"})
+	names := map[string]bool{}
+	for _, tp := range NewTopicTracker(dir, zap.NewNop()).GetAll() {
+		names[tp.Name] = true
+	}
+	if !names["parser"] || !names["cache"] {
+		t.Fatalf("sealed stores must still merge across processes: %v", names)
+	}
+	pa := NewUserProfileStore(dir, zap.NewNop())
+	pb := NewUserProfileStore(dir, zap.NewNop())
+	pa.Update(map[string]string{"name": "Dev"})
+	pb.Update(map[string]string{"role": "SRE"})
+	if p := NewUserProfileStore(dir, zap.NewNop()).Get(); p.Name != "Dev" || p.Role != "SRE" {
+		t.Fatalf("sealed profile merge: %+v", p)
+	}
+}

--- a/cli/workspace/memory/topics.go
+++ b/cli/workspace/memory/topics.go
@@ -12,6 +12,7 @@ import (
 
 // TopicTracker tracks recurring topics across conversations.
 type TopicTracker struct {
+	latch  storeLatch // read-only once a sealed file could not be opened
 	topics map[string]*Topic
 	mu     sync.RWMutex
 	path   string
@@ -234,7 +235,7 @@ func normalizeTopic(name string) string {
 
 func (tt *TopicTracker) load() {
 	data, err := readStoreFile(tt.path)
-	if err != nil {
+	if tt.latch.lockIfSealed(err, tt.logger, "topics") || err != nil {
 		return
 	}
 	var topics []Topic
@@ -255,6 +256,9 @@ func (tt *TopicTracker) load() {
 }
 
 func (tt *TopicTracker) persist() {
+	if tt.latch.locked() {
+		return // sealed file we cannot read: never overwrite it
+	}
 	tt.mergeFromDiskLocked()
 	topics := make([]Topic, 0, len(tt.topics))
 	for _, t := range tt.topics {

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -3752,5 +3752,8 @@
   "cfg.kv.sec.atrest_key": "Key fingerprint",
   "cfg.kv.sec.atrest_covers": "Covers",
   "cfg.kv.sec.atrest_covers_list": "sessions, transcripts, park snapshots, long-term memory (JSON stores), knowledge contexts, CCR archive, cost snapshots, memory exports",
-  "cfg.sub.server.otel": "OpenTelemetry export"
+  "cfg.sub.server.otel": "OpenTelemetry export",
+  "mem.cmd.stats.locked_store": "LOCKED read-only: %s store (%s) is sealed and this process cannot open it — %s. Set CHATCLI_ENCRYPTION_KEY (or CHATCLI_ENCRYPTION_KEY_PREVIOUS after a rotation); nothing is written until it opens.",
+  "cfg.kv.sec.atrest_locked": "Locked stores",
+  "cfg.val.sec.atrest_locked": "%s — sealed with a key this process does not have; writes refused to protect them"
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -3752,5 +3752,8 @@
   "cfg.kv.sec.atrest_key": "Key fingerprint",
   "cfg.kv.sec.atrest_covers": "Covers",
   "cfg.kv.sec.atrest_covers_list": "sessions, transcripts, park snapshots, long-term memory (JSON stores), knowledge contexts, CCR archive, cost snapshots, memory exports",
-  "cfg.sub.server.otel": "OpenTelemetry export"
+  "cfg.sub.server.otel": "OpenTelemetry export",
+  "mem.cmd.stats.locked_store": "LOCKED read-only: %s store (%s) is sealed and this process cannot open it — %s. Set CHATCLI_ENCRYPTION_KEY (or CHATCLI_ENCRYPTION_KEY_PREVIOUS after a rotation); nothing is written until it opens.",
+  "cfg.kv.sec.atrest_locked": "Locked stores",
+  "cfg.val.sec.atrest_locked": "%s — sealed with a key this process does not have; writes refused to protect them"
 }

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -3752,5 +3752,8 @@
   "cfg.kv.sec.atrest_key": "Fingerprint da chave",
   "cfg.kv.sec.atrest_covers": "Cobre",
   "cfg.kv.sec.atrest_covers_list": "sessões, transcripts, park snapshots, memória de longo prazo (stores JSON), contextos de conhecimento, arquivo CCR, snapshots de custo, exportações de memória",
-  "cfg.sub.server.otel": "Exportação OpenTelemetry"
+  "cfg.sub.server.otel": "Exportação OpenTelemetry",
+  "mem.cmd.stats.locked_store": "TRAVADO somente leitura: store %s (%s) está selado e este processo não consegue abri-lo — %s. Defina CHATCLI_ENCRYPTION_KEY (ou CHATCLI_ENCRYPTION_KEY_PREVIOUS após rotação); nada é gravado até abrir.",
+  "cfg.kv.sec.atrest_locked": "Stores travados",
+  "cfg.val.sec.atrest_locked": "%s — selados com uma chave que este processo não tem; escritas recusadas para protegê-los"
 }


### PR DESCRIPTION
## Summary

Audit III, PR 2 (P0 SEC-1; P1 MEM-1, MEM-3, MEM-4). Regressions from the at-rest expansion (#1466), fixed before anything else.

**Read-only latch (SEC-1).** `readStoreFile` now returns a typed `SealedStoreError` when a file is sealed and cannot be opened. Every memory substore (fact index and tombstones, episodes, topics, projects, profile, usage patterns, compactor state, graph cache) latches on that error: it loads empty in memory, logs one error naming the env vars, and refuses every persist and merge, so the sealed bytes on disk survive a gateway daemon, cron job or shell started without the key. The latched stores are listed in `/memory stats` and in the "Encryption at rest" block of `/config security`. A fresh install (no file) stays writable; corrupt JSON still goes to quarantine. Listing a retired key in `CHATCLI_ENCRYPTION_KEY_PREVIOUS` unlocks and writes resume.

**Sealed merge (MEM-3).** The multi-process merge of topics, projects and profile read raw bytes and silently skipped ciphertext; it now reads through the sealed-aware reader.

**Daily notes (MEM-1).** Written with the plain atomic writer, as documented (human-editable Markdown); the second append of a day no longer produces ciphertext followed by plaintext.

**Pending queue (MEM-4).** Segments are redacted before they reach disk and sealed when the key is set; draining opens them.

## Tests

`cli/workspace/memory/sealed_latch_test.go`: seal with key A, boot with no key and with key B, exercise every write path, assert every file byte-identical and the stores reported as locked; retired key unlocks; fresh install writable; daily notes plain with the key; merge across two sealed stores. `cli/memory_pending_test.go`: sealed and redacted queue that still drains. Full suite, golangci-lint and the local gates are green.