### PR TITLE
fix(context): one context estimate for the footer, the compactor and /context status; window-scaled retrieval budget

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -1069,6 +1069,7 @@ func (a *AgentMode) Run(ctx context.Context, query string, additionalContext str
 	// knowledge digests, then attachments — against the window; skills
 	// have their own run budget further down.
 	promptBudget := a.cli.newPrefixBudget(a.cli.Provider, a.cli.Model)
+	a.cli.applyRetrievedBudget(promptBudget)
 	promptBudget.spend(len(coreText) + len(toolsText))
 	// Attached knowledge bases ride in the same cacheable block: their index
 	// cards are deterministic (change only on attach/detach, like the plugin
@@ -1227,6 +1228,7 @@ func (a *AgentMode) Run(ctx context.Context, query string, additionalContext str
 	}
 	a.installAgentSystemMessage(sysMsg, currentModeName)
 	a.toolDefsChars = a.estimateToolDefsChars()
+	a.cli.toolDefsChars = a.toolDefsChars
 
 	currentQuery := query
 	if additionalContext != "" {
@@ -2263,7 +2265,8 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 
 		// Compact history if over budget (before building turn history)
 		cfg := a.cli.compactConfig(a.cli.Provider, a.cli.Model)
-		cfg.ReservedChars = a.toolDefsChars
+		a.cli.toolDefsChars = a.toolDefsChars
+		cfg.ReservedChars = a.cli.contextEstimate().ReservedChars()
 		// Tighter mode default (tool outputs are large) — unless the user
 		// (/autocompact) or the catalog declared a threshold, which wins.
 		if a.cli.autoCompact.get() <= 0 && catalog.GetCompactRatio(a.cli.Provider, a.cli.Model) <= 0 {

--- a/cli/audit3_pr14_test.go
+++ b/cli/audit3_pr14_test.go
@@ -1,0 +1,70 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/cli/ctxmgr"
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+func TestContextEstimate_CountsAllFourCategories(t *testing.T) {
+	c := &ChatCLI{logger: zap.NewNop(), Provider: "CLAUDEAI", Model: "claude-sonnet-5"}
+	c.history = []models.Message{
+		{Role: "system", Content: strings.Repeat("s", 4000)},
+		{Role: "user", Content: strings.Repeat("u", 2000)},
+		{Role: "assistant", Content: strings.Repeat("a", 2000)},
+	}
+	c.toolDefsChars = 8000
+	c.UserMaxTokens = 1000
+	e := c.contextEstimate()
+	if e.PrefixChars != 4000 || e.HistoryChars != 4000 || e.ToolDefChars != 8000 || e.ReserveTokens <= 0 {
+		t.Fatalf("estimate = %+v", e)
+	}
+	if e.TotalTokens() != e.PrefixTokens()+e.HistoryTokens()+e.ToolDefTokens()+e.ReserveTokens {
+		t.Fatal("total must sum the four categories")
+	}
+	if pct, ok := e.Pct(); !ok || pct <= 0 {
+		t.Fatalf("pct = %v %v", pct, ok)
+	}
+	// The compactor measures the history slice (system included), so the
+	// reserve is tool definitions + answer only; in chat the prefix lives
+	// outside the slice and is reserved too.
+	if inHist := e.ReservedChars(); inHist != 8000 {
+		t.Fatalf("reserved (prefix in history) = %d", inHist)
+	}
+	if answerReserveTokens(128000, 200000) != 50000 || answerReserveTokens(1000, 200000) != 1000 || answerReserveTokens(0, 200000) != 0 {
+		t.Fatal("answer reserve is max_tokens capped at the window share")
+	}
+	c.history = c.history[1:]
+	c.promptBreakdowns.record("chat", []promptSection{{Name: "core", Chars: 3000}})
+	e2 := c.contextEstimate()
+	if e2.PrefixChars != 3000 || e2.ReservedChars() != 3000+8000 {
+		t.Fatalf("chat reserve must include the prefix: %+v → %d", e2, e2.ReservedChars())
+	}
+	// The footer and /context status read the same numbers.
+	if pct, ok := c.projectedContextPct(e2.Window); !ok || pct <= 0 {
+		t.Fatalf("footer pct = %v %v", pct, ok)
+	}
+}
+
+func TestRetrievedBudgetFor_ScalesWithTheWindow(t *testing.T) {
+	if got := retrievedBudgetFor(1_000_000, 4); got != ctxmgr.DefaultRetrievedBudgetChars {
+		t.Fatalf("large window caps at the default: %d", got)
+	}
+	if got := retrievedBudgetFor(32_000, 4); got != int(32_000*4*retrievedShare) {
+		t.Fatalf("32K window scales: %d", got)
+	}
+	if got := retrievedBudgetFor(4_000, 4); got != retrievedFloorChars {
+		t.Fatalf("tiny window keeps the floor: %d", got)
+	}
+	if retrievedBudgetFor(0, 4) != 0 {
+		t.Fatal("no window → no override")
+	}
+}

--- a/cli/chat_pipeline.go
+++ b/cli/chat_pipeline.go
@@ -138,6 +138,7 @@ func (cli *ChatCLI) assembleChatSystemPrompt(
 	// grow without bound — attachments, digests, skills — against the
 	// window, degrading in the declared order: skills → digests → attach.
 	budget := cli.newPrefixBudget(cli.Provider, cli.Model)
+	cli.applyRetrievedBudget(budget)
 	mode := cli.modeAndLanguagePart()
 	out.add("mode", mode) // Part 0
 	budget.spend(len(mode.Text))
@@ -1057,27 +1058,12 @@ func (cli *ChatCLI) projectedContextPct(window int) (float64, bool) {
 	if window <= 0 || cli == nil {
 		return 0, false
 	}
-	chars := promptCharsOf(cli.history)
-	if !historyHasSystem(cli.history) {
-		chars += cli.promptBreakdowns.latestNamed("chat").TotalChars()
-	}
-	if chars <= 0 {
-		return 0, false
-	}
-	tokens := cli.calibrator().EstimateTokens(cli.Provider, cli.Model, chars)
-	if tokens <= 0 {
-		return 0, false
-	}
-	return float64(tokens) / float64(window) * 100, true
-}
-
-func historyHasSystem(history []models.Message) bool {
-	for _, m := range history {
-		if strings.EqualFold(m.Role, "system") {
-			return true
-		}
-	}
-	return false
+	// One estimate for the footer, the compactor and /context status; the
+	// answer reserve is capped against the window the caller measures.
+	e := cli.contextEstimate()
+	e.Window = window
+	e.ReserveTokens = answerReserveTokens(cli.getMaxTokensForCurrentLLM(), window)
+	return e.Pct()
 }
 
 // roundPct rounds a percentage to an int, floored at 0 and deliberately

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -357,6 +357,9 @@ type ChatCLI struct {
 	// pendingTurnContext is the chat turn's injected context text between
 	// assembly and commit (turn_context.go).
 	pendingTurnContext string
+	// toolDefsChars is the serialized size of the native tool definitions
+	// the agent/coder loop sends (0 in chat); part of the context estimate.
+	toolDefsChars int
 	// prefixRatios freezes the chars-per-token ratio the prefix budget uses
 	// per provider:model for the session, so cached sections never fold or
 	// unfold because the calibrator moved by a few percent (prompt_budget.go).

--- a/cli/cli_llm.go
+++ b/cli/cli_llm.go
@@ -211,7 +211,9 @@ func (cli *ChatCLI) compactHistoryIfNeeded(ctx context.Context) {
 	// The chat prefix never enters cli.history (it is spliced into a temp
 	// slice per turn), so reserve what the last assembled prefix took —
 	// otherwise the budget would be measured as if the prefix were free.
-	cfg.ReservedChars = cli.promptBreakdowns.latestNamed("chat").TotalChars()
+	// Prefix + tool definitions + answer reserve, the same categories the
+	// footer and /context status count (context_estimate.go).
+	cfg.ReservedChars = cli.contextEstimate().ReservedChars()
 	cli.warnIfHistoryExceedsProxyCap(cfg)
 	if !cli.historyCompactor.NeedsCompaction(cli.history, cfg) {
 		return

--- a/cli/context_estimate.go
+++ b/cli/context_estimate.go
@@ -1,0 +1,161 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * One context estimate.
+ *
+ * The footer's ctx%, the compactor's budget and /context status used to
+ * compute the window occupancy with three different formulas, none of
+ * which counted the tool definitions or the output reserve. This is the
+ * single source: {prefix, history, tool definitions, reserve}, the same
+ * categories Claude Code's /context shows.
+ */
+package cli
+
+import (
+	"strings"
+
+	"github.com/diillson/chatcli/cli/ctxmgr"
+	"github.com/diillson/chatcli/llm/catalog"
+	"github.com/diillson/chatcli/models"
+)
+
+// contextEstimate is a snapshot of what the next request would carry.
+type contextEstimate struct {
+	Provider, Model string
+	Window          int // model context window (tokens)
+	PrefixChars     int // system prompt (breakdown, or the system message when it lives in history)
+	HistoryChars    int // conversation without the system role
+	ToolDefChars    int // serialized native tool definitions (agent/coder)
+	ReserveTokens   int // max_tokens reserved for the answer
+	prefixInHistory bool
+	cli             *ChatCLI
+}
+
+// contextEstimate builds the estimate from live state.
+func (cli *ChatCLI) contextEstimate() contextEstimate {
+	e := contextEstimate{cli: cli}
+	if cli == nil {
+		return e
+	}
+	e.Provider, e.Model = cli.Provider, cli.Model
+	e.Window = catalog.GetContextWindow(cli.Provider, cli.Model)
+	var system, other []models.Message
+	for _, m := range cli.history {
+		if strings.EqualFold(m.Role, "system") {
+			system = append(system, m)
+		} else {
+			other = append(other, m)
+		}
+	}
+	e.HistoryChars = promptCharsOf(other)
+	if len(system) > 0 {
+		e.PrefixChars = promptCharsOf(system)
+		e.prefixInHistory = true
+	} else {
+		e.PrefixChars = cli.promptBreakdowns.latestNamed("chat").TotalChars()
+	}
+	e.ToolDefChars = cli.toolDefsChars
+	e.ReserveTokens = answerReserveTokens(cli.getMaxTokensForCurrentLLM(), e.Window)
+	return e
+}
+
+// reserveMaxShare caps the answer reserve counted against the window: a
+// model whose max output equals a third of its window would otherwise show
+// an empty conversation as a third full. The compactor's BudgetRatio
+// headroom is the same reserve, so the compactor does not add it again.
+const reserveMaxShare = 0.25
+
+// answerReserveTokens is max_tokens as sent, capped at the window share.
+func answerReserveTokens(maxTokens, window int) int {
+	if maxTokens <= 0 {
+		return 0
+	}
+	if window > 0 {
+		if capTokens := int(float64(window) * reserveMaxShare); maxTokens > capTokens {
+			return capTokens
+		}
+	}
+	return maxTokens
+}
+
+func (e contextEstimate) tokens(chars int) int {
+	if chars <= 0 || e.cli == nil {
+		return 0
+	}
+	return e.cli.calibrator().EstimateTokens(e.Provider, e.Model, chars)
+}
+
+// PrefixTokens, HistoryTokens and ToolDefTokens are the calibrated sizes.
+func (e contextEstimate) PrefixTokens() int  { return e.tokens(e.PrefixChars) }
+func (e contextEstimate) HistoryTokens() int { return e.tokens(e.HistoryChars) }
+func (e contextEstimate) ToolDefTokens() int { return e.tokens(e.ToolDefChars) }
+
+// TotalTokens is what the next request occupies: prefix, history, tool
+// definitions and the answer reserve.
+func (e contextEstimate) TotalTokens() int {
+	return e.PrefixTokens() + e.HistoryTokens() + e.ToolDefTokens() + e.ReserveTokens
+}
+
+// Pct is the window occupancy; ok is false without a window or content.
+func (e contextEstimate) Pct() (float64, bool) {
+	if e.Window <= 0 {
+		return 0, false
+	}
+	total := e.TotalTokens()
+	if total <= 0 || e.PrefixChars+e.HistoryChars+e.ToolDefChars <= 0 {
+		return 0, false
+	}
+	return float64(total) / float64(e.Window) * 100, true
+}
+
+// ReservedChars is what the compactor must leave free next to the
+// history it measures: the prefix when it does not live in the history
+// slice and the tool definitions. The answer reserve is the compactor's
+// own BudgetRatio headroom, so it is not added twice.
+func (e contextEstimate) ReservedChars() int {
+	n := e.ToolDefChars
+	if !e.prefixInHistory {
+		n += e.PrefixChars
+	}
+	return n
+}
+
+// retrievedShare is the window share retrieved passages may take per turn.
+const retrievedShare = 0.15
+
+// retrievedFloorChars keeps retrieval useful on small windows.
+const retrievedFloorChars = 4_000
+
+// retrievedBudgetFor scales the per-turn retrieved-passages budget with the
+// window: min(default, window × cpt × share), never under the floor.
+func retrievedBudgetFor(window int, cpt float64) int {
+	if window <= 0 {
+		return 0
+	}
+	if cpt <= 0 {
+		cpt = defaultCharsPerToken
+	}
+	n := int(float64(window) * cpt * retrievedShare)
+	if n < retrievedFloorChars {
+		n = retrievedFloorChars
+	}
+	if n > ctxmgr.DefaultRetrievedBudgetChars {
+		n = ctxmgr.DefaultRetrievedBudgetChars
+	}
+	return n
+}
+
+// applyRetrievedBudget points the context manager at the window-scaled
+// retrieval budget for this session (a no-op without a context handler).
+func (cli *ChatCLI) applyRetrievedBudget(b *prefixBudget) {
+	if cli == nil || cli.contextHandler == nil || b == nil {
+		return
+	}
+	mgr := cli.contextHandler.GetManager()
+	if mgr == nil {
+		return
+	}
+	mgr.SetRetrievedBudget(retrievedBudgetFor(b.Window, cli.frozenPrefixRatio(cli.Provider, cli.Model)))
+}

--- a/cli/context_status.go
+++ b/cli/context_status.go
@@ -54,6 +54,8 @@ type contextStatusReport struct {
 	History             historyStats
 	PromptTokens        int
 	HistoryTokens       int
+	ToolDefTokens       int // native tool definitions (agent/coder)
+	ReserveTokens       int // max_tokens reserved for the answer
 	TotalTokens         int
 	ProjectedPct        float64
 	CompactBudgetTokens int
@@ -124,7 +126,11 @@ func (cli *ChatCLI) buildContextStatusReport(ctx context.Context) contextStatusR
 	}
 	r.PromptTokens = toTokens(r.Prompt.TotalChars())
 	r.HistoryTokens = toTokens(historyChars)
-	r.TotalTokens = r.PromptTokens + r.HistoryTokens
+	// The same four categories the footer and the compactor use.
+	est := cli.contextEstimate()
+	r.ToolDefTokens = toTokens(est.ToolDefChars)
+	r.ReserveTokens = est.ReserveTokens
+	r.TotalTokens = r.PromptTokens + r.HistoryTokens + r.ToolDefTokens + r.ReserveTokens
 	if pb := cli.newPrefixBudget(cli.Provider, cli.Model); pb != nil && pb.MaxChars > 0 {
 		r.PrefixBudgetTokens = toTokens(pb.MaxChars)
 		if r.Prompt != nil {
@@ -207,6 +213,12 @@ func (cli *ChatCLI) showContextStatus(ctx context.Context) {
 	fmt.Printf("    %s ≈%s tok\n", kitPad(i18n.T("context.status.total_history")), formatTokenCount(int64(r.HistoryTokens)))
 	if r.ExactHistoryTokens > 0 {
 		fmt.Printf("    %s %s tok\n", kitPad(i18n.T("context.status.exact_history")), formatTokenCount(int64(r.ExactHistoryTokens)))
+	}
+	if r.ToolDefTokens > 0 {
+		fmt.Printf("    %s ≈%s tok\n", kitPad(i18n.T("context.status.total_tooldefs")), formatTokenCount(int64(r.ToolDefTokens)))
+	}
+	if r.ReserveTokens > 0 {
+		fmt.Printf("    %s %s tok\n", kitPad(i18n.T("context.status.total_reserve")), formatTokenCount(int64(r.ReserveTokens)))
 	}
 	if edits, toolUses, tokens := cli.costTracker.ContextEditStats(); edits > 0 {
 		fmt.Printf("    %s\n", colorize(i18n.T("context.status.provider_edits", edits, toolUses, formatTokenCount(tokens)), ColorGray))

--- a/cli/context_status_test.go
+++ b/cli/context_status_test.go
@@ -123,7 +123,8 @@ func TestBuildContextStatusReport_ProjectsWindowUse(t *testing.T) {
 		{Role: "assistant", Content: strings.Repeat("a", 2000)},
 	}
 	r := cli.buildContextStatusReport(context.Background())
-	if r.PromptTokens != 1100 || r.HistoryTokens != 1000 || r.TotalTokens != 2100 {
+	// Total counts the answer reserve too (the fourth category).
+	if r.PromptTokens != 1100 || r.HistoryTokens != 1000 || r.ReserveTokens <= 0 || r.TotalTokens != 2100+r.ReserveTokens {
 		t.Fatalf("tokens = prompt %d history %d total %d", r.PromptTokens, r.HistoryTokens, r.TotalTokens)
 	}
 	if r.Window <= 0 || r.ProjectedPct <= 0 || r.CompactAtPct != 75 {

--- a/cli/prompt_budget_test.go
+++ b/cli/prompt_budget_test.go
@@ -88,18 +88,20 @@ func TestProjectedContextPct_UnclampedAndAddsChatPrefix(t *testing.T) {
 	if !ok {
 		t.Fatal("projection must be available with history")
 	}
-	// (3000+1000+2000 chars) / 4 = 1500 tokens on a 1000 window = 150%
-	if pct < 149 || pct > 151 {
-		t.Fatalf("projected pct = %.1f, want ≈150", pct)
+	// (3000+1000+2000 chars) / 4 = 1500 tokens on a 1000 window = 150%,
+	// plus the answer reserve (max_tokens capped at 25% of the window).
+	want := 150 + float64(answerReserveTokens(cli.getMaxTokensForCurrentLLM(), window))/float64(window)*100
+	if pct < want-1 || pct > want+1 {
+		t.Fatalf("projected pct = %.1f, want ≈%.0f", pct, want)
 	}
-	if roundPct(pct) != 150 || clampPct(pct) != 100 {
+	if roundPct(pct) != int(want+0.5) || clampPct(pct) != 100 {
 		t.Fatal("roundPct must not clamp, clampPct must")
 	}
 	// Agent mode: the system message lives in the history — no prefix added.
 	cli.history = append([]models.Message{{Role: "system", Content: strings.Repeat("s", 4000)}}, cli.history...)
 	pct2, _ := cli.projectedContextPct(window)
-	if pct2 < 199 || pct2 > 201 {
-		t.Fatalf("with a system message the chat prefix is not added twice: %.1f", pct2)
+	if want2 := want + 50; pct2 < want2-1 || pct2 > want2+1 {
+		t.Fatalf("with a system message the chat prefix is not added twice: %.1f (want ≈%.0f)", pct2, want2)
 	}
 	if _, ok := cli.projectedContextPct(0); ok {
 		t.Fatal("no window, no projection")

--- a/i18n/locales/en-US.context-estimate.json
+++ b/i18n/locales/en-US.context-estimate.json
@@ -1,0 +1,4 @@
+{
+  "context.status.total_tooldefs": "Tool definitions",
+  "context.status.total_reserve": "Answer reserve (max_tokens)"
+}

--- a/i18n/locales/en.context-estimate.json
+++ b/i18n/locales/en.context-estimate.json
@@ -1,0 +1,4 @@
+{
+  "context.status.total_tooldefs": "Tool definitions",
+  "context.status.total_reserve": "Answer reserve (max_tokens)"
+}

--- a/i18n/locales/pt-BR.context-estimate.json
+++ b/i18n/locales/pt-BR.context-estimate.json
@@ -1,0 +1,4 @@
+{
+  "context.status.total_tooldefs": "Definições de tools",
+  "context.status.total_reserve": "Reserva da resposta (max_tokens)"
+}


### PR DESCRIPTION
## Summary

Audit III, PR 14 (P2 COST-6, COST-7, RAG-8).

- **One estimate (COST-6/7).** `cli/context_estimate.go`: `contextEstimate{PrefixChars, HistoryChars, ToolDefChars, ReserveTokens}` with calibrated token views, `TotalTokens()` and `Pct()`. The footer's `projectedContextPct`, the compactor's `ReservedChars` (chat and agent) and `/context status` all read it. Tool definitions (the agent/coder loop publishes its serialized size) and the answer reserve (`max_tokens` as sent, capped at 25% of the window so a 128K-output model does not show an empty conversation as a third full) are now counted; the compactor's reserved chars carry the prefix (when it lives outside the history slice) and the tool definitions, not the answer reserve, because its `BudgetRatio` headroom is that reserve. `/context status` prints "Tool definitions" and "Answer reserve" lines (locale fragment).
- **Window-scaled retrieval (RAG-8).** `retrievedBudgetFor(window, cpt) = min(24K, window × cpt × 15%)` with a 4K floor, applied through the prefix budget on the chat and agent paths via `Manager.SetRetrievedBudget` (which had no caller). No new env.

## Tests

`cli/audit3_pr14_test.go`: four categories summed, reserved chars with the prefix in and out of history, reserve cap, footer reads the same numbers, retrieval budget scaling/floor/cap. The two existing projection tests are updated for the reserve. golangci-lint and the local gates are green.