### PR TITLE
fix(cost): reset clears every aggregate, daily-aware budget notices, summarizer cache keyed by env, locked audit path fails closed

### DIFF
--- a/cli/audit3_pr21_test.go
+++ b/cli/audit3_pr21_test.go
@@ -1,0 +1,117 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/config"
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+func TestCostTrackerReset_ClearsEveryAggregate(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	ct := NewCostTracker()
+	t.Cleanup(ct.FlushDailySpend)
+	ct.RecordUsage("OPENAI", "gpt-5.6", 1000, 100)
+	ct.mu.Lock()
+	ct.cacheStorageUSD, ct.embeddingCostUSD, ct.compactionCostUSD, ct.memoryCostUSD = 1, 1, 1, 1
+	ct.cacheResources, ct.memoryCalls = 3, 2
+	ct.mu.Unlock()
+	ct.RecordContextEdits(2, 500)
+	ct.Reset()
+	if ct.TotalCost() != 0 {
+		t.Fatalf("total after reset = %v", ct.TotalCost())
+	}
+	snap := ct.Snapshot()
+	if snap.CacheStorageCostUSD != 0 || snap.EmbeddingCostUSD != 0 || snap.MemoryCostUSD != 0 || snap.CacheResources != 0 {
+		t.Fatalf("aggregates survived the reset: %+v", snap)
+	}
+	if e, _, _ := ct.ContextEditStats(); e != 0 {
+		t.Fatal("context edit stats survived the reset")
+	}
+}
+
+func TestBudgetMessage_DailyOnlyAndDailyTrippedFirst(t *testing.T) {
+	ct := NewCostTracker()
+	ct.mu.Lock()
+	ct.budgetLimitUSD, ct.dailyLimitUSD, ct.budgetWarningPct = 0, 1.0, 0.8
+	ct.dailySpentUSD = 0.9
+	msg := ct.budgetMessageLocked()
+	ct.mu.Unlock()
+	if msg == "" || !strings.Contains(msg, "0.9") {
+		t.Fatalf("a daily-only budget must announce its own warning: %q", msg)
+	}
+	ct.mu.Lock()
+	ct.dailySpentUSD = 1.2
+	exceeded := ct.budgetMessageLocked()
+	// Both limits set, only the daily one tripped: the daily message wins.
+	ct.budgetLimitUSD, ct.totalCostUSD = 100, 1.2
+	both := ct.budgetMessageLocked()
+	// Session limit set and daily far from its threshold: session message.
+	ct.dailySpentUSD, ct.totalCostUSD = 0.1, 95
+	session := ct.budgetMessageLocked()
+	ct.mu.Unlock()
+	if !strings.Contains(exceeded, "1.2") || !strings.Contains(both, "1.2") || !strings.Contains(both, "1.00") {
+		t.Fatalf("daily exceeded: %q / %q", exceeded, both)
+	}
+	if !strings.Contains(session, "100") {
+		t.Fatalf("session message when the daily limit is quiet: %q", session)
+	}
+}
+
+func TestCompactSummarizerClient_FollowsTheEnvValue(t *testing.T) {
+	c := newRPCChatCLI(t, &rpcChatFakeClient{reply: "ok"})
+	t.Setenv(CompactModelEnv, "")
+	if c.compactSummarizerClient() != nil {
+		t.Fatal("no handle → nil")
+	}
+	// An unusable handle is not pinned: the next call re-resolves.
+	t.Setenv(CompactModelEnv, "nope:not-a-model")
+	_ = c.compactSummarizerClient()
+	if c.compactSummarizerHandle != "" {
+		t.Fatal("a failed resolution must not be cached")
+	}
+	t.Setenv(CompactModelEnv, "")
+	if c.compactSummarizerClient() != nil {
+		t.Fatal("cleared handle → nil again")
+	}
+}
+
+func TestInitLLMAudit_LockedManagedPathFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+	managed := filepath.Join(dir, "managed.env")
+	unwritable := filepath.Join(dir, "missing-dir", "sub", "audit.jsonl")
+	if err := os.WriteFile(managed, []byte("!CHATCLI_AUDIT_LOG_PATH="+unwritable+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CHATCLI_MANAGED_CONFIG", managed)
+	config.ApplyManaged()
+	t.Setenv(AuditLogPathEnv, unwritable)
+	_ = os.MkdirAll(filepath.Dir(unwritable), 0o700)
+	_ = os.Chmod(filepath.Dir(filepath.Dir(unwritable)), 0o500)
+	t.Cleanup(func() { _ = os.Chmod(filepath.Dir(filepath.Dir(unwritable)), 0o700) })
+	c := &ChatCLI{logger: zap.NewNop()}
+	// Relative path under a locked policy: refused.
+	t.Setenv(AuditLogPathEnv, "relative/audit.jsonl")
+	if err := c.initLLMAuditErr("test"); !auditPathLocked() || !errors.Is(err, errAuditLocked) {
+		t.Fatalf("locked relative path must fail closed: locked=%v err=%v", auditPathLocked(), err)
+	}
+	// Unlocked policy: a bad path only disables auditing.
+	if err := os.WriteFile(managed, []byte("CHATCLI_AUDIT_LOG_PATH="+unwritable+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	config.ApplyManaged()
+	if err := c.initLLMAuditErr("test"); err != nil {
+		t.Fatalf("unlocked bad path must not block the session: %v", err)
+	}
+	_ = models.Message{}
+}

--- a/cli/audit3_pr21_test.go
+++ b/cli/audit3_pr21_test.go
@@ -66,18 +66,42 @@ func TestBudgetMessage_DailyOnlyAndDailyTrippedFirst(t *testing.T) {
 	if !strings.Contains(session, "100") {
 		t.Fatalf("session message when the daily limit is quiet: %q", session)
 	}
+	// Hard stop armed: the daily exceeded notice says turns are blocked.
+	ct.mu.Lock()
+	ct.budgetLimitUSD, ct.dailySpentUSD, ct.budgetHardStop = 0, 1.5, true
+	hard := ct.budgetMessageLocked()
+	ct.mu.Unlock()
+	if hard == exceeded || !strings.Contains(hard, "1.5") {
+		t.Fatalf("hard-stop daily notice must differ: %q", hard)
+	}
 }
 
 func TestCompactSummarizerClient_FollowsTheEnvValue(t *testing.T) {
-	c := newRPCChatCLI(t, &rpcChatFakeClient{reply: "ok"})
+	c := newResolverTestCLI("CLAUDEAI", "claude-sonnet-4-6", []string{"CLAUDEAI", "OPENAI"}, nil)
 	t.Setenv(CompactModelEnv, "")
 	if c.compactSummarizerClient() != nil {
 		t.Fatal("no handle → nil")
 	}
-	// An unusable handle is not pinned: the next call re-resolves.
-	t.Setenv(CompactModelEnv, "nope:not-a-model")
-	_ = c.compactSummarizerClient()
-	if c.compactSummarizerHandle != "" {
+	t.Setenv(CompactModelEnv, "claude-opus-4-5")
+	first := c.compactSummarizerClient()
+	if first == nil || c.compactSummarizerHandle != "claude-opus-4-5" || c.compactSummarizerModel == "" {
+		t.Fatalf("a usable handle resolves and is cached by value: %v %q", first, c.compactSummarizerHandle)
+	}
+	if again := c.compactSummarizerClient(); again != first {
+		t.Fatal("the same handle reuses the cached client")
+	}
+	// The env is reloadable: a new value re-resolves instead of staying
+	// pinned for the process.
+	t.Setenv(CompactModelEnv, "gpt-5.6")
+	second := c.compactSummarizerClient()
+	if second == nil || second == first || c.compactSummarizerHandle != "gpt-5.6" {
+		t.Fatalf("a changed handle must re-resolve: %v %q", second, c.compactSummarizerHandle)
+	}
+	// A provider that fails to resolve (transient outage, missing key) is
+	// not pinned: the next call re-resolves.
+	c.manager.(*minimalManager).failFor = map[string]error{"OPENAI": errors.New("provider down")}
+	t.Setenv(CompactModelEnv, "gpt-5.5")
+	if c.compactSummarizerClient() != nil || c.compactSummarizerHandle != "" {
 		t.Fatal("a failed resolution must not be cached")
 	}
 	t.Setenv(CompactModelEnv, "")
@@ -114,4 +138,33 @@ func TestInitLLMAudit_LockedManagedPathFailsClosed(t *testing.T) {
 		t.Fatalf("unlocked bad path must not block the session: %v", err)
 	}
 	_ = models.Message{}
+}
+
+func TestInitLLMAudit_LockedUnwritableAbsolutePathFailsClosed(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores directory permissions")
+	}
+	dir := t.TempDir()
+	sealed := filepath.Join(dir, "sealed")
+	if err := os.MkdirAll(sealed, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(sealed, 0o700) })
+	target := filepath.Join(sealed, "audit.jsonl")
+	managed := filepath.Join(dir, "managed.env")
+	if err := os.WriteFile(managed, []byte("!CHATCLI_AUDIT_LOG_PATH="+target+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CHATCLI_MANAGED_CONFIG", managed)
+	config.ApplyManaged()
+	t.Setenv(AuditLogPathEnv, target)
+	c := &ChatCLI{logger: zap.NewNop()}
+	if err := c.initLLMAuditErr("test"); !errors.Is(err, errAuditLocked) {
+		t.Fatalf("locked unwritable path must fail closed: %v", err)
+	}
+	// No audit path at all: nothing to do.
+	t.Setenv(AuditLogPathEnv, "")
+	if err := c.initLLMAuditErr("test"); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -329,8 +329,9 @@ type ChatCLI struct {
 	lastPromptChars int
 	// calibrationTurns counts chat turns to pace exact (count_tokens)
 	// calibration.
-	calibrationTurns      int
-	compactSummarizerOnce sync.Once
+	calibrationTurns        int
+	compactSummarizerMu     sync.Mutex
+	compactSummarizerHandle string // env value the cached summarizer was resolved from
 
 	// Session language-server pool behind the @lsp tool. Created lazily on
 	// the first @lsp call (starting gopls for sessions that never navigate

--- a/cli/compact_config.go
+++ b/cli/compact_config.go
@@ -171,7 +171,10 @@ func (cli *ChatCLI) compactSummarizerClient() client.LLMClient {
 		return cli.compactSummarizer
 	}
 	resolution := cli.resolveSkillClient(handle)
-	if resolution.Client == nil || (!resolution.Changed && resolution.UserMessage != "") {
+	// Usable means a DIFFERENT client than the session's: a handle that
+	// resolves to nothing (unknown model, provider down) falls back to the
+	// session client silently, and caching that would pin the fallback.
+	if resolution.Client == nil || !resolution.Changed {
 		if cli.logger != nil {
 			cli.logger.Warn("compact summarizer model not usable, keeping the session client",
 				zap.String("handle", handle), zap.String("reason", resolution.UserMessage))

--- a/cli/compact_config.go
+++ b/cli/compact_config.go
@@ -162,17 +162,28 @@ func (cli *ChatCLI) compactSummarizerClient() client.LLMClient {
 	if handle == "" || cli.manager == nil {
 		return nil
 	}
-	cli.compactSummarizerOnce.Do(func() {
-		resolution := cli.resolveSkillClient(handle)
-		if resolution.Client == nil || (!resolution.Changed && resolution.UserMessage != "") {
-			if cli.logger != nil {
-				cli.logger.Warn("compact summarizer model not usable, keeping the session client",
-					zap.String("handle", handle), zap.String("reason", resolution.UserMessage))
-			}
-			return
+	// Cached by the env value: CHATCLI_COMPACT_MODEL is reloadable, so a
+	// change (or a transient resolution failure) must not stay pinned for
+	// the process the way a sync.Once did.
+	cli.compactSummarizerMu.Lock()
+	defer cli.compactSummarizerMu.Unlock()
+	if cli.compactSummarizerHandle == handle {
+		return cli.compactSummarizer
+	}
+	resolution := cli.resolveSkillClient(handle)
+	if resolution.Client == nil || (!resolution.Changed && resolution.UserMessage != "") {
+		if cli.logger != nil {
+			cli.logger.Warn("compact summarizer model not usable, keeping the session client",
+				zap.String("handle", handle), zap.String("reason", resolution.UserMessage))
 		}
-		cli.compactSummarizer = resolution.Client
-		cli.compactSummarizerProvider, cli.compactSummarizerModel = resolution.Provider, resolution.Model
-	})
+		// Not cached: the next call retries (a transient failure must not
+		// pin the session client for the rest of the process).
+		cli.compactSummarizer, cli.compactSummarizerHandle = nil, ""
+		cli.compactSummarizerProvider, cli.compactSummarizerModel = "", ""
+		return nil
+	}
+	cli.compactSummarizer = resolution.Client
+	cli.compactSummarizerHandle = handle
+	cli.compactSummarizerProvider, cli.compactSummarizerModel = resolution.Provider, resolution.Model
 	return cli.compactSummarizer
 }

--- a/cli/cost_tracker.go
+++ b/cli/cost_tracker.go
@@ -402,6 +402,17 @@ func (ct *CostTracker) Reset() {
 	ct.sessionStart = now
 	ct.lastUpdate = now
 	ct.modelUsage = make(map[string]*ModelUsageRecord)
+	// Every aggregate the model map does not own: cache storage, memory
+	// worker, embeddings, compaction, cache resources and provider context
+	// edits — otherwise the total stays above zero and a hard stop armed
+	// by the old session survives the reset.
+	ct.cacheStorageUSD = 0
+	ct.cacheResources = 0
+	ct.memoryCostUSD = 0
+	ct.memoryCalls = 0
+	ct.embeddingCostUSD = 0
+	ct.compactionCostUSD = 0
+	ct.contextEditsApplied, ct.contextEditsToolUses, ct.contextEditsTokens = 0, 0, 0
 	ct.recomputeAggregates()
 	ct.lastAnnouncedLevel = BudgetOK
 	ct.lastSave = time.Time{}
@@ -894,6 +905,20 @@ func (ct *CostTracker) budgetLevelLocked() BudgetLevel {
 }
 
 func (ct *CostTracker) budgetMessageLocked() string {
+	// The daily limit speaks for itself when it tripped (or when it is the
+	// only limit configured); the session limit otherwise.
+	if ct.dailyLimitUSD > 0 && (ct.budgetLimitUSD <= 0 || ct.dailySpentUSD >= ct.dailyLimitUSD*ct.budgetWarningPct) {
+		dailyPct := ct.dailySpentUSD / ct.dailyLimitUSD * 100
+		switch {
+		case ct.dailySpentUSD >= ct.dailyLimitUSD:
+			if ct.budgetHardStop {
+				return i18n.T("cost.budget.daily_exceeded_hard", ct.dailySpentUSD, ct.dailyLimitUSD, dailyPct)
+			}
+			return i18n.T("cost.budget.daily_exceeded", ct.dailySpentUSD, ct.dailyLimitUSD, dailyPct)
+		case ct.dailySpentUSD >= ct.dailyLimitUSD*ct.budgetWarningPct:
+			return i18n.T("cost.budget.daily_warning", ct.dailySpentUSD, ct.dailyLimitUSD, dailyPct)
+		}
+	}
 	if ct.budgetLimitUSD <= 0 {
 		return ""
 	}

--- a/cli/llm_audit.go
+++ b/cli/llm_audit.go
@@ -20,6 +20,10 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/diillson/chatcli/config"
+	"github.com/diillson/chatcli/i18n"
 	"os"
 	"path/filepath"
 	"sync"
@@ -88,23 +92,51 @@ type llmAuditWriter struct {
 // gateway, mcp, ...). Failures are logged and leave auditing off — the
 // trail must never block a session from starting.
 func (cli *ChatCLI) initLLMAudit(surface string) {
+	if err := cli.initLLMAuditErr(surface); err != nil {
+		// A locked managed audit policy fails CLOSED: the operator pinned
+		// the trail and it cannot be written, so the session must not
+		// run unaudited.
+		fmt.Fprintln(os.Stderr, colorize("  "+i18n.T("audit.locked_unavailable", err), ColorRed))
+		os.Exit(1)
+	}
+}
+
+// errAuditLocked marks a locked managed audit path that cannot be opened.
+var errAuditLocked = errors.New("locked audit path unavailable")
+
+// auditPathLocked reports whether the audit path is pinned by managed.env.
+func auditPathLocked() bool {
+	entry, managed := config.ManagedEntryFor(AuditLogPathEnv)
+	return managed && entry.Locked
+}
+
+// initLLMAuditErr installs the auditor; the error is non-nil only when the
+// managed policy locks the path and the trail cannot be opened (an
+// unlocked path that fails still logs and leaves auditing off).
+func (cli *ChatCLI) initLLMAuditErr(surface string) error {
 	path := os.Getenv(AuditLogPathEnv)
 	if path == "" {
-		return
+		return nil
 	}
 	clean := filepath.Clean(path)
 	if !filepath.IsAbs(clean) {
 		if cli.logger != nil {
 			cli.logger.Error("audit log path must be absolute; LLM audit disabled", zap.String("path", path))
 		}
-		return
+		if auditPathLocked() {
+			return fmt.Errorf("%w: %s is not absolute", errAuditLocked, path)
+		}
+		return nil
 	}
 	chain, err := auditchain.Open(clean, auditchain.Options{})
 	if err != nil {
 		if cli.logger != nil {
 			cli.logger.Error("failed to open audit log for LLM requests", zap.String("path", clean), zap.Error(err))
 		}
-		return
+		if auditPathLocked() {
+			return fmt.Errorf("%w: %s: %s", errAuditLocked, clean, err.Error())
+		}
+		return nil
 	}
 	w := &llmAuditWriter{chain: chain, surface: surface, logger: cli.logger}
 	w.session = func() string {
@@ -122,6 +154,7 @@ func (cli *ChatCLI) initLLMAudit(surface string) {
 	}
 	cli.llmAudit = w
 	client.RegisterRequestAuditor(w.record)
+	return nil
 }
 
 // setSurface renames the surface for entries from now on (the gateway,

--- a/i18n/locales/en-US.cost-consistency.json
+++ b/i18n/locales/en-US.cost-consistency.json
@@ -1,0 +1,6 @@
+{
+  "cost.budget.daily_warning": "⚠ Daily budget: $%.4f of $%.2f spent today (%.0f%%).",
+  "cost.budget.daily_exceeded": "⛔ Daily budget exceeded: $%.4f of $%.2f (%.0f%%).",
+  "cost.budget.daily_exceeded_hard": "⛔ Daily budget exceeded: $%.4f of $%.2f (%.0f%%) — new LLM turns are blocked until tomorrow or /cost budget raises the limit.",
+  "audit.locked_unavailable": "The managed configuration locks the audit trail path and it cannot be written; refusing to start unaudited: %v"
+}

--- a/i18n/locales/en.cost-consistency.json
+++ b/i18n/locales/en.cost-consistency.json
@@ -1,0 +1,6 @@
+{
+  "cost.budget.daily_warning": "⚠ Daily budget: $%.4f of $%.2f spent today (%.0f%%).",
+  "cost.budget.daily_exceeded": "⛔ Daily budget exceeded: $%.4f of $%.2f (%.0f%%).",
+  "cost.budget.daily_exceeded_hard": "⛔ Daily budget exceeded: $%.4f of $%.2f (%.0f%%) — new LLM turns are blocked until tomorrow or /cost budget raises the limit.",
+  "audit.locked_unavailable": "The managed configuration locks the audit trail path and it cannot be written; refusing to start unaudited: %v"
+}

--- a/i18n/locales/pt-BR.cost-consistency.json
+++ b/i18n/locales/pt-BR.cost-consistency.json
@@ -1,0 +1,6 @@
+{
+  "cost.budget.daily_warning": "⚠ Orçamento diário: $%.4f de $%.2f gastos hoje (%.0f%%).",
+  "cost.budget.daily_exceeded": "⛔ Orçamento diário excedido: $%.4f de $%.2f (%.0f%%).",
+  "cost.budget.daily_exceeded_hard": "⛔ Orçamento diário excedido: $%.4f de $%.2f (%.0f%%) — novos turnos de LLM ficam bloqueados até amanhã ou até /cost budget subir o limite.",
+  "audit.locked_unavailable": "A configuração gerenciada trava o caminho da trilha de auditoria e ele não pode ser escrito; recusando iniciar sem auditoria: %v"
+}


### PR DESCRIPTION
## Summary

Audit III, PR 21 (P2 COST-4, COST-5, SEC-8; P3 CMP-19, COST-13). Cost command consistency.

- **Full reset (COST-4).** `Reset` zeroes cache storage cost and resource count, memory-worker cost and calls, embedding cost, compaction cost and the provider context-edit counters before recomputing, so the total is 0 and the hard stop cannot stay armed.
- **Daily-aware notices (COST-5).** `budgetMessageLocked` speaks for the daily limit when it is the only one configured or when it tripped (warning and exceeded, hard-stop variant), with their own i18n keys as a locale fragment; the session message otherwise.
- **Summarizer cache (CMP-19, COST-13).** `compactSummarizerClient` caches by the `CHATCLI_COMPACT_MODEL` value under a mutex; a failed resolution is not cached and the next call retries, so a reload or a transient failure is not pinned for the process.
- **Locked audit fails closed (SEC-8).** `initLLMAuditErr` returns an error when `managed.env` locks `CHATCLI_AUDIT_LOG_PATH` (the `!KEY=` form) and the trail cannot be opened (relative or unwritable); the boot path prints the localized notice and exits. An unlocked bad path still only disables auditing.

## Tests

`cli/audit3_pr21_test.go`: reset clears every aggregate; daily-only and daily-tripped messages, session message otherwise; summarizer re-resolves after an env change and never caches a failure; locked relative path refused while the unlocked one degrades. golangci-lint and the local gates are green.