### PR TITLE
fix(gateway): swap every per-conversation state with the tenant, guard the base memory worker, tag external memory calls, keep the workspace on queued segments

### DIFF
--- a/cli/audit3_pr6_test.go
+++ b/cli/audit3_pr6_test.go
@@ -1,0 +1,111 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+)
+
+func TestTenantSwap_CarriesPerConversationState(t *testing.T) {
+	cli := newTenantTestCLI(t)
+	ctx := context.Background()
+	// Base set: a bootstrap card, an undo snapshot, a recall trace, a
+	// forward watermark.
+	cli.history = []models.Message{{Role: "user", Content: "base turn"}}
+	cli.bootstrapCardState().chat = "BASE CARD"
+	cli.preCompaction = [][]models.Message{{{Role: "user", Content: "base undo"}}}
+	cli.rememberRecallTrace("base query", nil)
+	cli.extForwardState().forwarded = 7
+	cli.pendingInboundImages = []models.ImageContent{{Data: []byte("img")}}
+	cli.lastAgentReply = "base reply"
+
+	leave := cli.enterTenant(ctx, "telegram:42")
+	if leave == nil {
+		t.Fatal("tenant must be entered")
+	}
+	if cli.bootstrapCard != nil && cli.bootstrapCard.chat == "BASE CARD" {
+		t.Fatal("the base bootstrap card must not follow into the tenant")
+	}
+	if len(cli.preCompaction) != 0 || cli.lastRecallTrace != nil || cli.extForwardState().forwarded != 0 || len(cli.pendingInboundImages) != 0 || cli.lastAgentReply != "" {
+		t.Fatalf("per-conversation state leaked into the tenant: undo=%d trace=%v fwd=%d images=%d reply=%q",
+			len(cli.preCompaction), cli.lastRecallTrace, cli.extForwardState().forwarded, len(cli.pendingInboundImages), cli.lastAgentReply)
+	}
+	// The base memory worker must keep reading the BASE history while the
+	// tenant is active.
+	cli.history = []models.Message{{Role: "user", Content: "tenant turn"}}
+	if h := cli.baseHistory(); len(h) != 1 || h[0].Content != "base turn" {
+		t.Fatalf("base worker must read the base history during a tenant turn: %+v", h)
+	}
+	cli.bootstrapCardState().chat = "TENANT CARD"
+	cli.preCompaction = [][]models.Message{{{Role: "user", Content: "tenant undo"}}}
+	leave()
+	if cli.bootstrapCardState().chat != "BASE CARD" || len(cli.preCompaction) != 1 || cli.preCompaction[0][0].Content != "base undo" || cli.extForwardState().forwarded != 7 || cli.lastAgentReply != "base reply" {
+		t.Fatal("leaving the tenant must restore the base set's state")
+	}
+	if h := cli.baseHistory(); len(h) != 1 || h[0].Content != "base turn" {
+		t.Fatalf("base history after leave: %+v", h)
+	}
+	// Re-entering the same tenant brings its own state back.
+	leave2 := cli.enterTenant(ctx, "telegram:42")
+	if cli.bootstrapCardState().chat != "TENANT CARD" || len(cli.preCompaction) != 1 || cli.preCompaction[0][0].Content != "tenant undo" {
+		t.Fatal("re-entering a tenant must restore its own state")
+	}
+	leave2()
+}
+
+func TestExternalMemoryTools_CarryTheTenant(t *testing.T) {
+	cli := newTenantTestCLI(t)
+	f := &fakeToolCaller{answers: map[string]string{"memsvc/memory_recall": "- x"}, fail: map[string]bool{}}
+	cli.extToolCaller = f
+	t.Setenv(MemoryProviderEnv, "mcp:memsvc")
+	leave := cli.enterTenant(context.Background(), "slack:u1")
+	_ = cli.externalMemoryRecall(context.Background(), "q", []string{"q"})
+	cli.externalMemoryStore(context.Background(), "s", []models.Message{{Role: "user", Content: "hi"}})
+	waitCalls(t, f, "memsvc/memory_store", 1)
+	leave()
+	for _, args := range f.args {
+		if args["tenant"] != "slack:u1" {
+			t.Fatalf("every external memory call must carry the tenant: %v", args)
+		}
+	}
+}
+
+func TestPendingSegment_RestoresItsWorkspaceOnDrain(t *testing.T) {
+	active := &scriptedClient{name: "claude", response: "NOTHING_NEW"}
+	mw := newResilienceWorker(t, active)
+	mgr := mw.store.Manager()
+	recorded := filepath.Join(t.TempDir(), "proj-a")
+	mgr.SetWorkspaceDir(recorded)
+	path, err := mw.persistPending([]models.Message{{Role: "user", Content: "fato importante"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := os.ReadFile(path)
+	if len(raw) == 0 {
+		t.Fatal("segment written")
+	}
+	other := filepath.Join(t.TempDir(), "proj-b")
+	mgr.SetWorkspaceDir(other)
+	if got := mw.drainPending(context.Background()); got != 1 {
+		t.Fatalf("drained = %d", got)
+	}
+	if mgr.WorkspaceDir() != other {
+		t.Fatalf("the drainer's workspace must be restored after the segment: %s", mgr.WorkspaceDir())
+	}
+	restore := mw.enterSegmentWorkspace(recorded)
+	if mgr.WorkspaceDir() != recorded {
+		t.Fatal("enterSegmentWorkspace must switch")
+	}
+	restore()
+	if mgr.WorkspaceDir() != other {
+		t.Fatal("restore must switch back")
+	}
+}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -276,9 +276,7 @@ type ChatCLI struct {
 	// byte-stable across turns — it rides in the CACHED prefix of every
 	// surface's system prompt, and a per-turn count drift would bust that
 	// cache for no informational gain.
-	bootstrapCardOnce  sync.Once
-	bootstrapCardChat  string
-	bootstrapCardAgent string
+	bootstrapCard *bootstrapCardState // per store set: swapped with the tenant
 
 	// Content-aware, reversible context compression (CCR). Reduces verbose
 	// tool output (search/log/diff/JSON) before it reaches the model while
@@ -309,7 +307,7 @@ type ChatCLI struct {
 	// extToolCaller overrides the MCP manager for the extension points
 	// (tests); extForward tracks what was forwarded to the memory provider.
 	extToolCaller serverToolCaller
-	extForward    extForwardState
+	extForward    *extForwardState // per store set: swapped with the tenant
 
 	// Latest assembled system-prompt breakdown (chat and agent paths write
 	// it, /context status reads it).

--- a/cli/config_security_atrest.go
+++ b/cli/config_security_atrest.go
@@ -147,6 +147,7 @@ func (cli *ChatCLI) renderAtRestStatus(p string) {
 	}
 	kv(p, atrest.EnvPreviousKeys, fmt.Sprintf("%d", previous))
 	kv(p, i18n.T("cfg.kv.sec.atrest_covers"), i18n.T("cfg.kv.sec.atrest_covers_list"))
+	kv(p, i18n.T("cfg.kv.sec.tenant_shared"), i18n.T("cfg.kv.sec.tenant_shared_list"))
 	if locked := memory.LockedStores(); len(locked) > 0 {
 		names := make([]string, 0, len(locked))
 		for _, l := range locked {

--- a/cli/cost_cache_resources_test.go
+++ b/cli/cost_cache_resources_test.go
@@ -35,6 +35,7 @@ func TestCacheStoragePerMTokenHour(t *testing.T) {
 func TestRecordCacheStorage_PricesGrantedLifetimeAndPersistsInSnapshot(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	ct := NewCostTracker()
+	t.Cleanup(ct.FlushDailySpend)                         // the debounced daily-spend timer must not write during TempDir cleanup
 	ct.RecordUsage("GOOGLEAI", "gemini-2.5-flash", 10, 1) // makes the snapshot persistable
 	base := ct.TotalCost()
 

--- a/cli/cost_daily.go
+++ b/cli/cost_daily.go
@@ -76,14 +76,25 @@ func (ct *CostTracker) accrueDailyLocked() {
 	if ct.dailySaveTimer != nil {
 		ct.dailySaveTimer.Stop()
 	}
-	ct.dailySaveTimer = time.AfterFunc(dailySpendSaveDelay, ct.saveDailySpend)
+	// The path is resolved now, not when the timer fires: a late timer
+	// must write to the store it was scheduled for, never to whatever HOME
+	// points at 1.5s later (another tenant, another test's directory).
+	path := ct.dailySpendPath()
+	ct.dailySaveTimer = time.AfterFunc(dailySpendSaveDelay, func() { ct.saveDailySpendTo(path) })
 }
 
 // saveDailySpend persists today's spend (best-effort, atomic).
 func (ct *CostTracker) saveDailySpend() {
 	ct.mu.RLock()
-	f := dailySpendFileData{Date: ct.dailyDate, SpentUSD: ct.dailySpentUSD, Updated: time.Now().Format(time.RFC3339)}
 	path := ct.dailySpendPath()
+	ct.mu.RUnlock()
+	ct.saveDailySpendTo(path)
+}
+
+// saveDailySpendTo writes today's spend to path.
+func (ct *CostTracker) saveDailySpendTo(path string) {
+	ct.mu.RLock()
+	f := dailySpendFileData{Date: ct.dailyDate, SpentUSD: ct.dailySpentUSD, Updated: time.Now().Format(time.RFC3339)}
 	ct.mu.RUnlock()
 	data, err := json.MarshalIndent(f, "", "  ")
 	if err != nil {

--- a/cli/extension_providers.go
+++ b/cli/extension_providers.go
@@ -131,6 +131,7 @@ func (cli *ChatCLI) externalMemoryRecall(ctx context.Context, query string, hint
 	text, err := cli.callExtTool(ctx, server, extMemoryRecallTool, map[string]interface{}{
 		"query":        query,
 		"hints":        hints,
+		"tenant":       cli.activeTenant(),
 		"budget_chars": extRecallBudget,
 	}, extRecallTimeout)
 	if err != nil {
@@ -170,6 +171,7 @@ func (cli *ChatCLI) externalMemoryStore(ctx context.Context, session string, msg
 		if _, err := cli.callExtTool(detached, server, extMemoryStoreTool, map[string]interface{}{
 			"messages": payload,
 			"session":  session,
+			"tenant":   cli.activeTenant(),
 		}, extStoreTimeout); err != nil && cli.logger != nil && !errors.Is(err, errExtUnavailable) {
 			cli.logger.Debug("external memory store failed", zap.String("server", server), zap.Error(err))
 		}
@@ -223,6 +225,14 @@ func (cli *ChatCLI) externalSummarizer() ContextEngine {
 type extForwardState struct {
 	mu        sync.Mutex
 	forwarded int
+}
+
+// extForwardState returns the active set's forward watermark, creating it.
+func (cli *ChatCLI) extForwardState() *extForwardState {
+	if cli.extForward == nil {
+		cli.extForward = &extForwardState{}
+	}
+	return cli.extForward
 }
 
 // forwardNewHistory forwards history[forwarded:] to the provider and

--- a/cli/extension_providers_test.go
+++ b/cli/extension_providers_test.go
@@ -99,27 +99,27 @@ func TestForwardNewHistory_TracksTheMark(t *testing.T) {
 	cli.extToolCaller = f
 	t.Setenv(MemoryProviderEnv, "mcp:memsvc")
 	hist := []models.Message{{Role: "system", Content: "sys"}, {Role: "user", Content: "q1"}, {Role: "assistant", Content: "a1"}}
-	cli.forwardNewHistory(context.Background(), &cli.extForward, hist, "work")
+	cli.forwardNewHistory(context.Background(), cli.extForwardState(), hist, "work")
 	waitCalls(t, f, "memsvc/memory_store", 1)
 	if msgs, _ := f.args[0]["messages"].([]map[string]string); len(msgs) != 2 || msgs[0]["content"] != "q1" {
 		t.Fatalf("system messages are skipped, turns forwarded: %v", f.args[0])
 	}
 	// Nothing new: no call.
-	cli.forwardNewHistory(context.Background(), &cli.extForward, hist, "work")
+	cli.forwardNewHistory(context.Background(), cli.extForwardState(), hist, "work")
 	time.Sleep(50 * time.Millisecond)
 	if f.count("memsvc/memory_store") != 1 {
 		t.Fatal("no new messages must mean no call")
 	}
 	// New turn: only the delta.
 	hist = append(hist, models.Message{Role: "user", Content: "q2"})
-	cli.forwardNewHistory(context.Background(), &cli.extForward, hist, "work")
+	cli.forwardNewHistory(context.Background(), cli.extForwardState(), hist, "work")
 	waitCalls(t, f, "memsvc/memory_store", 2)
 	if msgs, _ := f.args[1]["messages"].([]map[string]string); len(msgs) != 1 || msgs[0]["content"] != "q2" {
 		t.Fatalf("delta = %v", f.args[1])
 	}
 	// Shrunk history (compaction/clear) resets the mark instead of skipping.
-	cli.forwardNewHistory(context.Background(), &cli.extForward, hist[:1], "work")
-	cli.forwardNewHistory(context.Background(), &cli.extForward, append(hist[:1], models.Message{Role: "user", Content: "after clear"}), "work")
+	cli.forwardNewHistory(context.Background(), cli.extForwardState(), hist[:1], "work")
+	cli.forwardNewHistory(context.Background(), cli.extForwardState(), append(hist[:1], models.Message{Role: "user", Content: "after clear"}), "work")
 	waitCalls(t, f, "memsvc/memory_store", 3)
 }
 

--- a/cli/memory_bootstrap.go
+++ b/cli/memory_bootstrap.go
@@ -35,6 +35,7 @@ package cli
 import (
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/diillson/chatcli/cli/board"
 )
@@ -83,7 +84,8 @@ const bootstrapCardChatDirective = "Never claim you have no memory of past sessi
 // memory surface is empty (a fresh install has nothing to navigate) or when
 // memory injection is off entirely.
 func (cli *ChatCLI) memoryBootstrapCards() (chatCard, agentCard string) {
-	cli.bootstrapCardOnce.Do(func() {
+	st := cli.bootstrapCardState()
+	st.once.Do(func() {
 		if loadMemoryMode() == memModeOff {
 			return
 		}
@@ -92,10 +94,29 @@ func (cli *ChatCLI) memoryBootstrapCards() (chatCard, agentCard string) {
 			return
 		}
 		body := bootstrapCardHeader + strings.Join(lines, "\n") + "\n"
-		cli.bootstrapCardChat = body + bootstrapCardChatDirective
-		cli.bootstrapCardAgent = body + bootstrapCardAgentDirective
+		st.chat = body + bootstrapCardChatDirective
+		st.agent = body + bootstrapCardAgentDirective
 	})
-	return cli.bootstrapCardChat, cli.bootstrapCardAgent
+	return st.chat, st.agent
+}
+
+// bootstrapCardState is the session-start memory card, frozen once per
+// STORE SET: under the gateway every tenant gets its own (its facts, its
+// sessions), and the swap installs it with the rest of the set — a
+// process-wide card leaked tenant A's counts and session title into
+// tenant B's cached system prompt.
+type bootstrapCardState struct {
+	once  sync.Once
+	chat  string
+	agent string
+}
+
+// bootstrapCardState returns the active set's card state, creating it.
+func (cli *ChatCLI) bootstrapCardState() *bootstrapCardState {
+	if cli.bootstrapCard == nil {
+		cli.bootstrapCard = &bootstrapCardState{}
+	}
+	return cli.bootstrapCard
 }
 
 // memoryBootstrapCardChat is the chat-surface accessor.

--- a/cli/memory_pending.go
+++ b/cli/memory_pending.go
@@ -57,6 +57,10 @@ type pendingSegment struct {
 	// after pendingMaxAttempts so an unparseable reply cannot wedge the
 	// queue forever (one requeue, then gone).
 	Attempts int `json:"attempts,omitempty"`
+	// Workspace is the project the segment was recorded in, so a drain in
+	// another directory labels episodes and resolves paths for the right
+	// project.
+	Workspace string `json:"workspace,omitempty"`
 }
 
 // pendingMaxAttempts is how many failed drains a queued segment survives.
@@ -159,7 +163,11 @@ func (mw *memoryWorker) persistPending(messages []models.Message) (string, error
 		redacted[i] = m
 		redacted[i].Content = redactSecretsForLLM(m.Content)
 	}
-	data, err := json.Marshal(pendingSegment{CreatedAt: time.Now(), Messages: redacted})
+	workspace := ""
+	if mw.store != nil && mw.store.Manager() != nil {
+		workspace = mw.store.Manager().WorkspaceDir()
+	}
+	data, err := json.Marshal(pendingSegment{CreatedAt: time.Now(), Messages: redacted, Workspace: workspace})
 	if err != nil {
 		return "", err
 	}
@@ -245,6 +253,22 @@ func (mw *memoryWorker) recordUsage(ec extractionClient, usage *models.UsageInfo
 	mw.cli.costTracker.RecordMemoryUsage(provider, model, usage)
 }
 
+// enterSegmentWorkspace points the store at the segment's workspace for
+// the extraction and returns the restore; a no-op when it is unknown or
+// already current.
+func (mw *memoryWorker) enterSegmentWorkspace(workspace string) func() {
+	if workspace == "" || mw.store == nil || mw.store.Manager() == nil {
+		return func() {}
+	}
+	mgr := mw.store.Manager()
+	prev := mgr.WorkspaceDir()
+	if prev == workspace {
+		return func() {}
+	}
+	mgr.SetWorkspaceDir(workspace)
+	return func() { mgr.SetWorkspaceDir(prev) }
+}
+
 // enforcePendingCap drops the oldest queued segments beyond pendingMaxFiles.
 func (mw *memoryWorker) enforcePendingCap() {
 	files := mw.pendingFiles()
@@ -291,7 +315,10 @@ func (mw *memoryWorker) drainPending(ctx context.Context) int {
 			_ = os.Remove(path)
 			continue
 		}
-		if err := mw.extractAndSave(ctx, seg.Messages); err != nil {
+		restore := mw.enterSegmentWorkspace(seg.Workspace)
+		err = mw.extractAndSave(ctx, seg.Messages)
+		restore()
+		if err != nil {
 			seg.Attempts++
 			if seg.Attempts >= pendingMaxAttempts {
 				mw.logger.Warn("Memory worker: pending segment failed repeatedly; dropping it",

--- a/cli/memory_worker.go
+++ b/cli/memory_worker.go
@@ -74,7 +74,27 @@ const (
 )
 
 func newMemoryWorker(cli *ChatCLI) *memoryWorker {
-	return newMemoryWorkerFor(cli, cli.memoryStore, defaultPendingDir(), func() []models.Message { return cli.history })
+	return newMemoryWorkerFor(cli, cli.memoryStore, defaultPendingDir(), cli.baseHistory)
+}
+
+// baseHistory is the history source of the BASE (shared) store set: the
+// live conversation while no tenant is active, the base set's own history
+// while a tenant's set is installed. Read at goroutine time, so a base
+// extraction that fires after a gateway swap can never distill tenant B's
+// turn into the shared store.
+func (cli *ChatCLI) baseHistory() []models.Message {
+	if cli == nil {
+		return nil
+	}
+	if cli.tenants != nil {
+		cli.tenants.mu.Lock()
+		active, base := cli.tenants.active, cli.tenants.base
+		cli.tenants.mu.Unlock()
+		if active != "" && base != nil {
+			return base.history
+		}
+	}
+	return cli.history
 }
 
 // newMemoryWorkerFor builds a worker over an explicit store, pending queue
@@ -119,7 +139,7 @@ func (mw *memoryWorker) stop() {
 // It runs in a goroutine — non-blocking to the main flow.
 func (mw *memoryWorker) nudge(ctx context.Context) {
 	if mw.cli != nil {
-		mw.cli.forwardNewHistory(ctx, &mw.cli.extForward, mw.history(), mw.cli.currentSessionName)
+		mw.cli.forwardNewHistory(ctx, mw.cli.extForwardState(), mw.history(), mw.cli.currentSessionName)
 	}
 	if mw.store == nil {
 		return

--- a/cli/tenant_scope.go
+++ b/cli/tenant_scope.go
@@ -65,6 +65,20 @@ type tenantStores struct {
 	boundSessionSync   time.Time
 	boundRemoteOnly    bool
 
+	// Per-conversation state that used to stay process-wide across a swap
+	// (Audit III SEC-3/SEC-4/MEM-5): every one of these is either derived
+	// from one tenant's history or would carry one tenant's data into
+	// another's turn.
+	bootstrapCard        *bootstrapCardState
+	extForward           *extForwardState
+	preCompaction        [][]models.Message
+	lastRecallTrace      *memoryRecallTrace
+	recalledFacts        []recalledFact
+	promptBreakdownLast  *promptBreakdown
+	promptBreakdownModes map[string]*promptBreakdown
+	pendingInboundImages []models.ImageContent
+	lastAgentReply       string
+
 	graphWired bool
 	lastUsed   time.Time
 }
@@ -127,6 +141,20 @@ func (cli *ChatCLI) captureStores(into *tenantStores) {
 	into.boundSessionSync = cli.boundSessionSync
 	into.boundRemoteOnly = cli.boundRemoteOnly
 	into.root = cli.stateRoot
+	into.bootstrapCard = cli.bootstrapCard
+	into.extForward = cli.extForward
+	into.preCompaction = cli.preCompaction
+	into.pendingInboundImages = cli.pendingInboundImages
+	into.lastAgentReply = cli.lastAgentReply
+	cli.recallTraceMu.Lock()
+	into.lastRecallTrace = cli.lastRecallTrace
+	cli.recallTraceMu.Unlock()
+	cli.recalled.mu.Lock()
+	into.recalledFacts = cli.recalled.facts
+	cli.recalled.mu.Unlock()
+	cli.promptBreakdowns.mu.Lock()
+	into.promptBreakdownLast, into.promptBreakdownModes = cli.promptBreakdowns.last, cli.promptBreakdowns.byMode
+	cli.promptBreakdowns.mu.Unlock()
 }
 
 // applyStores installs a set on the ChatCLI and re-registers the process
@@ -147,6 +175,20 @@ func (cli *ChatCLI) applyStores(ts *tenantStores) {
 	cli.currentSessionName = ts.currentSessionName
 	cli.boundSessionSync = ts.boundSessionSync
 	cli.boundRemoteOnly = ts.boundRemoteOnly
+	cli.bootstrapCard = ts.bootstrapCard
+	cli.extForward = ts.extForward
+	cli.preCompaction = ts.preCompaction
+	cli.pendingInboundImages = ts.pendingInboundImages
+	cli.lastAgentReply = ts.lastAgentReply
+	cli.recallTraceMu.Lock()
+	cli.lastRecallTrace = ts.lastRecallTrace
+	cli.recallTraceMu.Unlock()
+	cli.recalled.mu.Lock()
+	cli.recalled.facts = ts.recalledFacts
+	cli.recalled.mu.Unlock()
+	cli.promptBreakdowns.mu.Lock()
+	cli.promptBreakdowns.last, cli.promptBreakdowns.byMode = ts.promptBreakdownLast, ts.promptBreakdownModes
+	cli.promptBreakdowns.mu.Unlock()
 	if cli.stateRoot != ts.root {
 		// The outgoing root's learned ratios and daily spend are written
 		// before the swap.

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -3757,5 +3757,7 @@
   "cfg.kv.sec.atrest_locked": "Locked stores",
   "cfg.val.sec.atrest_locked": "%s — sealed with a key this process does not have; writes refused to protect them",
   "compact.nothing_to_compact": "Nothing to compact: the history already fits.",
-  "cost.cmd.memory_worker": "Memory worker: %d call(s) · %s (extraction, rollups, memory compaction)"
+  "cost.cmd.memory_worker": "Memory worker: %d call(s) · %s (extraction, rollups, memory compaction)",
+  "cfg.kv.sec.tenant_shared": "Shared across tenants",
+  "cfg.kv.sec.tenant_shared_list": "hooks, MCP manager (servers and OAuth), reflexion runner, REPL history file, hub database, scheduler — everything else is per tenant"
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -3757,5 +3757,7 @@
   "cfg.kv.sec.atrest_locked": "Locked stores",
   "cfg.val.sec.atrest_locked": "%s — sealed with a key this process does not have; writes refused to protect them",
   "compact.nothing_to_compact": "Nothing to compact: the history already fits.",
-  "cost.cmd.memory_worker": "Memory worker: %d call(s) · %s (extraction, rollups, memory compaction)"
+  "cost.cmd.memory_worker": "Memory worker: %d call(s) · %s (extraction, rollups, memory compaction)",
+  "cfg.kv.sec.tenant_shared": "Shared across tenants",
+  "cfg.kv.sec.tenant_shared_list": "hooks, MCP manager (servers and OAuth), reflexion runner, REPL history file, hub database, scheduler — everything else is per tenant"
 }

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -3757,5 +3757,7 @@
   "cfg.kv.sec.atrest_locked": "Stores travados",
   "cfg.val.sec.atrest_locked": "%s — selados com uma chave que este processo não tem; escritas recusadas para protegê-los",
   "compact.nothing_to_compact": "Nada a compactar: o histórico já cabe.",
-  "cost.cmd.memory_worker": "Memory worker: %d chamada(s) · %s (extração, rollups, compactação de memória)"
+  "cost.cmd.memory_worker": "Memory worker: %d chamada(s) · %s (extração, rollups, compactação de memória)",
+  "cfg.kv.sec.tenant_shared": "Compartilhado entre tenants",
+  "cfg.kv.sec.tenant_shared_list": "hooks, MCP manager (servidores e OAuth), reflexion runner, arquivo de histórico do REPL, banco do hub, scheduler — todo o resto é por tenant"
 }


### PR DESCRIPTION
## Summary

Audit III, PR 6 (P1 SEC-3, SEC-4, MEM-5; P2 MEM-11). Cross-tenant leaks in a co-located gateway.

- **Per-conversation state swaps with the set (SEC-4, MEM-5).** `tenantStores` now carries the session-start memory bootstrap card (a per-set `sync.Once` state instead of a process-wide one), the `/rewind compact` undo stack, the last auto-recall trace and recalled-fact evidence, the prompt breakdowns, the external memory provider's forward watermark, staged inbound images and the last agent reply. `captureStores`/`applyStores` move them with the stores, so tenant B never sees A's card, undo snapshots, images or recall.
- **Base worker guard (SEC-3).** The base memory worker's history source resolves at goroutine time to the base set's history while a tenant is active, so an extraction started by a REPL turn cannot read tenant B's history after the swap and write B's facts into the shared store.
- **External memory tools (MEM-5).** MCP `memory_recall` and `memory_store` carry a `tenant` argument so a shared server can scope by principal.
- **Queued segments (MEM-11).** `pendingSegment` persists the workspace; the drain extracts under it and restores the drainer's workspace after.
- `/config security` gains a "Shared across tenants" row naming what stays process-wide (hooks, MCP manager, reflexion runner, REPL history file, hub database, scheduler).

i18n (en, en-US, pt-BR); hub docs updated.

## Tests

`cli/audit3_pr6_test.go`: enter/leave/re-enter a tenant asserting every listed field isolates and restores; base history during a tenant turn; external calls carry the tenant; queued segment restores its workspace. Existing tenant and forward tests pass. Full suite, golangci-lint and the local gates are green.