### PR TITLE
fix(security): never hand ChatCLI's own secrets to MCP servers and executable plugins

### DIFF
--- a/cli/mcp/mcp_test.go
+++ b/cli/mcp/mcp_test.go
@@ -1649,3 +1649,32 @@ func TestLogRingSnapshotIsCopy(t *testing.T) {
 		t.Errorf("ring corrupted by snapshot mutation: got %q, want %q", got, "hello")
 	}
 }
+
+func TestBuildProcessEnvScrubsChatCLISecretsUnlessPassedThrough(t *testing.T) {
+	parent := []string{"PATH=/bin", "CHATCLI_ENCRYPTION_KEY=master", "CHATCLI_JWT_SECRET=jwt", "GH_TOKEN=abc"}
+	env := buildProcessEnv(parent, nil)
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "CHATCLI_ENCRYPTION_KEY=") || strings.HasPrefix(kv, "CHATCLI_JWT_SECRET=") {
+			t.Fatalf("server must not inherit ChatCLI secrets: %v", env)
+		}
+	}
+	if len(env) != 2 {
+		t.Fatalf("env = %v", env)
+	}
+	// A server that names the variable in its env map opts in.
+	env = buildProcessEnv(parent, map[string]string{"CHATCLI_JWT_SECRET": "${CHATCLI_JWT_SECRET}"})
+	got := ""
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "CHATCLI_JWT_SECRET=") {
+			got = kv
+		}
+	}
+	if got != "CHATCLI_JWT_SECRET=jwt" {
+		t.Fatalf("opt-in passthrough must expand against the parent: %v", env)
+	}
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "CHATCLI_ENCRYPTION_KEY=") {
+			t.Fatal("the other secrets stay scrubbed")
+		}
+	}
+}

--- a/cli/mcp/transport_stdio.go
+++ b/cli/mcp/transport_stdio.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/diillson/chatcli/utils"
 	"io"
 	"os"
 	"os/exec"
@@ -308,6 +309,9 @@ func (t *stdioTransport) drainStderr(name string, r io.ReadCloser) {
 // override wins (last assignment in cmd.Env takes precedence on Unix
 // and Windows).
 func buildProcessEnv(parent []string, overrides map[string]string) []string {
+	// ChatCLI's own secrets (encryption key, JWT secret, auth dir, audit
+	// path) never cross into a server unless its env map names them.
+	parent = utils.ScrubSecretEnv(parent, overrides)
 	if len(overrides) == 0 {
 		// Return the parent slice as-is — exec.Cmd treats nil as
 		// "inherit", but we want explicit inheritance regardless of

--- a/cli/plugins/env_scrub_test.go
+++ b/cli/plugins/env_scrub_test.go
@@ -1,0 +1,40 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package plugins
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestPlugin_ExecuteScrubsChatCLISecrets(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script fixture")
+	}
+	dir := t.TempDir()
+	script := filepath.Join(dir, "envdump")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nenv\n"), 0o700); err != nil { // #nosec G306 -- test fixture must be executable
+		t.Fatal(err)
+	}
+	t.Setenv("CHATCLI_ENCRYPTION_KEY", "master")
+	t.Setenv("CHATCLI_JWT_SECRET", "jwt")
+	t.Setenv("CHATCLI_PLUGIN_TEST_MARKER", "visible")
+	p := &ExecutablePlugin{metadata: Metadata{Name: "envdump"}, path: script}
+	out, err := p.Execute(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "CHATCLI_ENCRYPTION_KEY=") || strings.Contains(out, "CHATCLI_JWT_SECRET=") {
+		t.Fatalf("plugin inherited ChatCLI secrets:\n%s", out)
+	}
+	if !strings.Contains(out, "CHATCLI_PLUGIN_TEST_MARKER=visible") {
+		t.Fatalf("ordinary variables must still be inherited:\n%s", out)
+	}
+}

--- a/cli/plugins/plugin.go
+++ b/cli/plugins/plugin.go
@@ -74,6 +74,9 @@ func (p *ExecutablePlugin) ExecuteWithStream(ctx context.Context, args []string,
 	defer cancel()
 
 	cmd := exec.CommandContext(execCtx, p.path, args...) //#nosec G204 -- agent/CLI tool execution; commands validated by command_validator + policy_manager upstream
+	// Executable plugins inherit the environment minus ChatCLI's own
+	// secrets (encryption key, JWT secret, auth dir, audit path).
+	cmd.Env = utils.ScrubSecretEnv(os.Environ(), nil)
 
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {

--- a/utils/env_scrub.go
+++ b/utils/env_scrub.go
@@ -1,0 +1,60 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Subprocess environment scrub.
+ *
+ * MCP servers and executable plugins inherit the parent environment so
+ * launchers (npx, uvx, docker) find their binaries and caches. That
+ * inheritance also handed every child the secrets that protect ChatCLI's
+ * own state: the encryption-at-rest master key, the server's JWT secret,
+ * the auth directory and the audit trail path. A third-party server has
+ * no business with any of them; a server that genuinely needs one gets it
+ * through its own env map (opt-in passthrough).
+ */
+package utils
+
+import "strings"
+
+// SecretEnvDenylist are the variables never inherited by a subprocess:
+// exact names and prefixes (a trailing '*' matches any suffix).
+var SecretEnvDenylist = []string{
+	"CHATCLI_ENCRYPTION_KEY*",
+	"CHATCLI_JWT_SECRET",
+	"CHATCLI_AUTH_DIR",
+	"CHATCLI_AUDIT_LOG_PATH",
+	"CHATCLI_MANAGED_CONFIG",
+}
+
+// IsSecretEnvKey reports whether key is on the denylist.
+func IsSecretEnvKey(key string) bool {
+	for _, d := range SecretEnvDenylist {
+		if strings.HasSuffix(d, "*") {
+			if strings.HasPrefix(key, strings.TrimSuffix(d, "*")) {
+				return true
+			}
+			continue
+		}
+		if key == d {
+			return true
+		}
+	}
+	return false
+}
+
+// ScrubSecretEnv returns env without the denylisted variables, except the
+// keys listed in allow (the caller's explicit passthrough).
+func ScrubSecretEnv(env []string, allow map[string]string) []string {
+	out := make([]string, 0, len(env))
+	for _, kv := range env {
+		key, _, _ := strings.Cut(kv, "=")
+		if IsSecretEnvKey(key) {
+			if _, ok := allow[key]; !ok {
+				continue
+			}
+		}
+		out = append(out, kv)
+	}
+	return out
+}

--- a/utils/env_scrub_test.go
+++ b/utils/env_scrub_test.go
@@ -1,0 +1,40 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package utils
+
+import "testing"
+
+func TestScrubSecretEnv_DropsChatCLISecretsKeepsTheRest(t *testing.T) {
+	env := []string{"PATH=/usr/bin", "CHATCLI_ENCRYPTION_KEY=k", "CHATCLI_ENCRYPTION_KEY_PREVIOUS=old",
+		"CHATCLI_JWT_SECRET=j", "CHATCLI_AUTH_DIR=/a", "CHATCLI_AUDIT_LOG_PATH=/l", "CHATCLI_MANAGED_CONFIG=/m", "OPENAI_API_KEY=x", "HOME=/h"}
+	got := ScrubSecretEnv(env, nil)
+	want := []string{"PATH=/usr/bin", "OPENAI_API_KEY=x", "HOME=/h"}
+	if len(got) != len(want) {
+		t.Fatalf("scrubbed = %v", got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("scrubbed[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+	// Explicit passthrough keeps a denylisted key.
+	got = ScrubSecretEnv(env, map[string]string{"CHATCLI_AUDIT_LOG_PATH": "${CHATCLI_AUDIT_LOG_PATH}"})
+	if len(got) != 4 || got[3] != "HOME=/h" {
+		t.Fatalf("passthrough must keep the allowed key: %v", got)
+	}
+	found := false
+	for _, kv := range got {
+		if kv == "CHATCLI_AUDIT_LOG_PATH=/l" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("allowed key must survive")
+	}
+	if !IsSecretEnvKey("CHATCLI_ENCRYPTION_KEY_2") || IsSecretEnvKey("CHATCLI_ENCRYPTION") || IsSecretEnvKey("CHATCLI_MODEL") {
+		t.Fatal("prefix matching")
+	}
+}


### PR DESCRIPTION
## Summary

Audit III, PR 7 (P1 SEC-2).

MCP stdio servers and executable plugins were spawned with the full parent environment. That handed every third-party binary the secrets protecting ChatCLI's own state: `CHATCLI_ENCRYPTION_KEY` (and `_PREVIOUS`), `CHATCLI_JWT_SECRET`, `CHATCLI_AUTH_DIR`, `CHATCLI_AUDIT_LOG_PATH` and `CHATCLI_MANAGED_CONFIG`.

- `utils.ScrubSecretEnv` / `utils.SecretEnvDenylist` (exact names and `*` prefixes) drop those variables from a child environment.
- `buildProcessEnv` (MCP stdio) scrubs the parent before layering the server's env map; a server that names one of the keys in its own `env` opts in and still gets `${VAR}` expansion against the parent.
- `ExecutablePlugin.ExecuteWithStream` sets `cmd.Env` to the scrubbed environment (it previously inherited implicitly).

Provider API keys are not on the denylist: launchers and servers legitimately use them, and they were never ChatCLI-private.

## Tests

- `utils/env_scrub_test.go`: denylist, prefix matching, opt-in passthrough.
- `cli/mcp/mcp_test.go`: `TestBuildProcessEnvScrubsChatCLISecretsUnlessPassedThrough`.
- `cli/plugins/env_scrub_test.go`: runs a real plugin that dumps its environment and asserts the secrets are absent while ordinary variables remain.

golangci-lint and the local gates are green.