### PR TITLE
fix(session): exact schema gate, fork on its own journal with attachments, cost and CCR references, atomic state writes

### DIFF
--- a/cli/audit3_pr19_test.go
+++ b/cli/audit3_pr19_test.go
@@ -1,0 +1,77 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+func TestLoadSessionV2_RefusesANewerSchema(t *testing.T) {
+	t.Setenv("CHATCLI_ENCRYPTION_KEY", "")
+	dir := t.TempDir()
+	sm, err := NewSessionManagerAt(dir, zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "future.json"), []byte(`{"version":99,"chat_history":[],"unknown_field":"x"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err = sm.LoadSessionV2("future")
+	if !errors.Is(err, ErrSessionSchemaNewer) {
+		t.Fatalf("a newer schema must be refused, got %v", err)
+	}
+	// The current schema and legacy files still load.
+	if err := sm.SaveSession("now", []models.Message{{Role: "user", Content: "hi"}}); err != nil {
+		t.Fatal(err)
+	}
+	if sd, err := sm.LoadSessionV2("now"); err != nil || sd.Version != models.SessionSchemaVersion {
+		t.Fatalf("current schema: %+v %v", sd, err)
+	}
+}
+
+func TestBuildSessionData_CarriesCostAndCCRReferences(t *testing.T) {
+	c := &ChatCLI{logger: zap.NewNop(), costTracker: NewCostTracker()}
+	c.history = []models.Message{
+		{Role: "user", Content: "see <<ccr:abc123>> and <<ccr:def456>>"},
+		{Role: "assistant", Content: "again <<ccr:abc123>>"},
+	}
+	sd := c.buildSessionData()
+	if sd.CostSessionID == "" {
+		t.Fatal("cost session reference must be persisted")
+	}
+	if len(sd.CCRKeys) != 2 || sd.CCRKeys[0] != "abc123" || sd.CCRKeys[1] != "def456" {
+		t.Fatalf("ccr keys = %v", sd.CCRKeys)
+	}
+}
+
+func TestForkTranscriptJournal_SeedsANewTimeline(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "tr-parent.jsonl")
+	if err := os.WriteFile(src, []byte("{\"kind\":\"msg\"}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	c := &ChatCLI{logger: zap.NewNop(), transcript: &transcriptJournal{id: "tr-parent", path: src}}
+	id := c.forkTranscriptJournal()
+	if id == "" || id == "tr-parent" {
+		t.Fatalf("fork must get a fresh id: %q", id)
+	}
+	seeded, err := os.ReadFile(filepath.Join(dir, id+".jsonl"))
+	if err != nil || string(seeded) != "{\"kind\":\"msg\"}\n" {
+		t.Fatalf("fork journal must be seeded from the parent: %q %v", seeded, err)
+	}
+	if c.transcriptID() != "tr-parent" {
+		t.Fatal("the parent keeps its own journal")
+	}
+	if (&ChatCLI{}).forkTranscriptJournal() != "" {
+		t.Fatal("no journal → no fork id")
+	}
+}

--- a/cli/cli_session.go
+++ b/cli/cli_session.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -251,13 +252,37 @@ func (cli *ChatCLI) clearConversation(ctx context.Context) {
 // buildSessionData builds a SessionData from the current CLI state.
 // Uses ChatHistory field to store the unified history for backwards compatibility.
 func (cli *ChatCLI) buildSessionData() *SessionData {
-	return &SessionData{
-		Version:      2,
+	sd := &SessionData{
+		Version:      models.SessionSchemaVersion,
 		ChatHistory:  cli.history,
 		TranscriptID: cli.transcriptID(),
 		Attachments:  cli.sessionAttachments(),
 		Checkpoints:  cli.checkpointRecords(),
+		CCRKeys:      ccrKeysIn(cli.history),
 	}
+	if cli.costTracker != nil {
+		sd.CostSessionID = cli.costTracker.Snapshot().SessionID
+	}
+	return sd
+}
+
+// ccrMarkerRe matches the <<ccr:KEY>> markers the compression layer leaves
+// in place of archived content.
+var ccrMarkerRe = regexp.MustCompile(`<<ccr:([A-Za-z0-9_.-]+)>>`)
+
+// ccrKeysIn lists the distinct CCR keys the history references, in order.
+func ccrKeysIn(history []models.Message) []string {
+	seen := map[string]bool{}
+	var keys []string
+	for _, m := range history {
+		for _, sub := range ccrMarkerRe.FindAllStringSubmatch(m.Content, -1) {
+			if !seen[sub[1]] {
+				seen[sub[1]] = true
+				keys = append(keys, sub[1])
+			}
+		}
+	}
+	return keys
 }
 
 // restoreSessionData restores history from a SessionData.
@@ -502,19 +527,26 @@ func (cli *ChatCLI) handleDeleteSession(ctx context.Context, name string) {
 // If a session is loaded, forks from that. Otherwise, forks from in-memory history.
 func (cli *ChatCLI) handleForkSession(newName string) {
 	// Build session data from current state
-	sd := &SessionData{
-		Version:      2,
-		ChatHistory:  make([]models.Message, len(cli.history)),
-		TranscriptID: cli.transcriptID(),
-		Checkpoints:  cli.checkpointRecords(),
-	}
+	sd := cli.buildSessionData()
+	sd.ChatHistory = make([]models.Message, len(cli.history))
 	copy(sd.ChatHistory, cli.history)
+	// A fork is its own timeline: it gets a new transcript journal seeded
+	// from the parent's events (two sessions appending to one journal made
+	// undo pick whichever fork rewrote last) and keeps the attachments.
+	sd.TranscriptID = cli.forkTranscriptJournal()
 
 	// If the current session has a name (was loaded/saved), we can fork from file
 	if cli.currentSessionName != "" {
 		if err := cli.sessionManager.ForkSession(cli.currentSessionName, newName); err != nil {
 			fmt.Println(colorize(fmt.Sprintf("  %s", i18n.T("sess.cmd.fork_error", err)), ColorRed))
 			return
+		}
+		if forked, err := cli.sessionManager.LoadSessionV2(newName); err == nil {
+			forked.TranscriptID = sd.TranscriptID
+			forked.Attachments = sd.Attachments
+			forked.CostSessionID = sd.CostSessionID
+			forked.CCRKeys = sd.CCRKeys
+			_ = cli.sessionManager.SaveSessionV2(newName, forked)
 		}
 	} else {
 		// Fork from in-memory state

--- a/cli/coder/policy_manager.go
+++ b/cli/coder/policy_manager.go
@@ -339,7 +339,7 @@ func (pm *PolicyManager) save() error {
 	}
 
 	// M1: Use restrictive permissions so only the owner can read security rules
-	return os.WriteFile(pm.configPath, data, 0o600)
+	return utils.AtomicWriteFile(pm.configPath, data, 0o600)
 }
 
 func (pm *PolicyManager) defaultRules() {

--- a/cli/gateway_runtime_model.go
+++ b/cli/gateway_runtime_model.go
@@ -27,6 +27,7 @@ package cli
 
 import (
 	"encoding/json"
+	"github.com/diillson/chatcli/utils"
 	"os"
 	"path/filepath"
 
@@ -64,7 +65,7 @@ func (cli *ChatCLI) writeRuntimeModelState() {
 		cli.logger.Warn("gateway: could not marshal runtime-model state", zap.Error(err))
 		return
 	}
-	if err := os.WriteFile(path, data, 0o600); err != nil {
+	if err := utils.AtomicWriteFile(path, data, 0o600); err != nil {
 		cli.logger.Warn("gateway: could not write runtime-model state", zap.Error(err))
 	}
 }

--- a/cli/history_manager.go
+++ b/cli/history_manager.go
@@ -252,5 +252,5 @@ func (hm *HistoryManager) AppendAndRotateHistory(newCommands []string) error {
 	recentHistory := lines[startIndex:]
 
 	// Escrever as linhas recentes de volta no arquivo de histórico principal (agora vazio)
-	return os.WriteFile(hm.historyFile, []byte(strings.Join(recentHistory, "\n")), 0o600) //#nosec G703 -- path validated by engine.validatePath / SensitiveReadPaths.IsReadAllowed
+	return utils.AtomicWriteFile(hm.historyFile, []byte(strings.Join(recentHistory, "\n")), 0o600) //#nosec G703 -- path validated by engine.validatePath / SensitiveReadPaths.IsReadAllowed
 }

--- a/cli/mcp/oauth.go
+++ b/cli/mcp/oauth.go
@@ -257,7 +257,7 @@ func saveOAuthMeta(meta *oauthServerMeta) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0o600)
+	return utils.AtomicWriteFile(path, data, 0o600)
 }
 
 // hasStoredMCPOAuth reports whether we already hold OAuth metadata AND a

--- a/cli/selfevolve_manifest.go
+++ b/cli/selfevolve_manifest.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"github.com/diillson/chatcli/utils"
 	"os"
 	"path/filepath"
 
@@ -84,7 +85,7 @@ func (m *selfEvolveManifest) save() {
 	if err != nil {
 		return
 	}
-	_ = os.WriteFile(m.path, data, 0o600)
+	_ = utils.AtomicWriteFile(m.path, data, 0o600)
 }
 
 func hashContent(s string) string {

--- a/cli/session_manager.go
+++ b/cli/session_manager.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -48,6 +49,9 @@ func NewSessionManager(logger *zap.Logger) (*SessionManager, error) {
 	}
 	return NewSessionManagerAt(filepath.Join(homeDir, ".chatcli", "sessions"), logger)
 }
+
+// ErrSessionSchemaNewer marks a session file written by a newer ChatCLI.
+var ErrSessionSchemaNewer = errors.New("session schema newer than this build")
 
 // NewSessionManagerAt is NewSessionManager over an explicit store directory
 // (per-tenant store sets in the gateway, tests).
@@ -366,9 +370,14 @@ func (sm *SessionManager) LoadSessionV2(name string) (*SessionData, error) {
 		return nil, fmt.Errorf("%s: %w", i18n.T("session.decrypt_failed", name), err)
 	}
 
-	// Try v2 format first
+	// Try v2 format first. A file written by a newer schema is refused:
+	// loading it would silently rewrite it minus every field this build
+	// does not know.
 	var sd SessionData
 	if err := json.Unmarshal(data, &sd); err == nil && sd.Version >= 2 {
+		if sd.Version > models.SessionSchemaVersion {
+			return nil, fmt.Errorf("%w: %s", ErrSessionSchemaNewer, i18n.T("session.schema_newer", name, sd.Version, models.SessionSchemaVersion))
+		}
 		sm.logger.Info("Sessão v2 carregada com sucesso", zap.String("session", name))
 		return &sd, nil
 	}

--- a/cli/transcript_journal.go
+++ b/cli/transcript_journal.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/diillson/chatcli/models"
 	"github.com/diillson/chatcli/pkg/atrest"
+	"github.com/diillson/chatcli/utils"
 	"go.uber.org/zap"
 )
 
@@ -488,6 +489,32 @@ func (cli *ChatCLI) transcriptID() string {
 		return ""
 	}
 	return cli.transcript.id
+}
+
+// forkTranscriptJournal copies the live journal to a fresh id (the fork's
+// own timeline, seeded with the parent's events) and returns that id;
+// "" when journaling is off. The parent keeps writing to its own file.
+func (cli *ChatCLI) forkTranscriptJournal() string {
+	if cli == nil || cli.transcript == nil || cli.transcript.path == "" {
+		return ""
+	}
+	id := newTranscriptID(time.Now())
+	src := cli.transcript.path
+	dst := filepath.Join(filepath.Dir(src), id+filepath.Ext(src))
+	data, err := os.ReadFile(src) // #nosec G304 -- our own journal path under the state root
+	if err != nil && !os.IsNotExist(err) {
+		if cli.logger != nil {
+			cli.logger.Warn("transcript fork: cannot read the parent journal", zap.Error(err))
+		}
+		return ""
+	}
+	if err := utils.AtomicWriteFile(dst, data, 0o600); err != nil {
+		if cli.logger != nil {
+			cli.logger.Warn("transcript fork: cannot seed the new journal", zap.Error(err))
+		}
+		return ""
+	}
+	return id
 }
 
 // adoptTranscript switches the journal to the id a loaded session carries,

--- a/i18n/locales/en-US.session-schema.json
+++ b/i18n/locales/en-US.session-schema.json
@@ -1,0 +1,3 @@
+{
+  "session.schema_newer": "session %q was written by a newer ChatCLI (schema v%d; this build reads up to v%d) — update ChatCLI to open it"
+}

--- a/i18n/locales/en.session-schema.json
+++ b/i18n/locales/en.session-schema.json
@@ -1,0 +1,3 @@
+{
+  "session.schema_newer": "session %q was written by a newer ChatCLI (schema v%d; this build reads up to v%d) — update ChatCLI to open it"
+}

--- a/i18n/locales/pt-BR.session-schema.json
+++ b/i18n/locales/pt-BR.session-schema.json
@@ -1,0 +1,3 @@
+{
+  "session.schema_newer": "a sessão %q foi gravada por um ChatCLI mais novo (schema v%d; este build lê até v%d) — atualize o ChatCLI para abri-la"
+}

--- a/models/models.go
+++ b/models/models.go
@@ -184,7 +184,20 @@ type SessionData struct {
 	// load (the journal keeps every message ever seen; the session file
 	// stays small).
 	Checkpoints []SessionCheckpoint `json:"checkpoints,omitempty"`
+	// CostSessionID references the cost snapshot the conversation was
+	// billed under (~/.chatcli/costs/<id>.json) so a resumed session can
+	// show what it already spent.
+	CostSessionID string `json:"cost_session_id,omitempty"`
+	// CCRKeys are the compression-archive keys the history references
+	// (<<ccr:KEY>> markers), so a resumed session knows which archives it
+	// depends on and retention can keep them.
+	CCRKeys []string `json:"ccr_keys,omitempty"`
 }
+
+// SessionSchemaVersion is the session file schema this build writes and
+// the newest it reads; a newer file is refused rather than rewritten
+// minus the fields this build does not know.
+const SessionSchemaVersion = 2
 
 // IsTurnContext reports whether the message is ChatCLI-injected turn
 // context rather than user text (see MessageMeta.TurnContext).

--- a/pkg/persona/usage/usage.go
+++ b/pkg/persona/usage/usage.go
@@ -14,6 +14,7 @@ package usage
 
 import (
 	"encoding/json"
+	"github.com/diillson/chatcli/utils"
 	"os"
 	"path/filepath"
 	"sort"
@@ -125,5 +126,5 @@ func (s *Store) saveLocked(data map[string]Entry) {
 	if err != nil {
 		return
 	}
-	_ = os.WriteFile(s.path, raw, 0o600)
+	_ = utils.AtomicWriteFile(s.path, raw, 0o600)
 }

--- a/pkg/registry/config.go
+++ b/pkg/registry/config.go
@@ -6,6 +6,7 @@
 package registry
 
 import (
+	"github.com/diillson/chatcli/utils"
 	"os"
 	"path/filepath"
 	"strings"
@@ -130,7 +131,7 @@ func SaveConfig(cfg RegistriesConfig) error {
 		return err
 	}
 
-	return os.WriteFile(configPath, data, 0o600)
+	return utils.AtomicWriteFile(configPath, data, 0o600)
 }
 
 // applyEnvOverrides applies environment variable overrides to the config.

--- a/pkg/registry/skill_preferences.go
+++ b/pkg/registry/skill_preferences.go
@@ -21,6 +21,7 @@ package registry
 
 import (
 	"fmt"
+	"github.com/diillson/chatcli/utils"
 	"os"
 	"path/filepath"
 	"sync"
@@ -80,7 +81,7 @@ func (sp *SkillPreferences) Save() error {
 		return err
 	}
 
-	return os.WriteFile(sp.filePath, data, 0o600)
+	return utils.AtomicWriteFile(sp.filePath, data, 0o600)
 }
 
 // SetPreference sets the preferred source for a base skill name.


### PR DESCRIPTION
## Summary

Audit III, PR 19 (P2 CMP-12, CMP-13, CMP-15). Session schema and forks.

- **Exact version gate (CMP-13).** `models.SessionSchemaVersion` (2) is what this build writes and the newest it reads; `LoadSessionV2` refuses a file with a higher version (`ErrSessionSchemaNewer`, localized message as a locale fragment) instead of accepting any version ≥ 2 and rewriting it minus unknown fields. Legacy and current files load as before.
- **Schema completeness (CMP-13).** `SessionData` carries `CostSessionID` (the cost snapshot the conversation was billed under) and `CCRKeys` (the `<<ccr:KEY>>` archives the history references); `buildSessionData` fills both.
- **Forks (CMP-12).** `forkTranscriptJournal` copies the live journal to a fresh id (the fork's own timeline seeded with the parent's events) and the fork keeps attachments, cost reference and CCR keys; on the file path the forked session is re-saved with those fields. The parent keeps its own journal, so undo no longer picks whichever fork rewrote last.
- **Atomic state writes (CMP-15).** MCP OAuth tokens, the coder policy, the gateway runtime model, the self-evolve manifest, the registry config, skill preferences, the persona usage store and the rotated REPL history go through `utils.AtomicWriteFile`.

## Tests

`cli/audit3_pr19_test.go`: newer schema refused while current and legacy load; cost and CCR references persisted; fork journal seeded with a fresh id and the parent untouched. Existing session and fork suites green; golangci-lint and the local gates are green.