### PR TITLE
fix(cost): attribute usage to the call that produced it — summarizer, memory worker, streaming, Gemini thinking, provider resets

### DIFF
--- a/cli/audit2_p1_test.go
+++ b/cli/audit2_p1_test.go
@@ -19,15 +19,20 @@ import (
 type countingSummarizer struct {
 	calls   int
 	summary string
-	usage   *models.UsageInfo
+	usage   *models.UsageInfo // template; a fresh copy is stored per call, like real clients
+	last    *models.UsageInfo
 }
 
 func (c *countingSummarizer) GetModelName() string { return "counting" }
 func (c *countingSummarizer) SendPrompt(context.Context, string, []models.Message, int) (string, error) {
 	c.calls++
+	if c.usage != nil {
+		u := *c.usage
+		c.last = &u
+	}
 	return c.summary, nil
 }
-func (c *countingSummarizer) LastUsage() *models.UsageInfo { return c.usage }
+func (c *countingSummarizer) LastUsage() *models.UsageInfo { return c.last }
 
 func verbatimFixture() []models.Message {
 	h := []models.Message{{Role: "system", Content: "charter"}}
@@ -57,7 +62,7 @@ func hasVerbatim(h []models.Message) (int, bool) {
 func TestStructuredSummarize_KeepsPreserveVerbatimAfterSummary(t *testing.T) {
 	hc := NewHistoryCompactor(zap.NewNop())
 	cfg := CompactConfig{MinKeepRecent: 2}
-	got, err := hc.structuredSummarize(context.Background(), verbatimFixture(), &countingSummarizer{summary: strings.Repeat("## Summary\n- point ", 8)}, cfg)
+	got, _, err := hc.structuredSummarize(context.Background(), verbatimFixture(), &countingSummarizer{summary: strings.Repeat("## Summary\n- point ", 8)}, cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -129,7 +134,7 @@ func TestSummaryPassesGate(t *testing.T) {
 func TestStructuredSummarize_QualityGateRetriesThenFails(t *testing.T) {
 	hc := NewHistoryCompactor(zap.NewNop())
 	s := &countingSummarizer{summary: "I'm sorry, I cannot summarize this conversation for you today."}
-	_, err := hc.structuredSummarize(context.Background(), summarizeFixtureHistory(2), s, CompactConfig{MinKeepRecent: 2})
+	_, _, err := hc.structuredSummarize(context.Background(), summarizeFixtureHistory(2), s, CompactConfig{MinKeepRecent: 2})
 	if err == nil || s.calls != 2 {
 		t.Fatalf("a refusal must be retried once then rejected: err=%v calls=%d", err, s.calls)
 	}

--- a/cli/audit3_pr4_test.go
+++ b/cli/audit3_pr4_test.go
@@ -28,7 +28,7 @@ func TestVerbatimToolResult_SurvivesPairingAfterLevel2(t *testing.T) {
 		models.Message{Role: "tool", ToolCallID: "r1", Content: "RECALLED ORIGINAL " + strings.Repeat("x", 300), Meta: &models.MessageMeta{PreserveVerbatim: true}},
 		models.Message{Role: "assistant", Content: strings.Repeat("more answer ", 50)},
 		models.Message{Role: "user", Content: "recent 1"}, models.Message{Role: "user", Content: "recent 2"})
-	out, err := hc.structuredSummarize(context.Background(), h, &countingSummarizer{summary: strings.Repeat("## Summary\n- point ", 8)}, CompactConfig{MinKeepRecent: 2})
+	out, _, err := hc.structuredSummarize(context.Background(), h, &countingSummarizer{summary: strings.Repeat("## Summary\n- point ", 8)}, CompactConfig{MinKeepRecent: 2})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli/audit3_pr5_test.go
+++ b/cli/audit3_pr5_test.go
@@ -1,0 +1,124 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+func TestSummarizerUsage_OnlyFromItsOwnCall(t *testing.T) {
+	hc := NewHistoryCompactor(zap.NewNop())
+	// The client carries sticky usage from a previous interactive turn.
+	stale := &models.UsageInfo{PromptTokens: 9999, CompletionTokens: 9, IsReal: true}
+	s := &countingSummarizer{summary: strings.Repeat("## Summary\n- point ", 8), usage: stale}
+	// External engine serves the summary: the model is not called, no usage.
+	cfg := CompactConfig{MinKeepRecent: 2, ExternalSummarizer: engineFunc(func(context.Context, string, int, string) (string, error) {
+		return strings.Repeat("## External\n- point ", 8), nil
+	})}
+	_, usage, err := hc.structuredSummarize(context.Background(), summarizeFixtureHistory(2), s, cfg)
+	if err != nil || usage != nil || s.calls != 0 {
+		t.Fatalf("no model call → no usage: usage=%v calls=%d err=%v", usage, s.calls, err)
+	}
+	// Too-short history: early return, no usage.
+	if _, usage, _ := hc.structuredSummarize(context.Background(), summarizeFixtureHistory(2)[:3], s, CompactConfig{MinKeepRecent: 2}); usage != nil {
+		t.Fatal("early return must not book the stale usage")
+	}
+	// Real call: the client stores a fresh pointer → attributed.
+	fresh := &models.UsageInfo{PromptTokens: 100, CompletionTokens: 20, IsReal: true}
+	s2 := &usageSwitchingSummarizer{summary: strings.Repeat("## Summary\n- point ", 8), before: stale, after: fresh}
+	_, usage, err = hc.structuredSummarize(context.Background(), summarizeFixtureHistory(2), s2, CompactConfig{MinKeepRecent: 2})
+	if err != nil || usage != fresh {
+		t.Fatalf("the summarizer's own call must be attributed: %v %v", usage, err)
+	}
+	if sumUsage(nil, fresh) != fresh || sumUsage(fresh, nil) != fresh || sumUsage(fresh, fresh).PromptTokens != 200 {
+		t.Fatal("sumUsage")
+	}
+}
+
+// usageSwitchingSummarizer reports `before` until its first call, then `after`.
+type usageSwitchingSummarizer struct {
+	summary       string
+	before, after *models.UsageInfo
+	called        bool
+}
+
+func (u *usageSwitchingSummarizer) GetModelName() string { return "switching" }
+func (u *usageSwitchingSummarizer) SendPrompt(context.Context, string, []models.Message, int) (string, error) {
+	u.called = true
+	return u.summary, nil
+}
+func (u *usageSwitchingSummarizer) LastUsage() *models.UsageInfo {
+	if u.called {
+		return u.after
+	}
+	return u.before
+}
+
+func TestGeminiReasoningTokens_BilledAdditively(t *testing.T) {
+	usage := &models.UsageInfo{PromptTokens: 1000, CompletionTokens: 100, ReasoningTokens: 900, TotalTokens: 2000, IsReal: true}
+	gemini := estimateTurnCostUSD("googleai", "gemini-3.1-pro", usage)
+	base := estimateTurnCostUSD("googleai", "gemini-3.1-pro", &models.UsageInfo{PromptTokens: 1000, CompletionTokens: 100, TotalTokens: 1100, IsReal: true})
+	if !(gemini > base) {
+		t.Fatalf("thinking tokens must add to Gemini output cost: %f vs %f", gemini, base)
+	}
+	openai := estimateTurnCostUSD("openai", "gpt-5.6-terra", usage)
+	openaiBase := estimateTurnCostUSD("openai", "gpt-5.6-terra", &models.UsageInfo{PromptTokens: 1000, CompletionTokens: 100, TotalTokens: 1100, IsReal: true})
+	if openai != openaiBase {
+		t.Fatal("OpenAI reasoning tokens are already inside completion tokens")
+	}
+}
+
+func TestStreamingWithoutUsage_BooksAnEstimate(t *testing.T) {
+	ct := NewCostTracker()
+	ct.RecordRealUsage("openai", "gpt-5.6-terra", models.EstimateFromChars(40_000, 4_000))
+	if ct.TotalTokens() == 0 || ct.TotalCost() <= 0 {
+		t.Fatalf("an estimate must be counted: tokens=%d cost=%f", ct.TotalTokens(), ct.TotalCost())
+	}
+}
+
+func TestMemoryWorker_BudgetGateAndRequeueCap(t *testing.T) {
+	t.Setenv("CHATCLI_SESSION_BUDGET_USD", "0.01")
+	t.Setenv("CHATCLI_BUDGET_HARD_STOP", "true")
+	active := &scriptedClient{name: "claude", response: "NOTHING_NEW"}
+	mw := newResilienceWorker(t, active)
+	mw.cli.costTracker = NewCostTracker()
+	mw.cli.costTracker.RecordRealUsage("openai", "gpt-5.6-terra", &models.UsageInfo{PromptTokens: 5_000_000, CompletionTokens: 10, TotalTokens: 5_000_010, IsReal: true})
+	if _, err := mw.callExtraction(context.Background(), "p", nil); err == nil {
+		t.Fatal("the budget hard stop must gate background extraction")
+	}
+	t.Setenv("CHATCLI_BUDGET_HARD_STOP", "false")
+	mw.cli.costTracker.ReloadBudget()
+	// A segment whose provider keeps failing is retried once, then dropped.
+	atomic.StoreInt32(&active.failN, 99)
+	segment := []models.Message{{Role: "user", Content: "fato importante"}}
+	if _, err := mw.persistPending(segment); err != nil {
+		t.Fatal(err)
+	}
+	mw.drainPending(context.Background())
+	if got := len(mw.pendingFiles()); got != 1 {
+		t.Fatalf("first failure keeps the segment: %d", got)
+	}
+	mw.drainPending(context.Background())
+	if got := len(mw.pendingFiles()); got != 0 {
+		t.Fatalf("second failure drops it: %d", got)
+	}
+	// An unparseable reply is a failure (queued), not "nothing new".
+	if looksLikeExtraction("I cannot help with that") || !looksLikeExtraction("## DAILY\n- x") {
+		t.Fatal("looksLikeExtraction")
+	}
+	_ = errors.New
+	_ = os.Remove
+	_ = filepath.Join
+}

--- a/cli/chat_pipeline.go
+++ b/cli/chat_pipeline.go
@@ -770,9 +770,16 @@ func (cli *ChatCLI) executeStreamingTurn(
 	if result.WasStalled {
 		fmt.Printf("\n%s\n", colorize(i18n.T("sw.cmd.stream_stalled"), ColorYellow))
 	}
-	if result.Usage != nil && cli.costTracker != nil {
-		cli.costTracker.RecordRealUsage(resolution.Provider, resolution.Model, result.Usage)
-		cli.observeTokenCalibrationChars(resolution.Provider, resolution.Model, cli.lastPromptChars, result.Usage)
+	if cli.costTracker != nil {
+		usage := result.Usage
+		if usage == nil {
+			// A stream that ended without a usage block (a gateway that
+			// ignores stream_options, a cancelled or stalled stream) is not
+			// free: book a character estimate, flagged as such.
+			usage = models.EstimateFromChars(cli.lastPromptChars, len(result.Text))
+		}
+		cli.costTracker.RecordRealUsage(resolution.Provider, resolution.Model, usage)
+		cli.observeTokenCalibrationChars(resolution.Provider, resolution.Model, cli.lastPromptChars, usage)
 		cli.maybeAnnounceBudget()
 		cli.maybeAnnounceCacheMisses()
 	}

--- a/cli/compact_command.go
+++ b/cli/compact_command.go
@@ -162,12 +162,17 @@ CONVERSATION TO COMPACT:
 			cli.logger.Warn("context engine failed on guided compaction; using the session model", zap.Error(err))
 		}
 	}
+	var guidedUsage *models.UsageInfo
 	if strings.TrimSpace(response) == "" {
+		before := usageSnapshot(summarizer)
 		response, err = summarizer.SendPrompt(summarizeCtx, prompt, summaryHistory, 0)
+		guidedUsage = usageOfCall(summarizer, before)
 		// Auto-retry on OAuth token expiration (401)
 		if usingSession && cli.refreshClientOnAuthError(err) {
 			summarizer = cli.Client
+			before = usageSnapshot(summarizer)
 			response, err = summarizer.SendPrompt(summarizeCtx, prompt, summaryHistory, 0)
+			guidedUsage = usageOfCall(summarizer, before)
 		}
 	}
 	if err != nil {
@@ -212,7 +217,7 @@ CONVERSATION TO COMPACT:
 	result = append(result, cli.history[recentStart:]...)
 
 	cli.history = result
-	rep := CompactReport{Level: 2, SummaryUsage: summarizerUsage(cli.Client, cfg), SummaryProvider: cfg.SummarizerProvider, SummaryModel: cfg.SummarizerModel}
+	rep := CompactReport{Level: 2, SummaryUsage: guidedUsage, SummaryProvider: cfg.SummarizerProvider, SummaryModel: cfg.SummarizerModel}
 	if rep.SummaryProvider == "" {
 		rep.SummaryProvider, rep.SummaryModel = cli.Provider, cli.Model
 	}

--- a/cli/compact_config_test.go
+++ b/cli/compact_config_test.go
@@ -99,11 +99,11 @@ func TestStructuredSummarize_UsesConfiguredSummarizer(t *testing.T) {
 	}
 	cfg := CompactConfig{Provider: "CLAUDEAI", Model: "claude-sonnet-5", BudgetRatio: 0.75, MinKeepRecent: 4, CharsPerToken: 4}
 
-	if _, err := hc.structuredSummarize(context.Background(), history, session, cfg); err != nil {
+	if _, _, err := hc.structuredSummarize(context.Background(), history, session, cfg); err != nil {
 		t.Fatalf("summarize: %v", err)
 	}
 	cfg.SummarizerClient = cheap
-	if _, err := hc.structuredSummarize(context.Background(), history, session, cfg); err != nil {
+	if _, _, err := hc.structuredSummarize(context.Background(), history, session, cfg); err != nil {
 		t.Fatalf("summarize with cheap model: %v", err)
 	}
 	if len(calls) != 2 || calls[0] != "session" || calls[1] != "cheap" {

--- a/cli/cost_command.go
+++ b/cli/cost_command.go
@@ -267,10 +267,7 @@ func (cli *ChatCLI) renderCostSummary() {
 		fmt.Println(p + "    " + colorize(i18n.T("cost.cmd.embeddings",
 			ct.embeddingCalls, formatTokenCount(ct.embeddingTokens), fmt.Sprintf("$%.4f", ct.embeddingCostUSD)), ColorGray))
 	}
-	if ct.compactions > 0 {
-		fmt.Println(p + "    " + colorize(i18n.T("cost.cmd.compactions",
-			ct.compactions, ct.compactionsLevel3, fmt.Sprintf("$%.4f", ct.compactionCostUSD)), ColorGray))
-	}
+	printBackgroundCostLines(p, ct)
 	// Session prompt-cache telemetry: hit share, misses, rebuilds ChatCLI
 	// itself caused (compaction), and whether the prefix is still warm.
 	if stats := ct.cacheStatsLocked(); stats.Reported() {

--- a/cli/cost_compaction.go
+++ b/cli/cost_compaction.go
@@ -11,6 +11,13 @@
  */
 package cli
 
+import (
+	"fmt"
+
+	"github.com/diillson/chatcli/i18n"
+	"github.com/diillson/chatcli/models"
+)
+
 // RecordCompaction accounts one Compact run from its report.
 func (ct *CostTracker) RecordCompaction(rep CompactReport) {
 	if ct == nil || rep.Level == 0 {
@@ -28,6 +35,44 @@ func (ct *CostTracker) RecordCompaction(rep CompactReport) {
 	}
 	ct.compactionCostUSD += cost
 	ct.mu.Unlock()
+}
+
+// RecordMemoryUsage accounts one background memory-worker call
+// (extraction, rollup, memory compaction): the usage joins the totals
+// like any request and the memory slice is kept apart for /cost.
+func (ct *CostTracker) RecordMemoryUsage(provider, model string, usage *models.UsageInfo) {
+	if ct == nil || usage == nil {
+		return
+	}
+	cost := estimateTurnCostUSD(provider, model, usage)
+	ct.RecordRealUsage(provider, model, usage)
+	ct.mu.Lock()
+	ct.memoryCalls++
+	ct.memoryCostUSD += cost
+	ct.mu.Unlock()
+}
+
+// MemoryStats returns the session's background memory-worker counters.
+func (ct *CostTracker) MemoryStats() (calls int, costUSD float64) {
+	if ct == nil {
+		return 0, 0
+	}
+	ct.mu.RLock()
+	defer ct.mu.RUnlock()
+	return ct.memoryCalls, ct.memoryCostUSD
+}
+
+// printBackgroundCostLines renders the /cost lines for spend that no
+// interactive turn owns: the memory worker and the compaction summarizer
+// (caller holds ct.mu read lock).
+func printBackgroundCostLines(p string, ct *CostTracker) {
+	if ct.memoryCalls > 0 {
+		fmt.Println(p + "    " + colorize(i18n.T("cost.cmd.memory_worker", ct.memoryCalls, fmt.Sprintf("$%.4f", ct.memoryCostUSD)), ColorGray))
+	}
+	if ct.compactions > 0 {
+		fmt.Println(p + "    " + colorize(i18n.T("cost.cmd.compactions",
+			ct.compactions, ct.compactionsLevel3, fmt.Sprintf("$%.4f", ct.compactionCostUSD)), ColorGray))
+	}
 }
 
 // CompactionStats returns the session's compaction counters.

--- a/cli/cost_tracker.go
+++ b/cli/cost_tracker.go
@@ -116,6 +116,8 @@ type SessionCostData struct {
 	EmbeddingCalls         int     `json:"embedding_calls,omitempty"`
 	EmbeddingTokens        int64   `json:"embedding_tokens,omitempty"`
 	EmbeddingCostUSD       float64 `json:"embedding_cost_usd,omitempty"`
+	MemoryCalls            int     `json:"memory_calls,omitempty"`
+	MemoryCostUSD          float64 `json:"memory_cost_usd,omitempty"`
 	Compactions            int     `json:"compactions,omitempty"`
 	CompactionsLevel3      int     `json:"compactions_level3,omitempty"`
 	CompactionCostUSD      float64 `json:"compaction_cost_usd,omitempty"`
@@ -173,6 +175,8 @@ type CostTracker struct {
 	cacheStorageTokenHours float64
 	cacheStorageUSD        float64
 	compactions            int
+	memoryCalls            int
+	memoryCostUSD          float64
 	embeddingCalls         int
 	embeddingTokens        int64
 	embeddingCostUSD       float64
@@ -476,6 +480,8 @@ func (ct *CostTracker) snapshotLocked() SessionCostData {
 		EmbeddingCalls:         ct.embeddingCalls,
 		EmbeddingTokens:        ct.embeddingTokens,
 		EmbeddingCostUSD:       ct.embeddingCostUSD,
+		MemoryCalls:            ct.memoryCalls,
+		MemoryCostUSD:          ct.memoryCostUSD,
 		Compactions:            ct.compactions,
 		CompactionsLevel3:      ct.compactionsLevel3,
 		CompactionCostUSD:      ct.compactionCostUSD,
@@ -635,6 +641,8 @@ func (ct *CostTracker) RestoreSession(sessionID string) error {
 	ct.embeddingCalls = data.EmbeddingCalls
 	ct.embeddingTokens = data.EmbeddingTokens
 	ct.embeddingCostUSD = data.EmbeddingCostUSD
+	ct.memoryCalls = data.MemoryCalls
+	ct.memoryCostUSD = data.MemoryCostUSD
 	ct.compactions = data.Compactions
 	ct.compactionsLevel3 = data.CompactionsLevel3
 	ct.compactionCostUSD = data.CompactionCostUSD
@@ -742,6 +750,17 @@ func (ct *CostTracker) getOrCreateRecord(key, provider, model string) *ModelUsag
 	return rec
 }
 
+// reasoningTokensAdditive reports whether a provider's reasoning tokens are
+// reported outside the completion count (Gemini) and must be billed on
+// top of it.
+func reasoningTokensAdditive(provider string) bool {
+	switch strings.ToUpper(strings.TrimSpace(provider)) {
+	case "GOOGLEAI", "GEMINI", "GOOGLE":
+		return true
+	}
+	return false
+}
+
 // recomputeRecordCost prices one record in place — the ONLY cost formula
 // in the tracker; estimateTurnCostUSD delegates here so per-turn and
 // per-session math can never disagree.
@@ -765,6 +784,13 @@ func recomputeRecordCost(rec *ModelUsageRecord) {
 	completionTokens := unbilled(rec.CompletionTokens, rec.BilledCompletionTokens)
 	cacheRead := unbilled(rec.CacheReadTokens, rec.BilledCacheReadTokens)
 	cacheCreation := unbilled(rec.CacheCreationTokens, rec.BilledCacheCreationTokens)
+
+	// Gemini reports thinking tokens (thoughtsTokenCount) OUTSIDE the
+	// candidates count and bills them as output; OpenAI's reasoning tokens
+	// are already inside completion_tokens. Add them only where additive.
+	if reasoningTokensAdditive(rec.Provider) {
+		completionTokens += unbilled(rec.ReasoningTokens, 0)
+	}
 
 	billableInput := promptTokens
 	if !cacheTokensAdditive(rec.Provider, rec.Model) && cacheRead > 0 && cacheReadCost > 0 {
@@ -887,6 +913,7 @@ func estimateTurnCostUSD(provider, model string, usage *models.UsageInfo) float6
 	// session tracker applies — a second hand-rolled formula here is how the
 	// footer and /cost drift apart.
 	rec := &ModelUsageRecord{
+		ReasoningTokens:       int64(usage.ReasoningTokens),
 		Provider:              provider,
 		Model:                 model,
 		PromptTokens:          int64(usage.PromptTokens),

--- a/cli/extension_compactor_test.go
+++ b/cli/extension_compactor_test.go
@@ -50,7 +50,7 @@ func TestStructuredSummarize_ContextEngineReplacesAndFallsBack(t *testing.T) {
 		}
 		return "ENGINE SUMMARY\n## Files Read\n- none of note\n## Current Task State\n- the user asked for a refactor of the parser and the assistant delivered it", nil
 	})
-	out, err := hc.structuredSummarize(context.Background(), compactableHistory(), stub, cfg)
+	out, _, err := hc.structuredSummarize(context.Background(), compactableHistory(), stub, cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -59,7 +59,7 @@ func TestStructuredSummarize_ContextEngineReplacesAndFallsBack(t *testing.T) {
 	}
 
 	cfg.ExternalSummarizer = engineFunc(func(context.Context, string, int, string) (string, error) { return "", errors.New("engine down") })
-	out, err = hc.structuredSummarize(context.Background(), compactableHistory(), stub, cfg)
+	out, _, err = hc.structuredSummarize(context.Background(), compactableHistory(), stub, cfg)
 	if err != nil || stub.calls != 1 || !strings.Contains(out[0].Content, "EMBEDDED SUMMARY") {
 		t.Fatalf("engine failure must fall back: err=%v calls=%d", err, stub.calls)
 	}

--- a/cli/history_compactor.go
+++ b/cli/history_compactor.go
@@ -390,8 +390,7 @@ func (hc *HistoryCompactor) Compact(
 			zap.Int("remaining", hc.l2Backoff))
 	} else {
 		hc.emitStatus(CompactStageSummarize, i18n.T("compact.status.summarize"))
-		summarized, err = hc.structuredSummarize(ctx, history, llmClient, cfg)
-		rep.SummaryUsage = summarizerUsage(llmClient, cfg)
+		summarized, rep.SummaryUsage, err = hc.structuredSummarize(ctx, history, llmClient, cfg)
 	}
 	if err != nil {
 		// A cancellation from the user should propagate, not silently fall
@@ -456,13 +455,26 @@ func (hc *HistoryCompactor) Compact(
 // errL2Backoff marks a Level 2 skipped by the back-off (not a failure).
 var errL2Backoff = errors.New("level 2 skipped by back-off")
 
-// summarizerUsage reads what the Level 2 call consumed from the client
-// that served it (the configured summarizer, else the session client).
-func summarizerUsage(llmClient client.LLMClient, cfg CompactConfig) *models.UsageInfo {
-	c := llmClient
-	if cfg.SummarizerClient != nil {
-		c = cfg.SummarizerClient
+// usageOfCall returns the usage a client reported for the call made
+// between snapshot (its LastUsage before the call) and now — nil when the
+// client did not report new usage (the call did not happen, failed, or the
+// client keeps no usage). Comparing pointers, not values: providers store a
+// fresh UsageInfo per request, and the sticky previous one must never be
+// re-booked as this call's spend.
+func usageOfCall(c client.LLMClient, snapshot *models.UsageInfo) *models.UsageInfo {
+	ua, ok := c.(client.UsageAwareClient)
+	if !ok || ua == nil {
+		return nil
 	}
+	now := ua.LastUsage()
+	if now == nil || now == snapshot {
+		return nil
+	}
+	return now
+}
+
+// usageSnapshot reads a client's current LastUsage pointer (nil-safe).
+func usageSnapshot(c client.LLMClient) *models.UsageInfo {
 	if ua, ok := c.(client.UsageAwareClient); ok && ua != nil {
 		return ua.LastUsage()
 	}
@@ -564,7 +576,7 @@ func (hc *HistoryCompactor) structuredSummarize(
 	history []models.Message,
 	llmClient client.LLMClient,
 	cfg CompactConfig,
-) ([]models.Message, error) {
+) ([]models.Message, *models.UsageInfo, error) {
 	// Find boundaries: [system messages | middle (to summarize) | recent (keep verbatim)]
 	systemEnd := 0
 	for i, msg := range history {
@@ -579,12 +591,12 @@ func (hc *HistoryCompactor) structuredSummarize(
 	recentStart = snapToToolBlockBoundary(history, recentStart, systemEnd)
 	if recentStart <= systemEnd {
 		// Not enough messages to split — nothing to summarize
-		return history, nil
+		return history, nil, nil
 	}
 
 	middleMessages, verbatim := splitVerbatim(history[systemEnd:recentStart])
 	if len(middleMessages) < 4 {
-		return history, nil
+		return history, nil, nil
 	}
 
 	// Build input for the summarizer: budgeted against the summarizer's
@@ -612,6 +624,7 @@ func (hc *HistoryCompactor) structuredSummarize(
 	}
 	var response string
 	var err error
+	var usage *models.UsageInfo
 	if cfg.ExternalSummarizer != nil {
 		response, err = cfg.ExternalSummarizer.Compact(summarizeCtx, segment, summarizerInputBudget(cfg), "")
 		if err != nil && hc.logger != nil {
@@ -619,9 +632,11 @@ func (hc *HistoryCompactor) structuredSummarize(
 		}
 	}
 	if strings.TrimSpace(response) == "" {
+		before := usageSnapshot(summarizer)
 		response, err = summarizer.SendPrompt(summarizeCtx, prompt, summaryHistory, 0)
+		usage = usageOfCall(summarizer, before)
 		if err != nil {
-			return nil, fmt.Errorf("structured summarization LLM call failed: %w", err)
+			return nil, usage, fmt.Errorf("structured summarization LLM call failed: %w", err)
 		}
 	}
 	// Quality gate: a refusal, an empty or a truncated answer must never
@@ -631,12 +646,16 @@ func (hc *HistoryCompactor) structuredSummarize(
 		hc.logger.Warn("Level 2 summary rejected by the quality gate; retrying once",
 			zap.Int("chars", len(strings.TrimSpace(response))))
 		hc.emitStatus(CompactStageSummarize, i18n.T("compact.status.summary_retry"))
+		before := usageSnapshot(summarizer)
 		response, err = summarizer.SendPrompt(summarizeCtx, prompt, summaryHistory, 0)
+		if u := usageOfCall(summarizer, before); u != nil {
+			usage = sumUsage(usage, u)
+		}
 		if err != nil {
-			return nil, fmt.Errorf("structured summarization retry failed: %w", err)
+			return nil, usage, fmt.Errorf("structured summarization retry failed: %w", err)
 		}
 		if !summaryPassesGate(response, len(segment)) {
-			return nil, errSummaryRejected
+			return nil, usage, errSummaryRejected
 		}
 	}
 
@@ -665,7 +684,27 @@ func (hc *HistoryCompactor) structuredSummarize(
 	result = append(result, downgradeVerbatimResults(verbatim)...)
 	result = append(result, history[recentStart:]...)
 
-	return result, nil
+	return result, usage, nil
+}
+
+// sumUsage adds two usage records (nil-safe) so a retried summary bills
+// both calls.
+func sumUsage(a, b *models.UsageInfo) *models.UsageInfo {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+	out := *a
+	out.PromptTokens += b.PromptTokens
+	out.CompletionTokens += b.CompletionTokens
+	out.TotalTokens += b.TotalTokens
+	out.CacheReadInputTokens += b.CacheReadInputTokens
+	out.CacheCreationInputTokens += b.CacheCreationInputTokens
+	out.CacheCreation1hInputTokens += b.CacheCreation1hInputTokens
+	out.ReasoningTokens += b.ReasoningTokens
+	return &out
 }
 
 // errSummaryRejected marks a summary that failed the quality gate twice.

--- a/cli/history_compactor_archive_test.go
+++ b/cli/history_compactor_archive_test.go
@@ -46,7 +46,7 @@ func TestStructuredSummarize_ArchivesMiddleSegment(t *testing.T) {
 	cfg := CompactConfig{MinKeepRecent: 2}
 	history := summarizeFixtureHistory(cfg.MinKeepRecent)
 
-	got, err := hc.structuredSummarize(context.Background(), history, summarizerFake{}, cfg)
+	got, _, err := hc.structuredSummarize(context.Background(), history, summarizerFake{}, cfg)
 	if err != nil {
 		t.Fatalf("structuredSummarize: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestStructuredSummarize_NoLayerKeepsLegacyBehavior(t *testing.T) {
 	hc := NewHistoryCompactor(zap.NewNop())
 	cfg := CompactConfig{MinKeepRecent: 2}
 
-	got, err := hc.structuredSummarize(context.Background(), summarizeFixtureHistory(cfg.MinKeepRecent), summarizerFake{}, cfg)
+	got, _, err := hc.structuredSummarize(context.Background(), summarizeFixtureHistory(cfg.MinKeepRecent), summarizerFake{}, cfg)
 	if err != nil {
 		t.Fatalf("structuredSummarize: %v", err)
 	}

--- a/cli/history_compactor_blocksnap_test.go
+++ b/cli/history_compactor_blocksnap_test.go
@@ -69,7 +69,7 @@ func TestStructuredSummarize_TooSmallReturnsUnchanged(t *testing.T) {
 		{Role: "assistant", Content: "a"},
 		{Role: "user", Content: "u2"},
 	}
-	out, err := hc.structuredSummarize(context.Background(), history, nil, cfg)
+	out, _, err := hc.structuredSummarize(context.Background(), history, nil, cfg)
 	require.NoError(t, err)
 	assert.Equal(t, history, out)
 }
@@ -89,7 +89,7 @@ func TestStructuredSummarize_SnapKeepsToolBlockIntact(t *testing.T) {
 		{Role: "assistant", ToolCalls: []models.ToolCall{{ID: "web_fetch:0", Name: "web_fetch"}}},
 		models.NewToolResultMessage("web_fetch:0", "out", false, ""),
 	}
-	out, err := hc.structuredSummarize(context.Background(), history, nil, cfg)
+	out, _, err := hc.structuredSummarize(context.Background(), history, nil, cfg)
 	require.NoError(t, err)
 	assert.True(t, agent.ValidateToolResultPairing(out))
 }

--- a/cli/memory_pending.go
+++ b/cli/memory_pending.go
@@ -53,12 +53,21 @@ const (
 type pendingSegment struct {
 	CreatedAt time.Time        `json:"created_at"`
 	Messages  []models.Message `json:"messages"`
+	// Attempts counts drains that failed on this segment; it is dropped
+	// after pendingMaxAttempts so an unparseable reply cannot wedge the
+	// queue forever (one requeue, then gone).
+	Attempts int `json:"attempts,omitempty"`
 }
+
+// pendingMaxAttempts is how many failed drains a queued segment survives.
+const pendingMaxAttempts = 2
 
 // extractionClient pairs a provider name with its client for the fallback walk.
 type extractionClient struct {
-	name string
+	name string // provider name, for the fallback dedup and the logs
 	llm  client.LLMClient
+	// provider/model the usage is booked under ("" = the session's)
+	provider, model string
 }
 
 // extractionClients returns the clients to try for one extraction, in order:
@@ -68,8 +77,8 @@ type extractionClient struct {
 func (mw *memoryWorker) extractionClients() []extractionClient {
 	out := make([]extractionClient, 0, 4)
 	active := strings.ToUpper(strings.TrimSpace(mw.cli.Provider))
-	if c := mw.cli.getClient(); c != nil {
-		out = append(out, extractionClient{name: active, llm: c})
+	if c, provider, model := mw.backgroundClient(); c != nil {
+		out = append(out, extractionClient{name: active, llm: c, provider: provider, model: model})
 	}
 	raw := strings.TrimSpace(os.Getenv(envMemoryFallbackProviders))
 	if raw == "" {
@@ -95,6 +104,11 @@ func (mw *memoryWorker) extractionClients() []extractionClient {
 // returning the first success. Each attempt gets its own timeout so a hung
 // provider cannot consume the whole budget of the ones behind it.
 func (mw *memoryWorker) callExtraction(parent context.Context, prompt string, history []models.Message) (string, error) {
+	// Background spend is spend: the same budget gate the interactive turns
+	// and the scheduler honor.
+	if err := mw.cli.budgetBlockedErr(); err != nil {
+		return "", err
+	}
 	clients := mw.extractionClients()
 	if len(clients) == 0 {
 		return "", fmt.Errorf("no LLM client available for memory extraction")
@@ -102,10 +116,14 @@ func (mw *memoryWorker) callExtraction(parent context.Context, prompt string, hi
 	errs := make([]string, 0, len(clients))
 	for i, ec := range clients {
 		ctx, cancel := context.WithTimeout(parent, memoryExtractTimeout)
+		before := usageSnapshot(ec.llm)
 		response, err := ec.llm.SendPrompt(ctx, prompt, history, 0)
+		mw.recordUsage(ec, usageOfCall(ec.llm, before))
 		if mw.cli.refreshClientOnAuthError(err) {
 			if c := mw.cli.getClient(); c != nil {
+				before = usageSnapshot(c)
 				response, err = c.SendPrompt(ctx, prompt, history, 0)
+				mw.recordUsage(ec, usageOfCall(c, before))
 			}
 		}
 		cancel()
@@ -161,6 +179,72 @@ func (mw *memoryWorker) persistPending(messages []models.Message) (string, error
 	return path, nil
 }
 
+// rewritePending persists an updated segment (attempt counter) in place.
+func (mw *memoryWorker) rewritePending(path string, seg pendingSegment) {
+	data, err := json.Marshal(seg)
+	if err != nil {
+		return
+	}
+	if data, err = atrest.Seal(data); err != nil {
+		return
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil { // #nosec G304 -- our own queue dir
+		return
+	}
+	_ = os.Rename(tmp, path)
+}
+
+// backgroundClient returns the client the memory worker's own calls use:
+// the configured compaction/summarizer model (CHATCLI_COMPACT_MODEL) when
+// there is one, else a DEDICATED instance of the session's provider/model.
+// Never the interactive session's client: provider clients keep sticky
+// usage state, and a background call sharing it clobbers (and is
+// clobbered by) the concurrent interactive turn's usage.
+func (mw *memoryWorker) backgroundClient() (client.LLMClient, string, string) {
+	cli := mw.cli
+	if cli == nil {
+		return nil, "", ""
+	}
+	if c := cli.compactSummarizerClient(); c != nil {
+		return c, cli.compactSummarizerProvider, cli.compactSummarizerModel
+	}
+	mw.mu.Lock()
+	key := cli.Provider + ":" + cli.Model
+	if mw.dedicated != nil && mw.dedicatedKey == key {
+		c := mw.dedicated
+		mw.mu.Unlock()
+		return c, cli.Provider, cli.Model
+	}
+	mw.mu.Unlock()
+	var c client.LLMClient
+	if cli.manager != nil {
+		if fresh, err := cli.manager.GetClient(cli.Provider, cli.Model); err == nil && fresh != nil {
+			c = fresh
+		}
+	}
+	if c == nil {
+		c = cli.getClient() // no manager (tests, degraded boot): share, but still record
+	}
+	mw.mu.Lock()
+	mw.dedicated, mw.dedicatedKey = c, key
+	mw.mu.Unlock()
+	return c, cli.Provider, cli.Model
+}
+
+// recordUsage books a background call under the memory slice of the cost
+// tracker (provider:model parsed from the chain entry's name).
+func (mw *memoryWorker) recordUsage(ec extractionClient, usage *models.UsageInfo) {
+	if usage == nil || mw.cli == nil || mw.cli.costTracker == nil {
+		return
+	}
+	provider, model := ec.provider, ec.model
+	if provider == "" || model == "" {
+		provider, model = mw.cli.Provider, mw.cli.Model
+	}
+	mw.cli.costTracker.RecordMemoryUsage(provider, model, usage)
+}
+
 // enforcePendingCap drops the oldest queued segments beyond pendingMaxFiles.
 func (mw *memoryWorker) enforcePendingCap() {
 	files := mw.pendingFiles()
@@ -208,8 +292,16 @@ func (mw *memoryWorker) drainPending(ctx context.Context) int {
 			continue
 		}
 		if err := mw.extractAndSave(ctx, seg.Messages); err != nil {
+			seg.Attempts++
+			if seg.Attempts >= pendingMaxAttempts {
+				mw.logger.Warn("Memory worker: pending segment failed repeatedly; dropping it",
+					zap.String("file", path), zap.Int("attempts", seg.Attempts), zap.Error(err))
+				_ = os.Remove(path)
+				continue
+			}
+			mw.rewritePending(path, seg)
 			mw.logger.Warn("Memory worker: pending segment still failing; will retry later",
-				zap.String("file", path), zap.Error(err))
+				zap.String("file", path), zap.Int("attempts", seg.Attempts), zap.Error(err))
 			break
 		}
 		_ = os.Remove(path)

--- a/cli/memory_worker.go
+++ b/cli/memory_worker.go
@@ -45,6 +45,10 @@ type memoryWorker struct {
 	// lookupFallback resolves a fallback provider client; indirected so tests
 	// exercise the chain without a full LLM manager.
 	lookupFallback func(provider string) (client.LLMClient, error)
+	// dedicated is the worker's own client instance (backgroundClient),
+	// keyed by provider:model so a session model switch rebuilds it.
+	dedicated    client.LLMClient
+	dedicatedKey string
 }
 
 const (
@@ -250,13 +254,7 @@ func (mw *memoryWorker) runRollups(ctx context.Context) {
 	}
 	mgr := mw.store.Manager()
 
-	var sendPrompt func(ctx context.Context, prompt string) (string, error)
-	if llmClient := mw.cli.getClient(); llmClient != nil {
-		sendPrompt = func(ctx context.Context, prompt string) (string, error) {
-			history := []models.Message{{Role: "user", Content: prompt}}
-			return llmClient.SendPrompt(ctx, prompt, history, 0)
-		}
-	}
+	sendPrompt := mw.backgroundSendPrompt()
 
 	written, err := mgr.RunRollups(ctx, sendPrompt)
 	if err != nil {
@@ -403,6 +401,25 @@ items (bug fixed, feature built, decision made, incident resolved) — never
 greetings, questions or plans that didn't happen. Skip the section entirely if
 no work was completed.`
 
+// backgroundSendPrompt returns the prompt function rollups and memory
+// compaction use: the worker's dedicated client, gated by the budget and
+// booked under the memory slice. Nil when no client is available.
+func (mw *memoryWorker) backgroundSendPrompt() func(ctx context.Context, prompt string) (string, error) {
+	c, provider, model := mw.backgroundClient()
+	if c == nil {
+		return nil
+	}
+	return func(ctx context.Context, prompt string) (string, error) {
+		if err := mw.cli.budgetBlockedErr(); err != nil {
+			return "", err
+		}
+		before := usageSnapshot(c)
+		out, err := c.SendPrompt(ctx, prompt, []models.Message{{Role: "user", Content: prompt}}, 0)
+		mw.recordUsage(extractionClient{name: provider, llm: c, provider: provider, model: model}, usageOfCall(c, before))
+		return out, err
+	}
+}
+
 // buildExtractionSnippet renders the conversation segment the memory
 // extractor sees. Secrets are redacted BEFORE truncation and before the
 // text reaches the extraction LLM, so a token pasted into the chat can
@@ -488,6 +505,12 @@ func (mw *memoryWorker) extractAndSave(ctx context.Context, messages []models.Me
 		mw.logger.Debug("Memory worker: LLM returned nothing new")
 		return nil
 	}
+	if !looksLikeExtraction(response) {
+		// A refusal, a chat answer or a truncated reply is not "nothing new":
+		// surface it as a failure so the segment is queued and retried once
+		// (pendingMaxAttempts) instead of being silently discarded.
+		return fmt.Errorf("memory extraction reply unparseable (%d chars, no section markers)", len(response))
+	}
 
 	mw.logger.Debug("Memory worker: LLM response received",
 		zap.Int("response_len", len(response)),
@@ -531,17 +554,7 @@ func (mw *memoryWorker) maybeCompact(ctx context.Context) {
 
 	mw.logger.Info("Memory worker: starting compaction")
 
-	llmClient := mw.cli.getClient()
-	var sendPrompt func(ctx context.Context, prompt string) (string, error)
-
-	if llmClient != nil {
-		sendPrompt = func(ctx context.Context, prompt string) (string, error) {
-			history := []models.Message{
-				{Role: "user", Content: prompt},
-			}
-			return llmClient.SendPrompt(ctx, prompt, history, 0)
-		}
-	}
+	sendPrompt := mw.backgroundSendPrompt()
 
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
@@ -668,6 +681,18 @@ func parseMemoryResponse(response string) (daily string, longTerm string) {
 	}
 
 	return daily, longTerm
+}
+
+// looksLikeExtraction reports whether a reply carries any of the section
+// markers the parser understands.
+func looksLikeExtraction(s string) bool {
+	u := strings.ToUpper(s)
+	for _, k := range []string{"DAILY", "LONG", "FACT", "TOPIC", "PROJECT", "PROFILE", "EPISODE", "PATTERN", "MEMORY"} {
+		if strings.Contains(u, k) {
+			return true
+		}
+	}
+	return false
 }
 
 func isNothingNew(s string) bool {

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -3756,5 +3756,6 @@
   "mem.cmd.stats.locked_store": "LOCKED read-only: %s store (%s) is sealed and this process cannot open it — %s. Set CHATCLI_ENCRYPTION_KEY (or CHATCLI_ENCRYPTION_KEY_PREVIOUS after a rotation); nothing is written until it opens.",
   "cfg.kv.sec.atrest_locked": "Locked stores",
   "cfg.val.sec.atrest_locked": "%s — sealed with a key this process does not have; writes refused to protect them",
-  "compact.nothing_to_compact": "Nothing to compact: the history already fits."
+  "compact.nothing_to_compact": "Nothing to compact: the history already fits.",
+  "cost.cmd.memory_worker": "Memory worker: %d call(s) · %s (extraction, rollups, memory compaction)"
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -3756,5 +3756,6 @@
   "mem.cmd.stats.locked_store": "LOCKED read-only: %s store (%s) is sealed and this process cannot open it — %s. Set CHATCLI_ENCRYPTION_KEY (or CHATCLI_ENCRYPTION_KEY_PREVIOUS after a rotation); nothing is written until it opens.",
   "cfg.kv.sec.atrest_locked": "Locked stores",
   "cfg.val.sec.atrest_locked": "%s — sealed with a key this process does not have; writes refused to protect them",
-  "compact.nothing_to_compact": "Nothing to compact: the history already fits."
+  "compact.nothing_to_compact": "Nothing to compact: the history already fits.",
+  "cost.cmd.memory_worker": "Memory worker: %d call(s) · %s (extraction, rollups, memory compaction)"
 }

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -3756,5 +3756,6 @@
   "mem.cmd.stats.locked_store": "TRAVADO somente leitura: store %s (%s) está selado e este processo não consegue abri-lo — %s. Defina CHATCLI_ENCRYPTION_KEY (ou CHATCLI_ENCRYPTION_KEY_PREVIOUS após rotação); nada é gravado até abrir.",
   "cfg.kv.sec.atrest_locked": "Stores travados",
   "cfg.val.sec.atrest_locked": "%s — selados com uma chave que este processo não tem; escritas recusadas para protegê-los",
-  "compact.nothing_to_compact": "Nada a compactar: o histórico já cabe."
+  "compact.nothing_to_compact": "Nada a compactar: o histórico já cabe.",
+  "cost.cmd.memory_worker": "Memory worker: %d chamada(s) · %s (extração, rollups, compactação de memória)"
 }

--- a/llm/copilot/copilot_client.go
+++ b/llm/copilot/copilot_client.go
@@ -93,6 +93,9 @@ func (c *Client) getMaxTokens() int {
 
 // SendPrompt sends a prompt to the GitHub Copilot API and returns the response.
 func (c *Client) SendPrompt(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {
+	// A response without a usage block must not re-book the previous
+	// call's tokens as this call's: reset before the request.
+	c.usageState.StoreUsage(nil)
 	effectiveMaxTokens := maxTokens
 	if effectiveMaxTokens <= 0 {
 		effectiveMaxTokens = c.getMaxTokens()

--- a/llm/githubmodels/github_models_client.go
+++ b/llm/githubmodels/github_models_client.go
@@ -90,6 +90,9 @@ func (c *GitHubModelsClient) getModelsURL() string {
 
 // SendPrompt sends a prompt to the GitHub Models API.
 func (c *GitHubModelsClient) SendPrompt(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {
+	// A response without a usage block must not re-book the previous
+	// call's tokens as this call's: reset before the request.
+	c.usageState.StoreUsage(nil)
 	effectiveMaxTokens := maxTokens
 	if effectiveMaxTokens <= 0 {
 		effectiveMaxTokens = c.getMaxTokens()

--- a/llm/googleai/gemini_client.go
+++ b/llm/googleai/gemini_client.go
@@ -87,6 +87,9 @@ func (c *GeminiClient) GetModelName() string {
 
 // SendPrompt envia um prompt para o Gemini e retorna a resposta
 func (c *GeminiClient) SendPrompt(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {
+	// A response without a usage block must not re-book the previous
+	// call's tokens as this call's: reset before the request.
+	c.usageState.StoreUsage(nil)
 	effectiveMaxTokens := maxTokens
 	if effectiveMaxTokens <= 0 {
 		effectiveMaxTokens = c.getMaxTokens() // Fallback para a lógica antiga se nada for passado

--- a/llm/ollama/ollama_client.go
+++ b/llm/ollama/ollama_client.go
@@ -78,6 +78,9 @@ func (c *Client) getMaxTokens() int {
 }
 
 func (c *Client) SendPrompt(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {
+	// A response without a usage block must not re-book the previous
+	// call's tokens as this call's: reset before the request.
+	c.usageState.StoreUsage(nil)
 	effectiveMaxTokens := maxTokens
 	if effectiveMaxTokens <= 0 {
 		effectiveMaxTokens = c.getMaxTokens() // Fallback se nada for passado

--- a/llm/openaiassistant/openai_assistant_client.go
+++ b/llm/openaiassistant/openai_assistant_client.go
@@ -130,6 +130,9 @@ func (c *OpenAIAssistantClient) GetModelName() string {
 
 // SendPrompt envia uma mensagem para o thread atual e retorna a resposta
 func (c *OpenAIAssistantClient) SendPrompt(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {
+	// A response without a usage block must not re-book the previous
+	// call's tokens as this call's: reset before the request.
+	c.usageState.StoreUsage(nil)
 	start := time.Now()
 	client.LogRequestStart(c.logger, "OPENAI_ASSISTANT", c.model,
 		zap.Int("payload_bytes", len(prompt)),

--- a/llm/openairesponses/openai_responses_client.go
+++ b/llm/openairesponses/openai_responses_client.go
@@ -95,6 +95,9 @@ func supportsReasoningEffort(model string) bool {
 }
 
 func (c *OpenAIResponsesClient) SendPrompt(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {
+	// A response without a usage block must not re-book the previous
+	// call's tokens as this call's: reset before the request.
+	c.usageState.StoreUsage(nil)
 	effectiveMaxTokens := maxTokens
 	if effectiveMaxTokens <= 0 {
 		effectiveMaxTokens = c.getMaxTokens()

--- a/llm/openrouter/openrouter_client.go
+++ b/llm/openrouter/openrouter_client.go
@@ -308,6 +308,9 @@ func (c *OpenRouterClient) resolveTools() []interface{} {
 
 // SendPrompt sends a prompt to the OpenRouter API and returns the response.
 func (c *OpenRouterClient) SendPrompt(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {
+	// A response without a usage block must not re-book the previous
+	// call's tokens as this call's: reset before the request.
+	c.usageState.StoreUsage(nil)
 	effectiveMaxTokens := maxTokens
 	if effectiveMaxTokens <= 0 {
 		effectiveMaxTokens = c.getMaxTokens()

--- a/llm/xai/xai_client.go
+++ b/llm/xai/xai_client.go
@@ -77,6 +77,9 @@ func (c *XAIClient) getMaxTokens() int {
 
 // SendPrompt envia um prompt para o modelo e retorna a resposta.
 func (c *XAIClient) SendPrompt(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {
+	// A response without a usage block must not re-book the previous
+	// call's tokens as this call's: reset before the request.
+	c.usageState.StoreUsage(nil)
 	effectiveMaxTokens := maxTokens
 	if effectiveMaxTokens <= 0 {
 		effectiveMaxTokens = c.getMaxTokens() // Fallback para a lógica antiga se nada for passado

--- a/models/models.go
+++ b/models/models.go
@@ -218,8 +218,9 @@ type UsageInfo struct {
 	// Reported by OpenAI under usage.completion_tokens_details.reasoning_tokens
 	// (Chat Completions) or usage.output_tokens_details.reasoning_tokens
 	// (Responses API), and by Gemini under usageMetadata.thoughtsTokenCount.
-	// Billed as output tokens and already counted in CompletionTokens —
-	// this field is informational only.
+	// OpenAI counts them inside CompletionTokens (informational there);
+	// Gemini reports them OUTSIDE candidatesTokenCount and bills them as
+	// output, so the cost tracker adds them for Gemini.
 	ReasoningTokens int `json:"reasoning_tokens,omitempty"`
 
 	// CostUSD is the actual billed cost reported by the provider for this


### PR DESCRIPTION
## Summary

Audit III, PR 5 (P1 CMP-4, COST-1, COST-2, COST-3; P2 COST-9, MEM-6). Spend was being booked to the wrong call, or not at all.

- **Summarizer (CMP-4).** `structuredSummarize` returns the usage of its own call, detected as a fresh usage pointer after the request; early returns, an external context engine or a failure book nothing, and a retried summary bills both calls. `RecordCompaction` no longer re-books the previous turn's sticky usage; guided `/compact` uses the same capture.
- **Provider resets (COST-9).** xAI, Copilot, GitHub Models, OpenRouter, Gemini, Ollama, Responses and Assistants reset their usage state at request start, so a 200 without a usage block cannot re-book the previous call.
- **Gemini thinking (COST-1).** `thoughtsTokenCount` is billed additively as output for Gemini; OpenAI reasoning tokens stay informational (already inside `completion_tokens`).
- **Streaming (COST-2).** A stream that ends without usage (gateway ignoring `stream_options`, cancelled or stalled stream) books a character estimate flagged as such, and the calibrator ignores it.
- **Memory worker (COST-3, MEM-6).** Extraction, rollups and memory compaction run on the worker's own client — `CHATCLI_COMPACT_MODEL` when set (no new env), else a dedicated instance of the session model — so they never clobber the interactive turn's usage; every call is gated by the budget hard stop and booked under a memory slice (`/cost`: `Memory worker: N call(s) · $x`, persisted). An unparseable reply is a failure, not "nothing new": the segment is queued and retried once (`attempts` in the queue file), then dropped with a warning.

i18n (en, en-US, pt-BR) for the new `/cost` line; docs updated.

## Tests

`cli/audit3_pr5_test.go`: summarizer usage only from its own call (external engine, early return, real call, retry sum); Gemini additive vs OpenAI unchanged; estimate booked; memory worker budget gate and requeue cap. Existing summarizer fixtures now store a fresh usage per call like real clients. Full suite, golangci-lint and the local gates are green.