### PR TITLE
fix(security): share one locked, rotating, sealable audit chain across the REPL, gateway and gRPC server

### DIFF
--- a/cli/atrest_coverage_test.go
+++ b/cli/atrest_coverage_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/diillson/chatcli/cli/compress"
 	"github.com/diillson/chatcli/cli/ctxmgr"
@@ -185,4 +186,47 @@ func readFileString(t *testing.T, p string) string {
 		t.Fatal(err)
 	}
 	return string(b)
+}
+
+func TestVerifyAuditChain_LegacyTrailStillVerifies(t *testing.T) {
+	// A trail written by the version-1 writer (struct-order hash) verifies
+	// line by line, and a new entry appended by the chain writer links to
+	// its last hash.
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	var lines []string
+	prev := ""
+	for i := 1; i <= 2; i++ {
+		e := llmAuditEntry{Timestamp: "t", Kind: "llm", Phase: "send", Provider: "p", Model: "m", Seq: int64(i), PrevHash: prev}
+		e.Hash = auditEntryHash(e)
+		b, _ := json.Marshal(e)
+		lines = append(lines, string(b))
+		prev = e.Hash
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rep, err := VerifyAuditChain(path)
+	if err != nil || !rep.Intact() || rep.Chained != 2 {
+		t.Fatalf("legacy trail: %+v err=%v", rep, err)
+	}
+	t.Setenv(AuditLogPathEnv, path)
+	t.Setenv("CHATCLI_ENCRYPTION_KEY", "")
+	cli := &ChatCLI{logger: zap.NewNop()}
+	cli.initLLMAudit("test")
+	if cli.llmAudit == nil {
+		t.Fatal("auditor must start")
+	}
+	cli.llmAudit.record(client.RequestAuditEvent{Time: time.Now(), Phase: "send", Provider: "p", Model: "m"})
+	cli.llmAudit.close()
+	rep, _ = VerifyAuditChain(path)
+	if !rep.Intact() || rep.Chained != 3 {
+		t.Fatalf("new entry must continue the legacy chain: %+v", rep)
+	}
+	// Tampering with a legacy line still breaks the chain at that line.
+	raw, _ := os.ReadFile(path)
+	tampered := strings.Replace(string(raw), `"phase":"send"`, `"phase":"SEND"`, 1)
+	_ = os.WriteFile(path, []byte(tampered), 0o600)
+	if rep, _ := VerifyAuditChain(path); rep.Intact() || rep.BrokenAt != 1 {
+		t.Fatalf("legacy tamper: %+v", rep)
+	}
 }

--- a/cli/config_security_atrest.go
+++ b/cli/config_security_atrest.go
@@ -10,6 +10,7 @@ package cli
 
 import (
 	"fmt"
+	"github.com/diillson/chatcli/pkg/auditchain"
 	"os"
 	"path/filepath"
 	"strings"
@@ -128,9 +129,21 @@ func (cli *ChatCLI) configSecurityVerifyAudit(args []string) {
 	}
 	if rep.Intact() {
 		fmt.Println(colorize("  "+i18n.T("sec.cmd.verify_audit_ok", rep.Entries, rep.Chained, rep.Legacy), ColorGreen))
-		return
+	} else {
+		fmt.Println(colorize("  "+i18n.T("sec.cmd.verify_audit_broken", rep.BrokenAt, rep.Err, rep.Chained), ColorRed))
 	}
-	fmt.Println(colorize("  "+i18n.T("sec.cmd.verify_audit_broken", rep.BrokenAt, rep.Err, rep.Chained), ColorRed))
+	if rep.Sealed > 0 {
+		fmt.Println(colorize("  "+i18n.T("sec.cmd.verify_audit_sealed", rep.Sealed), ColorGray))
+	}
+	if rep.RotatedFrom != "" {
+		fmt.Println(colorize("  "+i18n.T("sec.cmd.verify_audit_rotated_from", rep.RotatedFrom), ColorGray))
+	}
+	if rep.Torn {
+		fmt.Println(colorize("  "+i18n.T("sec.cmd.verify_audit_torn"), ColorYellow))
+	}
+	if rotated := auditchain.Rotated(path); len(rotated) > 0 {
+		fmt.Println(colorize("  "+i18n.T("sec.cmd.verify_audit_rotated_files", len(rotated)), ColorGray))
+	}
 }
 
 // renderAtRestStatus prints the encryption-at-rest rows of /config security.

--- a/cli/llm_audit.go
+++ b/cli/llm_audit.go
@@ -17,8 +17,6 @@
 package cli
 
 import (
-	"bufio"
-	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -30,6 +28,7 @@ import (
 
 	"github.com/diillson/chatcli/llm/client"
 	"github.com/diillson/chatcli/models"
+	"github.com/diillson/chatcli/pkg/auditchain"
 	"go.uber.org/zap"
 )
 
@@ -75,16 +74,13 @@ type llmAuditEntry struct {
 
 // llmAuditWriter appends entries to the audit file.
 type llmAuditWriter struct {
-	mu       sync.Mutex
-	f        *os.File
-	enc      *json.Encoder
-	seq      int64
-	lastHash string
-	surface  string
-	session  func() string
-	tenant   func() string
-	usage    func() *models.UsageInfo
-	logger   *zap.Logger
+	mu      sync.Mutex
+	chain   *auditchain.Writer
+	surface string
+	session func() string
+	tenant  func() string
+	usage   func() *models.UsageInfo
+	logger  *zap.Logger
 }
 
 // initLLMAudit installs the request auditor when the audit path is
@@ -103,15 +99,14 @@ func (cli *ChatCLI) initLLMAudit(surface string) {
 		}
 		return
 	}
-	f, err := os.OpenFile(clean, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600) // #nosec G304 G703 -- operator-configured absolute path (env), cleaned and required absolute above
+	chain, err := auditchain.Open(clean, auditchain.Options{})
 	if err != nil {
 		if cli.logger != nil {
 			cli.logger.Error("failed to open audit log for LLM requests", zap.String("path", clean), zap.Error(err))
 		}
 		return
 	}
-	w := &llmAuditWriter{f: f, enc: json.NewEncoder(f), surface: surface, logger: cli.logger}
-	w.seq, w.lastHash = auditChainTail(clean)
+	w := &llmAuditWriter{chain: chain, surface: surface, logger: cli.logger}
 	w.session = func() string {
 		if cli.costTracker == nil {
 			return ""
@@ -185,21 +180,16 @@ func (w *llmAuditWriter) record(ev client.RequestAuditEvent) {
 			entry.CacheWriteTokens = u.CacheCreationInputTokens
 		}
 	}
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	w.seq++
-	entry.Seq = w.seq
-	entry.PrevHash = w.lastHash
-	entry.Hash = auditEntryHash(entry)
-	if err := w.enc.Encode(entry); err != nil && w.logger != nil {
+	// The chain writer assigns seq/prev_hash/hash under the file lock, so
+	// several processes (REPL, gateway, gRPC server) share one trail.
+	if err := w.chain.Append(entry); err != nil && w.logger != nil {
 		w.logger.Warn("audit log write failed", zap.Error(err))
-		return
 	}
-	w.lastHash = entry.Hash
 }
 
-// auditEntryHash computes the chain hash of an entry (its Hash field
-// excluded, PrevHash included).
+// auditEntryHash computes the version-1 chain hash of an entry (its Hash
+// field excluded, PrevHash included): struct-order canonical JSON. Kept
+// to verify trails written before the shared chain writer.
 func auditEntryHash(e llmAuditEntry) string {
 	e.Hash = ""
 	canonical, err := json.Marshal(e)
@@ -213,27 +203,16 @@ func auditEntryHash(e llmAuditEntry) string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
-// auditChainTail returns the last sequence number and hash recorded in an
-// existing trail (0, "" for a new or legacy file), so a restarted process
-// continues the chain instead of starting a new one.
-func auditChainTail(path string) (int64, string) {
-	f, err := os.Open(path) // #nosec G304 G703 -- operator-configured audit path (env), cleaned and required absolute by the caller
-	if err != nil {
-		return 0, ""
+// verifyLegacyAuditLine verifies one version-1 line (struct-order hash).
+func verifyLegacyAuditLine(line []byte, prev string) (string, bool) {
+	var e llmAuditEntry
+	if err := json.Unmarshal(line, &e); err != nil || e.PrevHash != prev {
+		return "", false
 	}
-	defer func() { _ = f.Close() }()
-	var seq int64
-	var last string
-	sc := bufio.NewScanner(f)
-	sc.Buffer(make([]byte, 0, 256*1024), 16*1024*1024)
-	for sc.Scan() {
-		var e llmAuditEntry
-		if err := json.Unmarshal(sc.Bytes(), &e); err != nil || e.Hash == "" {
-			continue
-		}
-		seq, last = e.Seq, e.Hash
+	if auditEntryHash(e) != e.Hash {
+		return "", false
 	}
-	return seq, last
+	return e.Hash, true
 }
 
 // AuditChainReport is the outcome of VerifyAuditChain.
@@ -243,51 +222,26 @@ type AuditChainReport struct {
 	Legacy   int // entries written before the chain existed
 	BrokenAt int // 1-based line of the first break (0 = intact)
 	Err      string
+	// Sealed counts entries stored encrypted; Torn flags an incomplete
+	// last line (a crash mid-write, not tampering); RotatedFrom names the
+	// file this trail continues when it starts mid-chain.
+	Sealed      int
+	Torn        bool
+	RotatedFrom string
 }
 
 // Intact reports whether every chained entry verified.
 func (r AuditChainReport) Intact() bool { return r.BrokenAt == 0 }
 
 // VerifyAuditChain re-hashes a trail and reports the first line whose hash
-// or previous-hash link does not match.
+// or previous-hash link does not match. Version-1 lines (written before
+// the shared chain writer) verify with the struct-order hash.
 func VerifyAuditChain(path string) (AuditChainReport, error) {
-	var rep AuditChainReport
-	f, err := os.Open(path) // #nosec G304 G703 -- operator-supplied audit path (env or /config security verify-audit argument typed by the operator)
-	if err != nil {
-		return rep, err
-	}
-	defer func() { _ = f.Close() }()
-	sc := bufio.NewScanner(f)
-	sc.Buffer(make([]byte, 0, 256*1024), 16*1024*1024)
-	prev := ""
-	line := 0
-	for sc.Scan() {
-		line++
-		if len(bytes.TrimSpace(sc.Bytes())) == 0 {
-			continue
-		}
-		rep.Entries++
-		var e llmAuditEntry
-		if err := json.Unmarshal(sc.Bytes(), &e); err != nil {
-			rep.BrokenAt, rep.Err = line, "unparseable entry"
-			return rep, nil
-		}
-		if e.Hash == "" {
-			rep.Legacy++
-			continue
-		}
-		rep.Chained++
-		if e.PrevHash != prev {
-			rep.BrokenAt, rep.Err = line, "previous-hash link mismatch"
-			return rep, nil
-		}
-		if auditEntryHash(e) != e.Hash {
-			rep.BrokenAt, rep.Err = line, "entry hash mismatch"
-			return rep, nil
-		}
-		prev = e.Hash
-	}
-	return rep, sc.Err()
+	rep, err := auditchain.Verify(path, verifyLegacyAuditLine)
+	return AuditChainReport{
+		Entries: rep.Entries, Chained: rep.Chained, Legacy: rep.Legacy, BrokenAt: rep.BrokenAt, Err: rep.Err,
+		Sealed: rep.Sealed, Torn: rep.Torn, RotatedFrom: rep.RotatedFrom,
+	}, err
 }
 
 // close detaches the sink and closes the file.
@@ -298,9 +252,8 @@ func (w *llmAuditWriter) close() {
 	client.RegisterRequestAuditor(nil)
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	if w.f != nil {
-		_ = w.f.Sync()
-		_ = w.f.Close()
-		w.f = nil
+	if w.chain != nil {
+		_ = w.chain.Close()
+		w.chain = nil
 	}
 }

--- a/cli/retention.go
+++ b/cli/retention.go
@@ -13,6 +13,7 @@ package cli
 
 import (
 	"fmt"
+	"github.com/diillson/chatcli/pkg/auditchain"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -28,6 +29,7 @@ import (
 // retentionReport is what one boot pass removed.
 type retentionReport struct {
 	Transcripts int // tenant transcripts removed (the shared set prunes on open)
+	AuditFiles  int // rotated audit trail files past the retention window
 	Parks       int
 	Costs       int
 }
@@ -60,8 +62,13 @@ func (cli *ChatCLI) runRetentionPass() retentionReport {
 			rep.Transcripts += pruneTranscripts(filepath.Join(root, transcriptDirName), ttl)
 		}
 	}
-	if cli != nil && cli.logger != nil && (rep.Parks > 0 || rep.Costs > 0) {
-		cli.logger.Info("retention pass", zap.Int("parks_removed", rep.Parks), zap.Int("cost_snapshots_removed", rep.Costs))
+	// Rotated audit trails (the live file is never touched) follow the
+	// same window; the operator keeps them elsewhere for longer retention.
+	if path := os.Getenv(AuditLogPathEnv); path != "" && filepath.IsAbs(filepath.Clean(path)) {
+		rep.AuditFiles = auditchain.PruneRotated(filepath.Clean(path), cutoff)
+	}
+	if cli != nil && cli.logger != nil && (rep.Parks > 0 || rep.Costs > 0 || rep.AuditFiles > 0) {
+		cli.logger.Info("retention pass", zap.Int("parks_removed", rep.Parks), zap.Int("cost_snapshots_removed", rep.Costs), zap.Int("audit_files_removed", rep.AuditFiles))
 	}
 	return rep
 }

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -3751,7 +3751,7 @@
   "cfg.sub.sec.atrest": "Encryption at rest",
   "cfg.kv.sec.atrest_key": "Key fingerprint",
   "cfg.kv.sec.atrest_covers": "Covers",
-  "cfg.kv.sec.atrest_covers_list": "sessions, transcripts, park snapshots, long-term memory (JSON stores), knowledge contexts, CCR archive, cost snapshots, memory exports",
+  "cfg.kv.sec.atrest_covers_list": "sessions, transcripts, park snapshots, long-term memory (JSON stores), knowledge contexts, CCR archive, cost snapshots, memory exports, audit trail (per line)",
   "cfg.sub.server.otel": "OpenTelemetry export",
   "mem.cmd.stats.locked_store": "LOCKED read-only: %s store (%s) is sealed and this process cannot open it — %s. Set CHATCLI_ENCRYPTION_KEY (or CHATCLI_ENCRYPTION_KEY_PREVIOUS after a rotation); nothing is written until it opens.",
   "cfg.kv.sec.atrest_locked": "Locked stores",
@@ -3759,5 +3759,9 @@
   "compact.nothing_to_compact": "Nothing to compact: the history already fits.",
   "cost.cmd.memory_worker": "Memory worker: %d call(s) · %s (extraction, rollups, memory compaction)",
   "cfg.kv.sec.tenant_shared": "Shared across tenants",
-  "cfg.kv.sec.tenant_shared_list": "hooks, MCP manager (servers and OAuth), reflexion runner, REPL history file, hub database, scheduler — everything else is per tenant"
+  "cfg.kv.sec.tenant_shared_list": "hooks, MCP manager (servers and OAuth), reflexion runner, REPL history file, hub database, scheduler — everything else is per tenant",
+  "sec.cmd.verify_audit_rotated_files": "%d rotated trail file(s) next to this one; verify each with its own path.",
+  "sec.cmd.verify_audit_rotated_from": "This file continues the chain of %s (rotated).",
+  "sec.cmd.verify_audit_sealed": "%d entries are stored encrypted (opened with the at-rest key).",
+  "sec.cmd.verify_audit_torn": "The last line is incomplete (a write was interrupted); it is not tampering and the next entry continues from the last complete line."
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -3751,7 +3751,7 @@
   "cfg.sub.sec.atrest": "Encryption at rest",
   "cfg.kv.sec.atrest_key": "Key fingerprint",
   "cfg.kv.sec.atrest_covers": "Covers",
-  "cfg.kv.sec.atrest_covers_list": "sessions, transcripts, park snapshots, long-term memory (JSON stores), knowledge contexts, CCR archive, cost snapshots, memory exports",
+  "cfg.kv.sec.atrest_covers_list": "sessions, transcripts, park snapshots, long-term memory (JSON stores), knowledge contexts, CCR archive, cost snapshots, memory exports, audit trail (per line)",
   "cfg.sub.server.otel": "OpenTelemetry export",
   "mem.cmd.stats.locked_store": "LOCKED read-only: %s store (%s) is sealed and this process cannot open it — %s. Set CHATCLI_ENCRYPTION_KEY (or CHATCLI_ENCRYPTION_KEY_PREVIOUS after a rotation); nothing is written until it opens.",
   "cfg.kv.sec.atrest_locked": "Locked stores",
@@ -3759,5 +3759,9 @@
   "compact.nothing_to_compact": "Nothing to compact: the history already fits.",
   "cost.cmd.memory_worker": "Memory worker: %d call(s) · %s (extraction, rollups, memory compaction)",
   "cfg.kv.sec.tenant_shared": "Shared across tenants",
-  "cfg.kv.sec.tenant_shared_list": "hooks, MCP manager (servers and OAuth), reflexion runner, REPL history file, hub database, scheduler — everything else is per tenant"
+  "cfg.kv.sec.tenant_shared_list": "hooks, MCP manager (servers and OAuth), reflexion runner, REPL history file, hub database, scheduler — everything else is per tenant",
+  "sec.cmd.verify_audit_rotated_files": "%d rotated trail file(s) next to this one; verify each with its own path.",
+  "sec.cmd.verify_audit_rotated_from": "This file continues the chain of %s (rotated).",
+  "sec.cmd.verify_audit_sealed": "%d entries are stored encrypted (opened with the at-rest key).",
+  "sec.cmd.verify_audit_torn": "The last line is incomplete (a write was interrupted); it is not tampering and the next entry continues from the last complete line."
 }

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -3751,7 +3751,7 @@
   "cfg.sub.sec.atrest": "Criptografia em repouso",
   "cfg.kv.sec.atrest_key": "Fingerprint da chave",
   "cfg.kv.sec.atrest_covers": "Cobre",
-  "cfg.kv.sec.atrest_covers_list": "sessões, transcripts, park snapshots, memória de longo prazo (stores JSON), contextos de conhecimento, arquivo CCR, snapshots de custo, exportações de memória",
+  "cfg.kv.sec.atrest_covers_list": "sessões, transcripts, park snapshots, memória de longo prazo (stores JSON), contextos de conhecimento, arquivo CCR, snapshots de custo, exportações de memória, trilha de auditoria (por linha)",
   "cfg.sub.server.otel": "Exportação OpenTelemetry",
   "mem.cmd.stats.locked_store": "TRAVADO somente leitura: store %s (%s) está selado e este processo não consegue abri-lo — %s. Defina CHATCLI_ENCRYPTION_KEY (ou CHATCLI_ENCRYPTION_KEY_PREVIOUS após rotação); nada é gravado até abrir.",
   "cfg.kv.sec.atrest_locked": "Stores travados",
@@ -3759,5 +3759,9 @@
   "compact.nothing_to_compact": "Nada a compactar: o histórico já cabe.",
   "cost.cmd.memory_worker": "Memory worker: %d chamada(s) · %s (extração, rollups, compactação de memória)",
   "cfg.kv.sec.tenant_shared": "Compartilhado entre tenants",
-  "cfg.kv.sec.tenant_shared_list": "hooks, MCP manager (servidores e OAuth), reflexion runner, arquivo de histórico do REPL, banco do hub, scheduler — todo o resto é por tenant"
+  "cfg.kv.sec.tenant_shared_list": "hooks, MCP manager (servidores e OAuth), reflexion runner, arquivo de histórico do REPL, banco do hub, scheduler — todo o resto é por tenant",
+  "sec.cmd.verify_audit_rotated_files": "%d arquivo(s) de trilha rotacionados ao lado deste; verifique cada um pelo próprio caminho.",
+  "sec.cmd.verify_audit_rotated_from": "Este arquivo continua a cadeia de %s (rotacionado).",
+  "sec.cmd.verify_audit_sealed": "%d entradas estão gravadas cifradas (abertas com a chave at-rest).",
+  "sec.cmd.verify_audit_torn": "A última linha está incompleta (uma escrita foi interrompida); não é adulteração e a próxima entrada continua a partir da última linha completa."
 }

--- a/pkg/auditchain/auditchain.go
+++ b/pkg/auditchain/auditchain.go
@@ -1,0 +1,593 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Hash-chained, multi-writer audit trail.
+ *
+ * Every line is a JSON object carrying seq, prev_hash, chain_v and hash,
+ * where hash = SHA-256(prev_hash ‖ 0x00 ‖ canonical JSON of the object
+ * without hash). Canonical means encoding/json's map encoding (sorted
+ * keys), so any writer — the REPL, a gateway, the gRPC server — chains
+ * the same way regardless of the Go struct it started from.
+ *
+ * Writers from different processes share one file: each append takes an
+ * exclusive file lock, re-reads the tail when the file changed under it
+ * (another writer appended, or the file rotated) and only then links the
+ * new line. Files rotate at MaxBytes; the first line of the new file
+ * names the file it continues (rotated_from) and links to its last hash,
+ * so Verify follows the chain across the rotation boundary. With
+ * encryption at rest enabled, every line is sealed before it hits disk.
+ *
+ * A torn last line (a crash mid-write) is reported, never mistaken for
+ * tampering: the reader skips it and the next append continues from the
+ * last complete line.
+ */
+package auditchain
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/diillson/chatcli/pkg/atrest"
+)
+
+const (
+	// ChainVersion is written on every line as chain_v.
+	ChainVersion = 2
+	// DefaultMaxBytes is the rotation threshold.
+	DefaultMaxBytes int64 = 64 << 20
+	// sealedPrefix marks an encrypted line.
+	sealedPrefix = "enc:"
+	// maxLine bounds one entry.
+	maxLine = 16 << 20
+)
+
+// Chain field names.
+const (
+	fieldSeq         = "seq"
+	fieldPrev        = "prev_hash"
+	fieldHash        = "hash"
+	fieldVersion     = "chain_v"
+	fieldRotatedFrom = "rotated_from"
+)
+
+// Options tunes a Writer.
+type Options struct {
+	// MaxBytes rotates the file when it reaches this size (0 = default,
+	// negative = never).
+	MaxBytes int64
+	// Seal encrypts each line with the at-rest key; nil means "when the
+	// key is configured".
+	Seal func() bool
+}
+
+// Writer appends chained entries to a file shared with other writers.
+type Writer struct {
+	mu       sync.Mutex
+	path     string
+	f        *os.File
+	seq      int64
+	last     string
+	size     int64
+	maxBytes int64
+	seal     func() bool
+}
+
+// Open opens (or creates) the trail at path and picks up its chain tail.
+func Open(path string, opts Options) (*Writer, error) {
+	f, err := openAppend(path)
+	if err != nil {
+		return nil, err
+	}
+	w := &Writer{path: path, f: f, maxBytes: opts.MaxBytes, seal: opts.Seal}
+	if w.maxBytes == 0 {
+		w.maxBytes = DefaultMaxBytes
+	}
+	if w.seal == nil {
+		w.seal = atrest.Enabled
+	}
+	w.refreshTail()
+	return w, nil
+}
+
+func openAppend(path string) (*os.File, error) {
+	return os.OpenFile(filepath.Clean(path), os.O_APPEND|os.O_CREATE|os.O_RDWR, 0o600) // #nosec G304 G703 -- operator-configured absolute audit path, cleaned; callers validate
+}
+
+// refreshTail re-reads seq/hash/size from the file (caller holds w.mu).
+func (w *Writer) refreshTail() {
+	st, err := w.f.Stat()
+	if err != nil {
+		return
+	}
+	w.size = st.Size()
+	if _, err := w.f.Seek(0, io.SeekStart); err != nil {
+		return
+	}
+	w.seq, w.last, _ = tailOf(w.f)
+}
+
+// Path returns the trail path.
+func (w *Writer) Path() string { return w.path }
+
+// Append chains v (any JSON object) onto the trail. The chain fields in v,
+// if any, are replaced.
+func (w *Writer) Append(v any) error {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return fmt.Errorf("audit entry must be a JSON object: %w", err)
+	}
+	for _, k := range []string{fieldSeq, fieldPrev, fieldHash, fieldVersion, fieldRotatedFrom} {
+		delete(m, k)
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if err := lockFile(w.f); err != nil {
+		return err
+	}
+	defer func() { _ = unlockFile(w.f) }()
+	if err := w.syncWithDisk(); err != nil {
+		return err
+	}
+	if w.maxBytes > 0 && w.size >= w.maxBytes {
+		if from, err := w.rotate(); err == nil && from != "" {
+			m[fieldRotatedFrom] = mustRaw(from)
+		}
+	}
+	line, hash, err := encodeEntry(m, w.seq+1, w.last)
+	if err != nil {
+		return err
+	}
+	if w.seal() {
+		sealed, err := atrest.Seal(line)
+		if err != nil {
+			return err
+		}
+		line = []byte(sealedPrefix + base64.StdEncoding.EncodeToString(sealed))
+	}
+	line = append(line, '\n')
+	if _, err := w.f.Write(line); err != nil {
+		return err
+	}
+	w.seq++
+	w.last = hash
+	w.size += int64(len(line))
+	return nil
+}
+
+// syncWithDisk notices another writer's appends or a rotation (caller
+// holds w.mu and the file lock).
+func (w *Writer) syncWithDisk() error {
+	onDisk, err := os.Stat(w.path)
+	if errors.Is(err, os.ErrNotExist) {
+		// Rotated (or removed) by another writer: reopen the live path.
+		return w.reopen()
+	}
+	if err != nil {
+		return err
+	}
+	cur, err := w.f.Stat()
+	if err != nil {
+		return err
+	}
+	if !os.SameFile(onDisk, cur) {
+		return w.reopen()
+	}
+	if cur.Size() != w.size {
+		w.refreshTail()
+	}
+	// A torn last line (crash mid-write; under the lock nobody else is
+	// mid-write) is terminated so the next entry starts on its own line.
+	if w.size > 0 {
+		var b [1]byte
+		if _, err := w.f.ReadAt(b[:], w.size-1); err == nil && b[0] != '\n' {
+			if _, err := w.f.Write([]byte{'\n'}); err != nil {
+				return err
+			}
+			w.size++
+		}
+	}
+	return nil
+}
+
+func (w *Writer) reopen() error {
+	nf, err := openAppend(w.path)
+	if err != nil {
+		return err
+	}
+	_ = unlockFile(w.f)
+	_ = w.f.Close()
+	w.f = nf
+	if err := lockFile(w.f); err != nil {
+		return err
+	}
+	w.refreshTail()
+	return nil
+}
+
+// rotate renames the current file aside and opens a fresh one; returns
+// the rotated file's base name (caller holds w.mu and the lock).
+func (w *Writer) rotate() (string, error) {
+	aside := w.path + "." + time.Now().UTC().Format("20060102T150405.000000000Z")
+	if err := os.Rename(w.path, aside); err != nil {
+		return "", err
+	}
+	nf, err := openAppend(w.path)
+	if err != nil {
+		return "", err
+	}
+	_ = unlockFile(w.f)
+	_ = w.f.Close()
+	w.f = nf
+	if err := lockFile(w.f); err != nil {
+		return "", err
+	}
+	// seq and last carry over: the new file continues the chain.
+	w.size = 0
+	return filepath.Base(aside), nil
+}
+
+// Close releases the file.
+func (w *Writer) Close() error {
+	if w == nil {
+		return nil
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.f == nil {
+		return nil
+	}
+	err := w.f.Close()
+	w.f = nil
+	return err
+}
+
+func mustRaw(s string) json.RawMessage {
+	b, _ := json.Marshal(s)
+	return b
+}
+
+// encodeEntry adds the chain fields and returns the line and its hash.
+func encodeEntry(m map[string]json.RawMessage, seq int64, prev string) ([]byte, string, error) {
+	m[fieldSeq] = mustRaw64(seq)
+	m[fieldVersion] = mustRaw64(ChainVersion)
+	if prev != "" {
+		m[fieldPrev] = mustRaw(prev)
+	}
+	hash, err := hashOf(m, prev)
+	if err != nil {
+		return nil, "", err
+	}
+	m[fieldHash] = mustRaw(hash)
+	line, err := json.Marshal(m)
+	if err != nil {
+		return nil, "", err
+	}
+	return line, hash, nil
+}
+
+func mustRaw64(n int64) json.RawMessage { return json.RawMessage(fmt.Sprintf("%d", n)) }
+
+// hashOf computes SHA-256(prev ‖ 0 ‖ canonical(m without hash)).
+func hashOf(m map[string]json.RawMessage, prev string) (string, error) {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		if k == fieldHash {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var canonical bytes.Buffer
+	canonical.WriteByte('{')
+	for i, k := range keys {
+		if i > 0 {
+			canonical.WriteByte(',')
+		}
+		kb, _ := json.Marshal(k)
+		canonical.Write(kb)
+		canonical.WriteByte(':')
+		var compact bytes.Buffer
+		if err := json.Compact(&compact, m[k]); err != nil {
+			return "", err
+		}
+		canonical.Write(compact.Bytes())
+	}
+	canonical.WriteByte('}')
+	h := sha256.New()
+	h.Write([]byte(prev))
+	h.Write([]byte{0})
+	h.Write(canonical.Bytes())
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// decodeLine opens a sealed line; plain lines pass through.
+func decodeLine(line []byte) ([]byte, error) {
+	if !bytes.HasPrefix(line, []byte(sealedPrefix)) {
+		return line, nil
+	}
+	if !atrest.Enabled() {
+		return nil, errors.New("sealed entry and no encryption key configured")
+	}
+	sealed, err := base64.StdEncoding.DecodeString(string(line[len(sealedPrefix):]))
+	if err != nil {
+		return nil, err
+	}
+	return atrest.Open(sealed)
+}
+
+// lineReader yields lines and whether each was newline-terminated.
+type lineReader struct {
+	r *bufio.Reader
+}
+
+func newLineReader(r io.Reader) *lineReader {
+	return &lineReader{r: bufio.NewReaderSize(r, 256*1024)}
+}
+
+// next returns the next line (without the newline), whether it was
+// terminated, and io.EOF when done.
+func (lr *lineReader) next() ([]byte, bool, error) {
+	line, err := lr.r.ReadBytes('\n')
+	if len(line) > maxLine {
+		return nil, false, errors.New("audit line exceeds the size limit")
+	}
+	if err == nil {
+		return bytes.TrimRight(line, "\r\n"), true, nil
+	}
+	if errors.Is(err, io.EOF) {
+		if len(line) == 0 {
+			return nil, false, io.EOF
+		}
+		return line, false, nil
+	}
+	return nil, false, err
+}
+
+// tailOf returns the last chained seq/hash in r, skipping a torn last line.
+func tailOf(r io.Reader) (int64, string, bool) {
+	lr := newLineReader(r)
+	var seq int64
+	var last string
+	torn := false
+	for {
+		line, terminated, err := lr.next()
+		if err != nil {
+			break
+		}
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		plain, err := decodeLine(line)
+		if err != nil {
+			if !terminated {
+				torn = true
+			}
+			continue
+		}
+		var e struct {
+			Seq  int64  `json:"seq"`
+			Hash string `json:"hash"`
+		}
+		if err := json.Unmarshal(plain, &e); err != nil || e.Hash == "" {
+			if !terminated {
+				torn = true
+			}
+			continue
+		}
+		seq, last = e.Seq, e.Hash
+	}
+	return seq, last, torn
+}
+
+// Tail returns the last chained seq/hash in the trail at path (0, "" for
+// a new or legacy file).
+func Tail(path string) (int64, string) {
+	f, err := os.Open(filepath.Clean(path)) // #nosec G304 G703 -- operator-configured audit path, cleaned; callers validate
+	if err != nil {
+		return 0, ""
+	}
+	defer func() { _ = f.Close() }()
+	seq, last, _ := tailOf(f)
+	return seq, last
+}
+
+// LegacyVerifier checks one pre-chain_v line: given the raw JSON and the
+// expected previous hash it returns the line's hash and whether the line
+// verified. nil treats such lines as legacy (counted, not verified).
+type LegacyVerifier func(line []byte, prev string) (hash string, ok bool)
+
+// Report is the outcome of Verify.
+type Report struct {
+	Entries     int
+	Chained     int    // entries carrying a hash
+	Legacy      int    // entries written before the chain existed
+	Sealed      int    // entries stored encrypted
+	BrokenAt    int    // 1-based line of the first break (0 = intact)
+	Err         string // what broke
+	Torn        bool   // the last line is incomplete (crash mid-write), not tampering
+	RotatedFrom string // the file this one continues, when it starts mid-chain
+}
+
+// Intact reports whether every chained entry verified.
+func (r Report) Intact() bool { return r.BrokenAt == 0 }
+
+// Verify re-hashes the trail at path and reports the first line whose hash
+// or previous-hash link does not match. legacy verifies version-1 lines.
+func Verify(path string, legacy LegacyVerifier) (Report, error) {
+	var rep Report
+	f, err := os.Open(filepath.Clean(path)) // #nosec G304 G703 -- operator-supplied audit path, cleaned; callers validate
+	if err != nil {
+		return rep, err
+	}
+	defer func() { _ = f.Close() }()
+	return verifyReader(f, legacy)
+}
+
+func verifyReader(r io.Reader, legacy LegacyVerifier) (Report, error) {
+	var rep Report
+	lr := newLineReader(r)
+	prev := ""
+	line := 0
+	// tornAt is a terminated but unparseable line waiting to see whether
+	// the chain resumes right after it (crash residue) or not (damage).
+	tornAt := 0
+	for {
+		raw, terminated, err := lr.next()
+		if errors.Is(err, io.EOF) {
+			if tornAt > 0 {
+				rep.Torn = true
+			}
+			return rep, nil
+		}
+		if err != nil {
+			return rep, err
+		}
+		line++
+		if len(bytes.TrimSpace(raw)) == 0 {
+			continue
+		}
+		rep.Entries++
+		plain, err := decodeLine(raw)
+		if err != nil {
+			if !terminated {
+				rep.Torn = true
+				rep.Entries--
+				return rep, nil
+			}
+			rep.BrokenAt, rep.Err = line, err.Error()
+			return rep, nil
+		}
+		if bytes.HasPrefix(raw, []byte(sealedPrefix)) {
+			rep.Sealed++
+		}
+		var m map[string]json.RawMessage
+		if err := json.Unmarshal(plain, &m); err != nil {
+			rep.Entries--
+			if !terminated {
+				rep.Torn = true
+				return rep, nil
+			}
+			if tornAt > 0 {
+				rep.BrokenAt, rep.Err = tornAt, "unparseable entry"
+				return rep, nil
+			}
+			tornAt = line
+			continue
+		}
+		hash := rawString(m[fieldHash])
+		if hash == "" {
+			rep.Legacy++
+			continue
+		}
+		if tornAt > 0 {
+			// The chain must resume exactly where it left off for the
+			// unparseable line to count as crash residue.
+			if rawString(m[fieldPrev]) != prev {
+				rep.BrokenAt, rep.Err = tornAt, "unparseable entry"
+				return rep, nil
+			}
+			rep.Torn, tornAt = true, 0
+		}
+		if _, v2 := m[fieldVersion]; !v2 {
+			// Version-1 line: struct-order canonical form, verified by the
+			// owner of that struct.
+			if legacy == nil {
+				// Counted, not verified; the chain still continues from it.
+				rep.Legacy++
+				prev = hash
+				continue
+			}
+			rep.Chained++
+			got, ok := legacy(plain, prev)
+			if !ok {
+				rep.BrokenAt, rep.Err = line, "entry hash mismatch"
+				return rep, nil
+			}
+			prev = got
+			continue
+		}
+		rep.Chained++
+		linked := rawString(m[fieldPrev])
+		if linked != prev {
+			from := rawString(m[fieldRotatedFrom])
+			if rep.Chained == 1 && from != "" {
+				rep.RotatedFrom = from
+				prev = linked
+			} else {
+				rep.BrokenAt, rep.Err = line, "previous-hash link mismatch"
+				return rep, nil
+			}
+		}
+		want, err := hashOf(m, prev)
+		if err != nil || want != hash {
+			rep.BrokenAt, rep.Err = line, "entry hash mismatch"
+			return rep, nil
+		}
+		prev = hash
+	}
+}
+
+func rawString(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return ""
+	}
+	return s
+}
+
+// Rotated lists the rotated files of the trail at path, oldest first.
+func Rotated(path string) []string {
+	matches, err := filepath.Glob(path + ".*")
+	if err != nil {
+		return nil
+	}
+	out := make([]string, 0, len(matches))
+	base := filepath.Base(path) + "."
+	for _, m := range matches {
+		name := filepath.Base(m)
+		if !strings.HasPrefix(name, base) || !strings.HasSuffix(name, "Z") {
+			continue
+		}
+		out = append(out, m)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// PruneRotated removes rotated files modified before cutoff and returns
+// how many went.
+func PruneRotated(path string, cutoff time.Time) int {
+	n := 0
+	for _, p := range Rotated(path) {
+		st, err := os.Stat(p)
+		if err != nil || !st.ModTime().Before(cutoff) {
+			continue
+		}
+		if os.Remove(p) == nil {
+			n++
+		}
+	}
+	return n
+}

--- a/pkg/auditchain/auditchain_test.go
+++ b/pkg/auditchain/auditchain_test.go
@@ -1,0 +1,220 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package auditchain
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+type sample struct {
+	Kind string `json:"kind"`
+	N    int    `json:"n"`
+}
+
+func never() bool { return false }
+
+func TestWriter_ChainsAndVerifies(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	w, err := Open(path, Options{Seal: never})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 1; i <= 3; i++ {
+		if err := w.Append(sample{Kind: "llm", N: i}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_ = w.Close()
+	rep, err := Verify(path, nil)
+	if err != nil || !rep.Intact() || rep.Chained != 3 || rep.Entries != 3 {
+		t.Fatalf("rep=%+v err=%v", rep, err)
+	}
+	if seq, last := Tail(path); seq != 3 || last == "" {
+		t.Fatalf("tail = %d %q", seq, last)
+	}
+	// A restarted writer continues the chain.
+	w2, _ := Open(path, Options{Seal: never})
+	_ = w2.Append(sample{Kind: "llm", N: 4})
+	_ = w2.Close()
+	if rep, _ := Verify(path, nil); !rep.Intact() || rep.Chained != 4 {
+		t.Fatalf("continued chain: %+v", rep)
+	}
+	// Tampering with a middle line breaks it there.
+	raw, _ := os.ReadFile(path)
+	lines := strings.Split(strings.TrimSpace(string(raw)), "\n")
+	lines[1] = strings.Replace(lines[1], `"n":2`, `"n":20`, 1)
+	_ = os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600)
+	if rep, _ := Verify(path, nil); rep.Intact() || rep.BrokenAt != 2 {
+		t.Fatalf("tamper must break at line 2: %+v", rep)
+	}
+}
+
+func TestWriter_TwoWritersShareOneTrail(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	a, _ := Open(path, Options{Seal: never})
+	b, _ := Open(path, Options{Seal: never})
+	defer func() { _ = a.Close(); _ = b.Close() }()
+	for i := 0; i < 5; i++ {
+		if err := a.Append(sample{Kind: "llm", N: i}); err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Append(sample{Kind: "grpc", N: i}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	rep, _ := Verify(path, nil)
+	if !rep.Intact() || rep.Chained != 10 {
+		t.Fatalf("interleaved writers must form one chain: %+v", rep)
+	}
+	if seq, _ := Tail(path); seq != 10 {
+		t.Fatalf("seq = %d", seq)
+	}
+}
+
+func TestWriter_RotatesAndVerifyFollowsTheBoundary(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	w, _ := Open(path, Options{Seal: never, MaxBytes: 200})
+	for i := 0; i < 12; i++ {
+		if err := w.Append(sample{Kind: "llm", N: i}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_ = w.Close()
+	rotated := Rotated(path)
+	if len(rotated) == 0 {
+		t.Fatal("expected rotated files")
+	}
+	live, _ := Verify(path, nil)
+	if !live.Intact() || live.RotatedFrom == "" {
+		t.Fatalf("live file must continue a rotated one: %+v", live)
+	}
+	total := live.Chained
+	for _, r := range rotated {
+		rep, _ := Verify(r, nil)
+		if !rep.Intact() {
+			t.Fatalf("rotated %s: %+v", r, rep)
+		}
+		total += rep.Chained
+	}
+	if total != 12 {
+		t.Fatalf("entries across files = %d", total)
+	}
+	if seq, _ := Tail(path); seq != 12 {
+		t.Fatalf("seq carries over rotation: %d", seq)
+	}
+	// Retention removes rotated files past the cutoff and never the live one.
+	old := time.Now().Add(-48 * time.Hour)
+	for _, r := range rotated {
+		_ = os.Chtimes(r, old, old)
+	}
+	if n := PruneRotated(path, time.Now().Add(-24*time.Hour)); n != len(rotated) {
+		t.Fatalf("pruned %d, want %d", n, len(rotated))
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatal("live trail must survive retention")
+	}
+	// A writer that still holds the rotated file notices and reopens.
+	w2, _ := Open(path, Options{Seal: never, MaxBytes: 200})
+	w3, _ := Open(path, Options{Seal: never, MaxBytes: 200})
+	for i := 0; i < 6; i++ {
+		_ = w2.Append(sample{N: i})
+	}
+	if err := w3.Append(sample{Kind: "late"}); err != nil {
+		t.Fatal(err)
+	}
+	_ = w2.Close()
+	_ = w3.Close()
+	if rep, _ := Verify(path, nil); !rep.Intact() {
+		t.Fatalf("writer holding a rotated file must reopen the live path: %+v", rep)
+	}
+}
+
+func TestVerify_TornTailIsNotTampering(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	w, _ := Open(path, Options{Seal: never})
+	_ = w.Append(sample{N: 1})
+	_ = w.Append(sample{N: 2})
+	_ = w.Close()
+	f, _ := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	_, _ = f.WriteString(`{"kind":"llm","seq":3,"prev_h`)
+	_ = f.Close()
+	rep, err := Verify(path, nil)
+	if err != nil || !rep.Intact() || !rep.Torn || rep.Chained != 2 {
+		t.Fatalf("torn tail: %+v err=%v", rep, err)
+	}
+	if seq, _ := Tail(path); seq != 2 {
+		t.Fatalf("tail skips the torn line: %d", seq)
+	}
+	// The next append starts on a fresh line and re-links to entry 2.
+	w2, _ := Open(path, Options{Seal: never})
+	if err := w2.Append(sample{N: 3}); err != nil {
+		t.Fatal(err)
+	}
+	_ = w2.Close()
+	rep, _ = Verify(path, nil)
+	if !rep.Intact() || rep.Chained != 3 {
+		t.Fatalf("after torn tail: %+v", rep)
+	}
+	raw, _ := os.ReadFile(path)
+	if strings.Count(string(raw), "\n") != 4 {
+		t.Fatalf("torn line must be terminated before the new entry:\n%s", raw)
+	}
+}
+
+func TestVerify_LegacyLinesUseTheOwnerHasher(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	// Two version-1 lines (no chain_v) with fake hashes, then a v2 line.
+	legacy := []string{`{"kind":"llm","seq":1,"hash":"h1"}`, `{"kind":"llm","seq":2,"prev_hash":"h1","hash":"h2"}`}
+	_ = os.WriteFile(path, []byte(strings.Join(legacy, "\n")+"\n"), 0o600)
+	w, _ := Open(path, Options{Seal: never})
+	_ = w.Append(sample{N: 3})
+	_ = w.Close()
+	calls := 0
+	hasher := func(line []byte, prev string) (string, bool) {
+		calls++
+		var e struct {
+			Prev string `json:"prev_hash"`
+			Hash string `json:"hash"`
+		}
+		_ = json.Unmarshal(line, &e)
+		return e.Hash, e.Prev == prev
+	}
+	rep, _ := Verify(path, hasher)
+	if !rep.Intact() || rep.Chained != 3 || calls != 2 {
+		t.Fatalf("legacy verification: %+v calls=%d", rep, calls)
+	}
+	if rep, _ := Verify(path, nil); !rep.Intact() || rep.Legacy != 2 || rep.Chained != 1 {
+		t.Fatalf("without a hasher legacy lines are counted, not verified: %+v", rep)
+	}
+}
+
+func TestWriter_SealsLinesWhenAsked(t *testing.T) {
+	t.Setenv("CHATCLI_ENCRYPTION_KEY", "audit-chain-test-key")
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	w, err := Open(path, Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = w.Append(sample{Kind: "secret", N: 1})
+	_ = w.Append(sample{Kind: "secret", N: 2})
+	_ = w.Close()
+	raw, _ := os.ReadFile(path)
+	if strings.Contains(string(raw), "secret") || !strings.HasPrefix(string(raw), sealedPrefix) {
+		t.Fatalf("lines must be sealed on disk:\n%s", raw)
+	}
+	rep, _ := Verify(path, nil)
+	if !rep.Intact() || rep.Sealed != 2 || rep.Chained != 2 {
+		t.Fatalf("sealed chain: %+v", rep)
+	}
+	if seq, _ := Tail(path); seq != 2 {
+		t.Fatalf("tail through sealed lines: %d", seq)
+	}
+}

--- a/pkg/auditchain/lock_unix.go
+++ b/pkg/auditchain/lock_unix.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package auditchain
+
+import (
+	"os"
+	"syscall"
+)
+
+// lockFile takes an exclusive advisory lock on f (blocking).
+func lockFile(f *os.File) error { return syscall.Flock(int(f.Fd()), syscall.LOCK_EX) }
+
+// unlockFile releases the lock taken by lockFile.
+func unlockFile(f *os.File) error { return syscall.Flock(int(f.Fd()), syscall.LOCK_UN) }

--- a/pkg/auditchain/lock_windows.go
+++ b/pkg/auditchain/lock_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package auditchain
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// lockFile takes an exclusive lock on the first byte of f (blocking);
+// every writer locks the same byte, which serializes appends.
+func lockFile(f *os.File) error {
+	ol := new(windows.Overlapped)
+	return windows.LockFileEx(windows.Handle(f.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, ol)
+}
+
+// unlockFile releases the lock taken by lockFile.
+func unlockFile(f *os.File) error {
+	ol := new(windows.Overlapped)
+	return windows.UnlockFileEx(windows.Handle(f.Fd()), 0, 1, 0, ol)
+}

--- a/server/audit.go
+++ b/server/audit.go
@@ -7,8 +7,7 @@ package server
 
 import (
 	"context"
-	"encoding/json"
-	"io"
+	"github.com/diillson/chatcli/pkg/auditchain"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,6 +24,7 @@ import (
 // AuditEntry is a structured audit log event for security-relevant operations.
 type AuditEntry struct {
 	Timestamp   string            `json:"timestamp"`
+	Kind        string            `json:"kind,omitempty"` // "grpc" (LLM entries in the same trail carry "llm")
 	RequestID   string            `json:"request_id"`
 	ClientID    string            `json:"client_id"`
 	ClientAddr  string            `json:"client_addr,omitempty"`
@@ -38,10 +38,9 @@ type AuditEntry struct {
 
 // AuditLogger provides structured audit logging for gRPC server operations.
 type AuditLogger struct {
-	mu         sync.Mutex
-	zapLogger  *zap.Logger
-	fileWriter io.WriteCloser
-	encoder    *json.Encoder
+	mu        sync.Mutex
+	zapLogger *zap.Logger
+	chain     *auditchain.Writer
 }
 
 // NewAuditLogger creates an audit logger. If CHATCLI_AUDIT_LOG_PATH is set,
@@ -53,12 +52,17 @@ func NewAuditLogger(logger *zap.Logger) *AuditLogger {
 
 	if path := os.Getenv("CHATCLI_AUDIT_LOG_PATH"); path != "" {
 		cleanPath := filepath.Clean(path)
-		f, err := os.OpenFile(cleanPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+		if !filepath.IsAbs(cleanPath) {
+			logger.Error("audit log path must be absolute; file audit disabled", zap.String("path", path))
+			return al
+		}
+		// The same hash-chained, file-locked trail the LLM auditor writes:
+		// gRPC entries interleave with LLM entries in one verifiable chain.
+		w, err := auditchain.Open(cleanPath, auditchain.Options{})
 		if err != nil {
 			logger.Error("failed to open audit log file", zap.String("path", path), zap.Error(err))
 		} else {
-			al.fileWriter = f
-			al.encoder = json.NewEncoder(f)
+			al.chain = w
 		}
 	}
 
@@ -80,17 +84,22 @@ func (al *AuditLogger) Log(entry AuditEntry) {
 		zap.String("duration", entry.Duration),
 	)
 
-	if al.encoder != nil {
+	if al.chain != nil {
+		if entry.Kind == "" {
+			entry.Kind = "grpc"
+		}
 		al.mu.Lock()
-		_ = al.encoder.Encode(entry)
+		if err := al.chain.Append(entry); err != nil {
+			al.zapLogger.Warn("audit log write failed", zap.Error(err))
+		}
 		al.mu.Unlock()
 	}
 }
 
 // Close shuts down the audit file writer.
 func (al *AuditLogger) Close() {
-	if al.fileWriter != nil {
-		if err := al.fileWriter.Close(); err != nil {
+	if al.chain != nil {
+		if err := al.chain.Close(); err != nil {
 			al.zapLogger.Error("failed to close audit log file", zap.Error(err))
 		}
 	}

--- a/server/audit_chain_test.go
+++ b/server/audit_chain_test.go
@@ -1,0 +1,51 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package server
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/diillson/chatcli/pkg/auditchain"
+	"go.uber.org/zap"
+)
+
+func TestAuditLogger_JoinsTheSharedChain(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	t.Setenv("CHATCLI_AUDIT_LOG_PATH", path)
+	t.Setenv("CHATCLI_ENCRYPTION_KEY", "")
+	// An LLM auditor (another process in production) already writes here.
+	llm, err := auditchain.Open(path, auditchain.Options{Seal: func() bool { return false }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = llm.Append(map[string]string{"kind": "llm", "phase": "send"})
+
+	al := NewAuditLogger(zap.NewNop())
+	if al.chain == nil {
+		t.Fatal("audit file must be open")
+	}
+	al.Log(AuditEntry{RequestID: "r1", ClientID: "c1", Method: "/chat", Result: "success"})
+	_ = llm.Append(map[string]string{"kind": "llm", "phase": "recv"})
+	al.Log(AuditEntry{RequestID: "r2", ClientID: "c1", Method: "/chat", Result: "denied"})
+	al.Close()
+	_ = llm.Close()
+
+	rep, err := auditchain.Verify(path, nil)
+	if err != nil || !rep.Intact() || rep.Chained != 4 {
+		t.Fatalf("gRPC and LLM entries must form one chain: %+v err=%v", rep, err)
+	}
+}
+
+func TestAuditLogger_RejectsRelativePath(t *testing.T) {
+	t.Setenv("CHATCLI_AUDIT_LOG_PATH", "relative/audit.jsonl")
+	al := NewAuditLogger(zap.NewNop())
+	if al.chain != nil {
+		t.Fatal("a relative audit path must not be opened")
+	}
+	al.Log(AuditEntry{RequestID: "r1"}) // zap only, no panic
+	al.Close()
+}


### PR DESCRIPTION
## Summary

Audit III, PR 8 (P1 SEC-6; the audit part of SEC-7).

The hash-chained LLM audit trail had four holes: no lock (a REPL and a gateway daemon writing the same file both seed seq/hash from the tail once and then interleave into guaranteed link mismatches), a third unchained writer (the gRPC server's audit logger on the same path), a torn last line accepted on append but reported as broken forever, and a plaintext file that never rotated.

- **`pkg/auditchain`** (new leaf package): `Writer.Append` takes an exclusive file lock (flock / LockFileEx), re-reads the tail when the file grew or was rotated under it, and links the line with a struct-independent canonical form (`chain_v: 2`, sorted-key JSON), so any Go struct from any process chains identically. Files rotate at 64 MiB (`Options.MaxBytes`); the first line of the new file carries `rotated_from` and the previous file's last hash, and `Verify` follows the boundary. A torn tail is terminated before the next append, skipped by `Tail`, and reported as `Torn` (crash residue), never as tampering. With encryption at rest enabled every line is sealed (`enc:` prefix) and opened transparently on verify.
- **LLM auditor** writes through the chain writer; `VerifyAuditChain` keeps its signature, verifies version-1 lines with the old struct-order hash (`LegacyVerifier`) and reports `Sealed`, `Torn`, `RotatedFrom`.
- **gRPC `AuditLogger`** joins the same chain (`kind: grpc`), rejects relative paths, and closes the writer.
- **Retention** prunes rotated trail files past the session window (the live file is never touched); `/config security verify-audit` prints sealed count, rotation origin, torn tail and rotated siblings; the at-rest coverage row lists the audit trail.

i18n (en, en-US, pt-BR).

## Tests

`pkg/auditchain`: chain/verify/tamper, two writers interleaving on one file, rotation with cross-file verification and pruning, a writer holding a rotated file reopening the live path, torn tail (not tampering, repaired on next append), legacy lines through the owner hasher, sealed lines. `server`: gRPC + LLM entries form one chain; relative path refused. `cli`: a version-1 trail still verifies, continues under the new writer, and tampering still breaks at the right line. golangci-lint and the local gates are green.