### PR TITLE
fix(context): mirror provider context edits locally — stub cleared tool results, skip calibration, note the rebuild, surface freed tokens

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -2446,9 +2446,16 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 			turnUsage = llmclient.GetUsageOrEstimate(turnClient, inputChars, len(aiResponse))
 			effProvider, effModel := a.effectiveRoute()
 			a.cli.costTracker.RecordRealUsage(effProvider, effModel, turnUsage)
+			// The provider context engine cleared tool results server-side:
+			// mirror that locally and do not calibrate on this turn (the
+			// chars sent no longer match the tokens counted).
+			edited := llmResp != nil && llmResp.ContextEdits != nil && llmResp.ContextEdits.ClearedToolUses > 0
+			if edited {
+				a.cli.mirrorContextEdits(llmResp.ContextEdits)
+			}
 			// Learn the real chars-per-token ratio for this provider/model
 			// from what was actually sent and what the API counted.
-			if turnUsage != nil && turnUsage.IsReal {
+			if turnUsage != nil && turnUsage.IsReal && !edited {
 				a.cli.calibrator().Observe(effProvider, effModel, promptCharsOf(turnHistory), contextTokens(effProvider, effModel, turnUsage))
 			}
 			a.cli.maybeAnnounceBudget()

--- a/cli/audit3_pr13_test.go
+++ b/cli/audit3_pr13_test.go
@@ -1,0 +1,57 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+func TestMirrorContextEdits_StubsOldestKeepsRecentBooksAndNotesRebuild(t *testing.T) {
+	c := &ChatCLI{logger: zap.NewNop(), costTracker: NewCostTracker()}
+	for i := 0; i < 8; i++ {
+		c.history = append(c.history,
+			models.Message{Role: "assistant", Content: "run", ToolCalls: []models.ToolCall{{ID: "c", Name: "read"}}},
+			models.Message{Role: "tool", ToolCallID: "c", Content: strings.Repeat("output ", 200)})
+	}
+	n := c.mirrorContextEdits(&models.ContextEdits{ClearedToolUses: 2, ClearedInputTokens: 9000})
+	if n != 2 {
+		t.Fatalf("stubbed = %d, want the two oldest results", n)
+	}
+	if !strings.HasPrefix(c.history[1].Content, clearedToolResultStub) || !strings.HasPrefix(c.history[3].Content, clearedToolResultStub) {
+		t.Fatal("the oldest tool results must be stubbed")
+	}
+	if strings.HasPrefix(c.history[5].Content, clearedToolResultStub) {
+		t.Fatal("a result the server kept must stay")
+	}
+	edits, uses, tokens := c.costTracker.ContextEditStats()
+	if edits != 1 || uses != 2 || tokens != 9000 {
+		t.Fatalf("stats = %d %d %d", edits, uses, tokens)
+	}
+	if !c.costTracker.cache.rebuildPending {
+		t.Fatal("a local stub changes the prefix: the next write is an expected rebuild")
+	}
+	// Server keeps the five most recent: with six groups and a claim of ten
+	// clears, only one is clearable; idempotent on a second pass.
+	c2 := &ChatCLI{logger: zap.NewNop(), costTracker: NewCostTracker()}
+	for i := 0; i < 6; i++ {
+		c2.history = append(c2.history,
+			models.Message{Role: "assistant", Content: "run", ToolCalls: []models.ToolCall{{ID: "c", Name: "read"}}},
+			models.Message{Role: "tool", ToolCallID: "c", Content: "out"})
+	}
+	if n := c2.mirrorContextEdits(&models.ContextEdits{ClearedToolUses: 10}); n != 1 {
+		t.Fatalf("keep threshold: stubbed=%d", n)
+	}
+	if n := c2.mirrorContextEdits(&models.ContextEdits{ClearedToolUses: 10}); n != 0 {
+		t.Fatalf("second pass must be idempotent: %d", n)
+	}
+	if c.mirrorContextEdits(nil) != 0 || (*ChatCLI)(nil).mirrorContextEdits(&models.ContextEdits{ClearedToolUses: 1}) != 0 {
+		t.Fatal("nil-safe")
+	}
+}

--- a/cli/context_edits.go
+++ b/cli/context_edits.go
@@ -1,0 +1,88 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Provider context edits, mirrored locally.
+ *
+ * With the provider context engine on (Anthropic context editing), the
+ * server clears the oldest tool results from the request it processes.
+ * Until now that stayed invisible here: the local history kept shipping
+ * the cleared results, the footer and the compactor over-estimated, the
+ * calibrator saw chars ≫ tokens and the next request's cache write
+ * counted as a miss. mirrorContextEdits closes the loop.
+ */
+package cli
+
+import (
+	"strings"
+
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+// contextEditKeepToolUses mirrors the keep threshold of the request block
+// (client.AnthropicContextManagement: the five most recent tool uses).
+const contextEditKeepToolUses = 5
+
+// clearedToolResultStub replaces a tool result the provider already
+// dropped; the original stays recoverable through CCR when archived.
+const clearedToolResultStub = "[tool result cleared by the provider context engine]"
+
+// mirrorContextEdits stubs the oldest tool results the provider cleared
+// (keeping the most recent tool uses, like the server), archives the
+// originals to CCR, notes the expected cache rebuild and books the
+// cleared tokens. Returns how many results were stubbed.
+func (cli *ChatCLI) mirrorContextEdits(edits *models.ContextEdits) int {
+	if cli == nil || edits == nil || edits.ClearedToolUses <= 0 {
+		return 0
+	}
+	// Tool-use groups oldest→newest: an assistant message with tool calls
+	// and the tool results answering it.
+	type group struct{ results []int }
+	var groups []group
+	for i, m := range cli.history {
+		switch {
+		case strings.EqualFold(m.Role, "assistant") && len(m.ToolCalls) > 0:
+			groups = append(groups, group{})
+		case strings.EqualFold(m.Role, "tool") && len(groups) > 0:
+			g := &groups[len(groups)-1]
+			g.results = append(g.results, i)
+		}
+	}
+	clearable := len(groups) - contextEditKeepToolUses
+	if clearable > edits.ClearedToolUses {
+		clearable = edits.ClearedToolUses
+	}
+	stubbed := 0
+	for gi := 0; gi < clearable && gi < len(groups); gi++ {
+		for _, idx := range groups[gi].results {
+			m := &cli.history[idx]
+			if m.Content == "" || strings.HasPrefix(m.Content, clearedToolResultStub) {
+				continue
+			}
+			stub := clearedToolResultStub
+			if cli.compressionLayer != nil {
+				if key, ok := cli.compressionLayer.Archive(m.Content); ok && key != "" {
+					stub += " — recover with @recall " + key
+				}
+			}
+			m.Content = stub
+			if m.Meta != nil {
+				m.Meta.PreserveVerbatim = false
+			}
+			stubbed++
+		}
+	}
+	if cli.costTracker != nil {
+		cli.costTracker.RecordContextEdits(edits.ClearedToolUses, edits.ClearedInputTokens)
+		if stubbed > 0 {
+			cli.costTracker.NoteExpectedCacheRebuild()
+		}
+	}
+	if cli.logger != nil {
+		cli.logger.Info("provider context edits mirrored locally",
+			zap.Int("cleared_tool_uses", edits.ClearedToolUses), zap.Int("cleared_input_tokens", edits.ClearedInputTokens), zap.Int("stubbed", stubbed))
+	}
+	return stubbed
+}

--- a/cli/context_status.go
+++ b/cli/context_status.go
@@ -208,6 +208,9 @@ func (cli *ChatCLI) showContextStatus(ctx context.Context) {
 	if r.ExactHistoryTokens > 0 {
 		fmt.Printf("    %s %s tok\n", kitPad(i18n.T("context.status.exact_history")), formatTokenCount(int64(r.ExactHistoryTokens)))
 	}
+	if edits, toolUses, tokens := cli.costTracker.ContextEditStats(); edits > 0 {
+		fmt.Printf("    %s\n", colorize(i18n.T("context.status.provider_edits", edits, toolUses, formatTokenCount(tokens)), ColorGray))
+	}
 	if r.Window > 0 {
 		fmt.Printf("    %s ≈%s tok (%s)\n", kitPad(i18n.T("context.status.total_projected")),
 			formatTokenCount(int64(r.TotalTokens)), colorize(fmt.Sprintf("%.0f%%", r.ProjectedPct), pctColor(r.ProjectedPct)))

--- a/cli/cost_tracker.go
+++ b/cli/cost_tracker.go
@@ -127,7 +127,11 @@ type SessionCostData struct {
 // with per-model granularity, real API usage data support, cache token pricing,
 // write-through session persistence, and configurable budget enforcement.
 type CostTracker struct {
-	mu sync.RWMutex
+	// Provider context engine bookkeeping (server-side clears).
+	contextEditsApplied  int
+	contextEditsToolUses int
+	contextEditsTokens   int64
+	mu                   sync.RWMutex
 
 	// storeDir overrides the snapshot directory (per-tenant store sets);
 	// empty means the process default (costStoreDir).
@@ -281,6 +285,30 @@ func modelKey(provider, model string) string {
 
 // RecordRealUsage records actual token usage from an API response.
 // This is the preferred path — provides accurate cost tracking.
+// RecordContextEdits books what the provider context engine cleared
+// server-side (tool results and the input tokens they held).
+func (ct *CostTracker) RecordContextEdits(clearedToolUses, clearedInputTokens int) {
+	if ct == nil {
+		return
+	}
+	ct.mu.Lock()
+	ct.contextEditsApplied++
+	ct.contextEditsToolUses += clearedToolUses
+	ct.contextEditsTokens += int64(clearedInputTokens)
+	ct.mu.Unlock()
+}
+
+// ContextEditStats returns how many provider context edits were applied
+// this session, the tool results cleared and the input tokens freed.
+func (ct *CostTracker) ContextEditStats() (edits, toolUses int, tokens int64) {
+	if ct == nil {
+		return 0, 0, 0
+	}
+	ct.mu.RLock()
+	defer ct.mu.RUnlock()
+	return ct.contextEditsApplied, ct.contextEditsToolUses, ct.contextEditsTokens
+}
+
 func (ct *CostTracker) RecordRealUsage(provider, model string, usage *models.UsageInfo) {
 	if usage == nil {
 		return

--- a/i18n/locales/en-US.context-edits.json
+++ b/i18n/locales/en-US.context-edits.json
@@ -1,0 +1,3 @@
+{
+  "context.status.provider_edits": "Provider context engine: %d edit(s) cleared %d tool result(s) server-side (≈%s tokens freed); the local history was stubbed to match."
+}

--- a/i18n/locales/en.context-edits.json
+++ b/i18n/locales/en.context-edits.json
@@ -1,0 +1,3 @@
+{
+  "context.status.provider_edits": "Provider context engine: %d edit(s) cleared %d tool result(s) server-side (≈%s tokens freed); the local history was stubbed to match."
+}

--- a/i18n/locales/pt-BR.context-edits.json
+++ b/i18n/locales/pt-BR.context-edits.json
@@ -1,0 +1,3 @@
+{
+  "context.status.provider_edits": "Context engine do provedor: %d edição(ões) limparam %d resultado(s) de tool no servidor (≈%s tokens liberados); o histórico local foi ajustado para bater."
+}

--- a/llm/claudeai/context_edits_test.go
+++ b/llm/claudeai/context_edits_test.go
@@ -1,0 +1,29 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package claudeai
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestParseClaudeToolResponse_CarriesAppliedContextEdits(t *testing.T) {
+	body := `{"content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn",
+	 "context_management":{"applied_edits":[{"type":"clear_tool_uses_20250919","cleared_tool_uses":3,"cleared_input_tokens":25000},{"type":"clear_tool_uses_20250919","cleared_tool_uses":1,"cleared_input_tokens":4000}]},
+	 "usage":{"input_tokens":10,"output_tokens":2}}`
+	resp, err := parseClaudeToolResponse(body, zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.ContextEdits == nil || resp.ContextEdits.ClearedToolUses != 4 || resp.ContextEdits.ClearedInputTokens != 29000 {
+		t.Fatalf("edits = %+v", resp.ContextEdits)
+	}
+	plain, _ := parseClaudeToolResponse(`{"content":[{"type":"text","text":"ok"}]}`, zap.NewNop())
+	if plain.ContextEdits != nil {
+		t.Fatal("no edits → nil")
+	}
+}

--- a/llm/claudeai/tool_use.go
+++ b/llm/claudeai/tool_use.go
@@ -326,6 +326,25 @@ func (c *ClaudeClient) buildToolRequest(ctx context.Context, jsonValue []byte, t
 	return req, nil
 }
 
+// parseAppliedEdits sums the applied_edits entries of a context_management
+// response block ({type, cleared_tool_uses, cleared_input_tokens}).
+func parseAppliedEdits(edits []interface{}) *models.ContextEdits {
+	out := &models.ContextEdits{}
+	for _, raw := range edits {
+		e, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if v, ok := e["cleared_tool_uses"].(float64); ok {
+			out.ClearedToolUses += int(v)
+		}
+		if v, ok := e["cleared_input_tokens"].(float64); ok {
+			out.ClearedInputTokens += int(v)
+		}
+	}
+	return out
+}
+
 // parseClaudeToolResponse parses the Anthropic API response with tool use support.
 func parseClaudeToolResponse(body string, logger *zap.Logger) (*models.LLMResponse, error) {
 	var result map[string]interface{}
@@ -376,10 +395,17 @@ func parseClaudeToolResponse(body string, logger *zap.Logger) (*models.LLMRespon
 
 	response.Content = strings.Join(textParts, "\n")
 
-	// Server-side context edits applied by the provider context engine.
+	// Server-side context edits applied by the provider context engine:
+	// parsed into the response so the caller can mirror them locally
+	// (stub the cleared results, skip calibration, note the rebuild).
 	if cm, ok := result["context_management"].(map[string]interface{}); ok {
-		if edits, ok := cm["applied_edits"].([]interface{}); ok && len(edits) > 0 && logger != nil {
-			logger.Info("anthropic context editing applied", zap.Int("edits", len(edits)))
+		if edits, ok := cm["applied_edits"].([]interface{}); ok && len(edits) > 0 {
+			response.ContextEdits = parseAppliedEdits(edits)
+			if logger != nil {
+				logger.Info("anthropic context editing applied", zap.Int("edits", len(edits)),
+					zap.Int("cleared_tool_uses", response.ContextEdits.ClearedToolUses),
+					zap.Int("cleared_input_tokens", response.ContextEdits.ClearedInputTokens))
+			}
 		}
 	}
 

--- a/models/tool_types.go
+++ b/models/tool_types.go
@@ -64,6 +64,19 @@ type LLMResponse struct {
 	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
 	Usage      *UsageInfo `json:"usage,omitempty"`
 	StopReason string     `json:"stop_reason,omitempty"`
+	// ContextEdits reports what the provider's context engine removed
+	// from the request server-side (Anthropic context editing); nil when
+	// nothing was edited.
+	ContextEdits *ContextEdits `json:"context_edits,omitempty"`
+}
+
+// ContextEdits sums the server-side edits a provider applied to one
+// request: how many tool results it cleared and how many input tokens
+// that freed. The local history still holds those results until the
+// caller stubs them (cli.mirrorContextEdits).
+type ContextEdits struct {
+	ClearedToolUses    int `json:"cleared_tool_uses"`
+	ClearedInputTokens int `json:"cleared_input_tokens"`
 }
 
 // HasToolCalls returns true if the response contains tool calls.


### PR DESCRIPTION
## Summary

Audit III, PR 13 (P2 CAG-9, COST-8). Provider context engine end-to-end.

- **Parsed (COST-8).** `parseClaudeToolResponse` sums `applied_edits` (`cleared_tool_uses`, `cleared_input_tokens`) into `LLMResponse.ContextEdits` (new, nil when nothing was edited).
- **Mirrored (CAG-9).** `cli.mirrorContextEdits` stubs the oldest tool results the server cleared, keeping the five most recent tool uses exactly like the request block asks, archives each original to CCR (recoverable with `@recall`), notes the expected cache rebuild and books the cleared count and tokens on the cost tracker. Idempotent: an already-stubbed result is never re-stubbed.
- **Calibration.** The agent loop skips the chars/token observation on an edited turn (the chars sent no longer match the tokens counted), so the calibrator is not poisoned.
- **Surfaced.** `/context status` prints the provider edits line (edits, tool results cleared, tokens freed). i18n as a locale fragment.
- **Scope check.** The OAuth path already sends `context_management` and the beta header; Bedrock has no native tool path, so there is nothing to apply there. Documented in the PR rather than changed.

## Tests

`llm/claudeai/context_edits_test.go`: applied edits summed across entries, nil without edits. `cli/audit3_pr13_test.go`: oldest results stubbed, recent kept, stats booked, rebuild armed, keep threshold honoured, idempotent, nil-safe. golangci-lint and the local gates are green.