### PR TITLE
fix(knowledge): hybrid retrieval as a vector-BM25 union fused by RRF, query embedded once per turn, system-only tagged reranker

### DIFF
--- a/cli/audit3_pr17_test.go
+++ b/cli/audit3_pr17_test.go
@@ -1,0 +1,48 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+// rerankFakeClient captures the rerank call.
+type rerankFakeClient struct {
+	prompt string
+	hist   []models.Message
+}
+
+func (f *rerankFakeClient) GetModelName() string { return "fake" }
+func (f *rerankFakeClient) SendPrompt(_ context.Context, p string, hist []models.Message, _ int) (string, error) {
+	f.prompt, f.hist = p, append([]models.Message(nil), hist...)
+	return "2,1", nil
+}
+
+func TestRerankPromptFunc_SystemOnlyPromptAndTaggedUsage(t *testing.T) {
+	fake := &rerankFakeClient{}
+	c := &ChatCLI{logger: zap.NewNop(), Client: fake, Provider: "OPENAI", Model: "gpt-5.6", costTracker: NewCostTracker()}
+	out, err := c.rerankPromptFunc()(context.Background(), "RANK THESE")
+	if err != nil || out != "2,1" {
+		t.Fatalf("out=%q err=%v", out, err)
+	}
+	if len(fake.hist) != 2 || fake.hist[0].Role != "system" || fake.hist[0].Content != "RANK THESE" || fake.hist[1].Role != "user" || fake.hist[1].Content != rerankUserTurn {
+		t.Fatalf("the instruction rides once as the system message: %+v", fake.hist)
+	}
+	if fake.prompt != rerankUserTurn {
+		t.Fatalf("prompt must be the fixed user turn, got %q", fake.prompt)
+	}
+	if calls, _ := c.costTracker.MemoryStats(); calls != 1 {
+		t.Fatalf("rerank usage must be booked as background spend: %d", calls)
+	}
+	// No client at all: unavailable.
+	if _, err := (&ChatCLI{logger: zap.NewNop()}).rerankPromptFunc()(context.Background(), "x"); err == nil {
+		t.Fatal("no client → ErrRerankUnavailable")
+	}
+}

--- a/cli/ctxmgr/audit3_pr17_test.go
+++ b/cli/ctxmgr/audit3_pr17_test.go
@@ -1,0 +1,103 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package ctxmgr
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/diillson/chatcli/utils"
+)
+
+// keywordProvider embeds by concept: texts mentioning a horse-like animal
+// share one direction, everything else another — so a passage can be
+// semantically close to a query it shares no word with.
+type keywordProvider struct{ queryEmbeds int }
+
+func (p *keywordProvider) Name() string   { return "fake:keyword" }
+func (p *keywordProvider) Dimension() int { return 3 }
+func (p *keywordProvider) Embed(_ context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 1 {
+		p.queryEmbeds++
+	}
+	out := make([][]float32, len(texts))
+	for i, t := range texts {
+		l := strings.ToLower(t)
+		switch {
+		case strings.Contains(l, "zebra") || strings.Contains(l, "equine"):
+			out[i] = []float32{1, 0, 0}
+		default:
+			out[i] = []float32{0, 1, 0}
+		}
+	}
+	return out, nil
+}
+
+func hybridContext() *FileContext {
+	fc := &FileContext{ID: "h1", Name: "h1", UpdatedAt: time.Now(), Mode: ModeKnowledge}
+	files := []utils.FileInfo{
+		{Path: "install.md", Content: "Installation guide: run the installer, then restart the installation service.\n", Type: "Markdown"},
+		{Path: "config.md", Content: "Installation options and configuration keys for the installer.\n", Type: "Markdown"},
+		{Path: "zebra.md", Content: "The zebra module handles striped rendering of charts.\n", Type: "Markdown"},
+	}
+	for i := range files {
+		files[i].Size = int64(len(files[i].Content))
+	}
+	fc.Files = files
+	fc.FileCount = len(files)
+	return fc
+}
+
+func TestRetrieveHybrid_UnionBringsVectorOnlyHits(t *testing.T) {
+	p := &keywordProvider{}
+	e := NewRetrievalEngine(p, t.TempDir(), nil)
+	fc := hybridContext()
+	if _, err := e.Warm(context.Background(), fc); err != nil {
+		t.Fatal(err)
+	}
+	// "installation" hits BM25 on two files; "equine" hits nothing lexically
+	// but the zebra passage is its nearest vector — the union must surface it.
+	scored, err := e.RetrieveHybridScored(context.Background(), fc, "equine installation", 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, s := range scored {
+		if s.Segment.FilePath == "zebra.md" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("vector-only hit must join the BM25 pool: %+v", scored)
+	}
+	if len(scored) < 2 || scored[0].Score <= scored[len(scored)-1].Score {
+		t.Fatalf("RRF order must be descending: %+v", scored)
+	}
+}
+
+func TestRetrieveHybrid_EmbedsTheQueryOncePerTurn(t *testing.T) {
+	p := &keywordProvider{}
+	e := NewRetrievalEngine(p, t.TempDir(), nil)
+	fc := hybridContext()
+	_, _ = e.Warm(context.Background(), fc)
+	p.queryEmbeds = 0
+	for i := 0; i < 3; i++ {
+		if _, err := e.RetrieveHybridScored(context.Background(), fc, "installation service", 3); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if p.queryEmbeds != 1 {
+		t.Fatalf("the same query must be embedded once, got %d", p.queryEmbeds)
+	}
+	if _, err := e.RetrieveHybridScored(context.Background(), fc, "another question", 3); err != nil {
+		t.Fatal(err)
+	}
+	if p.queryEmbeds != 2 {
+		t.Fatalf("a new query embeds once more: %d", p.queryEmbeds)
+	}
+}

--- a/cli/ctxmgr/retrieval.go
+++ b/cli/ctxmgr/retrieval.go
@@ -56,6 +56,9 @@ const (
 
 // RetrievalEngine builds and queries per-context passage vectors.
 type RetrievalEngine struct {
+	// queries caches query embeddings per provider for the turn's corpora
+	// (queryVector). A pointer so the engine value stays comparable.
+	queries  *queryVecCache
 	provider embedding.Provider
 	baseDir  string
 	segOpts  SegmentOptions
@@ -250,18 +253,27 @@ func (e *RetrievalEngine) RetrieveHybridScored(ctx context.Context, fc *FileCont
 		// Cheap — one query embedding, zero new passage embeddings.
 		return e.semanticOnlyScored(ctx, entry, query, k), nil
 	}
-	lexScores := normalizeHits(lexHits)
-	vecScores := e.rerankCandidates(ctx, entry, lexHits, query)
-
-	fused := make(map[int]float64, len(lexScores)+len(vecScores))
-	if len(vecScores) == 0 {
-		fused = lexScores
-	} else {
-		for i, s := range lexScores {
-			fused[i] += hybridLexWeight * s
+	// Hybrid is a UNION, not a BM25-gated rerank: the vector index's own
+	// top-k (over every passage already embedded) joins the BM25 pool, so
+	// a passage that says it in other words still surfaces. Reciprocal
+	// rank fusion replaces per-query min-max: ranks are comparable across
+	// corpora, where a single-hit corpus used to score 1.0 by construction.
+	lexRank := make(map[int]int, len(lexHits))
+	for r, h := range lexHits {
+		lexRank[h.idx] = r + 1
+	}
+	vecRank := e.vectorRanks(ctx, entry, lexHits, query, pool)
+	fused := make(map[int]float64, len(lexRank)+len(vecRank))
+	if len(vecRank) == 0 {
+		for i, s := range normalizeHits(lexHits) {
+			fused[i] = s
 		}
-		for i, s := range vecScores {
-			fused[i] += hybridVecWeight * s
+	} else {
+		for i, r := range lexRank {
+			fused[i] += hybridLexWeight * rrfScore(r)
+		}
+		for i, r := range vecRank {
+			fused[i] += hybridVecWeight * rrfScore(r)
 		}
 	}
 
@@ -330,20 +342,27 @@ func (e *RetrievalEngine) applyReranker(ctx context.Context, entry *lexCacheEntr
 	return append(out, order[head:]...)
 }
 
-// rerankCandidates embeds ONLY the BM25 candidates still missing from the
-// vector cache (≤ pool per query, one small provider batch), then returns
-// min-max-normalized cosine scores by segment index. Nil when embeddings are
-// unavailable or fail — the hybrid then runs lexical-only.
-func (e *RetrievalEngine) rerankCandidates(ctx context.Context, entry *lexCacheEntry, candidates []lexHit, query string) map[int]float64 {
+// rrfK is the reciprocal-rank-fusion constant (the usual 60).
+const rrfK = 60
+
+// rrfScore is the RRF contribution of a 1-based rank.
+func rrfScore(rank int) float64 { return 1 / float64(rrfK+rank) }
+
+// vectorRanks embeds the BM25 candidates still missing from the cache
+// (bounded, one small batch), then ranks the union of the index's own
+// top-pool cosine hits and the candidates by cosine score. Nil when
+// embeddings are unavailable or fail — the hybrid then runs lexical-only.
+func (e *RetrievalEngine) vectorRanks(ctx context.Context, entry *lexCacheEntry, candidates []lexHit, query string, pool int) map[int]int {
 	if !e.Enabled() || entry.vec == nil {
 		return nil
 	}
-	idxByID := make(map[string]int, len(candidates))
+	idxByID := make(map[string]int, len(entry.segs))
+	for i, s := range entry.segs {
+		idxByID[s.ID] = i
+	}
 	ids := make([]string, 0, len(candidates))
 	for _, h := range candidates {
-		s := entry.segs[h.idx]
-		idxByID[s.ID] = h.idx
-		ids = append(ids, s.ID)
+		ids = append(ids, entry.segs[h.idx].ID)
 	}
 	if missing := entry.vec.MissingFor(ids); len(missing) > 0 {
 		sub := make(map[string]string, len(missing))
@@ -355,29 +374,88 @@ func (e *RetrievalEngine) rerankCandidates(ctx context.Context, entry *lexCacheE
 			return nil
 		}
 	}
-	qv, err := entry.vec.EmbedQuery(ctx, query)
+	qv, err := e.queryVector(ctx, entry, query)
 	if err != nil {
 		e.logger.Warn("knowledge: query embedding failed; falling back to lexical retrieval", zap.Error(err))
 		return nil
 	}
-	hits := entry.vec.ScoreAgainst(qv, ids, segmentScoreFloor)
-	if len(hits) == 0 {
+	// Union: the index's top-pool over everything embedded so far plus the
+	// BM25 candidates scored against the same query vector.
+	seen := make(map[string]float64, pool+len(ids))
+	for _, h := range entry.vec.Search(qv, pool, segmentScoreFloor) {
+		seen[h.ID] = h.Score
+	}
+	for _, h := range entry.vec.ScoreAgainst(qv, ids, segmentScoreFloor) {
+		if _, ok := seen[h.ID]; !ok {
+			seen[h.ID] = h.Score
+		}
+	}
+	if len(seen) == 0 {
 		return nil
 	}
-	minS, maxS := hits[len(hits)-1].Score, hits[0].Score
-	out := make(map[int]float64, len(hits))
-	for _, h := range hits {
-		i, ok := idxByID[h.ID]
-		if !ok {
-			continue
-		}
-		if maxS > minS {
-			out[i] = (h.Score - minS) / (maxS - minS)
-		} else {
-			out[i] = 1
+	type scored struct {
+		idx   int
+		score float64
+	}
+	all := make([]scored, 0, len(seen))
+	for id, s := range seen {
+		if i, ok := idxByID[id]; ok {
+			all = append(all, scored{i, s})
 		}
 	}
+	sort.Slice(all, func(a, b int) bool {
+		if all[a].score != all[b].score {
+			return all[a].score > all[b].score
+		}
+		return all[a].idx < all[b].idx
+	})
+	out := make(map[int]int, len(all))
+	for r, s := range all {
+		out[s.idx] = r + 1
+	}
 	return out
+}
+
+// queryVecCacheMax bounds the per-engine query-vector cache; a turn asks
+// the same query against every attached corpus, and the cache turns those
+// N embedding calls into one.
+const queryVecCacheMax = 64
+
+// queryVecCache is the bounded query-embedding cache behind queryVector.
+type queryVecCache struct {
+	mu   sync.Mutex
+	vecs map[string][]float32
+}
+
+var queryCacheInit sync.Mutex
+
+// queryVector embeds query once per provider and reuses it across the
+// corpora of the same turn.
+func (e *RetrievalEngine) queryVector(ctx context.Context, entry *lexCacheEntry, query string) ([]float32, error) {
+	queryCacheInit.Lock()
+	if e.queries == nil {
+		e.queries = &queryVecCache{vecs: make(map[string][]float32, queryVecCacheMax)}
+	}
+	c := e.queries
+	queryCacheInit.Unlock()
+	key := entry.vec.ProviderName() + "\x00" + strings.TrimSpace(query)
+	c.mu.Lock()
+	if v, ok := c.vecs[key]; ok {
+		c.mu.Unlock()
+		return v, nil
+	}
+	c.mu.Unlock()
+	v, err := entry.vec.EmbedQuery(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	c.mu.Lock()
+	if len(c.vecs) >= queryVecCacheMax {
+		c.vecs = make(map[string][]float32, queryVecCacheMax)
+	}
+	c.vecs[key] = v
+	c.mu.Unlock()
+	return v, nil
 }
 
 // semanticOnly answers queries with zero lexical overlap using the vectors
@@ -386,7 +464,7 @@ func (e *RetrievalEngine) semanticOnlyScored(ctx context.Context, entry *lexCach
 	if !e.Enabled() || entry.vec == nil || entry.vec.Count() == 0 {
 		return nil
 	}
-	qv, err := entry.vec.EmbedQuery(ctx, query)
+	qv, err := e.queryVector(ctx, entry, query)
 	if err != nil {
 		e.logger.Warn("knowledge: query embedding failed; no results for non-lexical query", zap.Error(err))
 		return nil

--- a/cli/knowledge_rerank.go
+++ b/cli/knowledge_rerank.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/diillson/chatcli/cli/ctxmgr"
+	"github.com/diillson/chatcli/llm/client"
 	"github.com/diillson/chatcli/models"
 )
 
@@ -53,19 +54,30 @@ func (cli *ChatCLI) knowledgeReranker() ctxmgr.Reranker {
 	return nil
 }
 
+// rerankUserTurn is the fixed user message of a rerank call (model-facing).
+const rerankUserTurn = "Reply with the ranking now."
+
 // rerankPromptFunc binds the listwise reranker to the cheapest model the
 // session has: the compaction summarizer when configured, else the
 // session client. Resolved per call so @model switches are honored.
 func (cli *ChatCLI) rerankPromptFunc() ctxmgr.PromptFunc {
 	return func(ctx context.Context, prompt string) (string, error) {
 		c := cli.compactSummarizerClient()
+		provider, model := cli.compactSummarizerProvider, cli.compactSummarizerModel
 		if c == nil {
-			c = cli.Client
+			c, provider, model = cli.Client, cli.Provider, cli.Model
 		}
 		if c == nil {
 			return "", ctxmgr.ErrRerankUnavailable
 		}
-		return c.SendPrompt(ctx, prompt, []models.Message{{Role: "user", Content: prompt}}, 256)
+		// The instruction rides once, as the system message; the user turn
+		// only asks for the answer (the prompt used to be sent twice).
+		out, err := c.SendPrompt(ctx, rerankUserTurn, []models.Message{{Role: "system", Content: prompt}, {Role: "user", Content: rerankUserTurn}}, 256)
+		if err == nil && cli.costTracker != nil {
+			// Background spend, tagged like the memory worker's calls.
+			cli.costTracker.RecordMemoryUsage(provider, model, client.GetUsageOrEstimate(c, len(prompt)+len(rerankUserTurn), len(out)))
+		}
+		return out, err
 	}
 }
 

--- a/llm/embedding/vindex/audit3_pr10_test.go
+++ b/llm/embedding/vindex/audit3_pr10_test.go
@@ -84,3 +84,13 @@ func TestLoad_AdoptsTheProviderDimensionWhenDiskContradictsIt(t *testing.T) {
 		t.Fatal("old ids are missing again, the new one is stored")
 	}
 }
+
+func TestProviderName_NilSafe(t *testing.T) {
+	var none *Index
+	if none.ProviderName() != "" || (&Index{}).ProviderName() != "" {
+		t.Fatal("nil index or nil provider → empty name")
+	}
+	if idx := New(filepath.Join(t.TempDir(), "v.json"), &failAfterProvider{ok: 1, dim: 3, name: "fake:named"}); idx.ProviderName() != "fake:named" {
+		t.Fatalf("name = %q", idx.ProviderName())
+	}
+}

--- a/llm/embedding/vindex/vindex.go
+++ b/llm/embedding/vindex/vindex.go
@@ -212,6 +212,15 @@ func (x *Index) store(ids []string, vecs [][]float32) error {
 	return nil
 }
 
+// ProviderName names the embedding provider behind the index ("" when
+// disabled); the query cache is keyed by it.
+func (x *Index) ProviderName() string {
+	if x == nil || x.provider == nil {
+		return ""
+	}
+	return x.provider.Name()
+}
+
 // EmbedQuery embeds a single query string for use with Search.
 func (x *Index) EmbedQuery(ctx context.Context, query string) ([]float32, error) {
 	if !x.Enabled() {


### PR DESCRIPTION
## Summary

Audit III, PR 17 (P2 RAG-5; P3 RAG-9).

- **Union, not a gated rerank (RAG-5).** `RetrieveHybridScored` now takes the vector index's own top-pool cosine hits (over everything embedded so far) in union with the BM25 candidate pool (still embedded on demand, one bounded batch), and fuses by reciprocal rank fusion (k = 60, the existing 0.55/0.45 vector/lexical weights kept). A passage that says it in other words surfaces even when BM25 has other results; ranks are comparable across corpora, so a single-hit corpus no longer scores 1.0 by construction. The lexical floor and the semantic-only fallback are unchanged.
- **Query embedded once per turn (RAG-9).** A per-engine cache keyed by provider and query (bounded to 64 entries) turns N attached corpora into one query embedding; the semantic-only path uses it too.
- **Reranker (RAG-9).** The listwise prompt rides once as the system message with a fixed one-line user turn (it used to be sent twice), and its usage is booked as background spend on the cost tracker.

## Tests

`cli/ctxmgr/audit3_pr17_test.go`: a vector-only hit joins the BM25 pool and the RRF order is descending; the same query across three retrievals embeds once, a new query once more. Existing retrieval, knowledge and rerank suites green; golangci-lint and the local gates are green.