### PR TITLE
fix(knowledge): batched, single-flight embedding with skip-and-continue; binary/minified skip; passage hard cap; partial upsert persistence; rune-safe cuts

### DIFF
--- a/cli/ctxmgr/audit3_pr10_test.go
+++ b/cli/ctxmgr/audit3_pr10_test.go
@@ -1,0 +1,148 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package ctxmgr
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/diillson/chatcli/utils"
+)
+
+func TestSegmentOne_SkipsBinaryAndMinifiedCapsLongLines(t *testing.T) {
+	opts := SegmentOptions{}.sanitized()
+	if segs := segmentOne(utils.FileInfo{Path: "a.bin", Content: "abc\x00def", Type: "Binary"}, opts); len(segs) != 0 {
+		t.Fatal("NUL byte content must not be segmented")
+	}
+	if segs := segmentOne(utils.FileInfo{Path: "b.txt", Content: "ok\xff\xfe"}, opts); len(segs) != 0 {
+		t.Fatal("invalid UTF-8 must not be segmented")
+	}
+	minified := strings.Repeat("function a(){return 1};", 2000) + "\n" + strings.Repeat("var b=2;", 3000)
+	if segs := segmentOne(utils.FileInfo{Path: "bundle.min.js", Content: minified, Type: "JavaScript"}, opts); len(segs) != 0 {
+		t.Fatalf("minified bundle must be skipped, got %d passages", len(segs))
+	}
+	// Ordinary source with one very long line: the line is cut rune-safe
+	// at the hard cap and the rest of the file still segments.
+	long := strings.Repeat("é", opts.MaxChars*passageHardCapFactor) // 2 bytes each → over the cap
+	src := "line one\n" + long + "\nline three\n"
+	segs := segmentOne(utils.FileInfo{Path: "c.go", Content: src, Type: "Go"}, opts)
+	if len(segs) == 0 {
+		t.Fatal("ordinary text must segment")
+	}
+	for _, s := range segs {
+		if !utf8.ValidString(s.Content) {
+			t.Fatal("passage cut split a rune")
+		}
+		for _, l := range strings.Split(s.Content, "\n") {
+			if len(l) > opts.MaxChars*passageHardCapFactor+len("…") {
+				t.Fatalf("line over the hard cap: %d bytes", len(l))
+			}
+		}
+	}
+	if unembeddableReason("just a normal\nshort file\n") != "" || unembeddableReason(strings.Repeat("a normal line of code\n", 500)) != "" {
+		t.Fatal("ordinary text is embeddable")
+	}
+}
+
+// flakyProvider fails the embedding request that contains a poisoned text.
+type flakyProvider struct {
+	poison string
+	calls  int
+	texts  int
+}
+
+func (p *flakyProvider) Name() string   { return "fake:flaky" }
+func (p *flakyProvider) Dimension() int { return 3 }
+func (p *flakyProvider) Embed(_ context.Context, texts []string) ([][]float32, error) {
+	p.calls++
+	for _, t := range texts {
+		if strings.Contains(t, p.poison) {
+			return nil, errors.New("400 invalid input")
+		}
+	}
+	p.texts += len(texts)
+	out := make([][]float32, len(texts))
+	for i := range texts {
+		out[i] = []float32{1, 0, float32(i)}
+	}
+	return out, nil
+}
+
+func bigContext(n int, poisonAt int) *FileContext {
+	fc := &FileContext{ID: "big", Name: "big", UpdatedAt: time.Now(), Mode: ModeKnowledge}
+	for i := 0; i < n; i++ {
+		body := strings.Repeat("passage text ", 20)
+		if i == poisonAt {
+			body = "POISON " + body
+		}
+		fc.Files = append(fc.Files, utils.FileInfo{Path: "f" + itoa(i) + ".md", Content: body, Size: int64(len(body)), Type: "Markdown"})
+	}
+	fc.FileCount = len(fc.Files)
+	return fc
+}
+
+func TestWarm_SkipsAFailingBatchAndContinues(t *testing.T) {
+	p := &flakyProvider{poison: "POISON"}
+	e := NewRetrievalEngine(p, t.TempDir(), nil)
+	fc := bigContext(200, 10) // > 3 batches of 64; the poison sits in the first
+	n, err := e.Warm(context.Background(), fc)
+	if err == nil {
+		t.Fatal("the failing batch must be reported")
+	}
+	if n < 200-warmBatch || n >= 200 {
+		t.Fatalf("the other batches must still land: embedded=%d", n)
+	}
+	// A retrieval over the partially warmed context still answers, and
+	// does not re-send what is already embedded.
+	before := p.texts
+	hits, err := e.Retrieve(context.Background(), fc, "passage text", 3)
+	if err != nil || len(hits) == 0 {
+		t.Fatalf("retrieve after a partial warm: hits=%d err=%v", len(hits), err)
+	}
+	if p.texts-before > warmBatch {
+		t.Fatalf("retrieve re-embedded already-stored passages: %d", p.texts-before)
+	}
+}
+
+func TestRetrieve_EmbedsInBoundedBatchesUnderSingleFlight(t *testing.T) {
+	p := &warmProvider{}
+	e := NewRetrievalEngine(p, t.TempDir(), nil)
+	fc := bigContext(150, -1)
+	if _, err := e.Retrieve(context.Background(), fc, "passage text", 3); err != nil {
+		t.Fatal(err)
+	}
+	// 150 passages + 1 query: at least 3 passage requests, none above the batch.
+	if p.calls < 4 {
+		t.Fatalf("retrieve must batch its embeddings: calls=%d", p.calls)
+	}
+	// A poisoned context where every batch fails is a real error.
+	all := &flakyProvider{poison: "passage"}
+	e2 := NewRetrievalEngine(all, t.TempDir(), nil)
+	if _, err := e2.Retrieve(context.Background(), bigContext(5, -1), "passage text", 3); err == nil {
+		t.Fatal("nothing embedded must surface the provider error")
+	}
+}
+
+func TestFitSegments_RuneSafeCutAdjustsTheCitation(t *testing.T) {
+	seg := Segment{FilePath: "x.md", StartLine: 10, EndLine: 40, Content: strings.Repeat("ünïcödé line\n", 60)}
+	out := fitSegments([]Segment{seg}, 400)
+	if len(out) != 1 {
+		t.Fatalf("first passage must fit truncated: %d", len(out))
+	}
+	if !utf8.ValidString(out[0].Content) {
+		t.Fatal("cut split a rune")
+	}
+	if out[0].EndLine >= 40 || out[0].EndLine < 10 {
+		t.Fatalf("EndLine must follow the kept lines: %d", out[0].EndLine)
+	}
+	if want := 10 + strings.Count(out[0].Content, "\n"); out[0].EndLine != want {
+		t.Fatalf("EndLine=%d want %d", out[0].EndLine, want)
+	}
+}

--- a/cli/ctxmgr/manager.go
+++ b/cli/ctxmgr/manager.go
@@ -1055,7 +1055,11 @@ func fitSegments(segs []Segment, remaining int) []Segment {
 		cost := len(s.Content) + overhead
 		if cost > remaining {
 			if len(out) == 0 && remaining > overhead+200 {
-				s.Content = s.Content[:remaining-overhead-1] + "…"
+				// Rune-safe cut, and the citation range shrinks with it so
+				// the line numbers in the header stay true.
+				cut := alignRuneBefore(s.Content, remaining-overhead-1)
+				s.Content = s.Content[:cut] + "…"
+				s.EndLine = s.StartLine + strings.Count(s.Content, "\n")
 				out = append(out, s)
 			}
 			break

--- a/cli/ctxmgr/rerank.go
+++ b/cli/ctxmgr/rerank.go
@@ -216,7 +216,7 @@ func buildRerankPrompt(query string, cands []RerankCandidate) string {
 	for i, c := range cands {
 		snippet := strings.TrimSpace(c.Content)
 		if len(snippet) > rerankSnippetChars {
-			snippet = snippet[:rerankSnippetChars]
+			snippet = snippet[:alignRuneBefore(snippet, rerankSnippetChars)]
 		}
 		fmt.Fprintf(&b, "[%d] (%s) %s\n\n", i+1, c.FilePath, strings.ReplaceAll(snippet, "\n", " "))
 	}

--- a/cli/ctxmgr/retrieval.go
+++ b/cli/ctxmgr/retrieval.go
@@ -85,6 +85,10 @@ type lexCacheEntry struct {
 	segs        []Segment
 	lex         *lexicalIndex
 	vec         *vindex.Index
+	// embedMu single-flights the embedding of missing passages: a Retrieve
+	// that lands while Warm is running waits for it instead of sending the
+	// same ids to the provider a second time.
+	embedMu sync.Mutex
 }
 
 // NewRetrievalEngine wires an engine over an embedding provider. baseDir is the
@@ -141,14 +145,16 @@ func (e *RetrievalEngine) Retrieve(ctx context.Context, fc *FileContext, query s
 
 	idx := entry.vec // built and pruned by entryFor when the engine is enabled
 
-	if missing := idx.MissingFor(allIDs); len(missing) > 0 {
-		sub := make(map[string]string, len(missing))
-		for _, id := range missing {
-			sub[id] = byID[id].Content
-		}
-		if err := idx.Upsert(ctx, sub); err != nil {
-			return nil, fmt.Errorf("embed segments: %w", err)
-		}
+	// Missing passages are embedded in bounded batches (the same loop
+	// Warm uses), behind the entry's single-flight: a failing batch is
+	// skipped, the rest still land, and the search runs over what is
+	// embedded. Only a run that embedded nothing at all is an error.
+	byContent := make(map[string]string, len(segs))
+	for _, s := range segs {
+		byContent[s.ID] = s.Content
+	}
+	if embedded, err := e.embedMissing(ctx, entry, allIDs, byContent); err != nil && embedded == 0 && len(idx.MissingFor(allIDs)) == len(allIDs) {
+		return nil, fmt.Errorf("embed segments: %w", err)
 	}
 
 	qv, err := idx.EmbedQuery(ctx, query)
@@ -295,7 +301,7 @@ func (e *RetrievalEngine) applyReranker(ctx context.Context, entry *lexCacheEntr
 	for _, i := range order[:head] {
 		content := entry.segs[i].Content
 		if len(content) > rerankSnippetChars {
-			content = content[:rerankSnippetChars]
+			content = content[:alignRuneBefore(content, rerankSnippetChars)]
 		}
 		cands = append(cands, RerankCandidate{ID: entry.segs[i].ID, FilePath: entry.segs[i].FilePath, Content: content, Score: fused[i]})
 	}
@@ -462,8 +468,24 @@ func (e *RetrievalEngine) Warm(ctx context.Context, fc *FileContext) (int, error
 		ids = append(ids, s.ID)
 		byID[s.ID] = s.Content
 	}
+	return e.embedMissing(ctx, entry, ids, byID)
+}
+
+// embedMissing embeds the passages of ids missing from the entry's index
+// in warmBatch-sized requests, under the entry's single-flight. A batch
+// the provider rejects (400/413 on one poisonous passage, a transient
+// failure) is skipped and the remaining batches still go through; the
+// first error is returned with the count that did land. Cancellation
+// stops the loop.
+func (e *RetrievalEngine) embedMissing(ctx context.Context, entry *lexCacheEntry, ids []string, byID map[string]string) (int, error) {
+	if entry == nil || entry.vec == nil {
+		return 0, nil
+	}
+	entry.embedMu.Lock()
+	defer entry.embedMu.Unlock()
 	missing := entry.vec.MissingFor(ids)
 	embedded := 0
+	var firstErr error
 	for start := 0; start < len(missing); start += warmBatch {
 		if err := ctx.Err(); err != nil {
 			return embedded, err
@@ -477,11 +499,16 @@ func (e *RetrievalEngine) Warm(ctx context.Context, fc *FileContext) (int, error
 			batch[id] = byID[id]
 		}
 		if err := entry.vec.Upsert(ctx, batch); err != nil {
-			return embedded, err
+			if firstErr == nil {
+				firstErr = err
+			}
+			e.logger.Warn("embedding batch failed; skipping it and continuing",
+				zap.Int("batch_start", start), zap.Int("batch_size", len(batch)), zap.Error(err))
+			continue
 		}
 		embedded += len(batch)
 	}
-	return embedded, nil
+	return embedded, firstErr
 }
 
 // contextFingerprint identifies one revision of a context's content; caches

--- a/cli/ctxmgr/segment.go
+++ b/cli/ctxmgr/segment.go
@@ -19,6 +19,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/diillson/chatcli/utils"
 )
@@ -102,7 +103,26 @@ func segmentOne(f utils.FileInfo, opts SegmentOptions) []Segment {
 	if strings.TrimSpace(content) == "" {
 		return nil
 	}
+	// Binary and minified content never reaches the embedder: a NUL byte or
+	// invalid UTF-8 is binary; a file that is one or two enormous lines is
+	// a bundle nobody can cite a line of. One such passage used to poison
+	// the whole provider batch (400) and silently stop the warm-up.
+	if reason := unembeddableReason(content); reason != "" {
+		return nil
+	}
 	lines := strings.Split(content, "\n")
+	// Hard cap per passage: an over-long line is cut rune-safe at
+	// maxPassageBytes so a single line can never exceed a provider's
+	// per-input limit.
+	capBytes := opts.MaxChars * passageHardCapFactor
+	if capBytes <= 0 {
+		capBytes = defaultSegmentMaxChars * passageHardCapFactor
+	}
+	for i, l := range lines {
+		if len(l) > capBytes {
+			lines[i] = l[:alignRuneBefore(l, capBytes)] + "…"
+		}
+	}
 
 	var out []Segment
 	start := 0 // 0-based index into lines
@@ -153,6 +173,47 @@ func segmentOne(f utils.FileInfo, opts SegmentOptions) []Segment {
 		start = next
 	}
 	return out
+}
+
+// passageHardCapFactor × MaxChars is the byte ceiling of one passage line.
+const passageHardCapFactor = 4
+
+// minifiedLineBytes is the longest line a human-authored source file has;
+// beyond it, with almost no line breaks, the file is a bundle/minified
+// artifact. minifiedMinBytes keeps small one-liners (a long JSON line, a
+// data URI) on the normal path: they are capped, not dropped.
+const (
+	minifiedLineBytes = 4096
+	minifiedMinBytes  = 32 * 1024
+)
+
+// unembeddableReason classifies content the ingest must skip: "binary"
+// (NUL byte or invalid UTF-8) or "minified" (huge lines, no structure);
+// "" when the content is ordinary text.
+func unembeddableReason(content string) string {
+	if strings.IndexByte(content, 0) >= 0 || !utf8.ValidString(content) {
+		return "binary"
+	}
+	if len(content) < minifiedMinBytes {
+		return ""
+	}
+	longest, lines := 0, 1
+	start := 0
+	for i := 0; i <= len(content); i++ {
+		if i == len(content) || content[i] == '\n' {
+			if l := i - start; l > longest {
+				longest = l
+			}
+			if i < len(content) {
+				lines++
+			}
+			start = i + 1
+		}
+	}
+	if longest >= minifiedLineBytes && len(content)/lines >= minifiedLineBytes/4 {
+		return "minified"
+	}
+	return ""
 }
 
 // segmentID is a stable, collision-resistant key for the vector index. It folds

--- a/cli/workspace/instructions.go
+++ b/cli/workspace/instructions.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 )
 
 const (
@@ -175,7 +176,10 @@ func capInstructionDoc(doc string, limit int) string {
 		return doc
 	}
 	cut := limit
-	if i := strings.LastIndexByte(doc[:limit], '\n'); i > limit/2 {
+	for cut > 0 && !utf8.RuneStart(doc[cut]) {
+		cut-- // never split a multi-byte rune
+	}
+	if i := strings.LastIndexByte(doc[:cut], '\n'); i > limit/2 {
 		cut = i
 	}
 	return doc[:cut] + fmt.Sprintf("\n\n<!-- instruction files truncated at %d KiB -->", limit/1024)

--- a/llm/embedding/vindex/audit3_pr10_test.go
+++ b/llm/embedding/vindex/audit3_pr10_test.go
@@ -1,0 +1,86 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package vindex
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+// failAfterProvider answers n requests then fails; dim is what it emits.
+type failAfterProvider struct {
+	ok, calls int
+	dim       int
+	name      string
+}
+
+func (p *failAfterProvider) Name() string { return p.name }
+func (p *failAfterProvider) Dimension() int {
+	if p.calls == 0 {
+		return 0 // like Ollama: unknown until the first embed
+	}
+	return p.dim
+}
+func (p *failAfterProvider) Embed(_ context.Context, texts []string) ([][]float32, error) {
+	p.calls++
+	if p.calls > p.ok {
+		return nil, errors.New("503 provider down")
+	}
+	out := make([][]float32, len(texts))
+	for i := range texts {
+		v := make([]float32, p.dim)
+		v[0] = 1
+		out[i] = v
+	}
+	return out, nil
+}
+
+func TestUpsert_PersistsTheChunksThatSucceeded(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vec.json")
+	p := &failAfterProvider{ok: 2, dim: 3, name: "fake:x"}
+	idx := New(path, p)
+	items := map[string]string{}
+	for i := 0; i < UpsertBatch*3; i++ {
+		items[fmt.Sprintf("id%03d", i)] = "text"
+	}
+	err := idx.Upsert(context.Background(), items)
+	if err == nil {
+		t.Fatal("the failed chunk must be reported")
+	}
+	if got := idx.Count(); got != UpsertBatch*2 {
+		t.Fatalf("stored = %d, want the two successful chunks", got)
+	}
+	reloaded := New(path, &failAfterProvider{ok: 0, dim: 3, name: "fake:x"})
+	if reloaded.Count() != UpsertBatch*2 {
+		t.Fatalf("partial progress must be on disk: %d", reloaded.Count())
+	}
+}
+
+func TestLoad_AdoptsTheProviderDimensionWhenDiskContradictsIt(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vec.json")
+	first := New(path, &failAfterProvider{ok: 10, dim: 3, name: "ollama:m"})
+	if err := first.Upsert(context.Background(), map[string]string{"a": "x", "b": "y"}); err != nil {
+		t.Fatal(err)
+	}
+	// Same model name, different dimension (the model was swapped under
+	// the same tag); the provider reports 0 until it embeds.
+	swapped := New(path, &failAfterProvider{ok: 10, dim: 5, name: "ollama:m"})
+	if swapped.Count() != 2 {
+		t.Fatal("cache loads (dimension unknown yet)")
+	}
+	if err := swapped.Upsert(context.Background(), map[string]string{"c": "z"}); err != nil {
+		t.Fatalf("first embed with a contradicting dimension must re-seed, not fail: %v", err)
+	}
+	if swapped.Count() != 1 {
+		t.Fatalf("stale vectors must be discarded: size=%d", swapped.Count())
+	}
+	if len(swapped.MissingFor([]string{"a", "b", "c"})) != 2 {
+		t.Fatal("old ids are missing again, the new one is stored")
+	}
+}

--- a/llm/embedding/vindex/vindex.go
+++ b/llm/embedding/vindex/vindex.go
@@ -45,6 +45,9 @@ type Index struct {
 	entries  map[string][]float32
 	path     string
 	logger   *zap.Logger
+	// dimFromDisk marks a dimension taken from the cache file while the
+	// provider had not reported one yet (lazy probe on first embed).
+	dimFromDisk bool
 }
 
 // Option customizes an Index at construction.
@@ -135,14 +138,55 @@ func (x *Index) Upsert(ctx context.Context, items map[string]string) error {
 		ids = append(ids, id)
 		texts = append(texts, text)
 	}
-	vecs, err := x.provider.Embed(ctx, texts)
-	if err != nil {
-		return fmt.Errorf("embed batch: %w", err)
+	// Bounded provider requests: a large map is sent in chunks and every
+	// chunk that came back is written before an error is returned, so a
+	// flaky provider degrades instead of losing progress.
+	stored := 0
+	var firstErr error
+	for start := 0; start < len(ids); start += UpsertBatch {
+		if err := ctx.Err(); err != nil {
+			firstErr = err
+			break
+		}
+		end := start + UpsertBatch
+		if end > len(ids) {
+			end = len(ids)
+		}
+		vecs, err := x.provider.Embed(ctx, texts[start:end])
+		if err != nil {
+			firstErr = fmt.Errorf("embed batch: %w", err)
+			break
+		}
+		if len(vecs) != end-start {
+			firstErr = fmt.Errorf("provider returned %d vectors for %d inputs", len(vecs), end-start)
+			break
+		}
+		if err := x.store(ids[start:end], vecs); err != nil {
+			firstErr = err
+			break
+		}
+		stored += len(vecs)
 	}
-	if len(vecs) != len(ids) {
-		return fmt.Errorf("provider returned %d vectors for %d inputs", len(vecs), len(ids))
+	if stored == 0 && firstErr != nil {
+		return firstErr
 	}
+	if err := x.persist(); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	return firstErr
+}
+
+// UpsertBatch bounds one provider request inside Upsert.
+const UpsertBatch = 64
+
+// store writes one chunk of vectors. The dimension is learned from the
+// first vector; a dimension inherited from the on-disk cache that the
+// provider then contradicts (Ollama reports 0 until its first embed, so
+// the load check could not catch a same-name model swap) discards the
+// stale cache and adopts the provider's dimension.
+func (x *Index) store(ids []string, vecs [][]float32) error {
 	x.mu.Lock()
+	defer x.mu.Unlock()
 	for i, vec := range vecs {
 		if len(vec) == 0 {
 			continue
@@ -151,13 +195,20 @@ func (x *Index) Upsert(ctx context.Context, items map[string]string) error {
 			x.dim = len(vec)
 		}
 		if len(vec) != x.dim {
-			x.mu.Unlock()
-			return fmt.Errorf("provider %s emitted dim=%d but index dim=%d", x.provider.Name(), len(vec), x.dim)
+			if x.dimFromDisk {
+				x.logger.Warn("vindex dimension on disk contradicts the provider — auto-clearing for re-embed",
+					zap.Int("on_disk_dim", x.dim), zap.Int("provider_dim", len(vec)), zap.String("path", x.path))
+				x.entries = make(map[string][]float32)
+				x.dim = len(vec)
+				x.dimFromDisk = false
+			} else {
+				return fmt.Errorf("provider %s emitted dim=%d but index dim=%d", x.provider.Name(), len(vec), x.dim)
+			}
 		}
 		x.entries[ids[i]] = vec
 	}
-	x.mu.Unlock()
-	return x.persist()
+	x.dimFromDisk = false
+	return nil
 }
 
 // EmbedQuery embeds a single query string for use with Search.
@@ -323,6 +374,7 @@ func (x *Index) load() {
 		return
 	}
 	if f.Dimension > 0 {
+		x.dimFromDisk = x.dim == 0
 		x.dim = f.Dimension
 	}
 	if f.Entries != nil {


### PR DESCRIPTION
## Summary

Audit III, PR 10 (P1 RAG-1, RAG-2; P2 RAG-4; P3 RAG-13). Retrieval ingest robustness.

- **Batched, single-flight embedding (RAG-1).** `Retrieve` used to upsert every missing passage in one provider request (Voyage, OpenAI and Ollama send the whole list), so a large auto-RAG attach failed with 400/413 on the first turns, surfaced only as "semantic retrieval failed; skipping", while `Warm` double-embedded the same ids. `embedMissing` is now the one loop (64 per request) used by both, behind a per-context mutex: a `Retrieve` landing during a warm-up waits and then embeds only what is still missing.
- **Skip-and-continue (RAG-2).** A failing batch is logged and skipped; the remaining batches land; `Warm` returns the count and the first error; `Retrieve` searches over what is embedded and errors only when nothing at all embedded.
- **Ingest hygiene (RAG-2).** `unembeddableReason`: NUL byte or invalid UTF-8 → binary, ≥32 KiB with ≥4 KiB lines and almost no line breaks → minified; both are skipped at segmentation. Small one-liners stay (capped, not dropped). Every passage line is cut rune-safe at 4×MaxChars.
- **Partial upsert persistence (RAG-13).** `vindex.Upsert` sends chunks of `UpsertBatch` and persists every chunk that came back before returning the error. A dimension inherited from the cache file while the provider still reported 0 (Ollama before its first embed) that the provider then contradicts re-seeds the index instead of failing forever.
- **Rune-safe cuts with true citations (RAG-4).** `fitSegments` (EndLine recomputed from the kept lines), the rerank pool snippet, the rerank prompt snippet and `capInstructionDoc` no longer split a multi-byte rune.

## Tests

`cli/ctxmgr/audit3_pr10_test.go`: binary/minified skip and long-line cap; warm with a poisoned batch still embeds the other batches and a later retrieve answers without re-embedding; retrieve batches under the single-flight; all-failing provider is an error; fitSegments rune-safe with EndLine tracking. `llm/embedding/vindex/audit3_pr10_test.go`: two successful chunks persisted before the failure and reloaded; same-name dimension swap re-seeds. Existing suites, golangci-lint and the local gates are green.