### PR TITLE
fix(memory): drain the queued backlog at boot and on every tick, bounded shutdown wait, exit-tail queueing, race-free watermark

### DIFF
--- a/cli/audit3_pr15_test.go
+++ b/cli/audit3_pr15_test.go
@@ -1,0 +1,129 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/diillson/chatcli/models"
+)
+
+func waitUntil(t *testing.T, timeout time.Duration, cond func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return cond()
+}
+
+func TestMemoryWorker_BootDrainsTheQueuedBacklog(t *testing.T) {
+	active := &scriptedClient{name: "claude", response: "NOTHING_NEW"}
+	mw := newResilienceWorker(t, active)
+	// A single segment queued by an earlier one-shot session: fewer
+	// messages than the live-delta gate wants, so before the boot drain it
+	// sat in the queue until enough REPL turns arrived (or forever for a
+	// -p only user).
+	if _, err := mw.persistPending([]models.Message{{Role: "user", Content: "fact"}, {Role: "assistant", Content: "noted"}}); err != nil {
+		t.Fatal(err)
+	}
+	mw.start(context.Background())
+	if !waitUntil(t, 5*time.Second, func() bool { return len(mw.pendingFiles()) == 0 }) {
+		t.Fatalf("boot must drain the queue: %d segments left", len(mw.pendingFiles()))
+	}
+	if !mw.stopAndWait(5 * time.Second) {
+		t.Fatal("stop must return once the loop and the pass finished")
+	}
+}
+
+// blockingClient parks SendPrompt until released, to observe shutdown
+// waiting for an in-flight pass.
+type blockingClient struct {
+	release chan struct{}
+	started chan struct{}
+	once    sync.Once
+}
+
+func (b *blockingClient) GetModelName() string { return "blocking" }
+func (b *blockingClient) SendPrompt(ctx context.Context, _ string, _ []models.Message, _ int) (string, error) {
+	b.once.Do(func() { close(b.started) })
+	select {
+	case <-b.release:
+	case <-time.After(10 * time.Second):
+	}
+	return "NOTHING_NEW", nil
+}
+
+func TestMemoryWorker_StopWaitsForAnInFlightPassBounded(t *testing.T) {
+	bc := &blockingClient{release: make(chan struct{}), started: make(chan struct{})}
+	mw := newResilienceWorker(t, bc)
+	if _, err := mw.persistPending([]models.Message{{Role: "user", Content: "fact"}, {Role: "assistant", Content: "noted"}}); err != nil {
+		t.Fatal(err)
+	}
+	mw.start(context.Background())
+	select {
+	case <-bc.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the boot drain must start the extraction")
+	}
+	// Bounded: a hung provider call does not hold the exit.
+	begin := time.Now()
+	if mw.stopAndWait(200 * time.Millisecond) {
+		t.Fatal("stop must report the pass still running")
+	}
+	if time.Since(begin) > 2*time.Second {
+		t.Fatal("stop must return at the bound")
+	}
+	close(bc.release)
+	if !waitUntil(t, 5*time.Second, func() bool { return len(mw.pendingFiles()) == 0 }) {
+		t.Fatal("the released pass must still complete its write")
+	}
+}
+
+func TestFlushMemoryBeforeCompaction_WatermarkIsRaceFree(t *testing.T) {
+	active := &scriptedClient{name: "claude", response: "NOTHING_NEW"}
+	mw := newResilienceWorker(t, active)
+	c := mw.cli
+	c.memWorker = mw
+	c.history = []models.Message{{Role: "user", Content: "q"}, {Role: "assistant", Content: "a"}, {Role: "user", Content: "q2"}, {Role: "assistant", Content: "a2"}}
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(2)
+		go func() { defer wg.Done(); mw.maybeExtract(context.Background()) }()
+		go func() { defer wg.Done(); c.flushMemoryBeforeCompaction(context.Background()) }()
+	}
+	wg.Wait()
+	if mw.watermark() != len(c.history) {
+		t.Fatalf("watermark = %d", mw.watermark())
+	}
+	mw.stopAndWait(time.Second)
+}
+
+func TestShutdown_QueuesTheUnextractedTail(t *testing.T) {
+	active := &scriptedClient{name: "claude", response: "NOTHING_NEW"}
+	mw := newResilienceWorker(t, active)
+	c := mw.cli
+	c.memWorker = mw
+	c.history = []models.Message{{Role: "user", Content: "last question"}, {Role: "assistant", Content: "last answer"}}
+	c.queueMemoryBeforeCompaction()
+	files := mw.pendingFiles()
+	if len(files) != 1 {
+		t.Fatalf("the tail must be queued for the next session: %d", len(files))
+	}
+	if st, err := os.Stat(files[0]); err != nil || st.Size() == 0 {
+		t.Fatal("segment written")
+	}
+	if mw.watermark() != 2 {
+		t.Fatal("watermark advanced past the queued tail")
+	}
+}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -2191,9 +2191,12 @@ func (cli *ChatCLI) cleanup(ctx context.Context) {
 		}
 	}
 
-	// Stop background memory worker
+	// The unextracted tail of this session is queued for the next one
+	// (the last turns of every REPL session used to be lost), then the
+	// worker is stopped with a bounded wait for an in-flight pass.
 	if cli.memWorker != nil {
-		cli.memWorker.stop()
+		cli.queueMemoryBeforeCompaction()
+		cli.memWorker.stopAndWait(memoryStopWait)
 	}
 
 	// Drain and shut down the durable reflexion queue. Pending jobs

--- a/cli/memory_flush.go
+++ b/cli/memory_flush.go
@@ -25,7 +25,7 @@ func (cli *ChatCLI) unextractedSegment() []models.Message {
 	if cli == nil || cli.memWorker == nil || cli.memWorker.store == nil {
 		return nil
 	}
-	start := cli.memWorker.lastProcessedIdx
+	start := cli.memWorker.watermark()
 	if start < 0 || start >= len(cli.history) {
 		return nil
 	}
@@ -51,7 +51,7 @@ func (cli *ChatCLI) flushMemoryBeforeCompaction(ctx context.Context) {
 		return
 	}
 	cli.memWorker.nudgeSegment(ctx, seg)
-	cli.memWorker.lastProcessedIdx = len(cli.history)
+	cli.memWorker.setWatermark(len(cli.history))
 }
 
 // queueMemoryBeforeCompaction is the one-shot variant: the process exits
@@ -62,5 +62,5 @@ func (cli *ChatCLI) queueMemoryBeforeCompaction() {
 		return
 	}
 	cli.memWorker.queueSegmentForNextSession(seg)
-	cli.memWorker.lastProcessedIdx = len(cli.history)
+	cli.memWorker.setWatermark(len(cli.history))
 }

--- a/cli/memory_worker.go
+++ b/cli/memory_worker.go
@@ -29,9 +29,12 @@ type memoryWorker struct {
 	// that fires after a tenant switch must not read another tenant's turn.
 	store            *workspace.MemoryStore
 	history          func() []models.Message
-	lastProcessedIdx int // index of last message processed for memory
+	lastProcessedIdx int // index of last message processed for memory (guarded by mu)
 	mu               sync.Mutex
 	stopCh           chan struct{}
+	// wg tracks the loop and every extraction goroutine so shutdown can
+	// wait (bounded) for an in-flight pass instead of killing it mid-write.
+	wg sync.WaitGroup
 
 	// coord owns cadence, back-pressure and the circuit breaker for the
 	// extraction pass; the worker keeps only the memory-specific watermark and
@@ -122,7 +125,53 @@ func newMemoryWorkerFor(cli *ChatCLI, store *workspace.MemoryStore, pendingDir s
 // detached (cancellation governed by stopCh) and inherited by every
 // background-driven extraction/compaction.
 func (mw *memoryWorker) start(ctx context.Context) {
-	go mw.loop(context.WithoutCancel(ctx))
+	mw.spawn(func() { mw.loop(context.WithoutCancel(ctx)) })
+}
+
+// spawn runs fn on a tracked goroutine.
+func (mw *memoryWorker) spawn(fn func()) {
+	mw.wg.Add(1)
+	go func() {
+		defer mw.wg.Done()
+		fn()
+	}()
+}
+
+// watermark returns the index of the last live message already distilled.
+func (mw *memoryWorker) watermark() int {
+	mw.mu.Lock()
+	defer mw.mu.Unlock()
+	return mw.lastProcessedIdx
+}
+
+// setWatermark moves the distilled-up-to index.
+func (mw *memoryWorker) setWatermark(n int) {
+	mw.mu.Lock()
+	mw.lastProcessedIdx = n
+	mw.mu.Unlock()
+}
+
+// memoryStopWait bounds how long shutdown waits for an in-flight pass.
+const memoryStopWait = 5 * time.Second
+
+// stopAndWait signals the worker to stop and waits up to timeout for the
+// loop and any in-flight extraction to finish (a pass mid-write is
+// allowed to complete; a hung provider call is not allowed to hold the
+// exit). Reports whether everything finished in time.
+func (mw *memoryWorker) stopAndWait(timeout time.Duration) bool {
+	mw.stop()
+	done := make(chan struct{})
+	go func() {
+		mw.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return true
+	case <-time.After(timeout):
+		mw.logger.Warn("Memory worker: shutdown timed out with a pass still running", zap.Duration("waited", timeout))
+		return false
+	}
 }
 
 // stop signals the worker to stop.
@@ -151,7 +200,7 @@ func (mw *memoryWorker) nudge(ctx context.Context) {
 	// The extraction goroutine outlives the triggering request; detach
 	// cancellation while inheriting context values.
 	detached := context.WithoutCancel(ctx)
-	go mw.maybeExtract(detached)
+	mw.spawn(func() { mw.maybeExtract(detached) })
 }
 
 // queueSegmentForNextSession persists a conversation segment to the pending
@@ -191,7 +240,8 @@ func (mw *memoryWorker) nudgeSegment(ctx context.Context, segment []models.Messa
 	// RPC turns accumulate in the WAL until the min-new-messages threshold is
 	// met, mirroring the REPL's "extract every couple of turns" rhythm.
 	detached := context.WithoutCancel(ctx)
-	go mw.extractQueued(detached, mw.pendingBacklogCount())
+	backlog := mw.pendingBacklogCount()
+	mw.spawn(func() { mw.extractQueued(detached, backlog) })
 }
 
 // pendingBacklogCount sums the messages across every queued segment. The
@@ -246,11 +296,19 @@ func (mw *memoryWorker) loop(ctx context.Context) {
 	defer rollupTimer.Stop()
 	defer rollupTicker.Stop()
 
+	// Boot drain: segments queued by earlier sessions (one-shot turns,
+	// failed extractions, the tail of the previous REPL exit) are
+	// distilled now instead of waiting for enough live messages — a user
+	// who only ever runs -p would otherwise fill the queue and lose the
+	// oldest segments silently.
+	mw.drainBacklog(ctx)
+
 	for {
 		select {
 		case <-mw.stopCh:
 			return
 		case <-extractTicker.C:
+			mw.drainBacklog(ctx)
 			mw.maybeExtract(ctx)
 		case <-compactTicker.C:
 			mw.maybeCompact(ctx)
@@ -262,6 +320,23 @@ func (mw *memoryWorker) loop(ctx context.Context) {
 			mw.runRollups(ctx)
 		}
 	}
+}
+
+// drainBacklog runs a queued-segment pass when the on-disk queue is not
+// empty. The backlog counts as the new-work delta (at least the minimum,
+// so a single queued segment is enough); cooldown and breaker still apply.
+func (mw *memoryWorker) drainBacklog(ctx context.Context) {
+	if mw.store == nil || mw.pendingDir == "" {
+		return
+	}
+	n := mw.pendingBacklogCount()
+	if n == 0 {
+		return
+	}
+	if n < memoryMinNewMessages {
+		n = memoryMinNewMessages
+	}
+	mw.extractQueued(ctx, n)
 }
 
 // runRollups consolidates elapsed weeks/months into digests. Rollup passes


### PR DESCRIPTION
## Summary

Audit III, PR 15 (P1 MEM-2; P2 MEM-12, CMP-9). Memory worker lifecycle.

- **Boot and tick drain (MEM-2).** `drainPending` sat behind the live-message gate (≥4 new messages and the cooldown), and one-shot only enqueues, so a `-p`-only user filled the queue to its cap and lost the oldest segments silently. `drainBacklog` runs at loop start and on every extraction tick whenever the on-disk queue is non-empty; the backlog counts as the new-work delta (at least the minimum, so a single queued segment is enough), cooldown and breaker still apply.
- **Bounded shutdown (MEM-12).** The loop and every extraction goroutine are tracked by a WaitGroup; `stopAndWait(5s)` lets an in-flight pass finish its write and never lets a hung provider call hold the exit (it reports the timeout).
- **Exit-tail queueing (MEM-12).** REPL shutdown queues the unextracted tail for the next session before stopping the worker. The last turns of every REPL session were previously lost.
- **Watermark race (CMP-9).** `watermark()` / `setWatermark()` under the worker mutex; the flush path used the field bare while the worker wrote it under the lock.

## Tests

`cli/audit3_pr15_test.go` (run under `-race`): boot drains a single queued segment below the live-delta threshold; stop waits for an in-flight pass and returns at the bound when the provider hangs, and the released pass still completes; concurrent flush and extraction leave a consistent watermark with no race; shutdown queues the tail and advances the watermark. golangci-lint and the local gates are green.