### PR TITLE
fix(memory): cross-process lock around every merge-and-write of the shared stores

### DIFF
--- a/cli/ctxmgr/storage.go
+++ b/cli/ctxmgr/storage.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/diillson/chatcli/pkg/flock"
 	"os"
 	"path/filepath"
 	"time"
@@ -79,7 +80,12 @@ func (s *Storage) SaveContext(ctx *FileContext) error {
 		return fmt.Errorf("erro ao serializar contexto: %w", err)
 	}
 
-	if err := atomicWrite(filePath, data); err != nil {
+	// Cross-process: the REPL, the gateway and the MCP server share the
+	// context store; last-writer-wins used to drop one side's changes.
+	unlock := flock.Lock(filePath)
+	err = atomicWrite(filePath, data)
+	unlock()
+	if err != nil {
 		return fmt.Errorf("erro ao salvar contexto: %w", err)
 	}
 

--- a/cli/workspace/memory/audit3_pr20_test.go
+++ b/cli/workspace/memory/audit3_pr20_test.go
@@ -1,0 +1,41 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package memory
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestFactIndex_TwoProcessesMergeUnderTheLock(t *testing.T) {
+	dir := t.TempDir()
+	a := NewFactIndex(dir, DefaultConfig(), zap.NewNop())
+	b := NewFactIndex(dir, DefaultConfig(), zap.NewNop())
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(2)
+		// Every fact is lexically unrelated to the others so reconciliation
+		// never folds two of them into one.
+		go func(i int) {
+			defer wg.Done()
+			a.AddFact(fmt.Sprintf("ka%d qa%d ra%d sa%d ta%d", i, i*7, i*11, i*13, i*17), "project", nil)
+		}(i)
+		go func(i int) {
+			defer wg.Done()
+			b.AddFact(fmt.Sprintf("kb%d qb%d rb%d sb%d tb%d", i, i*7, i*11, i*13, i*17), "project", nil)
+		}(i)
+	}
+	wg.Wait()
+	// A third process reads the shared file: every fact both sides wrote
+	// must be there — no read-merge-write race lost the loser's entries.
+	c := NewFactIndex(dir, DefaultConfig(), zap.NewNop())
+	if got := len(c.GetAll()); got != 40 {
+		t.Fatalf("facts on disk = %d, want 40", got)
+	}
+}

--- a/cli/workspace/memory/episodes.go
+++ b/cli/workspace/memory/episodes.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/diillson/chatcli/cli/ctxmgr"
+	"github.com/diillson/chatcli/pkg/flock"
 	"os"
 	"sort"
 	"strings"
@@ -293,6 +294,10 @@ func (es *EpisodeStore) load() {
 // union: adopt every episode the other process appended, keep ours, and only
 // then apply the cap. Caller must hold the write lock.
 func (es *EpisodeStore) persistLocked() {
+	// One process merges and writes at a time: the other processes'
+	// new entries can no longer be lost between our read and our write.
+	unlock := flock.Lock(es.path)
+	defer unlock()
 	if es.latch.locked() {
 		return // sealed file we cannot read: never overwrite it
 	}

--- a/cli/workspace/memory/facts.go
+++ b/cli/workspace/memory/facts.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"github.com/diillson/chatcli/pkg/flock"
 	"math"
 	"os"
 	"sort"
@@ -1044,6 +1045,10 @@ func legacyConfidence(accessCount int) float64 {
 }
 
 func (fi *FactIndex) persistLocked() {
+	// One process merges and writes at a time: the other processes'
+	// new entries can no longer be lost between our read and our write.
+	unlock := flock.Lock(fi.path)
+	defer unlock()
 	fi.rev++
 	if fi.latch.locked() {
 		return // sealed file we cannot read: never overwrite it

--- a/cli/workspace/memory/profile.go
+++ b/cli/workspace/memory/profile.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"encoding/json"
+	"github.com/diillson/chatcli/pkg/flock"
 	"sort"
 	"strings"
 	"sync"
@@ -673,6 +674,10 @@ func (ps *UserProfileStore) load() {
 }
 
 func (ps *UserProfileStore) persist() {
+	// One process merges and writes at a time: the other processes'
+	// new entries can no longer be lost between our read and our write.
+	unlock := flock.Lock(ps.path)
+	defer unlock()
 	if ps.latch.locked() {
 		return // sealed file we cannot read: never overwrite it
 	}

--- a/cli/workspace/memory/projects.go
+++ b/cli/workspace/memory/projects.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"encoding/json"
+	"github.com/diillson/chatcli/pkg/flock"
 	"sort"
 	"strings"
 	"sync"
@@ -236,6 +237,10 @@ func (pt *ProjectTracker) load() {
 }
 
 func (pt *ProjectTracker) persist() {
+	// One process merges and writes at a time: the other processes'
+	// new entries can no longer be lost between our read and our write.
+	unlock := flock.Lock(pt.path)
+	defer unlock()
 	if pt.latch.locked() {
 		return // sealed file we cannot read: never overwrite it
 	}

--- a/cli/workspace/memory/topics.go
+++ b/cli/workspace/memory/topics.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"encoding/json"
+	"github.com/diillson/chatcli/pkg/flock"
 	"sort"
 	"strings"
 	"sync"
@@ -256,6 +257,10 @@ func (tt *TopicTracker) load() {
 }
 
 func (tt *TopicTracker) persist() {
+	// One process merges and writes at a time: the other processes'
+	// new entries can no longer be lost between our read and our write.
+	unlock := flock.Lock(tt.path)
+	defer unlock()
 	if tt.latch.locked() {
 		return // sealed file we cannot read: never overwrite it
 	}

--- a/llm/embedding/vindex/vindex.go
+++ b/llm/embedding/vindex/vindex.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/diillson/chatcli/pkg/flock"
 	"os"
 	"path/filepath"
 	"sort"
@@ -415,6 +416,8 @@ func (x *Index) persist() error {
 	// utils.AtomicWriteFile fsyncs the temp file before the rename (and the
 	// directory after), so a power loss cannot leave an empty or truncated
 	// index behind the new name.
+	unlock := flock.Lock(x.path)
+	defer unlock()
 	return utils.AtomicWriteFile(x.path, data, 0o600)
 }
 

--- a/pkg/flock/flock.go
+++ b/pkg/flock/flock.go
@@ -1,0 +1,46 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Cross-process file locks for the shared stores.
+ *
+ * The REPL, the gateway daemon and the MCP server merge-then-write the
+ * same JSON stores (memory indexes, contexts, vector caches). Without a
+ * lock, two processes could both read, both merge, and the second write
+ * would erase the first's new entries until that process persisted
+ * again. Lock takes an exclusive advisory lock on a sidecar next to the
+ * store (<path>.lock) for the merge + write critical section.
+ */
+package flock
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Lock takes the exclusive lock guarding path and returns the release
+// function. A lock that cannot be taken (read-only directory, exotic
+// filesystem) degrades to a no-op release: the store still works as it
+// did before locks existed.
+func Lock(path string) func() {
+	if path == "" {
+		return func() {}
+	}
+	lockPath := path + ".lock"
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o750); err != nil {
+		return func() {}
+	}
+	f, err := os.OpenFile(filepath.Clean(lockPath), os.O_CREATE|os.O_RDWR, 0o600) // #nosec G304 G703 -- sidecar next to a store path the caller owns
+	if err != nil {
+		return func() {}
+	}
+	if err := lockFile(f); err != nil {
+		_ = f.Close()
+		return func() {}
+	}
+	return func() {
+		_ = unlockFile(f)
+		_ = f.Close()
+	}
+}

--- a/pkg/flock/flock_test.go
+++ b/pkg/flock/flock_test.go
@@ -1,0 +1,43 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package flock
+
+import (
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestLock_SerializesCriticalSections(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store.json")
+	var wg sync.WaitGroup
+	inside, maxInside := 0, 0
+	var mu sync.Mutex
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			unlock := Lock(path)
+			mu.Lock()
+			inside++
+			if inside > maxInside {
+				maxInside = inside
+			}
+			mu.Unlock()
+			time.Sleep(5 * time.Millisecond)
+			mu.Lock()
+			inside--
+			mu.Unlock()
+			unlock()
+		}()
+	}
+	wg.Wait()
+	if maxInside != 1 {
+		t.Fatalf("critical sections overlapped: %d", maxInside)
+	}
+	Lock("")() // empty path is a no-op
+}

--- a/pkg/flock/lock_unix.go
+++ b/pkg/flock/lock_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package flock
+
+import (
+	"os"
+	"syscall"
+)
+
+func lockFile(f *os.File) error   { return syscall.Flock(int(f.Fd()), syscall.LOCK_EX) }
+func unlockFile(f *os.File) error { return syscall.Flock(int(f.Fd()), syscall.LOCK_UN) }

--- a/pkg/flock/lock_windows.go
+++ b/pkg/flock/lock_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package flock
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockFile(f *os.File) error {
+	ol := new(windows.Overlapped)
+	return windows.LockFileEx(windows.Handle(f.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, ol)
+}
+
+func unlockFile(f *os.File) error {
+	ol := new(windows.Overlapped)
+	return windows.UnlockFileEx(windows.Handle(f.Fd()), 0, 1, 0, ol)
+}


### PR DESCRIPTION
## Summary

Audit III, PR 20 (P2 MEM-10; P3 RAG-12). Multi-process store locking.

- **`pkg/flock`** (new leaf package): `Lock(path) func()` takes an exclusive advisory lock on `<path>.lock` (flock on Unix, LockFileEx on Windows) and degrades to a no-op release where a lock cannot be taken, so the stores keep working as before on exotic filesystems.
- **Memory stores (MEM-10).** The persist path of facts, episodes, topics, projects and the user profile — the functions that merge from disk and then rewrite — runs under the lock, so a read-merge-write race between the REPL, the gateway daemon and the MCP server can no longer lose the loser's new entries. Tombstone semantics are unchanged.
- **Contexts and vector index (RAG-12).** `Storage.SaveContext` and `vindex.Index.persist` take the same lock; last-writer-wins on a torn race is gone.

## Tests

`pkg/flock/flock_test.go`: eight goroutines never overlap inside the critical section. `cli/workspace/memory/audit3_pr20_test.go`: two independent fact indexes over one directory add 40 lexically unrelated facts concurrently and a third reader sees all 40 on disk. golangci-lint and the local gates are green.