### PR TITLE
fix(cache): provider cache parity — Bedrock system marker TTL, GPT-5.5 retention, cache key on OpenAI-compatible upstreams, OpenRouter marker cap

### DIFF
--- a/llm/bedrock/bedrock_client.go
+++ b/llm/bedrock/bedrock_client.go
@@ -573,7 +573,11 @@ func (c *BedrockClient) buildMessagesAndSystem(prompt string, history []models.M
 						"text": part.Text,
 					}
 					if part.CacheControl != nil {
-						block["cache_control"] = map[string]string{"type": part.CacheControl.Type}
+						// Same marker (and ttl) as the history breakpoint:
+						// Anthropic requires longer-lived breakpoints to
+						// precede shorter ones, so system and history must
+						// carry one lifetime.
+						block["cache_control"] = client.AnthropicCacheMarkerWithTTL(supportsExtendedCacheTTL(c.model))
 					}
 					systemBlocks = append(systemBlocks, block)
 				}

--- a/llm/bedrock/invoke_system_ttl_test.go
+++ b/llm/bedrock/invoke_system_ttl_test.go
@@ -1,0 +1,40 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package bedrock
+
+import (
+	"testing"
+
+	"github.com/diillson/chatcli/llm/client"
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+func TestInvokeModel_SystemMarkerCarriesTheSameTTLAsHistory(t *testing.T) {
+	t.Setenv(client.PromptCacheTTLEnv, "1h")
+	history := []models.Message{
+		{Role: "system", SystemParts: []models.ContentBlock{{Type: "text", Text: "stable charter", CacheControl: &models.CacheControl{Type: "ephemeral"}}, {Type: "text", Text: "volatile"}}},
+		{Role: "user", Content: "q1"}, {Role: "assistant", Content: "a1"},
+	}
+	c := &BedrockClient{model: "anthropic.claude-sonnet-5", logger: zap.NewNop()}
+	_, sys := c.buildMessagesAndSystem("q2", history)
+	blocks, ok := sys.([]map[string]interface{})
+	if !ok || len(blocks) == 0 {
+		t.Fatalf("system blocks: %#v", sys)
+	}
+	cc, _ := blocks[0]["cache_control"].(map[string]string)
+	if cc["ttl"] != "1h" {
+		t.Fatalf("system marker must carry the 1h ttl like the history breakpoint (ordering rule): %#v", cc)
+	}
+	// Older Claude: no ttl anywhere.
+	old := &BedrockClient{model: "anthropic.claude-3-7-sonnet-20250219-v1:0", logger: zap.NewNop()}
+	_, sys = old.buildMessagesAndSystem("q2", history)
+	blocks, _ = sys.([]map[string]interface{})
+	cc, _ = blocks[0]["cache_control"].(map[string]string)
+	if _, has := cc["ttl"]; has || cc["type"] != "ephemeral" {
+		t.Fatalf("older Claude keeps the 5m default: %#v", cc)
+	}
+}

--- a/llm/client/openai_cache_retention.go
+++ b/llm/client/openai_cache_retention.go
@@ -1,0 +1,32 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package client
+
+import "strings"
+
+// ExtendedPromptCache reports whether the operator asked for the long
+// cache lifetime (CHATCLI_PROMPT_CACHE_TTL=1h, or auto resolved to 1h).
+// One preference drives every provider that offers a longer retention:
+// Anthropic's 1h ttl and OpenAI's 24h prompt_cache_retention.
+func ExtendedPromptCache() bool { return AnthropicCacheTTL() == "1h" }
+
+// OpenAIPromptCacheRetention returns the prompt_cache_retention value to
+// send for model, "" when the field must not be sent. The field is
+// documented for gpt-5.5 / gpt-5.5-pro ("24h" is the only value they
+// accept) and deprecated from gpt-5.6 on in favor of
+// prompt_cache_options, whose ttl currently has a single value (30m) —
+// so nothing is sent there. Older models are left alone: an unknown
+// field is a 400 on strict upstreams.
+func OpenAIPromptCacheRetention(model string) string {
+	if !ExtendedPromptCache() {
+		return ""
+	}
+	m := strings.ToLower(strings.TrimSpace(model))
+	if strings.HasPrefix(m, "gpt-5.5") {
+		return "24h"
+	}
+	return ""
+}

--- a/llm/copilot/copilot_client.go
+++ b/llm/copilot/copilot_client.go
@@ -133,6 +133,12 @@ func (c *Client) SendPrompt(ctx context.Context, prompt string, history []models
 		"store":    false, // Copilot API: don't store conversations
 	}
 
+	// Automatic prompt caching routing hint on OpenAI-compatible upstreams
+	// (ignored by those that do not route on it). See client.PromptCacheKey.
+	if key := client.PromptCacheKey(history); key != "" {
+		payload["prompt_cache_key"] = key
+	}
+
 	// Copilot API: do NOT send max_tokens / maxOutputTokens
 	// as per the API contract. The API manages token limits internally.
 	// Only set if user explicitly configured it.

--- a/llm/copilot/prompt_cache_key_wire_test.go
+++ b/llm/copilot/prompt_cache_key_wire_test.go
@@ -1,0 +1,39 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package copilot
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	llmclient "github.com/diillson/chatcli/llm/client"
+	"github.com/diillson/chatcli/models"
+)
+
+func TestSendPrompt_SendsPromptCacheKey(t *testing.T) {
+	var body map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices": [{"message": {"role": "assistant", "content": "ok"}}]}`))
+	}))
+	defer server.Close()
+	t.Setenv("COPILOT_API_BASE_URL", server.URL)
+	c := NewClient(testProvider("test-token"), "gpt-5.6", testLogger(), 1, 0)
+	history := []models.Message{{Role: "system", Content: "You are ChatCLI."}, {Role: "user", Content: "Hi"}}
+	if _, err := c.SendPrompt(context.Background(), "Hi", history, 0); err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+	key, _ := body["prompt_cache_key"].(string)
+	if key == "" || key != llmclient.PromptCacheKey(history) {
+		t.Fatalf("prompt_cache_key = %q, want %q", key, llmclient.PromptCacheKey(history))
+	}
+}

--- a/llm/minimax/minimax_client.go
+++ b/llm/minimax/minimax_client.go
@@ -125,6 +125,12 @@ func (c *MiniMaxClient) SendPrompt(ctx context.Context, prompt string, history [
 			"messages":   messages,
 			"max_tokens": effectiveMaxTokens,
 		}
+
+		// Automatic prompt caching routing hint on OpenAI-compatible upstreams
+		// (ignored by those that do not route on it). See client.PromptCacheKey.
+		if key := client.PromptCacheKey(history); key != "" {
+			payload["prompt_cache_key"] = key
+		}
 	}
 
 	jsonValue, err := json.Marshal(payload)

--- a/llm/minimax/prompt_cache_key_wire_test.go
+++ b/llm/minimax/prompt_cache_key_wire_test.go
@@ -1,0 +1,47 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package minimax
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	llmclient "github.com/diillson/chatcli/llm/client"
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+func TestSendPrompt_SendsPromptCacheKey(t *testing.T) {
+	var body map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices": [{"message": {"role": "assistant", "content": "ok"}}]}`))
+	}))
+	defer server.Close()
+	c := NewMiniMaxClient(testProvider("k"), "MiniMax-M2.7", zap.NewNop(), 1, 0)
+	c.apiURL = server.URL
+	history := []models.Message{{Role: "system", Content: "You are ChatCLI."}, {Role: "user", Content: "Hi"}}
+	if _, err := c.SendPrompt(context.Background(), "Hi", history, 0); err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+	key, _ := body["prompt_cache_key"].(string)
+	if key == "" || key != llmclient.PromptCacheKey(history) {
+		t.Fatalf("prompt_cache_key = %q, want %q", key, llmclient.PromptCacheKey(history))
+	}
+	body = nil
+	if _, err := c.SendPrompt(context.Background(), "Hi", []models.Message{{Role: "user", Content: "Hi"}}, 0); err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+	if _, present := body["prompt_cache_key"]; present {
+		t.Fatal("no system prompt → the field is omitted")
+	}
+}

--- a/llm/minimax/tool_use.go
+++ b/llm/minimax/tool_use.go
@@ -73,6 +73,12 @@ func (c *MiniMaxClient) SendPromptWithTools(ctx context.Context, prompt string, 
 		payload["tools"] = toolDefs
 	}
 
+	// Automatic prompt caching routing hint on OpenAI-compatible upstreams
+	// (ignored by those that do not route on it). See client.PromptCacheKey.
+	if key := client.PromptCacheKey(history); key != "" {
+		payload["prompt_cache_key"] = key
+	}
+
 	jsonValue, err := json.Marshal(payload)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("llm.tool.error.marshaling_payload"), err)

--- a/llm/moonshot/moonshot_client.go
+++ b/llm/moonshot/moonshot_client.go
@@ -146,6 +146,12 @@ func (c *MoonshotClient) SendPrompt(ctx context.Context, prompt string, history 
 	}
 	c.applyThinking(payload)
 
+	// Automatic prompt caching routing hint on OpenAI-compatible upstreams
+	// (ignored by those that do not route on it). See client.PromptCacheKey.
+	if key := client.PromptCacheKey(history); key != "" {
+		payload["prompt_cache_key"] = key
+	}
+
 	jsonValue, err := json.Marshal(payload)
 	if err != nil {
 		c.logger.Error(i18n.T("llm.error.marshal_payload_for", "MOONSHOT"), zap.Error(err))

--- a/llm/moonshot/prompt_cache_key_wire_test.go
+++ b/llm/moonshot/prompt_cache_key_wire_test.go
@@ -1,0 +1,47 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package moonshot
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	llmclient "github.com/diillson/chatcli/llm/client"
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+func TestSendPrompt_SendsPromptCacheKey(t *testing.T) {
+	var body map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices": [{"message": {"role": "assistant", "content": "ok"}}]}`))
+	}))
+	defer server.Close()
+	c := NewMoonshotClient(testProvider("k"), "kimi-k2.6", zap.NewNop(), 1, 0)
+	c.apiURL = server.URL
+	history := []models.Message{{Role: "system", Content: "You are ChatCLI."}, {Role: "user", Content: "Hi"}}
+	if _, err := c.SendPrompt(context.Background(), "Hi", history, 0); err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+	key, _ := body["prompt_cache_key"].(string)
+	if key == "" || key != llmclient.PromptCacheKey(history) {
+		t.Fatalf("prompt_cache_key = %q, want %q", key, llmclient.PromptCacheKey(history))
+	}
+	body = nil
+	if _, err := c.SendPrompt(context.Background(), "Hi", []models.Message{{Role: "user", Content: "Hi"}}, 0); err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+	if _, present := body["prompt_cache_key"]; present {
+		t.Fatal("no system prompt → the field is omitted")
+	}
+}

--- a/llm/moonshot/tool_use.go
+++ b/llm/moonshot/tool_use.go
@@ -71,6 +71,12 @@ func (c *MoonshotClient) SendPromptWithTools(ctx context.Context, prompt string,
 	}
 	c.applyThinking(payload)
 
+	// Automatic prompt caching routing hint on OpenAI-compatible upstreams
+	// (ignored by those that do not route on it). See client.PromptCacheKey.
+	if key := client.PromptCacheKey(history); key != "" {
+		payload["prompt_cache_key"] = key
+	}
+
 	jsonValue, err := json.Marshal(payload)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("llm.tool.error.marshaling_payload"), err)

--- a/llm/openai/cache_retention_wire_test.go
+++ b/llm/openai/cache_retention_wire_test.go
@@ -1,0 +1,55 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	llmclient "github.com/diillson/chatcli/llm/client"
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+func TestSendPrompt_PromptCacheRetentionByModelAndPreference(t *testing.T) {
+	var body map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices": [{"message": {"role": "assistant", "content": "ok"}}]}`))
+	}))
+	defer server.Close()
+	t.Setenv("OPENAI_API_URL", server.URL)
+	history := []models.Message{{Role: "system", Content: "You are ChatCLI."}, {Role: "user", Content: "Hi"}}
+
+	send := func(model string) map[string]interface{} {
+		body = nil
+		c := NewOpenAIClient(testProvider("test-api-key"), model, zap.NewNop(), 1, 0)
+		if _, err := c.SendPrompt(context.Background(), "Hi", history, 0); err != nil {
+			t.Fatalf("SendPrompt: %v", err)
+		}
+		return body
+	}
+	t.Setenv(llmclient.PromptCacheTTLEnv, "1h")
+	if got := send("gpt-5.5")["prompt_cache_retention"]; got != "24h" {
+		t.Fatalf("gpt-5.5 with the extended preference must send 24h, got %#v", got)
+	}
+	if _, present := send("gpt-5.6")["prompt_cache_retention"]; present {
+		t.Fatal("gpt-5.6+ deprecates the field (prompt_cache_options has a single ttl); nothing must be sent")
+	}
+	if _, present := send("gpt-4.1")["prompt_cache_retention"]; present {
+		t.Fatal("older models must not receive the field")
+	}
+	t.Setenv(llmclient.PromptCacheTTLEnv, "5m")
+	if _, present := send("gpt-5.5")["prompt_cache_retention"]; present {
+		t.Fatal("default lifetime sends nothing")
+	}
+}

--- a/llm/openai/openai_client.go
+++ b/llm/openai/openai_client.go
@@ -134,6 +134,9 @@ func (c *OpenAIClient) SendPrompt(ctx context.Context, prompt string, history []
 	if key := client.PromptCacheKey(history); key != "" {
 		payload["prompt_cache_key"] = key
 	}
+	if r := client.OpenAIPromptCacheRetention(c.model); r != "" {
+		payload["prompt_cache_retention"] = r
+	}
 
 	// Skill effort hint → reasoning_effort (only for reasoning-capable models).
 	if eff := client.ReasoningEffortForOpenAI(client.EffortFromContext(ctx)); eff != "" && supportsOpenAIReasoningEffort(c.model) {
@@ -377,6 +380,9 @@ func (c *OpenAIClient) SendPromptStream(ctx context.Context, prompt string, hist
 
 	if key := client.PromptCacheKey(history); key != "" {
 		payload["prompt_cache_key"] = key
+	}
+	if r := client.OpenAIPromptCacheRetention(c.model); r != "" {
+		payload["prompt_cache_retention"] = r
 	}
 	jsonValue, err := json.Marshal(payload)
 	if err != nil {

--- a/llm/openai/tool_use.go
+++ b/llm/openai/tool_use.go
@@ -74,6 +74,9 @@ func (c *OpenAIClient) SendPromptWithTools(ctx context.Context, prompt string, h
 	if key := client.PromptCacheKey(history); key != "" {
 		payload["prompt_cache_key"] = key
 	}
+	if r := client.OpenAIPromptCacheRetention(c.model); r != "" {
+		payload["prompt_cache_retention"] = r
+	}
 
 	jsonValue, err := json.Marshal(payload)
 	if err != nil {

--- a/llm/openairesponses/openai_responses_client.go
+++ b/llm/openairesponses/openai_responses_client.go
@@ -155,6 +155,9 @@ func (c *OpenAIResponsesClient) SendPrompt(ctx context.Context, prompt string, h
 		if key := client.PromptCacheKey(history); key != "" {
 			reqBody["prompt_cache_key"] = key
 		}
+		if r := client.OpenAIPromptCacheRetention(c.model); r != "" {
+			reqBody["prompt_cache_retention"] = r
+		}
 	}
 
 	// Skill effort hint → reasoning.effort.

--- a/llm/openrouter/cache_marker_cap_test.go
+++ b/llm/openrouter/cache_marker_cap_test.go
@@ -1,0 +1,38 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package openrouter
+
+import "testing"
+
+func TestApplyOpenRouterCacheControlMarker_CapsAtFourKeepingTheLatest(t *testing.T) {
+	var messages []map[string]interface{}
+	for i := 0; i < 6; i++ {
+		messages = append(messages, map[string]interface{}{"role": "system", "content": "part"})
+	}
+	messages = append(messages, map[string]interface{}{"role": "user", "content": "hi"})
+	applyOpenRouterCacheControlMarker(messages, map[string]string{"type": "ephemeral"})
+	count := 0
+	marked := func(msg map[string]interface{}) bool {
+		parts, _ := msg["content"].([]map[string]interface{})
+		for _, p := range parts {
+			if _, ok := p["cache_control"]; ok {
+				return true
+			}
+		}
+		return false
+	}
+	for _, m := range messages {
+		if marked(m) {
+			count++
+		}
+	}
+	if count != anthropicMaxCacheMarkers {
+		t.Fatalf("markers = %d, want the upstream cap %d", count, anthropicMaxCacheMarkers)
+	}
+	if !marked(messages[6]) || marked(messages[0]) || marked(messages[1]) || !marked(messages[5]) {
+		t.Fatal("the rolling user breakpoint and the latest system markers must survive; the earliest go")
+	}
+}

--- a/llm/openrouter/openrouter_client.go
+++ b/llm/openrouter/openrouter_client.go
@@ -213,6 +213,41 @@ func applyOpenRouterCacheControlMarker(messages []map[string]interface{}, marker
 	if lastUser >= 0 {
 		mark(messages[lastUser])
 	}
+	capOpenRouterCacheMarkers(messages, anthropicMaxCacheMarkers)
+}
+
+// anthropicMaxCacheMarkers is the upstream cap on cache_control blocks per
+// request; more is a 400 from Anthropic behind OpenRouter.
+const anthropicMaxCacheMarkers = 4
+
+// capOpenRouterCacheMarkers keeps at most limit markers: the last user
+// message's marker (the rolling breakpoint) and the latest system markers;
+// earlier system markers are removed. Mirrors enforceCacheControlBudget on
+// the direct Anthropic and Bedrock paths.
+func capOpenRouterCacheMarkers(messages []map[string]interface{}, limit int) {
+	type slot struct{ part map[string]interface{} }
+	var marked []slot
+	for _, msg := range messages {
+		switch content := msg["content"].(type) {
+		case []map[string]interface{}:
+			for _, part := range content {
+				if _, ok := part["cache_control"]; ok {
+					marked = append(marked, slot{part})
+				}
+			}
+		case []interface{}:
+			for _, raw := range content {
+				if part, ok := raw.(map[string]interface{}); ok {
+					if _, ok := part["cache_control"]; ok {
+						marked = append(marked, slot{part})
+					}
+				}
+			}
+		}
+	}
+	for i := 0; len(marked)-i > limit; i++ {
+		delete(marked[i].part, "cache_control")
+	}
 }
 
 // buildPayload assembles the request payload with OpenRouter-specific options.

--- a/llm/xai/prompt_cache_key_wire_test.go
+++ b/llm/xai/prompt_cache_key_wire_test.go
@@ -1,0 +1,47 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package xai
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	llmclient "github.com/diillson/chatcli/llm/client"
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+func TestSendPrompt_SendsPromptCacheKey(t *testing.T) {
+	var body map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices": [{"message": {"role": "assistant", "content": "ok"}}]}`))
+	}))
+	defer server.Close()
+	c := NewXAIClient(testProvider("k"), "grok-4", zap.NewNop(), 1, 0)
+	c.apiURL = server.URL
+	history := []models.Message{{Role: "system", Content: "You are ChatCLI."}, {Role: "user", Content: "Hi"}}
+	if _, err := c.SendPrompt(context.Background(), "Hi", history, 0); err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+	key, _ := body["prompt_cache_key"].(string)
+	if key == "" || key != llmclient.PromptCacheKey(history) {
+		t.Fatalf("prompt_cache_key = %q, want %q", key, llmclient.PromptCacheKey(history))
+	}
+	body = nil
+	if _, err := c.SendPrompt(context.Background(), "Hi", []models.Message{{Role: "user", Content: "Hi"}}, 0); err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+	if _, present := body["prompt_cache_key"]; present {
+		t.Fatal("no system prompt → the field is omitted")
+	}
+}

--- a/llm/xai/xai_client.go
+++ b/llm/xai/xai_client.go
@@ -100,6 +100,12 @@ func (c *XAIClient) SendPrompt(ctx context.Context, prompt string, history []mod
 		"max_tokens": effectiveMaxTokens,
 	}
 
+	// Automatic prompt caching routing hint on OpenAI-compatible upstreams
+	// (ignored by those that do not route on it). See client.PromptCacheKey.
+	if key := client.PromptCacheKey(history); key != "" {
+		payload["prompt_cache_key"] = key
+	}
+
 	jsonValue, err := json.Marshal(payload)
 	if err != nil {
 		c.logger.Error(i18n.T("llm.error.marshal_payload_for", "xAI"), zap.Error(err))

--- a/llm/zai/prompt_cache_key_wire_test.go
+++ b/llm/zai/prompt_cache_key_wire_test.go
@@ -1,0 +1,47 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package zai
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	llmclient "github.com/diillson/chatcli/llm/client"
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+func TestSendPrompt_SendsPromptCacheKey(t *testing.T) {
+	var body map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices": [{"message": {"role": "assistant", "content": "ok"}}]}`))
+	}))
+	defer server.Close()
+	c := NewZAIClient(context.Background(), testProvider("k"), "glm-4.7", zap.NewNop(), 1, 0)
+	c.apiURL = server.URL
+	history := []models.Message{{Role: "system", Content: "You are ChatCLI."}, {Role: "user", Content: "Hi"}}
+	if _, err := c.SendPrompt(context.Background(), "Hi", history, 0); err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+	key, _ := body["prompt_cache_key"].(string)
+	if key == "" || key != llmclient.PromptCacheKey(history) {
+		t.Fatalf("prompt_cache_key = %q, want %q", key, llmclient.PromptCacheKey(history))
+	}
+	body = nil
+	if _, err := c.SendPrompt(context.Background(), "Hi", []models.Message{{Role: "user", Content: "Hi"}}, 0); err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+	if _, present := body["prompt_cache_key"]; present {
+		t.Fatal("no system prompt → the field is omitted")
+	}
+}

--- a/llm/zai/tool_use.go
+++ b/llm/zai/tool_use.go
@@ -67,6 +67,12 @@ func (c *ZAIClient) SendPromptWithTools(ctx context.Context, prompt string, hist
 		"max_tokens": effectiveMaxTokens,
 	}
 	c.applyThinking(payload)
+
+	// Automatic prompt caching routing hint on OpenAI-compatible upstreams
+	// (ignored by those that do not route on it). See client.PromptCacheKey.
+	if key := client.PromptCacheKey(history); key != "" {
+		payload["prompt_cache_key"] = key
+	}
 	if len(toolDefs) > 0 {
 		payload["tools"] = toolDefs
 	}

--- a/llm/zai/zai_client.go
+++ b/llm/zai/zai_client.go
@@ -210,6 +210,12 @@ func (c *ZAIClient) SendPrompt(ctx context.Context, prompt string, history []mod
 	}
 	c.applyThinking(payload)
 
+	// Automatic prompt caching routing hint on OpenAI-compatible upstreams
+	// (ignored by those that do not route on it). See client.PromptCacheKey.
+	if key := client.PromptCacheKey(history); key != "" {
+		payload["prompt_cache_key"] = key
+	}
+
 	jsonValue, err := json.Marshal(payload)
 	if err != nil {
 		c.logger.Error(i18n.T("llm.error.marshal_payload_for", "ZAI"), zap.Error(err))


### PR DESCRIPTION
## Summary

Audit III, PR 11 (P1 CAG-3; P2 CAG-5, CAG-6, CAG-10; P3 CAG-15).

- **Bedrock ordering rule (CAG-3).** InvokeModel and Mantle put a plain 5m marker on the system block while the history breakpoint carried the configured 1h ttl. Anthropic requires longer-lived breakpoints to precede shorter ones. The system block now uses `client.AnthropicCacheMarkerWithTTL(supportsExtendedCacheTTL(model))`, the same marker as the history breakpoint. Wire test: system marker carries `ttl: 1h` on Claude 4.5+/5, nothing on older Claude.
- **GPT-5.5 retention (CAG-5).** Verified against the current OpenAI SDK (`completion_create_params.py`): `prompt_cache_retention` accepts `in_memory` | `24h`, gpt-5.5 / gpt-5.5-pro accept only `24h`, and the field is deprecated from gpt-5.6 in favour of `prompt_cache_options` whose `ttl` currently has the single value `30m`. `client.OpenAIPromptCacheRetention` sends `24h` on gpt-5.5* when the existing extended-cache preference (`CHATCLI_PROMPT_CACHE_TTL=1h|auto→1h`) is set, on chat, streaming, tool-use and Responses (API-key path). Nothing new to configure.
- **Cache key parity (CAG-6).** `prompt_cache_key` is now sent by xAI, Z.ai, Moonshot, MiniMax (OpenAI path) and Copilot on chat and tool-use payloads. GitHub Models and the Bedrock OpenAI family are schema-validated upstreams where an unknown field is a hard 400; they stay untouched and the docs will say so.
- **OpenRouter marker cap (CAG-10).** `capOpenRouterCacheMarkers` keeps at most four `cache_control` blocks: the rolling user breakpoint and the latest system markers; earlier system markers go.
- **MiniMax Anthropic path (CAG-15).** Checked the MiniMax Anthropic-compatible API reference: no `cache_control`, `system` is a string. No markers sent; documented as not honoured.

## Tests

OpenAI retention by model and preference; cache key wire tests for the five providers (present with a system prompt, omitted without); Bedrock system marker ttl; OpenRouter cap. golangci-lint and the local gates are green.