### PR TITLE
fix(security): persisted-data hygiene — strict-policy redaction on every store, sealed REPL history, missing secret shapes, periodic tenant retention

### DIFF
--- a/cli/audit3_pr18_test.go
+++ b/cli/audit3_pr18_test.go
@@ -1,0 +1,113 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+func TestPersistRedact_StrictPolicyOnly(t *testing.T) {
+	secret := "token sk-" + strings.Repeat("a", 30)
+	t.Setenv("CHATCLI_ENV_REDACT_MODE", "permissive")
+	if persistRedact(secret) != secret {
+		t.Fatal("the permissive default keeps persisted stores verbatim")
+	}
+	t.Setenv("CHATCLI_ENV_REDACT_MODE", "strict")
+	if got := persistRedact(secret); strings.Contains(got, strings.Repeat("a", 30)) {
+		t.Fatalf("strict must mask: %q", got)
+	}
+	live := []models.Message{{Role: "user", Content: secret}}
+	stored := persistRedactMessages(live)
+	if live[0].Content != secret || strings.Contains(stored[0].Content, strings.Repeat("a", 30)) {
+		t.Fatal("redaction must copy, never touch the live history")
+	}
+}
+
+func TestSaveSession_StrictPolicyMasksSecretsOnDisk(t *testing.T) {
+	t.Setenv("CHATCLI_ENV_REDACT_MODE", "strict")
+	t.Setenv("CHATCLI_ENCRYPTION_KEY", "")
+	dir := t.TempDir()
+	sm, err := NewSessionManagerAt(dir, zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	secret := "ghp_" + strings.Repeat("b", 30)
+	history := []models.Message{{Role: "user", Content: "my token is " + secret}}
+	if err := sm.SaveSession("s", history); err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := os.ReadFile(filepath.Join(dir, "s.json"))
+	if strings.Contains(string(raw), secret) {
+		t.Fatal("the session file must not hold the raw token under strict")
+	}
+	if history[0].Content != "my token is "+secret {
+		t.Fatal("the live history stays intact")
+	}
+}
+
+func TestHistoryManager_SealsLinesAtRest(t *testing.T) {
+	t.Setenv("CHATCLI_ENCRYPTION_KEY", "history-test-key")
+	t.Setenv("CHATCLI_DISABLE_HISTORY", "false")
+	path := filepath.Join(t.TempDir(), ".chatcli_history")
+	t.Setenv("HISTORY_FILE", path)
+	hm := NewHistoryManager(zap.NewNop())
+	if hm.GetHistoryFilePath() != path {
+		t.Skipf("history path not overridable here: %s", hm.GetHistoryFilePath())
+	}
+	if err := hm.AppendAndRotateHistory([]string{"/session load prod", "hello world"}); err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := os.ReadFile(path)
+	if strings.Contains(string(raw), "hello world") || !strings.Contains(string(raw), historySealedPrefix) {
+		t.Fatalf("history must be sealed on disk:\n%s", raw)
+	}
+	got, err := hm.LoadHistory()
+	if err != nil || len(got) != 2 || got[1] != "hello world" {
+		t.Fatalf("sealed history must load back: %v %v", got, err)
+	}
+}
+
+func TestRetention_PrunesOldFilesAndLoops(t *testing.T) {
+	dir := t.TempDir()
+	old := filepath.Join(dir, "old.json")
+	fresh := filepath.Join(dir, "fresh.json")
+	other := filepath.Join(dir, "old.txt")
+	for _, p := range []string{old, fresh, other} {
+		_ = os.WriteFile(p, []byte("x"), 0o600)
+	}
+	past := time.Now().Add(-48 * time.Hour)
+	_ = os.Chtimes(old, past, past)
+	_ = os.Chtimes(other, past, past)
+	if n := pruneFilesOlderThan(dir, time.Now().Add(-24*time.Hour), ".json"); n != 1 {
+		t.Fatalf("pruned %d", n)
+	}
+	if _, err := os.Stat(fresh); err != nil {
+		t.Fatal("fresh file must survive")
+	}
+	if _, err := os.Stat(other); err != nil {
+		t.Fatal("other extensions untouched when an extension is given")
+	}
+	if n := pruneFilesOlderThan(filepath.Join(dir, "missing"), time.Now(), ""); n != 0 {
+		t.Fatal("missing dir is a no-op")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { (&ChatCLI{logger: zap.NewNop()}).runRetentionLoop(ctx, time.Hour); close(done) }()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("retention loop must stop with its context")
+	}
+}

--- a/cli/compact_command.go
+++ b/cli/compact_command.go
@@ -195,7 +195,7 @@ CONVERSATION TO COMPACT:
 	// legacy lossy behavior.
 	recallNote := ""
 	if cli.compressionLayer != nil {
-		if key, ok := cli.compressionLayer.Archive(renderMessagesForArchive(middleMessages)); ok {
+		if key, ok := cli.compressionLayer.Archive(persistRedact(renderMessagesForArchive(middleMessages))); ok {
 			recallNote = "\n\n[full transcript of the summarized segment recoverable via @recall " +
 				compress.FormatMarker(key) + "]"
 		}

--- a/cli/compaction_hooks.go
+++ b/cli/compaction_hooks.go
@@ -156,7 +156,7 @@ func archiveDroppedMessages(layer *compress.Layer, before, after []models.Messag
 	if len(dropped) == 0 {
 		return ""
 	}
-	key, ok := layer.Archive(renderMessagesForArchive(dropped))
+	key, ok := layer.Archive(persistRedact(renderMessagesForArchive(dropped)))
 	if !ok {
 		return ""
 	}

--- a/cli/gateway_command.go
+++ b/cli/gateway_command.go
@@ -303,6 +303,10 @@ func (cli *ChatCLI) runGateway(ctx context.Context, broker hub.Store) error {
 	}
 
 	imgOutbox := newGatewayImageOutbox()
+	// The daemon lives for days: re-run retention periodically (the REPL
+	// runs it once at boot) so tenant parks, sessions, transcripts and the
+	// memory queue actually expire.
+	go cli.runRetentionLoop(ctx, retentionInterval)
 	runner := gateway.NewRunner(adapters, cli.gatewayAgentFunc(sessions, transcriber, imgOutbox), cli.logger, 0)
 	runner.SetThinkingNotice(i18n.T("gateway.thinking"))
 	runner.SetVoicePrefs(gateway.SharedVoicePrefs())

--- a/cli/history_compactor.go
+++ b/cli/history_compactor.go
@@ -514,7 +514,7 @@ func (hc *HistoryCompactor) capVerbatim(history []models.Message, budget int) []
 		}
 		stub := "[recalled original aged out of the window (" + FormatPayloadSize(len(m.Content)) + ")"
 		if hc.compress != nil {
-			if key, ok := hc.compress.Archive(m.Content); ok {
+			if key, ok := hc.compress.Archive(persistRedact(m.Content)); ok {
 				stub += "; recover again with @recall " + compress.FormatMarker(key)
 			}
 		}

--- a/cli/history_manager.go
+++ b/cli/history_manager.go
@@ -7,7 +7,9 @@ package cli
 
 import (
 	"bufio"
+	"encoding/base64"
 	"fmt"
+	"github.com/diillson/chatcli/pkg/atrest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -91,6 +93,15 @@ func (hm *HistoryManager) LoadHistory() ([]string, error) {
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		line := scanner.Text()
+		if strings.HasPrefix(line, historySealedPrefix) {
+			plain, err := openHistoryLine(line)
+			if err != nil {
+				// Sealed with a key this process does not hold: skip the
+				// entry rather than surface ciphertext as a command.
+				continue
+			}
+			line = plain
+		}
 		history = append(history, line)
 	}
 
@@ -100,6 +111,31 @@ func (hm *HistoryManager) LoadHistory() ([]string, error) {
 	}
 
 	return history, nil
+}
+
+// historySealedPrefix marks a history line sealed with the at-rest key.
+const historySealedPrefix = "enc:"
+
+// sealHistoryLine encrypts one history entry for disk.
+func sealHistoryLine(cmd string) (string, error) {
+	sealed, err := atrest.Seal([]byte(cmd))
+	if err != nil {
+		return "", err
+	}
+	return historySealedPrefix + base64.StdEncoding.EncodeToString(sealed), nil
+}
+
+// openHistoryLine decrypts a sealed history entry.
+func openHistoryLine(line string) (string, error) {
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(line, historySealedPrefix))
+	if err != nil {
+		return "", err
+	}
+	plain, err := atrest.Open(raw)
+	if err != nil {
+		return "", err
+	}
+	return string(plain), nil
 }
 
 // AppendAndRotateHistory salva o histórico no arquivo e faz backup se o tamanho exceder o limite
@@ -191,6 +227,16 @@ func (hm *HistoryManager) AppendAndRotateHistory(newCommands []string) error {
 
 	writer := bufio.NewWriter(f)
 	for _, cmd := range redacted {
+		// Encryption at rest covers the prompt history too: every line is
+		// sealed like the memory WAL and the transcript journal.
+		if atrest.Enabled() {
+			sealed, err := sealHistoryLine(cmd)
+			if err != nil {
+				hm.logger.Warn("Erro ao selar linha do histórico", zap.Error(err))
+				continue
+			}
+			cmd = sealed
+		}
 		if _, err := fmt.Fprintln(writer, cmd); err != nil {
 			// Ignorar erro de escrita individual, mas logar
 			hm.logger.Warn("Erro ao escrever comando no histórico", zap.String("command", cmd), zap.Error(err))

--- a/cli/hub_sync.go
+++ b/cli/hub_sync.go
@@ -325,5 +325,5 @@ func (cli *ChatCLI) mirrorHubTurn(ctx context.Context, userText, assistantText s
 	if cli.hubSync == nil {
 		return
 	}
-	cli.hubSync.mirrorTurn(ctx, userText, assistantText)
+	cli.hubSync.mirrorTurn(ctx, persistRedact(userText), persistRedact(assistantText))
 }

--- a/cli/persist_redact.go
+++ b/cli/persist_redact.go
@@ -1,0 +1,43 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Persisted-data redaction.
+ *
+ * Secret redaction always runs on the LLM-bound path. What ChatCLI writes
+ * to disk for itself — sessions, the transcript journal, CCR archives,
+ * hub mirrors — kept the raw text, so a token pasted once lived on in
+ * every store. The strict policy (CHATCLI_ENV_REDACT_MODE=strict, the
+ * existing switch) now also masks what is persisted; the permissive
+ * default keeps stores verbatim so /rewind and exports stay faithful.
+ */
+package cli
+
+import "github.com/diillson/chatcli/models"
+
+// persistRedactEnabled reports whether persisted stores are redacted.
+func persistRedactEnabled() bool { return contentRedactModeFromEnv() == contentRedactStrict }
+
+// persistRedact masks secrets in text bound for a persistent store under
+// the strict policy; identity otherwise.
+func persistRedact(text string) string {
+	if text == "" || !persistRedactEnabled() {
+		return text
+	}
+	return redactSecretsForLLM(text)
+}
+
+// persistRedactMessages returns a redacted copy of msgs under the strict
+// policy (the live history is never touched); the same slice otherwise.
+func persistRedactMessages(msgs []models.Message) []models.Message {
+	if len(msgs) == 0 || !persistRedactEnabled() {
+		return msgs
+	}
+	out := make([]models.Message, len(msgs))
+	for i, m := range msgs {
+		out[i] = m
+		out[i].Content = redactSecretsForLLM(m.Content)
+	}
+	return out
+}

--- a/cli/retention.go
+++ b/cli/retention.go
@@ -12,6 +12,7 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"github.com/diillson/chatcli/pkg/auditchain"
 	"os"
@@ -29,6 +30,8 @@ import (
 // retentionReport is what one boot pass removed.
 type retentionReport struct {
 	Transcripts int // tenant transcripts removed (the shared set prunes on open)
+	Sessions    int // tenant sessions past the window (the shared set's sessions are the user's)
+	Pending     int // queued memory segments older than the window
 	AuditFiles  int // rotated audit trail files past the retention window
 	Parks       int
 	Costs       int
@@ -55,11 +58,19 @@ func (cli *ChatCLI) runRetentionPass() retentionReport {
 	if dir := costStoreDir(); dir != "" {
 		rep.Costs = pruneCostSnapshotsOlderThan(dir, cutoff)
 	}
-	// Tenant store sets (gateway isolation) follow the same policy.
+	// Queued memory segments are a buffer, not an archive: past the
+	// window they are stale conversation nobody will distill.
+	rep.Pending += pruneFilesOlderThan(defaultPendingDir(), cutoff, ".json")
+	// Tenant store sets (gateway isolation) follow the same policy, and
+	// their parks and sessions expire too: a gateway principal's state is
+	// transient by contract, unlike the user's own named sessions.
 	if cli != nil && cli.stateRoot != "" {
 		for _, root := range tenantRoots(cli.stateRoot) {
 			rep.Costs += pruneCostSnapshotsOlderThan(filepath.Join(root, "costs"), cutoff)
 			rep.Transcripts += pruneTranscripts(filepath.Join(root, transcriptDirName), ttl)
+			rep.Parks += pruneFilesOlderThan(filepath.Join(root, "parked"), cutoff, "")
+			rep.Sessions += pruneFilesOlderThan(filepath.Join(root, "sessions"), cutoff, ".json")
+			rep.Pending += pruneFilesOlderThan(filepath.Join(root, "memory", "pending"), cutoff, ".json")
 		}
 	}
 	// Rotated audit trails (the live file is never touched) follow the
@@ -67,10 +78,57 @@ func (cli *ChatCLI) runRetentionPass() retentionReport {
 	if path := os.Getenv(AuditLogPathEnv); path != "" && filepath.IsAbs(filepath.Clean(path)) {
 		rep.AuditFiles = auditchain.PruneRotated(filepath.Clean(path), cutoff)
 	}
-	if cli != nil && cli.logger != nil && (rep.Parks > 0 || rep.Costs > 0 || rep.AuditFiles > 0) {
-		cli.logger.Info("retention pass", zap.Int("parks_removed", rep.Parks), zap.Int("cost_snapshots_removed", rep.Costs), zap.Int("audit_files_removed", rep.AuditFiles))
+	if cli != nil && cli.logger != nil && (rep.Parks > 0 || rep.Costs > 0 || rep.AuditFiles > 0 || rep.Sessions > 0 || rep.Pending > 0) {
+		cli.logger.Info("retention pass", zap.Int("parks_removed", rep.Parks), zap.Int("cost_snapshots_removed", rep.Costs), zap.Int("audit_files_removed", rep.AuditFiles), zap.Int("sessions_removed", rep.Sessions), zap.Int("pending_removed", rep.Pending))
 	}
 	return rep
+}
+
+// pruneFilesOlderThan removes the regular files of dir (with the given
+// extension, any when "") modified before cutoff; missing dir = 0.
+func pruneFilesOlderThan(dir string, cutoff time.Time, ext string) int {
+	if dir == "" {
+		return 0
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0
+	}
+	n := 0
+	for _, e := range entries {
+		if e.IsDir() || (ext != "" && filepath.Ext(e.Name()) != ext) {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil || !info.ModTime().Before(cutoff) {
+			continue
+		}
+		if os.Remove(filepath.Join(dir, e.Name())) == nil {
+			n++
+		}
+	}
+	return n
+}
+
+// retentionInterval is how often a long-lived process (the gateway
+// daemon) re-runs the pass; the REPL runs it once at boot.
+const retentionInterval = 6 * time.Hour
+
+// runRetentionLoop repeats the retention pass until ctx ends.
+func (cli *ChatCLI) runRetentionLoop(ctx context.Context, every time.Duration) {
+	if every <= 0 {
+		every = retentionInterval
+	}
+	t := time.NewTicker(every)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			cli.runRetentionPass()
+		}
+	}
 }
 
 // pruneCostSnapshotsOlderThan removes cost snapshots modified before cutoff.

--- a/cli/session_manager.go
+++ b/cli/session_manager.go
@@ -268,6 +268,16 @@ func (sm *SessionManager) SaveSessionV2(name string, sd *SessionData) error {
 	}
 
 	sd.Version = 2
+	// Strict redaction policy: what reaches disk is masked (a copy; the
+	// live history stays intact for the running session).
+	if persistRedactEnabled() {
+		clone := *sd
+		clone.ChatHistory = persistRedactMessages(sd.ChatHistory)
+		clone.AgentHistory = persistRedactMessages(sd.AgentHistory)
+		clone.CoderHistory = persistRedactMessages(sd.CoderHistory)
+		clone.SharedMemory = persistRedactMessages(sd.SharedMemory)
+		sd = &clone
+	}
 	// Derive a topic title once at save time so machine names
 	// (autosave-20260720-1504) stay recognizable in list/search/recall.
 	// An explicitly set title always wins.

--- a/cli/transcript_journal.go
+++ b/cli/transcript_journal.go
@@ -241,6 +241,11 @@ func (j *transcriptJournal) appendEvents(events []transcriptEvent) error {
 		}
 	}
 	for _, ev := range events {
+		if ev.Message != nil && persistRedactEnabled() {
+			redacted := *ev.Message
+			redacted.Content = persistRedact(ev.Message.Content)
+			ev.Message = &redacted
+		}
 		line, err := json.Marshal(ev)
 		if err != nil {
 			_ = f.Close()

--- a/utils/secret_shapes_test.go
+++ b/utils/secret_shapes_test.go
@@ -1,0 +1,42 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package utils
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMaskSensitiveInText_CoversTheMissingShapes(t *testing.T) {
+	// Fixtures are assembled at runtime so no secret-shaped literal sits in
+	// the source (push protection scans the tree; the point of the test is
+	// that these shapes never reach disk in the first place).
+	join := func(parts ...string) string { return strings.Join(parts, "") }
+	cases := map[string]string{
+		"slack bot":  join("xox", "b-", "1234567890", "-", "abcdefghijklmnop"),
+		"slack hook": join("https://hooks.slack.com/", "services/T000/B000/", "XXXXXXXXXXXXXXXX"),
+		"pem":        join("-----BEGIN RSA ", "PRIVATE KEY-----\nMIIEow\nABCD\n-----END RSA ", "PRIVATE KEY-----"),
+		"postgres":   join("postgres://app:", "S3cr3tPassw0rd", "@db.internal:5432/app"),
+		"mongodb":    join("mongodb+srv://user:", "hunter2", "@cluster0.example.net/db"),
+		"aws secret": join("aws_secret_", "access_key = ", "wJalrXUtnFEMI/K7MDENG/bPxRfiCY", "EXAMPLEKEY"),
+		"gcp sa":     join(`{"type":"service_account","private_`, `key_id":"0123456789abcdef"}`),
+		"azure":      join("DefaultEndpointsProtocol=https;AccountName=x;Account", "Key=abcdefghijklmnopqrstuvwxyz0123456789ABCD=="),
+		"sas":        join("https://acct.blob.core.windows.net/c?sv=2020&", "sig=abcdefghijklmnopqrstuvwxyz0123"),
+	}
+	needles := map[string]string{
+		"slack bot": "abcdefghijklmnop", "slack hook": "XXXXXXXXXXXXXXXX", "pem": "MIIEow", "postgres": "S3cr3tPassw0rd",
+		"mongodb": "hunter2", "aws secret": "wJalrXUtnFEMI", "gcp sa": "0123456789abcdef", "azure": "abcdefghijklmnopqrstuvwxyz0123456789ABCD", "sas": "abcdefghijklmnopqrstuvwxyz0123",
+	}
+	for name, in := range cases {
+		out := maskSensitiveInText(in)
+		if strings.Contains(out, needles[name]) {
+			t.Errorf("%s: secret survived: %q", name, out)
+		}
+	}
+	if out := maskSensitiveInText("https://example.com/path and postgres://db.internal/app"); out != "https://example.com/path and postgres://db.internal/app" {
+		t.Fatalf("urls without credentials must stay: %q", out)
+	}
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -128,8 +128,20 @@ var sensitiveTextPatterns = []struct {
 	{regexp.MustCompile(`github_pat_[a-zA-Z0-9_]{20,}`), "[REDACTED_GH_PAT]"},
 	// Google AI
 	{regexp.MustCompile(`AIza[0-9A-Za-z\-_]{30,}`), "[REDACTED_GOOGLE_API_KEY]"},
-	// AWS keys
+	// AWS keys (access key id; secret access key by assignment)
 	{regexp.MustCompile(`AKIA[0-9A-Z]{16}`), "[REDACTED_AWS_KEY]"},
+	{regexp.MustCompile(`(?i)(aws_secret_access_key\s*[=:]\s*"?)[A-Za-z0-9/+=]{40}`), "${1}[REDACTED_AWS_SECRET]"},
+	// Slack tokens (bot, user, app, refresh, config) and webhooks
+	{regexp.MustCompile(`xox[baprs]-[A-Za-z0-9-]{10,}`), "[REDACTED_SLACK_TOKEN]"},
+	{regexp.MustCompile(`https://hooks\.slack\.com/services/[A-Za-z0-9/]+`), "https://hooks.slack.com/services/[REDACTED]"},
+	// PEM private keys (RSA, EC, OpenSSH, PKCS#8, encrypted)
+	{regexp.MustCompile(`(?s)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----`), "-----BEGIN PRIVATE KEY-----[REDACTED]-----END PRIVATE KEY-----"},
+	// Connection strings carrying credentials (postgres, mysql, mongodb, redis, amqp, ...)
+	{regexp.MustCompile(`(?i)\b([a-z][a-z0-9+.-]*://[^/\s:@]+:)[^@\s]+@`), "${1}[REDACTED]@"},
+	// GCP service-account JSON and Azure storage / SAS keys
+	{regexp.MustCompile(`("private_key_id")\s*:\s*"[^"]+"`), `${1}:"[REDACTED]"`},
+	{regexp.MustCompile(`(?i)(AccountKey=)[A-Za-z0-9+/=]{20,}`), "${1}[REDACTED]"},
+	{regexp.MustCompile(`(?i)(SharedAccessSignature=|sig=)[A-Za-z0-9%+/=]{20,}`), "${1}[REDACTED]"},
 	// Bearer tokens e JWTs (parte do meio)
 	{regexp.MustCompile(`(?i)Bearer\s+[A-Za-z0-9\.\-_]+`), "Bearer [REDACTED]"},
 	{regexp.MustCompile(`ey[A-Za-z0-9-_=]+\.ey[A-Za-z0-9-_=]+\.[A-Za-z0-9-_.+/=]+`), "[REDACTED_JWT]"},


### PR DESCRIPTION
## Summary

Audit III, PR 18 (P2 SEC-7 REPL-history part, SEC-9, SEC-10).

- **Persisted redaction (SEC-9).** `persistRedact` / `persistRedactMessages`: under `CHATCLI_ENV_REDACT_MODE=strict` (existing switch, no new env) the session file, the transcript journal, CCR archives (compaction hooks, `/compact`, the compactor's per-message archive) and hub mirrors are masked with the same redactor the LLM path uses. The permissive default keeps stores verbatim so `/rewind` and exports stay faithful; redaction always works on a copy, the live history is never touched.
- **Missing shapes (SEC-9).** Slack `xox[baprs]-` tokens and incoming-webhook URLs, PEM private-key blocks (any type, multi-line), connection strings carrying credentials (`scheme://user:pass@` — URLs without credentials untouched), `aws_secret_access_key` assignments, GCP service-account `private_key_id`, Azure `AccountKey=` and SAS `sig=`.
- **Sealed REPL history (SEC-7).** `.chatcli_history` lines are sealed with the at-rest key (`enc:` prefix) and opened on load; lines sealed with a key this process does not hold are skipped rather than shown as ciphertext. Rotation copies sealed lines as they are.
- **Retention (SEC-10).** The gateway daemon re-runs the pass every 6 h (`runRetentionLoop`, stops with the context); tenant roots also expire `parked/`, `sessions/` and `memory/pending/` past the session window; the base memory queue drops segments older than the window. The user's own named sessions are not touched.

## Tests

`cli/audit3_pr18_test.go`: strict-vs-permissive, copy semantics, session file masked on disk with the live history intact, sealed history round trip, prune by age and extension, retention loop stops. `utils/secret_shapes_test.go`: nine new shapes masked (fixtures assembled at runtime so push protection never sees a secret-shaped literal), credential-free URLs preserved. golangci-lint and the local gates are green.