### PR TITLE
fix(context): recover from context overflow on chat, RPC, one-shot and MoA; classify every provider's overflow body; per-session recovery budgets

### DIFF
--- a/cli/agent/audit3_pr9_test.go
+++ b/cli/agent/audit3_pr9_test.go
@@ -1,0 +1,62 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package agent
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+func TestLevel1Recovery_DoesNotTouchThePackageBudgets(t *testing.T) {
+	turn, per := DefaultTurnBudgetChars, DefaultPerResultMaxChars
+	history := []models.Message{
+		{Role: "assistant", Content: "run", ToolCalls: []models.ToolCall{{ID: "c1", Name: "read"}}},
+		{Role: "tool", ToolCallID: "c1", Content: strings.Repeat("x", per+100)},
+	}
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cr := NewContextRecovery(DefaultContextRecoveryConfig(), zap.NewNop())
+			out, ok := cr.RecoverContextOverflow(append([]models.Message(nil), history...))
+			if !ok || len(out) == 0 {
+				t.Error("recovery must run")
+			}
+			// Another session reading the defaults concurrently must see
+			// them unchanged (the race detector flags a mutation).
+			if DefaultTurnBudgetChars != turn || DefaultPerResultMaxChars != per {
+				t.Error("package budgets mutated by a session's recovery")
+			}
+		}()
+	}
+	wg.Wait()
+	if DefaultTurnBudgetChars != turn || DefaultPerResultMaxChars != per {
+		t.Fatal("package budgets changed")
+	}
+	// Explicit budgets tighten the result without the globals.
+	out, rep := EnforceToolResultBudgetWith(history, 1000, 500, zap.NewNop())
+	if rep == nil || len(out[1].Content) >= per {
+		t.Fatalf("explicit per-result budget must apply: %d chars", len(out[1].Content))
+	}
+	if _, rep := EnforceToolResultBudgetWith(history, 0, 0, zap.NewNop()); rep == nil {
+		t.Fatal("zero budgets fall back to the defaults")
+	}
+}
+
+func TestIsContextTooLongError_DelegatesToTheSharedClassifier(t *testing.T) {
+	if !IsContextTooLongError(errors.New("input token count (99) exceeds the maximum number of tokens allowed")) {
+		t.Fatal("gemini phrasing must classify")
+	}
+	if IsContextTooLongError(errors.New("rate limit exceeded")) {
+		t.Fatal("rate limit is not overflow")
+	}
+}

--- a/cli/agent/context_recovery.go
+++ b/cli/agent/context_recovery.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/diillson/chatcli/llm/client"
 	"github.com/diillson/chatcli/models"
 	"go.uber.org/zap"
 )
@@ -140,17 +141,12 @@ func (cr *ContextRecovery) level1Recovery(history []models.Message) []models.Mes
 	// Step 1: Tool result pairing cleanup
 	history, _ = EnsureToolResultPairing(history, cr.logger)
 
-	// Step 2: Halve the budget limits
-	origTurnBudget := DefaultTurnBudgetChars
-	origPerResult := DefaultPerResultMaxChars
-	DefaultTurnBudgetChars = int(float64(origTurnBudget) * cr.config.AggressiveBudgetRatio)
-	DefaultPerResultMaxChars = int(float64(origPerResult) * cr.config.AggressiveBudgetRatio)
-
-	history, _ = EnforceToolResultBudget(history, cr.logger)
-
-	// Restore original limits
-	DefaultTurnBudgetChars = origTurnBudget
-	DefaultPerResultMaxChars = origPerResult
+	// Step 2: Halve the budget limits — for this session only. The
+	// package defaults are shared by every session of a gateway/rpcserve
+	// process and must never be mutated from a recovery.
+	turnBudget := int(float64(DefaultTurnBudgetChars) * cr.config.AggressiveBudgetRatio)
+	perResult := int(float64(DefaultPerResultMaxChars) * cr.config.AggressiveBudgetRatio)
+	history, _ = EnforceToolResultBudgetWith(history, turnBudget, perResult, cr.logger)
 
 	// Step 3: Truncate large assistant messages (reasoning, explanations)
 	for i := range history {
@@ -276,15 +272,7 @@ func IsContextTooLongError(err error) bool {
 	if err == nil {
 		return false
 	}
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "context length") ||
-		strings.Contains(msg, "too long") ||
-		strings.Contains(msg, "maximum context") ||
-		strings.Contains(msg, "prompt is too long") ||
-		strings.Contains(msg, "request too large") ||
-		strings.Contains(msg, "max_tokens") && strings.Contains(msg, "exceed") ||
-		strings.Contains(msg, "input too long") ||
-		strings.Contains(msg, "token limit")
+	return client.IsContextOverflowError(err)
 }
 
 // IsPayloadTooLargeError detects HTTP 413 responses and proxy-level body

--- a/cli/agent/tool_result_budget.go
+++ b/cli/agent/tool_result_budget.go
@@ -100,6 +100,20 @@ type BudgetReport struct {
 //
 // Returns the (possibly modified) history and a report.
 func EnforceToolResultBudget(history []models.Message, logger *zap.Logger) ([]models.Message, *BudgetReport) {
+	return EnforceToolResultBudgetWith(history, DefaultTurnBudgetChars, DefaultPerResultMaxChars, logger)
+}
+
+// EnforceToolResultBudgetWith is EnforceToolResultBudget with explicit
+// budgets, so a session can tighten its own limits (context recovery)
+// without touching the package defaults shared by every other session
+// of the process.
+func EnforceToolResultBudgetWith(history []models.Message, turnBudget, perResult int, logger *zap.Logger) ([]models.Message, *BudgetReport) {
+	if turnBudget <= 0 {
+		turnBudget = DefaultTurnBudgetChars
+	}
+	if perResult <= 0 {
+		perResult = DefaultPerResultMaxChars
+	}
 	report := &BudgetReport{}
 
 	if len(history) == 0 {
@@ -142,9 +156,9 @@ func EnforceToolResultBudget(history []models.Message, logger *zap.Logger) ([]mo
 			report.TotalToolResults++
 			report.TotalOriginalChars += int64(len(msg.Content))
 
-			if len(msg.Content) > DefaultPerResultMaxChars {
+			if len(msg.Content) > perResult {
 				history[idx].Content = truncateWithDiskPersist(
-					msg.Content, msg.ToolCallID, DefaultPerResultMaxChars, logger)
+					msg.Content, msg.ToolCallID, perResult, logger)
 				report.ResultsTruncated++
 				report.ResultsPersistedDisk++
 				report.BytesSavedToDisk += int64(len(msg.Content)) - int64(len(history[idx].Content))
@@ -159,7 +173,7 @@ func EnforceToolResultBudget(history []models.Message, logger *zap.Logger) ([]mo
 			turnSize += len(history[idx].Content)
 		}
 
-		if turnSize <= DefaultTurnBudgetChars {
+		if turnSize <= turnBudget {
 			continue
 		}
 
@@ -178,13 +192,13 @@ func EnforceToolResultBudget(history []models.Message, logger *zap.Logger) ([]mo
 
 		// Progressively truncate the largest results until under budget
 		for _, sr := range sorted {
-			if turnSize <= DefaultTurnBudgetChars {
+			if turnSize <= turnBudget {
 				break
 			}
 
 			content := history[sr.idx].Content
 			// Target: reduce this result to bring turn under budget
-			excess := turnSize - DefaultTurnBudgetChars
+			excess := turnSize - turnBudget
 			targetSize := len(content) - excess
 			if targetSize < PreviewHeadChars+PreviewTailChars+200 {
 				targetSize = PreviewHeadChars + PreviewTailChars + 200

--- a/cli/audit3_pr9_test.go
+++ b/cli/audit3_pr9_test.go
@@ -1,0 +1,105 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+)
+
+// overflowFakeClient fails with a context-overflow error until failures
+// are exhausted, then answers.
+type overflowFakeClient struct {
+	rpcChatFakeClient
+	failures int
+	calls    int
+	sizes    []int
+}
+
+func (f *overflowFakeClient) SendPrompt(ctx context.Context, p string, hist []models.Message, n int) (string, error) {
+	if !strings.HasPrefix(p, "hi") {
+		// The compactor's summarizer call rides the same fake client.
+		return "summary", nil
+	}
+	f.calls++
+	chars := 0
+	for _, m := range hist {
+		chars += len(m.Content)
+	}
+	f.sizes = append(f.sizes, chars)
+	if f.calls <= f.failures {
+		return "", errors.New("This model's maximum context length is 8192 tokens. However, your messages resulted in 9000 tokens.")
+	}
+	return f.rpcChatFakeClient.SendPrompt(ctx, p, hist, n)
+}
+
+func bulkyHistory(n int) []models.Message {
+	var h []models.Message
+	for i := 0; i < n; i++ {
+		h = append(h, models.Message{Role: "user", Content: strings.Repeat("q", 3000)}, models.Message{Role: "assistant", Content: strings.Repeat("a", 6000)})
+	}
+	return h
+}
+
+func TestRunChatTurnRPC_RecoversFromContextOverflow(t *testing.T) {
+	fake := &overflowFakeClient{rpcChatFakeClient: rpcChatFakeClient{reply: "recovered"}, failures: 2}
+	c := newRPCChatCLI(t, &fake.rpcChatFakeClient)
+	c.Client = fake
+	turn, err := c.RunChatTurnRPC(context.Background(), "sess-ovf", "hi", bulkyHistory(30), RPCChatOpts{})
+	if err != nil {
+		t.Fatalf("the RPC turn must recover: %v", err)
+	}
+	if turn.Reply != "recovered" || fake.calls != 3 {
+		t.Fatalf("reply=%q calls=%d", turn.Reply, fake.calls)
+	}
+	if fake.sizes[2] >= fake.sizes[0] {
+		t.Fatalf("each retry must carry a smaller history: %v", fake.sizes)
+	}
+}
+
+func TestRunChatTurnRPC_OverflowRecoveryIsBounded(t *testing.T) {
+	fake := &overflowFakeClient{failures: 100}
+	c := newRPCChatCLI(t, &fake.rpcChatFakeClient)
+	c.Client = fake
+	_, err := c.RunChatTurnRPC(context.Background(), "sess-ovf2", "hi", bulkyHistory(30), RPCChatOpts{})
+	if err == nil {
+		t.Fatal("a provider that always overflows must fail the turn")
+	}
+	// one send + refresh-on-auth check (no) + MaxRecoveryAttempts retries
+	if fake.calls != 1+3 {
+		t.Fatalf("calls = %d, want the bounded 4", fake.calls)
+	}
+}
+
+func TestRecoverOverflow_IgnoresOtherErrors(t *testing.T) {
+	c := newRPCChatCLI(t, &rpcChatFakeClient{})
+	c.history = bulkyHistory(3)
+	before := len(c.history)
+	rec := c.newOverflowRecovery("chat", nil)
+	if c.recoverOverflow(context.Background(), rec, errors.New("401 unauthorized")) || len(c.history) != before {
+		t.Fatal("non-overflow errors must not touch the history")
+	}
+	if c.recoverOverflow(context.Background(), rec, context.Canceled) {
+		t.Fatal("cancellation is never recovered")
+	}
+	// A standalone thread (MoA participant) compacts without touching cli.history.
+	thread := bulkyHistory(20)
+	out, ok := rec.recoverHistory(errors.New("prompt is too long: 9 tokens > 8 maximum"), thread)
+	if !ok || len(c.history) != before {
+		t.Fatalf("standalone recovery: ok=%v history=%d", ok, len(c.history))
+	}
+	total := 0
+	for _, m := range out {
+		total += len(m.Content)
+	}
+	if total >= 20*9000 {
+		t.Fatalf("standalone thread must shrink: %d", total)
+	}
+}

--- a/cli/cli_llm.go
+++ b/cli/cli_llm.go
@@ -71,6 +71,21 @@ func (cli *ChatCLI) processLLMRequest(parentCtx context.Context, in string) {
 		ctx, resolution.Client, userInput, additionalContext,
 		tempHistory, effectiveMaxTokens, resolution, stopSpinner,
 	)
+	// Context overflow / payload rejection: compact (bounded) and resend
+	// with the prefix rebuilt over the recovered history — the same
+	// recovery the agent loop has, now on the chat surface.
+	rec := cli.newOverflowRecovery("chat", func(msg string) {
+		fmt.Printf("\r\033[K  %s\n", colorize(msg, ColorYellow))
+	})
+	for llmErr != nil && cli.recoverOverflow(ctx, rec, llmErr) {
+		tempHistory = cli.buildChatTempHistoryWithContext(assembly.parts, assembly.turnContext, userInput, additionalContext, images)
+		cli.lastPromptChars = promptCharsOf(tempHistory) + len(userInput+additionalContext)
+		cli.animation.ShowThinkingAnimation(resolution.Client.GetModelName())
+		aiResponse, llmErr = cli.executeLLMTurn(
+			ctx, resolution.Client, userInput, additionalContext,
+			tempHistory, effectiveMaxTokens, resolution, stopSpinner,
+		)
+	}
 	cli.handleChatTurnResult(
 		ctx, llmErr, userMessage, aiResponse, resolution.Client, resolution,
 		userInput, additionalContext, time.Since(turnStart),

--- a/cli/moa_turn.go
+++ b/cli/moa_turn.go
@@ -116,6 +116,17 @@ func (cli *ChatCLI) moaTurn(ts moaToolset) moa.Turn {
 		}
 		if !ts.any() {
 			out, err := c.SendPrompt(ctx, prompt, history, 0)
+			// A participant's thread is its own: overflow recovery compacts
+			// that thread (bounded) and retries instead of failing the panel.
+			rec := cli.newOverflowRecovery("moa", nil)
+			for err != nil {
+				h, ok := rec.recoverHistory(err, history)
+				if !ok {
+					break
+				}
+				history = h
+				out, err = c.SendPrompt(ctx, prompt, history, 0)
+			}
 			if err == nil {
 				cli.recordMoaUsage(ref, c, prompt, history, out)
 			}
@@ -220,8 +231,17 @@ func (cli *ChatCLI) runMoaTurnXML(
 	}
 	prompt += instruction
 
+	rec := cli.newOverflowRecovery("moa", nil)
 	for round := 0; ; round++ {
 		resp, err := c.SendPrompt(ctx, prompt, history, 0)
+		for err != nil {
+			h, ok := rec.recoverHistory(err, history)
+			if !ok {
+				break
+			}
+			history = h
+			resp, err = c.SendPrompt(ctx, prompt, history, 0)
+		}
 		if err != nil {
 			return "", err
 		}

--- a/cli/oneshot_mode.go
+++ b/cli/oneshot_mode.go
@@ -264,6 +264,11 @@ func (cli *ChatCLI) RunOnce(ctx context.Context, input string, disableAnimation 
 	if cli.refreshClientOnAuthError(err) {
 		aiResponse, err = activeClient.SendPrompt(ctx, userInput+additionalContext, cli.history, effectiveMaxTokens)
 	}
+	// Overflow recovery (bounded), notices on stderr so stdout stays pipeable.
+	rec := cli.newOverflowRecovery("oneshot", func(msg string) { fmt.Fprintf(os.Stderr, "  %s\n", msg) })
+	for err != nil && cli.recoverOverflow(ctx, rec, err) {
+		aiResponse, err = activeClient.SendPrompt(ctx, userInput+additionalContext, cli.history, effectiveMaxTokens)
+	}
 
 	if !disableAnimation {
 		cli.animation.StopThinkingAnimation()

--- a/cli/overflow_recovery.go
+++ b/cli/overflow_recovery.go
@@ -1,0 +1,102 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Context-overflow recovery for the non-agent loops.
+ *
+ * The agent/coder loop has recovered from "context too long" and
+ * proxy-payload rejections for a long time (aggressive budget → level 2 →
+ * emergency truncation, then retry). The chat REPL, RPC chat (MCP, ACP,
+ * gateway), one-shot and MoA participants simply failed the turn. They
+ * now share one bounded helper with the same guarantees a planned
+ * compaction gives: memory flushed first, hooks told, dropped messages
+ * archived to CCR, the cache rebuild accounted for.
+ */
+package cli
+
+import (
+	"context"
+	"errors"
+
+	"github.com/diillson/chatcli/cli/agent"
+	"github.com/diillson/chatcli/i18n"
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+// overflowRecovery bounds recovery attempts for one turn on one surface.
+type overflowRecovery struct {
+	cr      *agent.ContextRecovery
+	surface string
+	notify  func(string)
+}
+
+// newOverflowRecovery starts a per-turn recovery budget. notify renders a
+// one-line notice to the user (nil = silent, e.g. RPC surfaces).
+func (cli *ChatCLI) newOverflowRecovery(surface string, notify func(string)) *overflowRecovery {
+	logger := zap.NewNop()
+	if cli != nil && cli.logger != nil {
+		logger = cli.logger
+	}
+	return &overflowRecovery{cr: agent.NewContextRecovery(agent.DefaultContextRecoveryConfig(), logger), surface: surface, notify: notify}
+}
+
+// overflowLike reports whether err is a context overflow or a payload
+// rejection worth recovering from given the history size.
+func overflowLike(err error, history []models.Message) bool {
+	if err == nil || errors.Is(err, context.Canceled) {
+		return false
+	}
+	if agent.IsContextTooLongError(err) {
+		return true
+	}
+	chars := 0
+	for _, m := range history {
+		chars += len(m.Content)
+	}
+	return agent.IsLikelyPayloadProblem(err, chars)
+}
+
+// recover compacts cli.history in place after an overflow error and
+// reports whether the caller should rebuild its request and retry. It
+// never retries past the configured attempts and never touches the
+// history for any other error.
+func (cli *ChatCLI) recoverOverflow(ctx context.Context, rec *overflowRecovery, err error) bool {
+	if cli == nil || rec == nil || !overflowLike(err, cli.history) || !rec.cr.CanRecoverContextOverflow() {
+		return false
+	}
+	cli.flushMemoryBeforeCompaction(ctx)
+	cli.beforeCompaction(ctx, compactTriggerRecovery)
+	recovered, ok := rec.cr.RecoverContextOverflow(cli.history)
+	if !ok {
+		return false
+	}
+	if note := archiveDroppedMessages(cli.compressionLayer, cli.history, recovered); note != "" {
+		recovered = append(recovered, models.Message{Role: "user", Content: note})
+	}
+	cli.history = recovered
+	if cli.costTracker != nil {
+		cli.costTracker.NoteExpectedCacheRebuild()
+	}
+	cli.firePostCompact(ctx, compactTriggerRecovery)
+	if cli.logger != nil {
+		cli.logger.Warn("Context overflow recovered; retrying the turn",
+			zap.String("surface", rec.surface), zap.Int("history", len(cli.history)), zap.Error(err))
+	}
+	if rec.notify != nil {
+		rec.notify(i18n.T("chat.recovery.retrying", rec.surface))
+	}
+	return true
+}
+
+// recoverOverflowHistory is the standalone-history variant for callers
+// whose conversation is not cli.history (a MoA participant's own thread):
+// no hooks, no CCR — the thread is transient — just the bounded compaction
+// and the retry decision.
+func (rec *overflowRecovery) recoverHistory(err error, history []models.Message) ([]models.Message, bool) {
+	if rec == nil || !overflowLike(err, history) || !rec.cr.CanRecoverContextOverflow() {
+		return history, false
+	}
+	return rec.cr.RecoverContextOverflow(history)
+}

--- a/cli/rpc_chat.go
+++ b/cli/rpc_chat.go
@@ -130,6 +130,13 @@ func (cli *ChatCLI) runChatTurnSerialized(
 	if cli.refreshClientOnAuthError(err) {
 		reply, err = activeClient.SendPrompt(ctx, input+additionalContext, tempHistory, maxTokens)
 	}
+	// Overflow recovery (bounded): the unattended surfaces used to fail
+	// the turn outright where the REPL agent loop recovered.
+	rec := cli.newOverflowRecovery("rpc", nil)
+	for err != nil && cli.recoverOverflow(ctx, rec, err) {
+		tempHistory = cli.buildChatTempHistoryWithContext(assembly.parts, assembly.turnContext, input, additionalContext, images)
+		reply, err = activeClient.SendPrompt(ctx, input+additionalContext, tempHistory, maxTokens)
+	}
 	if err != nil {
 		return RPCChatTurn{}, err
 	}

--- a/i18n/fragments_test.go
+++ b/i18n/fragments_test.go
@@ -1,0 +1,35 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package i18n
+
+import (
+	"strings"
+	"testing"
+
+	"golang.org/x/text/language"
+)
+
+func TestFragments_MergeIntoTheirLocale(t *testing.T) {
+	Init()
+	for _, tag := range []language.Tag{language.MustParse("en"), language.MustParse("en-US"), language.MustParse("pt-BR")} {
+		v, ok := rawByTag[tag]["chat.recovery.retrying"]
+		if !ok || strings.TrimSpace(v) == "" || v == "chat.recovery.retrying" {
+			t.Fatalf("%s: fragment key must load into the locale (got %q)", tag, v)
+		}
+		if _, ok := rawByTag[tag]["cmd.help"]; !ok {
+			// The base catalog must still be there alongside the fragment.
+			if len(rawByTag[tag]) < 1000 {
+				t.Fatalf("%s: base catalog missing: %d keys", tag, len(rawByTag[tag]))
+			}
+		}
+	}
+	// No phantom "en.recovery" locale was registered.
+	for tag := range rawByTag {
+		if strings.Contains(tag.String(), "recovery") {
+			t.Fatalf("fragment registered as a locale: %s", tag)
+		}
+	}
+}

--- a/i18n/i18n.go
+++ b/i18n/i18n.go
@@ -80,20 +80,36 @@ func initI18n() {
 	}
 
 	registeredTags := []language.Tag{defaultLang}
+	seen := map[language.Tag]bool{defaultLang: true}
 
+	// A locale is the union of its base file (en.json) and its fragments
+	// (en.<feature>.json): a feature ships its strings in its own small
+	// file instead of editing the shared catalog, so parallel changes
+	// never conflict. Base files load first (whatever ReadDir's order),
+	// so a fragment may override the base deliberately.
+	ordered := make([]string, 0, len(files))
 	for _, file := range files {
-		fileName := file.Name()
-		if !strings.HasSuffix(fileName, ".json") {
-			continue
+		if strings.HasSuffix(file.Name(), ".json") && !isLocaleFragment(file.Name()) {
+			ordered = append(ordered, file.Name())
 		}
+	}
+	for _, file := range files {
+		if strings.HasSuffix(file.Name(), ".json") && isLocaleFragment(file.Name()) {
+			ordered = append(ordered, file.Name())
+		}
+	}
+	for _, fileName := range ordered {
 
-		tagStr := strings.TrimSuffix(fileName, ".json")
+		tagStr, _, _ := strings.Cut(strings.TrimSuffix(fileName, ".json"), ".")
 		tag, err := language.Parse(tagStr)
 		if err != nil {
 			continue
 		}
 
-		registeredTags = append(registeredTags, tag)
+		if !seen[tag] {
+			seen[tag] = true
+			registeredTags = append(registeredTags, tag)
+		}
 
 		content, err := localesFS.ReadFile("locales/" + fileName)
 		if err != nil {
@@ -105,7 +121,12 @@ func initI18n() {
 			continue
 		}
 
-		rawByTag[tag] = translations
+		if rawByTag[tag] == nil {
+			rawByTag[tag] = make(map[string]string, len(translations))
+		}
+		for key, value := range translations {
+			rawByTag[tag][key] = value
+		}
 		for key, value := range translations {
 			if err := message.SetString(tag, key, value); err != nil {
 				fmt.Printf("aviso i18n: falha ao definir a string para a chave '%s': %v\n", key, err)
@@ -125,6 +146,11 @@ func initI18n() {
 		rawTag = registeredTags[idx]
 	}
 	printer = message.NewPrinter(bestTag)
+}
+
+// isLocaleFragment reports whether name is <tag>.<feature>.json.
+func isLocaleFragment(name string) bool {
+	return strings.Contains(strings.TrimSuffix(name, ".json"), ".")
 }
 
 // ActiveTag returns the resolved language tag (e.g. "pt-BR", "en-US", "en").

--- a/i18n/locales/en-US.recovery.json
+++ b/i18n/locales/en-US.recovery.json
@@ -1,0 +1,3 @@
+{
+  "chat.recovery.retrying": "⚠ The request did not fit the model's context window; history was compacted (%s) and the turn is being retried."
+}

--- a/i18n/locales/en.recovery.json
+++ b/i18n/locales/en.recovery.json
@@ -1,0 +1,3 @@
+{
+  "chat.recovery.retrying": "⚠ The request did not fit the model's context window; history was compacted (%s) and the turn is being retried."
+}

--- a/i18n/locales/pt-BR.recovery.json
+++ b/i18n/locales/pt-BR.recovery.json
@@ -1,0 +1,3 @@
+{
+  "chat.recovery.retrying": "⚠ A requisição não coube na janela de contexto do modelo; o histórico foi compactado (%s) e o turno está sendo reenviado."
+}

--- a/llm/client/overflow.go
+++ b/llm/client/overflow.go
@@ -1,0 +1,74 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Context-overflow classification shared by every loop that can recover
+ * from it (agent/coder, chat REPL, RPC chat, one-shot, MoA) and by the
+ * fallback chain. Providers phrase the same condition differently; the
+ * patterns below are the documented bodies of OpenAI (chat and
+ * Responses), Anthropic, Gemini, xAI, Mistral, Groq, Cohere, DeepSeek,
+ * Bedrock and OpenAI-compatible gateways.
+ */
+package client
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/diillson/chatcli/utils"
+)
+
+// overflowPhrases are matched case-insensitively against the error text.
+var overflowPhrases = []string{
+	"context length",
+	"context window",
+	"context_length_exceeded",
+	"context-length-exceeded",
+	"maximum context",
+	"max context",
+	"prompt is too long",
+	"prompt too long",
+	"input too long",
+	"input is too long",
+	"request too large",
+	"too many tokens",
+	"token limit",
+	"input token count",
+	"maximum prompt length",
+	"maximum number of tokens",
+	"exceeds the maximum",
+	"exceeds model",
+	"reduce the length",
+	"reduce your prompt",
+	"messages too long",
+	"conversation too long",
+	"too long",
+}
+
+// IsContextOverflowError reports whether err is the provider telling us the
+// request does not fit the model's context window (or its input token
+// limit). A 400/413 utils.APIError whose body pairs a token/length word
+// with an excess word counts too, so unlisted phrasings still classify.
+func IsContextOverflowError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, p := range overflowPhrases {
+		if strings.Contains(msg, p) {
+			return true
+		}
+	}
+	if strings.Contains(msg, "max_tokens") && strings.Contains(msg, "exceed") {
+		return true
+	}
+	var apiErr *utils.APIError
+	if errors.As(err, &apiErr) && (apiErr.StatusCode == 400 || apiErr.StatusCode == 413) {
+		body := strings.ToLower(apiErr.Message)
+		hasSubject := strings.Contains(body, "token") || strings.Contains(body, "context") || strings.Contains(body, "length") || strings.Contains(body, "prompt")
+		hasExcess := strings.Contains(body, "exceed") || strings.Contains(body, "too large") || strings.Contains(body, "too long") || strings.Contains(body, "limit") || strings.Contains(body, "maximum")
+		return hasSubject && hasExcess
+	}
+	return false
+}

--- a/llm/client/overflow_test.go
+++ b/llm/client/overflow_test.go
@@ -1,0 +1,45 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package client
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/diillson/chatcli/utils"
+)
+
+func TestIsContextOverflowError_ProviderBodies(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"openai chat", errors.New("This model's maximum context length is 128000 tokens. However, your messages resulted in 130000 tokens."), true},
+		{"openai responses", errors.New("Your input exceeds the context window of this model. Please adjust your input and try again."), true},
+		{"openai code", errors.New(`{"error":{"code":"context_length_exceeded","message":"..."}}`), true},
+		{"anthropic", errors.New("prompt is too long: 250000 tokens > 200000 maximum"), true},
+		{"gemini", errors.New("The input token count (1200000) exceeds the maximum number of tokens allowed (1048576)."), true},
+		{"xai", errors.New("This request exceeds the maximum prompt length for the model."), true},
+		{"mistral", errors.New("Prompt contains 40000 tokens, too large for model with 32768 maximum context length"), true},
+		{"bedrock", errors.New("ValidationException: Input is too long for requested model."), true},
+		{"groq", errors.New("Please reduce the length of the messages or completion."), true},
+		{"status-aware 400", &utils.APIError{StatusCode: 400, Message: "invalid request: total tokens 300k exceed what the model supports"}, true},
+		{"wrapped", fmt.Errorf("send: %w", &utils.APIError{StatusCode: 413, Message: "prompt length above the limit"}), true},
+		{"rate limit", errors.New("Rate limit exceeded: too many requests, retry after 20s"), false},
+		{"rate limit 429", &utils.APIError{StatusCode: 429, Message: "tokens per minute limit exceeded"}, false},
+		{"auth", &utils.APIError{StatusCode: 401, Message: "invalid api key"}, false},
+		{"timeout", errors.New("context deadline exceeded"), false},
+		{"bad request other", &utils.APIError{StatusCode: 400, Message: "unknown parameter: foo"}, false},
+		{"nil", nil, false},
+	}
+	for _, c := range cases {
+		if got := IsContextOverflowError(c.err); got != c.want {
+			t.Errorf("%s: got %v want %v (%v)", c.name, got, c.want, c.err)
+		}
+	}
+}

--- a/llm/fallback/chain.go
+++ b/llm/fallback/chain.go
@@ -335,7 +335,7 @@ func ClassifyError(err error) ErrorClass {
 		return ErrorClassServerError
 	case strings.Contains(msg, "model not found") || strings.Contains(msg, "404"):
 		return ErrorClassModelNotFound
-	case strings.Contains(msg, "context length") || strings.Contains(msg, "too long") || strings.Contains(msg, "max tokens"):
+	case client.IsContextOverflowError(err) || strings.Contains(msg, "max tokens"):
 		return ErrorClassContextTooLong
 	default:
 		return ErrorClassUnknown

--- a/tools/qg/i18nparity/fragments_test.go
+++ b/tools/qg/i18nparity/fragments_test.go
@@ -1,0 +1,52 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package i18nparity
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadLocales_MergesFragments(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, body string) {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("en.json", `{"a":"A"}`)
+	write("en.feature.json", `{"b":"B"}`)
+	write("pt-BR.json", `{"a":"A"}`)
+	write("pt-BR.feature.json", `{"b":"B"}`)
+	write("en-US.json", `{"a":"A"}`)
+	locales, err := LoadLocales(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(locales) != 3 {
+		t.Fatalf("fragments must not become locales: %d", len(locales))
+	}
+	for _, l := range locales {
+		switch l.Name {
+		case "en", "pt-BR":
+			if l.Keys["b"] != "B" || len(l.Fragments) != 1 {
+				t.Fatalf("%s: fragment not merged: %+v", l.Name, l)
+			}
+		case "en-US":
+			if _, ok := l.Keys["b"]; ok {
+				t.Fatal("en-US has no fragment")
+			}
+		default:
+			t.Fatalf("unexpected locale %q", l.Name)
+		}
+	}
+	// Parity still catches the locale that lacks the fragment's key.
+	missing := MissingByLocale(locales)
+	if len(missing["en-US"]) != 1 || missing["en-US"][0] != "b" {
+		t.Fatalf("missing = %v", missing)
+	}
+}

--- a/tools/qg/i18nparity/locales.go
+++ b/tools/qg/i18nparity/locales.go
@@ -25,6 +25,8 @@ type Locale struct {
 	Name string            // basename without extension, e.g. "en-US"
 	Path string            // full path to the JSON file
 	Keys map[string]string // top-level flat keys (this project's convention)
+	// Fragments are the <tag>.<feature>.json files merged into Keys.
+	Fragments []string
 }
 
 // LoadLocales reads every *.json under dir into a slice of Locale. The
@@ -38,10 +40,23 @@ func LoadLocales(dir string) ([]Locale, error) {
 	}
 
 	locales := make([]Locale, 0, len(entries))
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
-			continue
+	byName := map[string]int{}
+	// Base files first, fragments after — a fragment sorts before its base
+	// ("en.feature.json" < "en.json") and must merge into it, not the
+	// other way round.
+	ordered := make([]os.DirEntry, 0, len(entries))
+	for pass := 0; pass < 2; pass++ {
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+				continue
+			}
+			fragment := strings.Contains(strings.TrimSuffix(e.Name(), ".json"), ".")
+			if (pass == 0) != fragment {
+				ordered = append(ordered, e)
+			}
 		}
+	}
+	for _, e := range ordered {
 		path := filepath.Join(dir, e.Name())
 		// #nosec G304 -- path is dir (caller-controlled at the CLI flag)
 		// plus a directory entry returned by os.ReadDir; cannot escape dir.
@@ -63,11 +78,22 @@ func LoadLocales(dir string) ([]Locale, error) {
 				keys[k] = s
 			}
 		}
-		locales = append(locales, Locale{
-			Name: strings.TrimSuffix(e.Name(), ".json"),
-			Path: path,
-			Keys: keys,
-		})
+		// A locale is its base file plus its fragments (<tag>.<feature>.json),
+		// exactly as the runtime loader merges them.
+		name, _, isFragment := strings.Cut(strings.TrimSuffix(e.Name(), ".json"), ".")
+		if idx, ok := byName[name]; ok {
+			for k, v := range keys {
+				locales[idx].Keys[k] = v
+			}
+			locales[idx].Fragments = append(locales[idx].Fragments, path)
+			continue
+		}
+		loc := Locale{Name: name, Path: path, Keys: keys}
+		if isFragment {
+			loc.Fragments = []string{path}
+		}
+		byName[name] = len(locales)
+		locales = append(locales, loc)
 	}
 
 	if len(locales) == 0 {


### PR DESCRIPTION
## Summary

Audit III, PR 9 (P1 CMP-6; P2 CMP-7, CMP-16).

Provider context-overflow recovery existed only in the agent/coder loop. The chat REPL, RPC chat (MCP, ACP, gateway), one-shot and MoA participants failed the turn on the same error.

- **Shared recovery (CMP-6).** `cli/overflow_recovery.go`: a per-turn, bounded helper (`MaxRecoveryAttempts`, same levels as the agent loop: aggressive tool-result budget → level 2 → emergency truncation) that flushes memory first, tells the compaction hooks (`recovery` trigger), archives the dropped messages to CCR, notes the expected cache rebuild and lets the caller rebuild its request and retry. Wired into the chat REPL (prefix and turn context rebuilt over the recovered history), RPC chat, one-shot (notice on stderr so stdout stays pipeable) and both MoA participant paths (each participant recovers its own thread; the panel no longer fails). Squad workers run the agent loop and were already covered.
- **Classifier (CMP-7).** `client.IsContextOverflowError` in `llm/client` covers OpenAI chat and Responses ("context window"), the `context_length_exceeded` code, Anthropic, Gemini ("input token count … exceeds"), xAI ("maximum prompt length"), Mistral, Groq and Bedrock bodies, plus a status-aware check on a 400/413 `utils.APIError` pairing a token/length/context word with an excess word. `agent.IsContextTooLongError` delegates to it and the fallback chain classifies with it, so all three agree.
- **Per-session budgets (CMP-16).** `EnforceToolResultBudgetWith(history, turnBudget, perResult, logger)`; level-1 recovery passes halved budgets for the session instead of mutating `DefaultTurnBudgetChars` / `DefaultPerResultMaxChars`, which every session of a gateway or rpcserve process shares.

i18n (en, en-US, pt-BR).

## Tests

- `llm/client/overflow_test.go`: provider-body table (nine positives incl. wrapped and status-aware; rate limit, 429, auth, timeout, unrelated 400 negatives).
- `cli/agent/audit3_pr9_test.go`: eight concurrent recoveries under the race detector never change the package budgets; explicit budgets apply; zero falls back.
- `cli/audit3_pr9_test.go`: an RPC turn recovers after two overflows with a smaller history on each retry; a provider that always overflows fails after the bounded attempts; non-overflow errors and cancellation never touch the history; a standalone MoA thread shrinks without touching the session history.

golangci-lint and the local gates are green.

## Locale fragments

Second commit: the i18n loader and the `qg-i18n-parity` tool merge `<tag>.<feature>.json` into the `<tag>` locale (base file first, fragments after). A feature now ships its strings in its own small files (`en.recovery.json`, `en-US.recovery.json`, `pt-BR.recovery.json`) instead of editing the shared catalogs, which is what made every parallel PR conflict. Tests: `i18n/fragments_test.go`, `tools/qg/i18nparity/fragments_test.go`.