### PR TITLE
fix(context): byte-stable system prompt with per-turn context as a flagged user message, stable cache key, frozen prefix ratio

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -1187,18 +1187,18 @@ func (a *AgentMode) Run(ctx context.Context, query string, additionalContext str
 		channelsText = a.cli.mcpManager.Channels().FormatForPrompt(5)
 	}
 
-	// The scratch dir path is per-process, so it rides in the uncached
-	// dynamic tail rather than the cacheable tools block (see
-	// buildSessionWorkspaceHint).
+	// The scratch dir path is fixed for the process, so it belongs to the
+	// cacheable tools block: stable for the session, never in the tail.
 	if wsLine := sessionWorkspaceDynamicLine(); wsLine != "" {
-		if dynamicText == "" {
-			dynamicText = wsLine
-		} else {
-			dynamicText = strings.TrimRight(dynamicText, "\n") + "\n" + wsLine
-		}
+		toolsText = strings.TrimRight(toolsText, "\n") + "\n\n" + wsLine
 	}
 
-	sysMsg := buildAgentSystemMessage(coreText, toolsText, workspaceText, skillsText, orchestratorText, channelsText, dynamicText)
+	// The per-turn context (date, proactive recall, channel pushes) never
+	// enters the system message: it rides as a flagged user-role message
+	// before the query (turn_context.go), so the system prompt stays
+	// byte-stable and the prefix cache keeps hitting across runs.
+	turnContextText := composeTurnContext(channelsText, dynamicText)
+	sysMsg := buildAgentSystemMessage(coreText, toolsText, workspaceText, skillsText, orchestratorText, "", "")
 	breakdownMode := "agent"
 	if isCoder {
 		breakdownMode = "coder"
@@ -1209,8 +1209,7 @@ func (a *AgentMode) Run(ctx context.Context, query string, additionalContext str
 		{Name: "orchestrator", Chars: len(strings.TrimSpace(orchestratorText)), Cached: true},
 		{Name: "workspace_memory", Chars: len(strings.TrimSpace(workspaceText))},
 		{Name: "skills", Chars: len(strings.TrimSpace(skillsText))},
-		{Name: "mcp_channels", Chars: len(strings.TrimSpace(channelsText))},
-		{Name: "dynamic", Chars: len(strings.TrimSpace(dynamicText))},
+		{Name: "turn_context", Chars: len(strings.TrimSpace(turnContextText))},
 	})
 
 	// Inicializa ou atualiza o histórico com o System Prompt correto.
@@ -1241,6 +1240,7 @@ func (a *AgentMode) Run(ctx context.Context, query string, additionalContext str
 		}
 	}
 
+	a.appendTurnContext(turnContextText)
 	a.cli.history = append(a.cli.history, models.Message{Role: "user", Content: currentQuery, Images: a.pendingUserImages})
 	a.pendingUserImages = nil
 
@@ -1301,6 +1301,28 @@ func (a *AgentMode) beginOrchestratorRun(ctx context.Context, query, systemPromp
 		Task:   query,
 		Origin: orchOrigin,
 	})
+}
+
+// composeTurnContext joins the per-turn blocks (MCP channel pushes first,
+// then date/recall) into the text of the run's turn context message.
+func composeTurnContext(channelsText, dynamicText string) string {
+	out := strings.TrimSpace(dynamicText)
+	if c := strings.TrimSpace(channelsText); c != "" {
+		if out == "" {
+			return c
+		}
+		out = c + "\n\n" + out
+	}
+	return out
+}
+
+// appendTurnContext appends the flagged turn context message (no-op when
+// empty).
+func (a *AgentMode) appendTurnContext(text string) {
+	if strings.TrimSpace(text) == "" {
+		return
+	}
+	a.cli.history = append(a.cli.history, models.TurnContextMessage(turnContextHeader+text))
 }
 
 // installAgentSystemMessage purges stale mode system messages and installs the
@@ -2140,7 +2162,7 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 			// Same trigger surface for proactive recall: a follow-up asking
 			// about past work re-ranks memory/sessions against ITS words.
 			if rb := a.followUpRecallBlocks(ctx, userMsg); rb != "" {
-				a.cli.history = append(a.cli.history, models.Message{Role: "user", Content: rb})
+				a.cli.history = append(a.cli.history, models.TurnContextMessage(turnContextHeader+rb))
 			}
 		}
 

--- a/cli/agent_system_prompt.go
+++ b/cli/agent_system_prompt.go
@@ -30,12 +30,16 @@ import (
 //	tools        — plugin tool catalog + session workspace hint
 //	orchestrator — agent registry catalog (multi-agent prompt)
 //
-// Volatile per turn → NO cache hint, appended after the cached prefix:
+// Volatile per RUN → NO cache hint, appended after the cached prefix:
 //
 //	workspace    — bootstrap files + MEMORY retrieval (hint-driven)
 //	skills       — pinned + auto-activated + manual skills (query-driven)
-//	channels     — MCP push ring (newest messages each turn)
-//	dynamic      — wall-clock timestamp + cwd disambiguation
+//
+// The per-TURN context (date, proactive recall, MCP channel pushes) is not
+// a system block at all any more: it rides as a flagged user-role message
+// before the query (turn_context.go), so the system message is byte-stable
+// across runs. channels/dynamic stay as parameters for compatibility and
+// are empty in production.
 //
 // Two representations are produced and kept in sync:
 //

--- a/cli/chat_pipeline.go
+++ b/cli/chat_pipeline.go
@@ -51,14 +51,20 @@ import (
 // model resolver. The *Hit and filePaths fields are diagnostic only —
 // emitted to debug logs and consumed by tests.
 type chatSystemAssembly struct {
-	parts     []models.ContentBlock
-	sections  []promptSection // parallel labels for /context status
-	modelHint string
-	effort    client.SkillEffort
-	pinnedHit int
-	autoHit   int
-	manualHit bool
-	filePaths []string
+	parts    []models.ContentBlock
+	sections []promptSection // parallel labels for /context status
+	// turnContext holds the per-turn volatile blocks (recall, skills,
+	// channels, watcher, date). They never enter the system message: they
+	// ride as a flagged user-role message right before the user's turn,
+	// so the system prompt stays byte-stable and the provider prefix cache
+	// keeps hitting (see models.TurnContextMessage).
+	turnContext []models.ContentBlock
+	modelHint   string
+	effort      client.SkillEffort
+	pinnedHit   int
+	autoHit     int
+	manualHit   bool
+	filePaths   []string
 }
 
 // assembleChatSystemPrompt builds every structured system-prompt block for a
@@ -176,32 +182,32 @@ func (cli *ChatCLI) assembleChatSystemPrompt(
 	// fresh session hintless — exactly when proactive recall matters most.
 	hints := cli.turnHints(userInput)
 	if part, ok := cli.workspaceContextPart(ctx, userInput, hints); ok { // Part 4
-		out.add("workspace_memory", part)
+		out.addTurn("workspace_memory", part)
 	}
 	// Part 4b: semantic /context retrieval (--rag). Query-driven, so it lives
 	// here in the volatile zone — never the cached prefix it would otherwise
 	// poison for every block after it.
-	out.add("retrieved", cli.retrievedContextParts(ctx, userInput)...)
+	out.addTurn("retrieved", cli.retrievedContextParts(ctx, userInput)...)
 	if manualSkill != nil { // Part 5
 		if block := renderManualSkillBlock(manualSkill, manualSkillArgs); block != "" {
-			out.add("skill_manual", models.ContentBlock{Type: "text", Text: block})
+			out.addTurn("skill_manual", models.ContentBlock{Type: "text", Text: block})
 		}
 	}
 	if block, ok := autoSkillBlockLimited(autoActivated, skillBudget); ok { // Part 6
-		out.add("skills_auto", block)
+		out.addTurn("skills_auto", block)
 	}
 	if part, ok := cli.mcpChannelPart(); ok { // Part 7
-		out.add("mcp_channels", part)
+		out.addTurn("mcp_channels", part)
 	}
 	if part, ok := cli.watcherContextPart(); ok { // Part 8
-		out.add("watcher", part)
+		out.addTurn("watcher", part)
 	}
 	// Part 8b: proactive memory auto-recall — top hint-matching facts, only
 	// meaningful in index mode (full mode already pushes the whole
 	// retrieval). Mirrors the agent/coder wiring; own env gate inside.
 	if cli.chatEffectiveMemoryMode() == memModeIndex {
 		if ar := cli.memoryAutoRecallBlockCtx(ctx, hints, userInput); ar != "" {
-			out.add("memory_recall", models.ContentBlock{Type: "text", Text: ar})
+			out.addTurn("memory_recall", models.ContentBlock{Type: "text", Text: ar})
 		}
 	}
 	// Part 8c: proactive SESSION recall (own gate, orthogonal to the memory
@@ -211,10 +217,10 @@ func (cli *ChatCLI) assembleChatSystemPrompt(
 	// header: chat has no @session tool, so the model surfaces the pointer
 	// to the user instead of pulling.
 	if sr := cli.chatSessionAutoRecallBlock(hints, userInput); sr != "" {
-		out.add("session_recall", models.ContentBlock{Type: "text", Text: sr})
+		out.addTurn("session_recall", models.ContentBlock{Type: "text", Text: sr})
 	}
 	if part, ok := cli.dynamicContextPart(); ok { // Part 9
-		out.add("dynamic", part)
+		out.addTurn("dynamic", part)
 	}
 	cli.promptBreakdowns.recordDegraded("chat", budget.Degraded(), out.sections)
 	return out
@@ -339,6 +345,9 @@ func (cli *ChatCLI) turnHints(userInput string) []string {
 	}
 	texts := make([]string, 0, window+1)
 	for _, msg := range cli.history[len(cli.history)-window:] {
+		if msg.IsTurnContext() {
+			continue // injected context is not a hint about what the user wants
+		}
 		texts = append(texts, msg.Content)
 	}
 	if s := strings.TrimSpace(userInput); s != "" {
@@ -613,6 +622,38 @@ func (cli *ChatCLI) watcherContextPart() (models.ContentBlock, bool) {
 func (cli *ChatCLI) buildChatTempHistory(
 	parts []models.ContentBlock, userInput, additionalContext string, images []models.ImageContent,
 ) []models.Message {
+	return cli.buildChatTempHistoryWithContext(parts, nil, userInput, additionalContext, images)
+}
+
+// turnContextText joins the volatile blocks into the text of the turn
+// context message ("" when there is nothing volatile this turn).
+func turnContextText(blocks []models.ContentBlock) string {
+	var b strings.Builder
+	for _, blk := range blocks {
+		t := strings.TrimSpace(blk.Text)
+		if t == "" {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteString("\n\n")
+		}
+		b.WriteString(t)
+	}
+	if b.Len() == 0 {
+		return ""
+	}
+	return turnContextHeader + b.String()
+}
+
+// turnContextHeader tells the model what the injected message is. English
+// on purpose: it is model-facing, like the mode banners.
+const turnContextHeader = "[TURN CONTEXT — injected by ChatCLI for this turn, not written by the user]\n"
+
+// buildChatTempHistoryWithContext is buildChatTempHistory with the turn
+// context message spliced right before the user's turn.
+func (cli *ChatCLI) buildChatTempHistoryWithContext(
+	parts []models.ContentBlock, turnContext []models.ContentBlock, userInput, additionalContext string, images []models.ImageContent,
+) []models.Message {
 	// Purge stale `[ACTIVE MODE: …]` system messages left behind by a
 	// previous /agent or /coder run in the same session. Without this,
 	// the chat LLM call would receive the fresh ChatModeSystemHint in
@@ -635,6 +676,9 @@ func (cli *ChatCLI) buildChatTempHistory(
 		if msg.Role != "system" {
 			tempHistory = append(tempHistory, msg)
 		}
+	}
+	if text := turnContextText(turnContext); text != "" {
+		tempHistory = append(tempHistory, models.TurnContextMessage(text))
 	}
 	tempHistory = append(tempHistory, models.Message{
 		Role:    "user",
@@ -826,6 +870,12 @@ func (cli *ChatCLI) handleChatTurnResult(
 		return
 	}
 
+	// The turn context message is persisted too: the next request must
+	// replay exactly the bytes this one sent, or the prefix cache misses at
+	// this position. Flagged, so exports and extraction can tell it apart.
+	if text := cli.takePendingTurnContext(); text != "" {
+		cli.history = append(cli.history, models.TurnContextMessage(text))
+	}
 	cli.history = append(cli.history, userMessage)
 	cli.history = append(cli.history, models.Message{Role: "assistant", Content: aiResponse})
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -355,8 +355,16 @@ type ChatCLI struct {
 	recallTraceMu   sync.Mutex
 	lastRecallTrace *memoryRecallTrace
 	// otlp is the OpenTelemetry metrics exporter (nil unless OTEL_* is set).
-	otlp        *telemetry.Exporter
-	lastEscTime time.Time // for Esc+Esc double-press detection
+	otlp *telemetry.Exporter
+	// pendingTurnContext is the chat turn's injected context text between
+	// assembly and commit (turn_context.go).
+	pendingTurnContext string
+	// prefixRatios freezes the chars-per-token ratio the prefix budget uses
+	// per provider:model for the session, so cached sections never fold or
+	// unfold because the calibrator moved by a few percent (prompt_budget.go).
+	prefixRatiosMu sync.Mutex
+	prefixRatios   map[string]float64
+	lastEscTime    time.Time // for Esc+Esc double-press detection
 
 	// Background memory annotation worker
 	memWorker        *memoryWorker

--- a/cli/cli_llm.go
+++ b/cli/cli_llm.go
@@ -54,7 +54,8 @@ func (cli *ChatCLI) processLLMRequest(parentCtx context.Context, in string) {
 	cli.compactHistoryIfNeeded(ctx)
 
 	assembly := cli.assembleChatSystemPrompt(ctx, userInput, additionalContext)
-	tempHistory := cli.buildChatTempHistory(assembly.parts, userInput, additionalContext, images)
+	tempHistory := cli.buildChatTempHistoryWithContext(assembly.parts, assembly.turnContext, userInput, additionalContext, images)
+	cli.setPendingTurnContext(turnContextText(assembly.turnContext))
 	// What the wire carries this turn — the calibrator's chars side.
 	cli.lastPromptChars = promptCharsOf(tempHistory) + len(userInput+additionalContext)
 	userMessage := models.Message{Role: "user", Content: userInput + additionalContext, Images: images}

--- a/cli/memory_autorecall_agent_test.go
+++ b/cli/memory_autorecall_agent_test.go
@@ -46,8 +46,8 @@ func TestBuildWorkspaceBlocks_InjectsAutoRecallInIndexMode(t *testing.T) {
 	if strings.Contains(workspaceText, "[MEMORY AUTO-RECALL]") {
 		t.Errorf("auto-recall must NEVER land in the cacheable workspace block: %s", workspaceText)
 	}
-	if !strings.Contains(dynamicText, "Current date and time") {
-		t.Errorf("wall-clock context must survive alongside auto-recall: %s", dynamicText)
+	if !strings.Contains(dynamicText, "Current date:") {
+		t.Errorf("the date context must survive alongside auto-recall: %s", dynamicText)
 	}
 	_ = cli
 }

--- a/cli/memory_worker.go
+++ b/cli/memory_worker.go
@@ -410,6 +410,9 @@ no work was completed.`
 func buildExtractionSnippet(messages []models.Message) strings.Builder {
 	var sb strings.Builder
 	for _, msg := range messages {
+		if msg.IsTurnContext() {
+			continue // ChatCLI's own recall/date block is not something to learn from
+		}
 		content := redactSecretsForLLM(msg.Content)
 		// Truncate very long messages to keep the extraction prompt small
 		if len(content) > 1500 {

--- a/cli/prompt_breakdown.go
+++ b/cli/prompt_breakdown.go
@@ -16,6 +16,7 @@
 package cli
 
 import (
+	"strings"
 	"sync"
 	"time"
 
@@ -115,5 +116,18 @@ func (a *chatSystemAssembly) add(label string, blocks ...models.ContentBlock) {
 	for _, b := range blocks {
 		a.parts = append(a.parts, b)
 		a.sections = append(a.sections, promptSection{Name: label, Chars: len(b.Text), Cached: b.CacheControl != nil})
+	}
+}
+
+// addTurn records a volatile section and routes its blocks to the turn
+// context message instead of the system message (turn_context.go).
+func (a *chatSystemAssembly) addTurn(label string, blocks ...models.ContentBlock) {
+	for _, b := range blocks {
+		if strings.TrimSpace(b.Text) == "" {
+			continue
+		}
+		b.CacheControl = nil
+		a.turnContext = append(a.turnContext, b)
+		a.sections = append(a.sections, promptSection{Name: label, Chars: len(b.Text)})
 	}
 }

--- a/cli/prompt_budget.go
+++ b/cli/prompt_budget.go
@@ -58,15 +58,39 @@ type prefixBudget struct {
 // window and the learned chars-per-token ratio.
 func (cli *ChatCLI) newPrefixBudget(provider, model string) *prefixBudget {
 	window := catalog.GetContextWindow(provider, model)
-	cpt, _ := globalTokenCalibrator.CharsPerToken(provider, model)
-	if cpt <= 0 {
-		cpt = defaultCharsPerToken
-	}
+	cpt := cli.frozenPrefixRatio(provider, model)
 	limit := int(float64(window) * prefixMaxShare * cpt)
 	if limit < prefixFloorChars {
 		limit = prefixFloorChars
 	}
 	return &prefixBudget{Window: window, MaxChars: limit}
+}
+
+// frozenPrefixRatio returns the chars-per-token ratio the prefix budget
+// uses for provider/model, fixed at first use for the session: the learned
+// ratio keeps moving by EMA on every request, and a budget that follows it
+// folds and unfolds cached sections (attachments, digests, pinned skills)
+// between turns — a prefix rebuild each time. A model switch keys a fresh
+// ratio.
+func (cli *ChatCLI) frozenPrefixRatio(provider, model string) float64 {
+	if cli == nil {
+		return defaultCharsPerToken
+	}
+	key := calibrationKey(provider, model)
+	cli.prefixRatiosMu.Lock()
+	defer cli.prefixRatiosMu.Unlock()
+	if r, ok := cli.prefixRatios[key]; ok && r > 0 {
+		return r
+	}
+	cpt, _ := cli.calibrator().CharsPerToken(provider, model)
+	if cpt <= 0 {
+		cpt = defaultCharsPerToken
+	}
+	if cli.prefixRatios == nil {
+		cli.prefixRatios = map[string]float64{}
+	}
+	cli.prefixRatios[key] = cpt
+	return cpt
 }
 
 // spend records chars already placed in the prefix.

--- a/cli/rpc_chat.go
+++ b/cli/rpc_chat.go
@@ -109,7 +109,8 @@ func (cli *ChatCLI) runChatTurnSerialized(
 	cli.compactHistoryIfNeeded(ctx)
 
 	assembly := cli.assembleChatSystemPrompt(ctx, input, additionalContext)
-	tempHistory := cli.buildChatTempHistory(assembly.parts, input, additionalContext, images)
+	tempHistory := cli.buildChatTempHistoryWithContext(assembly.parts, assembly.turnContext, input, additionalContext, images)
+	turnCtx := turnContextText(assembly.turnContext)
 
 	activeClient, resProvider, resModel, err := cli.resolveRPCChatClient(assembly.modelHint, o)
 	if err != nil {
@@ -134,6 +135,9 @@ func (cli *ChatCLI) runChatTurnSerialized(
 	}
 
 	userMessage := models.Message{Role: "user", Content: input + additionalContext, Images: images}
+	if turnCtx != "" {
+		cli.history = append(cli.history, models.TurnContextMessage(turnCtx))
+	}
 	cli.history = append(cli.history, userMessage, models.Message{Role: "assistant", Content: reply})
 	cli.mirrorHubTurn(ctx, userMessage.Content, reply)
 

--- a/cli/rpc_chat_test.go
+++ b/cli/rpc_chat_test.go
@@ -104,9 +104,20 @@ func TestRunChatTurnRPC_FullPipelineParity(t *testing.T) {
 	if len(fake.lastHist) == 0 || fake.lastHist[0].Role != "system" {
 		t.Fatalf("first message sent to the LLM must be the assembled system prompt; got %+v", fake.lastHist)
 	}
-	sys := fake.lastHist[0].Content
-	if !strings.Contains(sys, "ZETA-SKILL-BODY") && !strings.Contains(sys, "zeta-skill") {
-		t.Errorf("trigger-activated skill missing from system prompt:\n%s", sys)
+	// Trigger-activated skills are per-turn context: they ride in the
+	// flagged turn context message right before the user's turn, never in
+	// the (byte-stable) system message.
+	var sent strings.Builder
+	for _, m := range fake.lastHist {
+		if m.IsTurnContext() {
+			sent.WriteString(m.Content)
+		}
+	}
+	if !strings.Contains(sent.String(), "ZETA-SKILL-BODY") && !strings.Contains(sent.String(), "zeta-skill") {
+		t.Errorf("trigger-activated skill missing from the turn context:\n%v", fake.lastHist)
+	}
+	if strings.Contains(fake.lastHist[0].Content, "ZETA-SKILL-BODY") {
+		t.Error("auto skills must not be in the system message any more")
 	}
 	if len(fake.lastHist[0].SystemParts) == 0 {
 		t.Error("SystemParts must be populated (Anthropic cache-control path)")
@@ -120,9 +131,17 @@ func TestRunChatTurnRPC_FullPipelineParity(t *testing.T) {
 		t.Errorf("prior session history missing from the LLM call:\n%s", joined)
 	}
 
-	// Returned history = prior + user + assistant.
-	if len(turn.History) != len(prior)+2 {
-		t.Fatalf("history len = %d, want %d", len(turn.History), len(prior)+2)
+	// Returned history = prior + user + assistant, plus the flagged turn
+	// context message the pipeline persists so the next request replays
+	// the same bytes (it is not user text and is excluded from the count).
+	real := 0
+	for _, m := range turn.History {
+		if !m.IsTurnContext() {
+			real++
+		}
+	}
+	if real != len(prior)+2 {
+		t.Fatalf("history len = %d (non-context), want %d", real, len(prior)+2)
 	}
 	last := turn.History[len(turn.History)-1]
 	if last.Role != "assistant" || last.Content != "hello from fake" {

--- a/cli/session_autorecall.go
+++ b/cli/session_autorecall.go
@@ -218,7 +218,7 @@ func formatSessionAge(saved time.Time) string {
 // or "" when there is none.
 func lastUserMessage(history []models.Message) string {
 	for i := len(history) - 1; i >= 0; i-- {
-		if history[i].Role == "user" {
+		if history[i].Role == "user" && !history[i].IsTurnContext() {
 			return history[i].Content
 		}
 	}

--- a/cli/session_transcript.go
+++ b/cli/session_transcript.go
@@ -152,6 +152,9 @@ func renderTranscriptMarkdown(msgs []models.Message, session, transcriptID strin
 		if m.Meta != nil && m.Meta.IsSummary {
 			label = role + " · summary"
 		}
+		if m.IsTurnContext() {
+			label = role + " · turn context (injected by ChatCLI)"
+		}
 		fmt.Fprintf(&b, "### #%d %s\n\n", i+1, label)
 		if c := strings.TrimSpace(m.Content); c != "" {
 			b.WriteString(c + "\n\n")

--- a/cli/turn_context.go
+++ b/cli/turn_context.go
@@ -1,0 +1,37 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Per-turn context as a user-turn message.
+ *
+ * Everything that changes from one turn to the next — the date, the
+ * proactive memory and session recall, auto-activated skills, MCP channel
+ * pushes, the watcher snapshot — used to trail the system message. Every
+ * provider caches by prefix, so a system message that differs each turn
+ * made every breakpoint after it miss: each turn re-wrote the whole
+ * conversation into the cache and read nothing back. Those blocks now ride
+ * as one flagged user-role message placed right before the user's turn,
+ * persisted with the conversation so the next request replays identical
+ * bytes; the system message is byte-stable for the session.
+ */
+package cli
+
+// setPendingTurnContext stashes the turn context text between assembly and
+// the commit of a successful chat turn.
+func (cli *ChatCLI) setPendingTurnContext(text string) {
+	if cli == nil {
+		return
+	}
+	cli.pendingTurnContext = text
+}
+
+// takePendingTurnContext returns and clears the stashed text.
+func (cli *ChatCLI) takePendingTurnContext() string {
+	if cli == nil {
+		return ""
+	}
+	t := cli.pendingTurnContext
+	cli.pendingTurnContext = ""
+	return t
+}

--- a/cli/turn_context_test.go
+++ b/cli/turn_context_test.go
@@ -118,3 +118,40 @@ func TestAgentSystemMessage_NoVolatileBlocks(t *testing.T) {
 		t.Fatal("turn context message shape")
 	}
 }
+
+func TestTurnContext_AgentHelpersAndPendingStash(t *testing.T) {
+	if composeTurnContext("", "") != "" || composeTurnContext("chan", "") != "chan" || composeTurnContext("", "dyn") != "dyn" {
+		t.Fatal("composeTurnContext edge cases")
+	}
+	if got := composeTurnContext("chan", "dyn"); got != "chan\n\ndyn" {
+		t.Fatalf("channels precede the dynamic block: %q", got)
+	}
+	cli := &ChatCLI{}
+	a := &AgentMode{cli: cli}
+	a.appendTurnContext("   ")
+	if len(cli.history) != 0 {
+		t.Fatal("empty turn context appends nothing")
+	}
+	a.appendTurnContext("Current date: 2026-09-03")
+	if len(cli.history) != 1 || !cli.history[0].IsTurnContext() || !strings.HasPrefix(cli.history[0].Content, turnContextHeader) {
+		t.Fatalf("turn context message shape: %+v", cli.history)
+	}
+	cli.setPendingTurnContext("ctx")
+	if cli.takePendingTurnContext() != "ctx" || cli.takePendingTurnContext() != "" {
+		t.Fatal("pending turn context is taken once")
+	}
+	var nilCLI *ChatCLI
+	nilCLI.setPendingTurnContext("x")
+	if nilCLI.takePendingTurnContext() != "" {
+		t.Fatal("nil-safe")
+	}
+	if turnContextText(nil) != "" || turnContextText([]models.ContentBlock{{Text: "  "}}) != "" {
+		t.Fatal("no volatile blocks → no message")
+	}
+	if key := llmclient.PromptCacheKey(nil); key != "" {
+		t.Fatal("no system message → no key")
+	}
+	if r := (*ChatCLI)(nil).frozenPrefixRatio("openai", "gpt-5.6-terra"); r != defaultCharsPerToken {
+		t.Fatal("nil CLI falls back to the default ratio")
+	}
+}

--- a/cli/turn_context_test.go
+++ b/cli/turn_context_test.go
@@ -1,0 +1,120 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/cli/workspace"
+	llmclient "github.com/diillson/chatcli/llm/client"
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+// TestChatSystemPrompt_ByteStableAcrossTurns is the contract behind the
+// prefix cache: two consecutive chat turns must assemble a system message
+// with identical bytes, with everything per-turn in the turn context.
+func TestChatSystemPrompt_ByteStableAcrossTurns(t *testing.T) {
+	cli, _ := newPipelineCLI(t, nil)
+	ch, err := NewContextHandler(zap.NewNop())
+	if err != nil {
+		t.Skipf("NewContextHandler unavailable: %v", err)
+	}
+	cli.contextHandler = ch
+	if cli.contextBuilder == nil {
+		bl := workspace.NewBootstrapLoader(t.TempDir(), t.TempDir(), zap.NewNop())
+		cli.contextBuilder = workspace.NewContextBuilder(bl, workspace.NewMemoryStore(t.TempDir(), zap.NewNop()), t.TempDir())
+	}
+	first := cli.assembleChatSystemPrompt(testCtx(), "first question about the parser", "")
+	sys1 := combinedSystemMessage(first.parts)
+	cli.history = append(cli.history,
+		models.TurnContextMessage(turnContextText(first.turnContext)),
+		models.Message{Role: "user", Content: "first question about the parser"},
+		models.Message{Role: "assistant", Content: "answer one"})
+	second := cli.assembleChatSystemPrompt(testCtx(), "now something about deployments", "")
+	sys2 := combinedSystemMessage(second.parts)
+	if sys1.Content != sys2.Content {
+		t.Fatalf("system message must be byte-stable across turns:\n--- turn 1 ---\n%s\n--- turn 2 ---\n%s", sys1.Content, sys2.Content)
+	}
+	for i, p := range second.parts {
+		if p.CacheControl == nil {
+			t.Fatalf("system part %d carries no cache hint: volatile content leaked into the system message: %q", i, p.Text)
+		}
+	}
+	if strings.Contains(sys2.Content, "Current date") {
+		t.Fatal("the date must not be in the system message")
+	}
+	ctxText := turnContextText(second.turnContext)
+	if !strings.HasPrefix(ctxText, turnContextHeader) || !strings.Contains(ctxText, "Current date:") {
+		t.Fatalf("turn context must carry the header and the date: %q", ctxText)
+	}
+	if strings.Contains(ctxText, ":") && strings.Contains(ctxText, "Current date:") {
+		line := ctxText[strings.Index(ctxText, "Current date:"):]
+		if len(strings.Fields(line)) > 0 && strings.Count(strings.SplitN(line, "\n", 2)[0], ":") > 1 {
+			t.Fatalf("date must be day-resolution, no clock: %q", strings.SplitN(line, "\n", 2)[0])
+		}
+	}
+	// Temp history: [system, ..., turn context, user]; the injected message is flagged.
+	temp := cli.buildChatTempHistoryWithContext(second.parts, second.turnContext, "now something about deployments", "", nil)
+	last, prev := temp[len(temp)-1], temp[len(temp)-2]
+	if last.Role != "user" || last.Content != "now something about deployments" || !prev.IsTurnContext() {
+		t.Fatalf("turn context must sit right before the user's turn: %+v %+v", prev, last)
+	}
+	// Hints ignore the injected block; the extraction snippet skips it.
+	hints := cli.turnHints("x")
+	for _, h := range hints {
+		if strings.Contains(strings.ToLower(h), "turn context") {
+			t.Fatalf("hints must not come from injected context: %v", hints)
+		}
+	}
+	snippet := buildExtractionSnippet(cli.history)
+	if strings.Contains(snippet.String(), turnContextHeader) {
+		t.Fatal("memory extraction must skip injected turn context")
+	}
+	if lastUserMessage([]models.Message{{Role: "user", Content: "real"}, models.TurnContextMessage("ctx")}) != "real" {
+		t.Fatal("lastUserMessage must skip injected context")
+	}
+}
+
+func TestPromptCacheKey_StableWhenVolatileContentChanges(t *testing.T) {
+	stable := models.ContentBlock{Type: "text", Text: "STABLE SYSTEM", CacheControl: &models.CacheControl{Type: "ephemeral"}}
+	h1 := []models.Message{{Role: "system", Content: "STABLE SYSTEM\n\nvolatile A", SystemParts: []models.ContentBlock{stable, {Type: "text", Text: "volatile A"}}}}
+	h2 := []models.Message{{Role: "system", Content: "STABLE SYSTEM\n\nvolatile B", SystemParts: []models.ContentBlock{stable, {Type: "text", Text: "volatile B"}}}}
+	k1, k2 := llmclient.PromptCacheKey(h1), llmclient.PromptCacheKey(h2)
+	if k1 == "" || k1 != k2 {
+		t.Fatalf("key must follow the marked parts only: %q vs %q", k1, k2)
+	}
+	if llmclient.PromptCacheKey([]models.Message{{Role: "system", Content: "plain"}}) == "" {
+		t.Fatal("flat content keeps working when nothing is marked")
+	}
+}
+
+func TestPrefixBudget_RatioFrozenPerSession(t *testing.T) {
+	cli := &ChatCLI{stateRoot: t.TempDir(), Provider: "openai", Model: "gpt-5.6-terra"}
+	b1 := cli.newPrefixBudget("openai", "gpt-5.6-terra")
+	cli.calibrator().Observe("openai", "gpt-5.6-terra", 20_000, 10_000) // ratio 2.0 learned mid-session
+	b2 := cli.newPrefixBudget("openai", "gpt-5.6-terra")
+	if b1.MaxChars != b2.MaxChars {
+		t.Fatalf("the prefix budget must not move with the calibrator mid-session: %d vs %d", b1.MaxChars, b2.MaxChars)
+	}
+	if cli.newPrefixBudget("openai", "gpt-5.5").MaxChars == 0 {
+		t.Fatal("another model keys its own ratio")
+	}
+}
+
+func TestAgentSystemMessage_NoVolatileBlocks(t *testing.T) {
+	msg := buildAgentSystemMessage("core", "tools", "workspace", "skills", "orch", "", "")
+	for _, p := range msg.SystemParts {
+		if strings.Contains(p.Text, "Current date") {
+			t.Fatal("agent system message must not carry the date")
+		}
+	}
+	ctx := models.TurnContextMessage(turnContextHeader + "Current date: 2026-09-03")
+	if !ctx.IsTurnContext() || ctx.Role != "user" {
+		t.Fatal("turn context message shape")
+	}
+}

--- a/cli/workspace/context_builder.go
+++ b/cli/workspace/context_builder.go
@@ -253,7 +253,7 @@ func (cb *ContextBuilder) BuildDynamicContext() string {
 	// Day resolution on purpose: this block rides in the per-turn context
 	// message, and a wall-clock second would make it differ on every
 	// request for nothing the model needs.
-	parts = append(parts, fmt.Sprintf("Current date: %s (%s, %s)", now.Format("2006-01-02"), now.Weekday(), now.Format("MST")))
+	parts = append(parts, "Current date: "+now.Format("2006-01-02")+" ("+now.Weekday().String()+", "+now.Format("MST")+")")
 
 	if cb.workspaceDir != "" {
 		parts = append(parts, fmt.Sprintf("Current working directory: %s", cb.workspaceDir))

--- a/cli/workspace/context_builder.go
+++ b/cli/workspace/context_builder.go
@@ -250,7 +250,10 @@ func appendMatchingRules(rules *RulesLoader, hints []string, parts []string) []s
 func (cb *ContextBuilder) BuildDynamicContext() string {
 	now := time.Now()
 	var parts []string
-	parts = append(parts, fmt.Sprintf("Current date and time: %s", now.Format("2006-01-02 15:04:05 MST")))
+	// Day resolution on purpose: this block rides in the per-turn context
+	// message, and a wall-clock second would make it differ on every
+	// request for nothing the model needs.
+	parts = append(parts, fmt.Sprintf("Current date: %s (%s, %s)", now.Format("2006-01-02"), now.Weekday(), now.Format("MST")))
 
 	if cb.workspaceDir != "" {
 		parts = append(parts, fmt.Sprintf("Current working directory: %s", cb.workspaceDir))

--- a/cli/workspace/context_builder_test.go
+++ b/cli/workspace/context_builder_test.go
@@ -70,7 +70,7 @@ func TestContextBuilder_DynamicContext(t *testing.T) {
 	cb := NewContextBuilder(bl, ms, wsDir)
 
 	dyn := cb.BuildDynamicContext()
-	if !strings.Contains(dyn, "Current date and time") {
+	if !strings.Contains(dyn, "Current date: ") || strings.Contains(dyn, ":00") {
 		t.Errorf("expected dynamic context with date, got %q", dyn)
 	}
 	if !strings.Contains(dyn, "Current working directory: "+wsDir) {

--- a/llm/client/prompt_cache_key.go
+++ b/llm/client/prompt_cache_key.go
@@ -26,13 +26,27 @@ func PromptCacheKey(history []models.Message) string {
 		if !strings.EqualFold(strings.TrimSpace(msg.Role), "system") {
 			continue
 		}
-		text := msg.Content
-		if text == "" && len(msg.SystemParts) > 0 {
+		// Only the cache-marked (stable) parts feed the key: hashing the flat
+		// content pulled every volatile block in, so the key changed each
+		// turn and the shard affinity it exists for was never earned.
+		text := ""
+		if len(msg.SystemParts) > 0 {
 			var b strings.Builder
 			for _, p := range msg.SystemParts {
-				b.WriteString(p.Text)
+				if p.CacheControl != nil {
+					b.WriteString(p.Text)
+				}
 			}
 			text = b.String()
+			if text == "" {
+				for _, p := range msg.SystemParts {
+					b.WriteString(p.Text)
+				}
+				text = b.String()
+			}
+		}
+		if text == "" {
+			text = msg.Content
 		}
 		if strings.TrimSpace(text) == "" {
 			return ""

--- a/models/models.go
+++ b/models/models.go
@@ -39,6 +39,15 @@ type MessageMeta struct {
 	// stale skill guidance.
 	SkillNames string `json:"skill_names,omitempty"`
 
+	// TurnContext marks a user-role message ChatCLI itself injected at a
+	// turn boundary with per-turn context (date, proactive recall, active
+	// skills, channel pushes) — the Claude Code "system reminder" pattern.
+	// Keeping it OUT of the system message keeps the system prompt
+	// byte-stable across turns, which is what lets every provider's
+	// prefix cache hit. Structural so consumers (memory extraction, hint
+	// builders, exports) can tell it from what the user typed.
+	TurnContext bool `json:"turn_context,omitempty"`
+
 	// SkillCollapsed is true once ApplySkillAging reduced this skill block
 	// to a stub, so the pass never collapses the same block twice.
 	SkillCollapsed bool `json:"skill_collapsed,omitempty"`
@@ -175,6 +184,18 @@ type SessionData struct {
 	// load (the journal keeps every message ever seen; the session file
 	// stays small).
 	Checkpoints []SessionCheckpoint `json:"checkpoints,omitempty"`
+}
+
+// IsTurnContext reports whether the message is ChatCLI-injected turn
+// context rather than user text (see MessageMeta.TurnContext).
+func (m Message) IsTurnContext() bool {
+	return m.Meta != nil && m.Meta.TurnContext
+}
+
+// TurnContextMessage builds the flagged user-role message that carries
+// per-turn context.
+func TurnContextMessage(text string) Message {
+	return Message{Role: "user", Content: text, Meta: &MessageMeta{TurnContext: true}}
 }
 
 // SessionCheckpoint is one persisted /rewind point.


### PR DESCRIPTION
## Summary

Audit III, PR 1 (P0 CAG-1; P1 CAG-2, CAG-7). The prompt cache was writing the whole conversation every turn and reading nothing back, on every prefix-caching provider.

**Byte-stable system prompt (CAG-1).** The system message carried a per-second timestamp plus the hint-driven recall blocks, so every breakpoint after it missed on every turn. Every per-turn block — date (now day-resolution), proactive memory and session recall, auto-activated and manual skills, MCP channel pushes, watcher snapshot, retrieved passages — now leaves the system message and rides as one user-role message flagged `Meta.TurnContext` (the Claude Code "system reminder" pattern), placed right before the user's turn. It is persisted with the conversation, so the next request replays identical bytes up to the previous breakpoint. Chat, RPC chat (MCP/ACP/gateway) and agent/coder share the mechanism; agent runs and type-ahead follow-ups append the flagged message before the query; the scratch-dir line moves into the cacheable tools block. Memory extraction, turn hints, session recall and the transcript export recognize the flag and never treat the injected text as user text.

**Stable cache key (CAG-2).** `PromptCacheKey` hashes only the cache-marked stable parts of the system message (whole message when nothing is marked), so OpenAI-family shard affinity survives across turns.

**Frozen prefix ratio (CAG-7).** The prefix budget takes the chars-per-token ratio once per provider:model for the session instead of following the calibrator's EMA, so attachments, digests and pinned skills stop folding and unfolding between turns.

The cwd disambiguation directive keeps its exact wording; `/context status` gains a `turn_context` section in place of the old volatile ones.

## Tests

`cli/turn_context_test.go`: two consecutive chat turns assemble a byte-identical system message with every part cache-marked and no date in it; the turn context carries the header and a day-resolution date and sits right before the user's turn; hints, extraction and `lastUserMessage` skip it; cache key stable when volatile content changes; prefix budget unchanged after the calibrator learns a new ratio; agent system message carries no date. RPC and workspace tests updated to the new placement. Full suite, golangci-lint and the local gates are green.