### PR TITLE
fix(cost): cache telemetry truth — subset-schema total misses, per-provider first and hit ratio, expected rebuilds on every prefix change, Bedrock TTL as sent

### DIFF
--- a/cli/audit3_pr12_test.go
+++ b/cli/audit3_pr12_test.go
@@ -1,0 +1,92 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"testing"
+	"time"
+
+	llmclient "github.com/diillson/chatcli/llm/client"
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+func TestCacheTelemetry_SubsetSchemaTotalMissCounts(t *testing.T) {
+	c := &cacheTelemetry{}
+	now := time.Now()
+	// First request: a cache write on OpenAI shows up as cached_tokens=0 —
+	// not a miss, there was nothing to hit yet.
+	c.observe("OPENAI", "gpt-5.6", &models.UsageInfo{PromptTokens: 5000}, now)
+	if c.requests != 0 || c.misses != 0 {
+		t.Fatalf("first uncached request is not a miss: %+v", c)
+	}
+	c.observe("OPENAI", "gpt-5.6", &models.UsageInfo{PromptTokens: 5000, CacheReadInputTokens: 4800}, now)
+	// A sizeable prompt served with nothing from cache after a hit: total miss.
+	for i := 0; i < cacheMissStreakAlert; i++ {
+		c.observe("OPENAI", "gpt-5.6", &models.UsageInfo{PromptTokens: 5000}, now)
+	}
+	if c.misses != cacheMissStreakAlert || !c.alertArmed {
+		t.Fatalf("total misses must count and arm the streak alert: misses=%d armed=%v", c.misses, c.alertArmed)
+	}
+	// A tiny prompt below the provider's cacheable minimum is never a miss.
+	before := c.misses
+	c.observe("OPENAI", "gpt-5.6", &models.UsageInfo{PromptTokens: 200}, now)
+	if c.misses != before {
+		t.Fatal("prompts under the cacheable minimum are not misses")
+	}
+	// Additive schema with no marker reported: still nothing to learn.
+	c.observe("CLAUDEAI", "claude-sonnet-5", &models.UsageInfo{PromptTokens: 9000}, now)
+	if c.misses != before {
+		t.Fatal("no marker on an additive schema is not a miss")
+	}
+}
+
+func TestCacheTelemetry_FirstAndHitRatioArePerProvider(t *testing.T) {
+	ct := NewCostTracker()
+	now := time.Now()
+	// Anthropic: one write then reads → high hit ratio.
+	ct.cache.observe("CLAUDEAI", "claude-sonnet-5", &models.UsageInfo{PromptTokens: 100, CacheCreationInputTokens: 9000}, now)
+	ct.cache.observe("CLAUDEAI", "claude-sonnet-5", &models.UsageInfo{PromptTokens: 100, CacheReadInputTokens: 9000}, now)
+	// Switching to OpenAI: its first request must not be counted as a miss
+	// (the Anthropic "first" was already spent), and its ratio is its own.
+	ct.cache.observe("OPENAI", "gpt-5.6", &models.UsageInfo{PromptTokens: 5000}, now)
+	if ct.cache.misses != 0 {
+		t.Fatalf("the first OpenAI request is not a miss: %+v", ct.cache)
+	}
+	ct.cache.observe("OPENAI", "gpt-5.6", &models.UsageInfo{PromptTokens: 5000, CacheReadInputTokens: 1000}, now)
+	stats := ct.CacheStats()
+	// OpenAI bucket (the uncached first request teaches nothing and is not
+	// counted): 1000 cached of 5000 prompt tokens → 20%, not the
+	// Anthropic-inflated blend.
+	if stats.HitPct < 19 || stats.HitPct > 21 {
+		t.Fatalf("hit ratio must be the last provider's own: %.1f", stats.HitPct)
+	}
+}
+
+func TestCacheTTLFor_BedrockReportsTheMarkerActuallySent(t *testing.T) {
+	t.Setenv(llmclient.PromptCacheTTLEnv, "1h")
+	if got := cacheTTLFor("BEDROCK", "anthropic.claude-sonnet-5"); got != "1h" {
+		t.Fatalf("Claude 4.5+ on Bedrock carries the 1h marker: %s", got)
+	}
+	if got := cacheTTLFor("BEDROCK", "anthropic.claude-3-7-sonnet-20250219-v1:0"); got != "5m" {
+		t.Fatalf("older Claude keeps 5m: %s", got)
+	}
+	t.Setenv(llmclient.PromptCacheTTLEnv, "5m")
+	if got := cacheTTLFor("BEDROCK", "anthropic.claude-sonnet-5"); got != "5m" {
+		t.Fatalf("default lifetime: %s", got)
+	}
+}
+
+func TestNotePrefixChanged_MarksTheNextWriteAsRebuild(t *testing.T) {
+	c := &ChatCLI{logger: zap.NewNop(), costTracker: NewCostTracker()}
+	c.notePrefixChanged("switch model")
+	if !c.costTracker.cache.rebuildPending {
+		t.Fatal("prefix change must arm the expected-rebuild flag")
+	}
+	var nilCLI *ChatCLI
+	nilCLI.notePrefixChanged("noop") // must not panic
+	(&ChatCLI{}).notePrefixChanged("no tracker")
+}

--- a/cli/cli_llm.go
+++ b/cli/cli_llm.go
@@ -309,6 +309,7 @@ func (cli *ChatCLI) applyProviderSwitch(ctx context.Context, newProvider string)
 	cli.Client = newClient
 	cli.Provider = newProvider
 	cli.Model = newModel
+	cli.notePrefixChanged("switch provider")
 	fmt.Println(i18n.T("status.provider_switched", cli.Client.GetModelName(), cli.Provider))
 	fmt.Println()
 	cli.refreshModelCache(ctx)
@@ -455,6 +456,7 @@ func (cli *ChatCLI) handleSwitchCommand(ctx context.Context, userInput string) {
 		} else {
 			cli.Client = newClient
 			cli.Model = newModel
+			cli.notePrefixChanged("switch model")
 			fmt.Println(i18n.T("cli.switch.change_model_success", cli.Client.GetModelName(), cli.Provider))
 			// Mirror the live choice for a running/future gateway daemon (separate process).
 			cli.writeRuntimeModelState()

--- a/cli/command_handler.go
+++ b/cli/command_handler.go
@@ -369,6 +369,13 @@ func (ch *CommandHandler) handleContextCommand(ctx context.Context, userInput st
 		return
 	}
 
+	if f := strings.Fields(userInput); len(f) > 1 {
+		switch strings.ToLower(f[1]) {
+		case "attach", "add", "detach", "remove":
+			// Attached contexts are part of the stable prefix.
+			defer ch.cli.notePrefixChanged("context " + strings.ToLower(f[1]))
+		}
+	}
 	if err := ch.cli.contextHandler.HandleContextCommand(ctx, sessionID, userInput); err != nil {
 		fmt.Println(colorize(fmt.Sprintf(" ❌ %s", err.Error()), ColorYellow))
 	}
@@ -424,6 +431,7 @@ func (ch *CommandHandler) handleSessionCommand(ctx context.Context, userInput st
 			ch.cli.handleSaveSession(ctx, name)
 		} else {
 			ch.cli.handleLoadSession(ctx, name)
+			ch.cli.notePrefixChanged("session " + command) // a loaded history is a new prefix
 		}
 		ch.cli.stampBoundSession()
 		// A loaded session is a different thread: rotate the shared hub

--- a/cli/command_handler_plugins.go
+++ b/cli/command_handler_plugins.go
@@ -130,6 +130,9 @@ func (ch *CommandHandler) handleSkillCommand(ctx context.Context, userInput stri
 		return
 	}
 	ch.cli.skillHandler.HandleCommand(ctx, userInput)
+	if f := strings.Fields(userInput); len(f) > 1 && (f[1] == "pin" || f[1] == "unpin") {
+		ch.cli.notePrefixChanged("skill " + f[1]) // pinned skills live in the stable prefix
+	}
 }
 
 func (ch *CommandHandler) handlePluginCommand(userInput string) {
@@ -359,6 +362,7 @@ func (ch *CommandHandler) handleAgentPersonaSubcommand(userInput string) bool {
 			return true
 		}
 		ch.cli.personaHandler.AttachAgent(args[2])
+		ch.cli.notePrefixChanged("agent attach")
 		return true
 	case "detach", "remove", "rm":
 		if len(args) < 3 {
@@ -366,6 +370,7 @@ func (ch *CommandHandler) handleAgentPersonaSubcommand(userInput string) bool {
 			return true
 		}
 		ch.cli.personaHandler.DetachAgent(args[2])
+		ch.cli.notePrefixChanged("agent detach")
 		return true
 	case "show":
 		full := false

--- a/cli/cost_cache_telemetry.go
+++ b/cli/cost_cache_telemetry.go
@@ -18,8 +18,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/diillson/chatcli/llm/bedrock"
 	llmclient "github.com/diillson/chatcli/llm/client"
 	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
 )
 
 const (
@@ -32,7 +34,21 @@ const (
 	// cacheMissStreakAlert is how many consecutive misses trigger the
 	// one-shot "your stable prefix is changing every turn" notice.
 	cacheMissStreakAlert = 3
+	// subsetMinCacheableTokens is the smallest prompt the subset-schema
+	// providers cache at all (OpenAI, Gemini, xAI, Kimi: 1024 tokens); a
+	// shorter prompt served with cached_tokens=0 is not a miss.
+	subsetMinCacheableTokens = 1024
 )
+
+// providerCache is the per-provider slice of the telemetry: "first request"
+// and the hit ratio are per provider because every provider has its own
+// cache, its own schema and its own prefix.
+type providerCache struct {
+	requests    int
+	readTokens  int64
+	writeTokens int64
+	inputTokens int64
+}
 
 // cacheTelemetry is the tracker-side accumulator. All methods are called
 // with the tracker's mutex held.
@@ -50,6 +66,22 @@ type cacheTelemetry struct {
 	rebuildPending bool // set by NoteExpectedCacheRebuild until the next request
 	missStreak     int
 	alertArmed     bool // a streak notice is waiting to be shown
+
+	byProvider map[string]*providerCache
+}
+
+// bucket returns (creating) the per-provider slice.
+func (c *cacheTelemetry) bucket(provider string) *providerCache {
+	if c.byProvider == nil {
+		c.byProvider = make(map[string]*providerCache)
+	}
+	key := strings.ToUpper(strings.TrimSpace(provider))
+	b := c.byProvider[key]
+	if b == nil {
+		b = &providerCache{}
+		c.byProvider[key] = b
+	}
+	return b
 }
 
 // observe folds one real usage report into the telemetry.
@@ -59,22 +91,32 @@ func (c *cacheTelemetry) observe(provider, model string, u *models.UsageInfo, no
 	prompt := int64(u.PromptTokens)
 	additive := cacheTokensAdditive(provider, model)
 
+	b := c.bucket(provider)
+	first := b.requests == 0
 	if read == 0 && write == 0 {
-		// Provider reported no cache activity: nothing to learn about the
-		// cache from this request (and no basis to call it a miss).
-		return
+		// No cache activity reported. On an additive schema (Anthropic,
+		// Bedrock) that means no marker was placed — nothing to learn. On a
+		// subset schema (OpenAI, Gemini, xAI, Kimi) cached_tokens=0 on a
+		// prompt the provider would have cached IS the total miss: the
+		// prefix changed or expired.
+		if additive || first || prompt < subsetMinCacheableTokens {
+			return
+		}
 	}
-	first := c.requests == 0
 	c.requests++
 	c.readTokens += read
 	c.lastActivity = now
 	c.lastProvider = provider
 	c.lastModel = model
+	b.requests++
+	b.readTokens += read
+	b.inputTokens += prompt
 
 	var miss bool
 	if additive {
 		c.writeTokens += write
 		c.inputTokens += prompt
+		b.writeTokens += write
 		// Anthropic/Bedrock: the write is the part of the prefix the cache
 		// did not hold. A large write after the first request means the
 		// prefix changed (or expired).
@@ -154,6 +196,11 @@ func cacheTTLFor(provider, model string) string {
 	m := strings.ToLower(model)
 	if strings.Contains(p, "claudeai") || strings.Contains(m, "claude") || strings.Contains(m, "fable") {
 		if strings.Contains(p, "bedrock") {
+			// The marker Converse/InvokeModel actually sent: 1h only on
+			// the Claude generations that accept the ttl field.
+			if bedrock.SupportsExtendedCacheTTL(model) {
+				return llmclient.AnthropicCacheTTL()
+			}
 			return "5m"
 		}
 		return llmclient.AnthropicCacheTTL()
@@ -202,11 +249,33 @@ func (ct *CostTracker) cacheStatsLocked() CacheStats {
 	if c.requests == 0 {
 		return stats
 	}
+	// The hit ratio is the last-used provider's own: each provider has its
+	// own cache and schema, so blending an additive and a subset provider
+	// into one ratio would describe neither.
 	additive := cacheTokensAdditive(c.lastProvider, c.lastModel)
-	stats.HitPct = cacheHitPct(additive, c.readTokens, c.writeTokens, c.inputTokens)
+	if b := c.byProvider[strings.ToUpper(strings.TrimSpace(c.lastProvider))]; b != nil {
+		stats.HitPct = cacheHitPct(additive, b.readTokens, b.writeTokens, b.inputTokens)
+	} else {
+		stats.HitPct = cacheHitPct(additive, c.readTokens, c.writeTokens, c.inputTokens)
+	}
 	stats.TTL = cacheTTLFor(c.lastProvider, c.lastModel)
 	stats.Warm = time.Since(c.lastActivity) < cacheTTLDuration(stats.TTL)
 	return stats
+}
+
+// notePrefixChanged records that an operation just changed the stable
+// prefix on purpose (/switch, /agent attach|detach, /session load|attach,
+// MCP server start/stop/restart/reload/login/logout, skill pin|unpin), so
+// the next request's cache write reads as an expected rebuild, not as an
+// unstable-prefix miss.
+func (cli *ChatCLI) notePrefixChanged(reason string) {
+	if cli == nil || cli.costTracker == nil {
+		return
+	}
+	cli.costTracker.NoteExpectedCacheRebuild()
+	if cli.logger != nil {
+		cli.logger.Debug("prefix changed; next cache write is an expected rebuild", zap.String("reason", reason))
+	}
 }
 
 // NoteExpectedCacheRebuild tells the telemetry that ChatCLI just rewrote

--- a/cli/cost_cache_telemetry_test.go
+++ b/cli/cost_cache_telemetry_test.go
@@ -116,11 +116,17 @@ func TestCacheStats_TTLFollowsConfiguredAnthropicTTL(t *testing.T) {
 	if s := ct.CacheStats(); s.TTL != "1h" || !s.Warm {
 		t.Fatalf("stats = %+v", s)
 	}
-	// Bedrock keeps the wire default.
+	// Bedrock reports the marker it actually sent: 1h on Claude 4.5+, the
+	// wire default on older Claude.
 	ct2 := NewCostTracker()
 	ct2.RecordRealUsage("BEDROCK", "global.anthropic.claude-sonnet-5", realUsage(500, 100, 100))
-	if s := ct2.CacheStats(); s.TTL != "5m" {
+	if s := ct2.CacheStats(); s.TTL != "1h" {
 		t.Fatalf("bedrock ttl = %s", s.TTL)
+	}
+	ct3 := NewCostTracker()
+	ct3.RecordRealUsage("BEDROCK", "anthropic.claude-3-7-sonnet-20250219-v1:0", realUsage(500, 100, 100))
+	if s := ct3.CacheStats(); s.TTL != "5m" {
+		t.Fatalf("older Claude on bedrock ttl = %s", s.TTL)
 	}
 }
 

--- a/cli/mcp_command.go
+++ b/cli/mcp_command.go
@@ -68,6 +68,11 @@ func (cli *ChatCLI) handleMCPCommand(ctx context.Context, userInput string) {
 	}
 
 	switch subcommand {
+	case "restart", "start", "stop", "reload", "login", "auth", "logout":
+		// The MCP tool catalog is part of the stable prefix.
+		defer cli.notePrefixChanged("mcp " + subcommand)
+	}
+	switch subcommand {
 	case "", "status":
 		cli.mcpShowStatus(name)
 	case "tools":

--- a/llm/bedrock/bedrock_client.go
+++ b/llm/bedrock/bedrock_client.go
@@ -473,7 +473,7 @@ func (c *BedrockClient) sendPromptAnthropicModel(ctx context.Context, wireModel,
 	// cache_control object for Claude 4.5+ (docs.aws.amazon.com/bedrock/
 	// latest/userguide/prompt-caching.html), so the configured TTL applies
 	// there; older Claude keeps the 5-minute wire default.
-	client.MarkAnthropicHistoryBreakpoint(client.AnthropicMessages{Maps: messages}, client.AnthropicCacheMarkerWithTTL(supportsExtendedCacheTTL(wireModel)))
+	client.MarkAnthropicHistoryBreakpoint(client.AnthropicMessages{Maps: messages}, client.AnthropicCacheMarkerWithTTL(extendedCacheTTLModel(wireModel)))
 	enforceCacheControlBudget(reqBody, anthropicMaxCacheBreakpoints)
 
 	payload, err := json.Marshal(reqBody)
@@ -577,7 +577,7 @@ func (c *BedrockClient) buildMessagesAndSystem(prompt string, history []models.M
 						// Anthropic requires longer-lived breakpoints to
 						// precede shorter ones, so system and history must
 						// carry one lifetime.
-						block["cache_control"] = client.AnthropicCacheMarkerWithTTL(supportsExtendedCacheTTL(c.model))
+						block["cache_control"] = client.AnthropicCacheMarkerWithTTL(extendedCacheTTLModel(c.model))
 					}
 					systemBlocks = append(systemBlocks, block)
 				}
@@ -607,11 +607,16 @@ func (c *BedrockClient) buildMessagesAndSystem(prompt string, history []models.M
 	return messages, nil
 }
 
-// supportsExtendedCacheTTL reports whether Bedrock honors the 1-hour
+// extendedCacheTTLModel reports whether Bedrock honors the 1-hour
 // cache TTL for the model: every Claude from the 4.5 generation on
 // (Sonnet/Opus 4.5+, Haiku 4.5, the 5.x line, Fable/Mythos). Claude 3.x
 // and non-Anthropic vendors keep the 5-minute default.
-func supportsExtendedCacheTTL(model string) bool {
+// SupportsExtendedCacheTTL reports whether the Bedrock Claude model accepts
+// the 1h cache ttl (Claude 4.5+); telemetry reads it to report the TTL the
+// request actually carried.
+func SupportsExtendedCacheTTL(model string) bool { return extendedCacheTTLModel(model) }
+
+func extendedCacheTTLModel(model string) bool {
 	m := strings.ToLower(model)
 	if !strings.Contains(m, "claude") {
 		return false

--- a/llm/bedrock/cache_ttl_test.go
+++ b/llm/bedrock/cache_ttl_test.go
@@ -19,12 +19,12 @@ func TestSupportsExtendedCacheTTL_Gate(t *testing.T) {
 	yes := []string{"anthropic.claude-sonnet-4-6", "anthropic.claude-opus-4-8", "anthropic.claude-sonnet-5", "anthropic.claude-fable-5-1", "anthropic.claude-haiku-4-5-20251001-v1:0", "us.anthropic.claude-opus-4-5-20251101-v1:0"}
 	no := []string{"anthropic.claude-3-7-sonnet-20250219-v1:0", "anthropic.claude-3-5-sonnet-20241022-v2:0", "amazon.nova-pro-v1:0", "meta.llama4", "openai.gpt-5.6-terra"}
 	for _, m := range yes {
-		if !supportsExtendedCacheTTL(m) {
+		if !extendedCacheTTLModel(m) {
 			t.Fatalf("%s must support the 1h TTL", m)
 		}
 	}
 	for _, m := range no {
-		if supportsExtendedCacheTTL(m) {
+		if extendedCacheTTLModel(m) {
 			t.Fatalf("%s must not get a 1h TTL", m)
 		}
 	}

--- a/llm/bedrock/converse_family.go
+++ b/llm/bedrock/converse_family.go
@@ -347,7 +347,7 @@ func converseSupportsCachePoint(model string) bool {
 // lifetime on Claude 4.5+ ("ttl":"1h" per the Bedrock prompt-caching
 // guide), empty (wire default, 5 minutes) for Nova and older Claude.
 func converseCacheTTL(model string) bedrockruntimetypes.CacheTTL {
-	if !supportsExtendedCacheTTL(model) || client.AnthropicCacheTTL() != "1h" {
+	if !extendedCacheTTLModel(model) || client.AnthropicCacheTTL() != "1h" {
 		return ""
 	}
 	return bedrockruntimetypes.CacheTTLOneHour

--- a/llm/bedrock/mantle.go
+++ b/llm/bedrock/mantle.go
@@ -204,7 +204,7 @@ func (c *BedrockClient) sendPromptAnthropicMantle(ctx context.Context, prompt st
 	applyAnthropicThinkingForEffort(reqBody, c.model, ctx)
 	// Rolling conversation breakpoint; the configured TTL applies on Claude
 	// 4.5+ (Bedrock accepts "ttl":"1h" in cache_control).
-	client.MarkAnthropicHistoryBreakpoint(client.AnthropicMessages{Maps: messages}, client.AnthropicCacheMarkerWithTTL(supportsExtendedCacheTTL(c.model)))
+	client.MarkAnthropicHistoryBreakpoint(client.AnthropicMessages{Maps: messages}, client.AnthropicCacheMarkerWithTTL(extendedCacheTTLModel(c.model)))
 	enforceCacheControlBudget(reqBody, anthropicMaxCacheBreakpoints)
 
 	payload, err := json.Marshal(reqBody)


### PR DESCRIPTION
## Summary

Audit III, PR 12 (P2 CAG-4, CAG-8; P3 CAG-12).

- **Subset-schema total misses (CAG-4).** `observe` returned before the miss branch whenever the provider reported no cache fields, so OpenAI, Gemini, xAI and Kimi never registered a total miss, the 3-miss alert could not fire and `HitPct` was inflated. A prompt at or above the provider's cacheable minimum (1024 tokens) served with `cached_tokens=0` after that provider's first request now counts as a miss (or as the expected rebuild when one is pending). Additive schemas with no marker still teach nothing.
- **Per-provider first and ratio (CAG-8).** `byProvider` buckets: "first request" and the hit ratio are per provider, so switching from Anthropic to OpenAI does not spend the other's first, and `/cost` shows the last-used provider's own ratio instead of blending an additive and a subset schema.
- **Expected rebuilds on every prefix change (CAG-8).** `notePrefixChanged(reason)` is called from `/switch` (provider and model), `/agent attach|detach`, `/context attach|detach`, `/session load|attach`, MCP `start|stop|restart|reload|login|logout` and skill `pin|unpin`, so the next cache write reads as a rebuild, not an unstable-prefix miss.
- **Bedrock TTL as sent (CAG-12).** `cacheTTLFor` asks `bedrock.SupportsExtendedCacheTTL` (new exported wrapper) and reports 1h on Claude 4.5+ when configured; older Claude keeps 5m. The existing test that encoded the hard-coded 5m is updated to the truthful value.

## Tests

`cli/audit3_pr12_test.go`: subset total misses count and arm the streak alert, sub-minimum prompts and marker-less additive requests do not; per-provider first and ratio; Bedrock TTL by model and preference; `notePrefixChanged` arms the flag and is nil-safe. Existing telemetry suite green; golangci-lint and the local gates are green.