### PR TITLE
fix(context): verbatim results survive pairing, verbatim cap for convergence, skipped-compaction bookkeeping, shared restore helper

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -2294,11 +2294,15 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 			a.cli.beforeCompaction(ctx, compactTriggerAuto)
 			compacted, compactErr := a.cli.historyCompactor.Compact(ctx, a.cli.history, a.cli.Client, cfg)
 			a.cli.historyCompactor.SetStatusCallback(nil)
-			if compactErr == nil {
+			switch {
+			case compactErr == nil && !historiesEqual(compacted, a.cli.history):
 				a.cli.history = compacted
 				a.cli.noteCompactionApplied(ctx, compactTriggerAuto)
-			} else if errors.Is(compactErr, context.Canceled) {
+			case errors.Is(compactErr, context.Canceled):
+				a.cli.compactionSkipped(ctx, compactTriggerAuto)
 				return compactErr
+			default:
+				a.cli.compactionSkipped(ctx, compactTriggerAuto)
 			}
 		}
 
@@ -2575,6 +2579,9 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 				a.cli.flushMemoryBeforeCompaction(ctx)
 				a.cli.beforeCompaction(ctx, compactTriggerRecovery)
 				recoveredHistory, recovered := contextRecovery.RecoverContextOverflow(a.cli.history)
+				if !recovered {
+					a.cli.compactionSkipped(ctx, compactTriggerRecovery)
+				}
 				if recovered {
 					if note := archiveDroppedMessages(a.cli.compressionLayer, a.cli.history, recoveredHistory); note != "" {
 						recoveredHistory = append(recoveredHistory, models.Message{Role: "user", Content: note})

--- a/cli/audit3_pr4_test.go
+++ b/cli/audit3_pr4_test.go
@@ -1,0 +1,139 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/cli/agent"
+	"github.com/diillson/chatcli/cli/compress"
+	"github.com/diillson/chatcli/cli/hooks"
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+func TestVerbatimToolResult_SurvivesPairingAfterLevel2(t *testing.T) {
+	hc := NewHistoryCompactor(zap.NewNop())
+	h := []models.Message{{Role: "system", Content: "charter"}}
+	for i := 0; i < 3; i++ {
+		h = append(h, models.Message{Role: "user", Content: strings.Repeat("question detail ", 50)}, models.Message{Role: "assistant", Content: strings.Repeat("answer detail ", 50)})
+	}
+	h = append(h,
+		models.Message{Role: "assistant", ToolCalls: []models.ToolCall{{ID: "r1", Name: "recall", Arguments: map[string]interface{}{"key": "k"}}}},
+		models.Message{Role: "tool", ToolCallID: "r1", Content: "RECALLED ORIGINAL " + strings.Repeat("x", 300), Meta: &models.MessageMeta{PreserveVerbatim: true}},
+		models.Message{Role: "assistant", Content: strings.Repeat("more answer ", 50)},
+		models.Message{Role: "user", Content: "recent 1"}, models.Message{Role: "user", Content: "recent 2"})
+	out, err := hc.structuredSummarize(context.Background(), h, &countingSummarizer{summary: strings.Repeat("## Summary\n- point ", 8)}, CompactConfig{MinKeepRecent: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	repaired, rep := agent.EnsureToolResultPairing(out, zap.NewNop())
+	if rep.OrphanResultsRemoved != 0 {
+		t.Fatalf("the verbatim result must not be an orphan after compaction: %+v", rep)
+	}
+	found := false
+	for _, m := range repaired {
+		if m.Meta != nil && m.Meta.PreserveVerbatim && strings.Contains(m.Content, "RECALLED ORIGINAL") {
+			found = true
+			if m.Role != "user" || m.ToolCallID != "" {
+				t.Fatalf("verbatim result must be downgraded to a user message: %+v", m.Role)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("verbatim content must survive Level 2 and the pairing repair")
+	}
+}
+
+func TestVerbatimCap_CompactionConverges(t *testing.T) {
+	layer := compress.NewLayer(compress.Config{Mode: compress.ModeLossyWithCCR, Store: compress.NewMemoryStore()})
+	hc := NewHistoryCompactor(zap.NewNop())
+	hc.SetCompressionLayer(layer)
+	cfg := CompactConfig{Provider: "openai", Model: "gpt-5.6-terra", MinKeepRecent: 2, BudgetRatio: 0.5, CharsPerToken: 4, MaxPayloadBytes: 8000}
+	budget := hc.CharBudget(cfg)
+	h := []models.Message{{Role: "system", Content: "charter"}}
+	// Six recalled originals, each a third of the budget: exempt from every
+	// level, they used to keep the history above budget forever.
+	for i := 0; i < 6; i++ {
+		h = append(h, models.Message{Role: "user", Content: strings.Repeat("v", budget/3), Meta: &models.MessageMeta{PreserveVerbatim: true}})
+	}
+	h = append(h, models.Message{Role: "user", Content: "recent 1"}, models.Message{Role: "assistant", Content: "recent 2"})
+	out, err := hc.Compact(context.Background(), h, &countingSummarizer{summary: strings.Repeat("## Summary\n- point ", 8)}, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hc.NeedsCompaction(out, cfg) {
+		t.Fatalf("compaction must converge under budget: %d > %d", totalChars(out), budget)
+	}
+	stubs, recall := 0, 0
+	for _, m := range out {
+		if strings.Contains(m.Content, "aged out of the window") {
+			stubs++
+			if strings.Contains(m.Content, "@recall") {
+				recall++
+			}
+		}
+	}
+	if stubs == 0 || recall != stubs {
+		t.Fatalf("aged verbatim results must be stubbed with a recall marker: stubs=%d recall=%d", stubs, recall)
+	}
+}
+
+func TestSkippedCompaction_PopsSnapshotAndPairsHooks(t *testing.T) {
+	cli := &ChatCLI{logger: zap.NewNop(), costTracker: NewCostTracker(), hookManager: hooks.NewManager(zap.NewNop())}
+	cli.history = []models.Message{{Role: "user", Content: "a"}, {Role: "assistant", Content: "b"}}
+	cli.beforeCompaction(context.Background(), compactTriggerAuto)
+	if len(cli.preCompaction) != 1 {
+		t.Fatal("beforeCompaction pushes a snapshot")
+	}
+	cli.compactionSkipped(context.Background(), compactTriggerAuto)
+	if len(cli.preCompaction) != 0 {
+		t.Fatal("a skipped compaction must pop its snapshot")
+	}
+	if cli.undoCompaction() {
+		t.Fatal("nothing to undo after a skipped compaction")
+	}
+	if !historiesEqual(cli.history, cli.history) || historiesEqual(cli.history, cli.history[:1]) {
+		t.Fatal("historiesEqual")
+	}
+	ev := cli.compactionEvent(hooks.EventPostCompact, compactTriggerManual)
+	ev.Outcome = compactOutcomeSkipped
+	if ev.Outcome != "skipped" || ev.Trigger != "manual" {
+		t.Fatal("event shape")
+	}
+}
+
+func TestRewindCheckpoint_UsesTheSharedRestoreBookkeeping(t *testing.T) {
+	cli := journaledCLI(t)
+	cli.history = longHistory(2)
+	cli.syncTranscript()
+	cli.saveCheckpoint()
+	cli.history = append(cli.history, models.Message{Role: "user", Content: "later"})
+	cli.syncTranscript()
+	cli.preCompaction = [][]models.Message{longHistory(1)}
+	// Restore the checkpoint the way showRewindMenu does, through the shared helper.
+	cp := cli.checkpoints[0]
+	cli.history = append([]models.Message(nil), cp.History...)
+	cli.afterHistoryRestore()
+	if len(cli.preCompaction) != 0 {
+		t.Fatal("restore must clear the undo stack of the abandoned timeline")
+	}
+	events, _ := cli.transcriptEvents()
+	rewrites := 0
+	for _, e := range events {
+		if e.Kind == "rewrite" {
+			rewrites++
+		}
+	}
+	if rewrites == 0 {
+		t.Fatal("restore must be journaled as a rewrite")
+	}
+	if _, _, rebuilds := cli.costTracker.CacheStats().Requests, 0, cli.costTracker.CacheStats().Rebuilds; rebuilds < 0 {
+		t.Fatal("cache telemetry consulted")
+	}
+}

--- a/cli/cli_llm.go
+++ b/cli/cli_llm.go
@@ -208,10 +208,12 @@ func (cli *ChatCLI) compactHistoryIfNeeded(ctx context.Context) {
 	cli.beforeCompaction(ctx, compactTriggerAuto)
 	compacted, err := cli.historyCompactor.Compact(ctx, cli.history, cli.Client, cfg)
 	cli.historyCompactor.SetStatusCallback(nil)
-	if err == nil {
-		cli.history = compacted
-		cli.noteCompactionApplied(ctx, compactTriggerAuto)
+	if err != nil || historiesEqual(compacted, cli.history) {
+		cli.compactionSkipped(ctx, compactTriggerAuto)
+		return
 	}
+	cli.history = compacted
+	cli.noteCompactionApplied(ctx, compactTriggerAuto)
 }
 
 // warnIfHistoryExceedsProxyCap fires a once-per-session notice when the

--- a/cli/compact_command.go
+++ b/cli/compact_command.go
@@ -49,8 +49,13 @@ func (cli *ChatCLI) handleCompactCommand(ctx context.Context, userInput string) 
 		cli.flushMemoryBeforeCompaction(ctx)
 		compacted, err := cli.historyCompactor.Compact(ctx, cli.history, cli.Client, cfg)
 		cli.historyCompactor.SetStatusCallback(nil)
-		if err != nil {
-			fmt.Println(colorize(fmt.Sprintf("  %s", i18n.T("compact.error.failed", err)), ColorYellow))
+		if err != nil || historiesEqual(compacted, cli.history) {
+			cli.compactionSkipped(ctx, compactTriggerManual)
+			if err != nil {
+				fmt.Println(colorize(fmt.Sprintf("  %s", i18n.T("compact.error.failed", err)), ColorYellow))
+			} else {
+				fmt.Println(colorize("  "+i18n.T("compact.nothing_to_compact"), ColorGray))
+			}
 			return
 		}
 
@@ -167,11 +172,13 @@ CONVERSATION TO COMPACT:
 	}
 	if err != nil {
 		cli.logger.Warn("Guided compaction failed", zap.Error(err))
+		cli.compactionSkipped(ctx, compactTriggerManual)
 		fmt.Println(colorize(fmt.Sprintf("  %s", i18n.T("compact.error.failed", err)), ColorYellow))
 		return
 	}
 	if !summaryPassesGate(response, sb.Len()) {
 		cli.logger.Warn("Guided compaction summary rejected by the quality gate", zap.Int("chars", len(strings.TrimSpace(response))))
+		cli.compactionSkipped(ctx, compactTriggerManual)
 		fmt.Println(colorize("  "+i18n.T("compact.error.summary_rejected"), ColorYellow))
 		return
 	}
@@ -201,7 +208,7 @@ CONVERSATION TO COMPACT:
 			SummaryOf: len(middleMessages),
 		},
 	})
-	result = append(result, verbatim...)
+	result = append(result, downgradeVerbatimResults(verbatim)...)
 	result = append(result, cli.history[recentStart:]...)
 
 	cli.history = result

--- a/cli/compaction_hooks.go
+++ b/cli/compaction_hooks.go
@@ -42,13 +42,66 @@ func (cli *ChatCLI) beforeCompaction(ctx context.Context, trigger string) {
 	cli.hookManager.Fire(ctx, cli.compactionEvent(hooks.EventPreCompact, trigger))
 }
 
+// Compaction outcomes reported to hooks (CHATCLI_HOOK_OUTCOME).
+const (
+	compactOutcomeApplied = "applied"
+	compactOutcomeSkipped = "skipped"
+)
+
 // firePostCompact runs the PostCompact hooks detached from the turn's
-// deadline (the turn must not wait on them).
+// deadline (the turn must not wait on them), reporting outcome "applied".
 func (cli *ChatCLI) firePostCompact(ctx context.Context, trigger string) {
+	cli.firePostCompactOutcome(ctx, trigger, compactOutcomeApplied)
+}
+
+func (cli *ChatCLI) firePostCompactOutcome(ctx context.Context, trigger, outcome string) {
 	if cli == nil || cli.hookManager == nil {
 		return
 	}
-	cli.hookManager.FireAsync(context.WithoutCancel(ctx), cli.compactionEvent(hooks.EventPostCompact, trigger))
+	ev := cli.compactionEvent(hooks.EventPostCompact, trigger)
+	ev.Outcome = outcome
+	cli.hookManager.FireAsync(context.WithoutCancel(ctx), ev)
+}
+
+// compactionSkipped closes a compaction that changed nothing (no-op,
+// rejected summary, failure): the undo snapshot beforeCompaction pushed is
+// popped — /rewind compact must never "restore" an identical history and
+// push a bogus checkpoint — and the PreCompact hook gets its paired
+// PostCompact with outcome "skipped".
+func (cli *ChatCLI) compactionSkipped(ctx context.Context, trigger string) {
+	if cli == nil {
+		return
+	}
+	cli.dropPreCompactionSnapshot()
+	cli.firePostCompactOutcome(ctx, trigger, compactOutcomeSkipped)
+}
+
+// historiesEqual reports whether two histories carry the same messages.
+func historiesEqual(a, b []models.Message) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Role != b[i].Role || a[i].Content != b[i].Content || a[i].ToolCallID != b[i].ToolCallID || len(a[i].ToolCalls) != len(b[i].ToolCalls) {
+			return false
+		}
+	}
+	return true
+}
+
+// afterHistoryRestore is the shared bookkeeping of every history restore
+// (/rewind checkpoint, /rewind compact): the journal records the rewrite,
+// the cache telemetry expects a rebuild, and the undo stack is cleared —
+// its snapshots belong to the timeline that was just left.
+func (cli *ChatCLI) afterHistoryRestore() {
+	if cli == nil {
+		return
+	}
+	cli.syncTranscript()
+	if cli.costTracker != nil {
+		cli.costTracker.NoteExpectedCacheRebuild()
+	}
+	cli.preCompaction = nil
 }
 
 func (cli *ChatCLI) compactionEvent(typ hooks.EventType, trigger string) hooks.HookEvent {

--- a/cli/history_compactor.go
+++ b/cli/history_compactor.go
@@ -362,6 +362,17 @@ func (hc *HistoryCompactor) Compact(
 		return history, nil
 	}
 
+	// Verbatim cap: a growing pile of recalled originals must not keep the
+	// history above budget forever (they are exempt from every level).
+	history = hc.capVerbatim(history, budget)
+	current = totalChars(history)
+	if current <= budget {
+		hc.emitStatus(CompactStageDone, i18n.T("compact.status.trim_sufficient",
+			FormatPayloadSize(before), FormatPayloadSize(current)))
+		hc.setReport(CompactReport{Level: 1})
+		return history, nil
+	}
+
 	// LEVEL 2: Structured summarization of old messages (requires LLM call)
 	rep := CompactReport{Level: 2, SummaryProvider: cfg.SummarizerProvider, SummaryModel: cfg.SummarizerModel}
 	if rep.SummaryProvider == "" {
@@ -456,6 +467,79 @@ func summarizerUsage(llmClient client.LLMClient, cfg CompactConfig) *models.Usag
 		return ua.LastUsage()
 	}
 	return nil
+}
+
+// verbatimBudgetShare is the share of the character budget the
+// PreserveVerbatim messages may hold in total. Beyond it the oldest
+// verbatim results are archived to CCR (recoverable with @recall) and
+// stubbed, so a pile of recalled originals can never keep the history
+// above budget forever — the compactor must converge.
+const verbatimBudgetShare = 0.25
+
+// capVerbatim enforces verbatimBudgetShare: oldest verbatim messages past
+// the cap are archived (when a CCR layer exists), replaced by a short stub
+// and lose the flag. Returns the history (a copy when anything changed).
+func (hc *HistoryCompactor) capVerbatim(history []models.Message, budget int) []models.Message {
+	limit := int(float64(budget) * verbatimBudgetShare)
+	total := 0
+	for _, m := range history {
+		if m.Meta != nil && m.Meta.PreserveVerbatim {
+			total += len(m.Content)
+		}
+	}
+	if total <= limit {
+		return history
+	}
+	out := make([]models.Message, len(history))
+	copy(out, history)
+	for i := range out {
+		if total <= limit {
+			break
+		}
+		m := out[i]
+		if m.Meta == nil || !m.Meta.PreserveVerbatim || m.Role == "system" {
+			continue
+		}
+		stub := "[recalled original aged out of the window (" + FormatPayloadSize(len(m.Content)) + ")"
+		if hc.compress != nil {
+			if key, ok := hc.compress.Archive(m.Content); ok {
+				stub += "; recover again with @recall " + compress.FormatMarker(key)
+			}
+		}
+		stub += "]"
+		total -= len(m.Content)
+		meta := *m.Meta
+		meta.PreserveVerbatim = false
+		m.Content = stub
+		m.Meta = &meta
+		out[i] = m
+		hc.logger.Info("verbatim cap: archived and stubbed an aged recall result", zap.Int("index", i))
+	}
+	return out
+}
+
+// downgradeVerbatimResults turns verbatim tool results that are about to be
+// re-appended without their owning assistant tool_calls message into
+// user-role messages: the tool-result pairing repair would otherwise delete
+// them as orphans, defeating PreserveVerbatim for native tools.
+func downgradeVerbatimResults(verbatim []models.Message) []models.Message {
+	out := make([]models.Message, len(verbatim))
+	for i, m := range verbatim {
+		if m.Role == "tool" || m.ToolCallID != "" {
+			body := m.Content
+			if id := m.ToolCallID; id != "" {
+				body = "[recalled original — tool result " + id + ", kept verbatim through compaction]\n" + body
+			}
+			meta := models.MessageMeta{PreserveVerbatim: true}
+			if m.Meta != nil {
+				meta = *m.Meta
+				meta.PreserveVerbatim = true
+			}
+			m = models.Message{Role: "user", Content: body, Meta: &meta}
+		}
+		out[i] = m
+	}
+	return out
 }
 
 // splitVerbatim separates the messages flagged PreserveVerbatim from a
@@ -578,7 +662,7 @@ func (hc *HistoryCompactor) structuredSummarize(
 			SummaryOf: len(middleMessages),
 		},
 	})
-	result = append(result, verbatim...)
+	result = append(result, downgradeVerbatimResults(verbatim)...)
 	result = append(result, history[recentStart:]...)
 
 	return result, nil
@@ -786,7 +870,7 @@ func (hc *HistoryCompactor) emergencyTruncate(history []models.Message, cfg Comp
 			SummaryOf: droppedCount,
 		},
 	})
-	result = append(result, verbatim...)
+	result = append(result, downgradeVerbatimResults(verbatim)...)
 	result = append(result, history[recentStart:]...)
 
 	return result

--- a/cli/hooks/manager.go
+++ b/cli/hooks/manager.go
@@ -197,6 +197,7 @@ func (m *Manager) executeCommandHook(ctx context.Context, hook HookConfig, event
 		"CHATCLI_HOOK_TOOL="+event.ToolName,
 		"CHATCLI_HOOK_SESSION="+event.SessionID,
 		"CHATCLI_HOOK_TRIGGER="+event.Trigger,
+		"CHATCLI_HOOK_OUTCOME="+event.Outcome,
 	)
 
 	err := cmd.Run()

--- a/cli/hooks/types.go
+++ b/cli/hooks/types.go
@@ -107,6 +107,10 @@ type HookEvent struct {
 	// pressure at a turn boundary), "manual" (/compact) or "recovery"
 	// (context-overflow recovery after a rejected request).
 	Trigger string `json:"trigger,omitempty"`
+	// Outcome says what a compaction event produced: "applied" (the history
+	// changed) or "skipped" (nothing changed: no-op, rejected summary,
+	// failure). Every PreCompact is paired with exactly one PostCompact.
+	Outcome string `json:"outcome,omitempty"`
 }
 
 // HookResult is the result of a hook execution.

--- a/cli/oneshot_mode.go
+++ b/cli/oneshot_mode.go
@@ -245,9 +245,11 @@ func (cli *ChatCLI) RunOnce(ctx context.Context, input string, disableAnimation 
 			fmt.Fprintf(os.Stderr, "  %s\n", msg)
 		})
 		cli.beforeCompaction(ctx, compactTriggerAuto)
-		if compacted, compactErr := cli.historyCompactor.Compact(ctx, cli.history, activeClient, cfg); compactErr == nil {
+		if compacted, compactErr := cli.historyCompactor.Compact(ctx, cli.history, activeClient, cfg); compactErr == nil && !historiesEqual(compacted, cli.history) {
 			cli.history = compacted
 			cli.noteCompactionApplied(ctx, compactTriggerAuto)
+		} else {
+			cli.compactionSkipped(ctx, compactTriggerAuto)
 		}
 		cli.historyCompactor.SetStatusCallback(nil)
 	}

--- a/cli/rewind.go
+++ b/cli/rewind.go
@@ -124,6 +124,7 @@ func (cli *ChatCLI) showRewindMenu() bool {
 
 	// Trim checkpoints to the restored point
 	cli.checkpoints = cli.checkpoints[:cpIdx+1]
+	cli.afterHistoryRestore()
 
 	fmt.Printf("  %s %s\n",
 		colorize("↩", ColorGreen),

--- a/cli/rewind_compact.go
+++ b/cli/rewind_compact.go
@@ -43,6 +43,15 @@ func (cli *ChatCLI) rememberPreCompaction() {
 	}
 }
 
+// dropPreCompactionSnapshot pops the newest undo snapshot (a compaction
+// that changed nothing has nothing to undo).
+func (cli *ChatCLI) dropPreCompactionSnapshot() {
+	if cli == nil || len(cli.preCompaction) == 0 {
+		return
+	}
+	cli.preCompaction = cli.preCompaction[:len(cli.preCompaction)-1]
+}
+
 // errNoCompactionToUndo marks a /rewind compact with nothing to restore.
 var errNoCompactionToUndo = errors.New("no compaction to undo")
 
@@ -85,10 +94,7 @@ func (cli *ChatCLI) undoCompaction() bool {
 	before := len(cli.history)
 	cli.saveCheckpoint()
 	cli.history = history
-	cli.syncTranscript()
-	if cli.costTracker != nil {
-		cli.costTracker.NoteExpectedCacheRebuild()
-	}
+	cli.afterHistoryRestore()
 	fmt.Printf("  %s %s\n", colorize("↩", ColorGreen), i18n.T("rewind.compact.restored", before, len(cli.history), source))
 	return true
 }

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -3755,5 +3755,6 @@
   "cfg.sub.server.otel": "OpenTelemetry export",
   "mem.cmd.stats.locked_store": "LOCKED read-only: %s store (%s) is sealed and this process cannot open it — %s. Set CHATCLI_ENCRYPTION_KEY (or CHATCLI_ENCRYPTION_KEY_PREVIOUS after a rotation); nothing is written until it opens.",
   "cfg.kv.sec.atrest_locked": "Locked stores",
-  "cfg.val.sec.atrest_locked": "%s — sealed with a key this process does not have; writes refused to protect them"
+  "cfg.val.sec.atrest_locked": "%s — sealed with a key this process does not have; writes refused to protect them",
+  "compact.nothing_to_compact": "Nothing to compact: the history already fits."
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -3755,5 +3755,6 @@
   "cfg.sub.server.otel": "OpenTelemetry export",
   "mem.cmd.stats.locked_store": "LOCKED read-only: %s store (%s) is sealed and this process cannot open it — %s. Set CHATCLI_ENCRYPTION_KEY (or CHATCLI_ENCRYPTION_KEY_PREVIOUS after a rotation); nothing is written until it opens.",
   "cfg.kv.sec.atrest_locked": "Locked stores",
-  "cfg.val.sec.atrest_locked": "%s — sealed with a key this process does not have; writes refused to protect them"
+  "cfg.val.sec.atrest_locked": "%s — sealed with a key this process does not have; writes refused to protect them",
+  "compact.nothing_to_compact": "Nothing to compact: the history already fits."
 }

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -3755,5 +3755,6 @@
   "cfg.sub.server.otel": "Exportação OpenTelemetry",
   "mem.cmd.stats.locked_store": "TRAVADO somente leitura: store %s (%s) está selado e este processo não consegue abri-lo — %s. Defina CHATCLI_ENCRYPTION_KEY (ou CHATCLI_ENCRYPTION_KEY_PREVIOUS após rotação); nada é gravado até abrir.",
   "cfg.kv.sec.atrest_locked": "Stores travados",
-  "cfg.val.sec.atrest_locked": "%s — selados com uma chave que este processo não tem; escritas recusadas para protegê-los"
+  "cfg.val.sec.atrest_locked": "%s — selados com uma chave que este processo não tem; escritas recusadas para protegê-los",
+  "compact.nothing_to_compact": "Nada a compactar: o histórico já cabe."
 }


### PR DESCRIPTION
## Summary

Audit III, PR 4 (P1 CMP-3, CMP-5; P2 CMP-10, CMP-11).

- **Verbatim pairing (CMP-3).** `PreserveVerbatim` tool results re-appended by Level 2, Level 3 or guided `/compact` without their owning assistant tool call are downgraded to user-role messages (content kept, flag kept), so `EnsureToolResultPairing` never removes them as orphans. PreserveVerbatim now actually holds for native tools.
- **Convergence (CMP-5).** Verbatim messages are capped at 25% of the character budget: beyond it the oldest are archived to CCR (when a layer exists), replaced by a stub carrying the `@recall` marker and lose the flag. A pinned corpus larger than the budget now converges instead of triggering Level 1/2/3 on every turn.
- **Skipped compactions (CMP-10).** Every compaction site (chat, agent/coder, one-shot, `/compact` automatic and guided, overflow recovery) closes a run that changed nothing by popping the undo snapshot and firing the paired `PostCompact` hook with `outcome=skipped` (`CHATCLI_HOOK_OUTCOME`; `applied` otherwise). `/rewind compact` can no longer "restore" an identical history. `/compact` on a history that already fits says so.
- **Shared restore (CMP-11).** `/rewind` checkpoint restore and `/rewind compact` use one post-restore helper: journal rewrite, expected cache rebuild noted, undo stack cleared.

i18n (en, en-US, pt-BR) for the new notice; hooks docs and the recovery guarantees updated.

## Tests

`cli/audit3_pr4_test.go`: verbatim tool result survives Level 2 plus pairing repair as a user message; oversized verbatim corpus converges with recall-marked stubs; skipped compaction pops the snapshot and undo is a no-op; checkpoint restore clears the undo stack and journals a rewrite. Full suite, golangci-lint and the local gates are green.