### PR TITLE
fix(agents): workers share the orchestrator's compactor, overflow recovery and journal

### DIFF
--- a/cli/agent/workers/audit3_pr22_test.go
+++ b/cli/agent/workers/audit3_pr22_test.go
@@ -1,0 +1,96 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package workers
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+// overflowThenDoneClient overflows once, then answers with a final text.
+type overflowThenDoneClient struct{ calls int }
+
+func (m *overflowThenDoneClient) GetModelName() string { return "mock" }
+func (m *overflowThenDoneClient) SendPrompt(_ context.Context, _ string, hist []models.Message, _ int) (string, error) {
+	m.calls++
+	if m.calls == 1 {
+		return "", errors.New("prompt is too long: 250000 tokens > 200000 maximum")
+	}
+	return "TASK DONE: the worker finished", nil
+}
+
+// recordingWindow is a WindowManager that records what the loop asked.
+type recordingWindow struct {
+	mu        sync.Mutex
+	needs     bool
+	compacted int
+	turns     [][]models.Message
+	names     []string
+}
+
+func (w *recordingWindow) NeedsCompaction([]models.Message) bool { return w.needs }
+func (w *recordingWindow) Compact(_ context.Context, h []models.Message) ([]models.Message, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.compacted++
+	return h, nil
+}
+func (w *recordingWindow) NoteTurn(worker string, turn []models.Message) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.names = append(w.names, worker)
+	w.turns = append(w.turns, turn)
+}
+
+func TestRunWorkerReAct_RecoversFromOverflowAndUsesTheSharedWindow(t *testing.T) {
+	win := &recordingWindow{needs: true}
+	RegisterWorkerWindow(win)
+	t.Cleanup(func() { RegisterWorkerWindow(nil) })
+	client := &overflowThenDoneClient{}
+	config := WorkerReActConfig{MaxTurns: 5, SystemPrompt: "you are a worker"}
+	result, err := RunWorkerReAct(context.Background(), config, "task", client, nil, NewSkillSet(), nil, zap.NewNop())
+	if err != nil {
+		t.Fatalf("the worker must recover from the overflow: %v", err)
+	}
+	if !strings.Contains(result.Output, "TASK DONE") || client.calls != 2 {
+		t.Fatalf("output=%q calls=%d", result.Output, client.calls)
+	}
+	win.mu.Lock()
+	defer win.mu.Unlock()
+	if win.compacted == 0 {
+		t.Fatal("the shared compactor must run when the window says so")
+	}
+	if len(win.turns) == 0 || len(win.turns[0]) == 0 {
+		t.Fatal("each worker turn must be journaled through NoteTurn")
+	}
+}
+
+func TestRunWorkerReAct_OverflowRecoveryIsBounded(t *testing.T) {
+	RegisterWorkerWindow(nil)
+	always := &alwaysOverflowClient{}
+	config := WorkerReActConfig{MaxTurns: 10, SystemPrompt: "worker"}
+	_, err := RunWorkerReAct(context.Background(), config, "task", always, nil, NewSkillSet(), nil, zap.NewNop())
+	if err == nil {
+		t.Fatal("a provider that always overflows must fail the worker")
+	}
+	if always.calls > 4 {
+		t.Fatalf("recovery must stay bounded: %d calls", always.calls)
+	}
+}
+
+type alwaysOverflowClient struct{ calls int }
+
+func (m *alwaysOverflowClient) GetModelName() string { return "mock" }
+func (m *alwaysOverflowClient) SendPrompt(_ context.Context, _ string, _ []models.Message, _ int) (string, error) {
+	m.calls++
+	return "", errors.New("This model's maximum context length is 8192 tokens")
+}

--- a/cli/agent/workers/context_tools.go
+++ b/cli/agent/workers/context_tools.go
@@ -64,6 +64,7 @@ var (
 	// squadCompressionLayer is the session CCR layer, shared so worker-loop
 	// microcompact preserves dropped bytes exactly like the orchestrator's.
 	squadCompressionLayer *compress.Layer
+	workerWindow          WindowManager
 )
 
 // RegisterCCRRecaller wires (or clears, with nil) the CCR key expander used
@@ -97,6 +98,33 @@ func RegisterSquadCompressionLayer(layer *compress.Layer) {
 	workerHooksMu.Lock()
 	squadCompressionLayer = layer
 	workerHooksMu.Unlock()
+}
+
+// WindowManager is the orchestrator's window management shared with the
+// worker loop: the same compactor (with the tenant's CCR), so a long
+// worker run gets compaction, not only the L0 microcompact, and its turns
+// are journaled under the parent session.
+type WindowManager interface {
+	// NeedsCompaction reports whether history crossed the compaction budget.
+	NeedsCompaction(history []models.Message) bool
+	// Compact rewrites history under the budget; an error keeps it as is.
+	Compact(ctx context.Context, history []models.Message) ([]models.Message, error)
+	// NoteTurn journals the messages one worker turn appended.
+	NoteTurn(worker string, turn []models.Message)
+}
+
+// RegisterWorkerWindow installs the orchestrator's window manager for
+// every worker loop of this process (nil clears it).
+func RegisterWorkerWindow(wm WindowManager) {
+	workerHooksMu.Lock()
+	workerWindow = wm
+	workerHooksMu.Unlock()
+}
+
+func currentWorkerWindow() WindowManager {
+	workerHooksMu.RLock()
+	defer workerHooksMu.RUnlock()
+	return workerWindow
 }
 
 func currentCCRRecaller() func(string) (string, bool) {

--- a/cli/agent/workers/worker_react.go
+++ b/cli/agent/workers/worker_react.go
@@ -170,6 +170,13 @@ func RunWorkerReAct(
 	// byte stays recoverable via the recall tool.
 	mcCfg := agent.DefaultMicrocompactConfig()
 	mcCfg.CCR = currentSquadCompressionLayer()
+	// The orchestrator's window management (compactor with the tenant's
+	// CCR, journal) and the same bounded overflow recovery the main loop
+	// has: a worker no longer fails its task when the provider says the
+	// context is too long.
+	window := currentWorkerWindow()
+	recovery := agent.NewContextRecovery(agent.DefaultContextRecoveryConfig(), logger)
+	workerName := liveRun.Snapshot().Agent
 
 	// --- Failure tracking for reflection ---
 	consecutiveFailures := 0
@@ -179,8 +186,7 @@ func RunWorkerReAct(
 	emptyTurns := 0
 
 	for turn := 0; turn < maxTurns; turn++ {
-		select {
-		case <-ctx.Done():
+		if ctx.Err() != nil {
 			return &AgentResult{
 				CallID:    callID,
 				Output:    finalOutput.String(),
@@ -188,7 +194,6 @@ func RunWorkerReAct(
 				Duration:  time.Since(startTime),
 				ToolCalls: allToolCalls,
 			}, ctx.Err()
-		default:
 		}
 
 		liveRun.SetTurn(turn+1, maxTurns)
@@ -198,20 +203,21 @@ func RunWorkerReAct(
 		// point where injecting context cannot split a tool_use/tool_result
 		// pair. Merged into a trailing user message when one exists so
 		// strict-alternation providers never see two user turns in a row.
-		if snap := liveRun.Snapshot(); snap.Agent != "" {
-			if inbox := mail.Default().Drain(snap.Agent); len(inbox) > 0 {
-				history = appendInboxMessage(history, mail.FormatInbox(inbox))
-			}
-		}
+		history = drainWorkerInbox(liveRun, history)
 
 		// Progressively compact old tool results (turn boundary only, so a
 		// tool_use/tool_result pair is never split). CCR-backed when the
 		// session layer is registered — otherwise same legacy behavior the
 		// orchestrator had before CCR.
 		history, _ = agent.ApplyMicrocompact(history, turn, mcCfg, logger)
+		history = applyWorkerWindow(ctx, window, history, logger)
 
 		// --- Call LLM (native or text mode) ---
 		responseText, nativeToolCalls, stopReason, newHistory, err := callWorkerLLM(ctx, useNativeTools, toolAware, llmClient, history, toolDefs)
+		if recovered, retry := recoverWorkerOverflow(err, recovery, history, turn, logger); retry {
+			history = recovered
+			continue
+		}
 		if err != nil {
 			return &AgentResult{
 				CallID:    callID,
@@ -221,6 +227,7 @@ func RunWorkerReAct(
 				ToolCalls: allToolCalls,
 			}, err
 		}
+		noteWorkerTurn(window, workerName, history, newHistory)
 		history = newHistory
 
 		// --- Resolve tool calls to unified format ---
@@ -367,6 +374,60 @@ func RunWorkerReAct(
 		ToolCalls:     allToolCalls,
 		ParallelCalls: maxParallel,
 	}, nil
+}
+
+// drainWorkerInbox merges the agent's squad mailbox into the history at
+// the turn boundary (nil-safe).
+func drainWorkerInbox(liveRun *runs.Run, history []models.Message) []models.Message {
+	snap := liveRun.Snapshot()
+	if snap.Agent == "" {
+		return history
+	}
+	inbox := mail.Default().Drain(snap.Agent)
+	if len(inbox) == 0 {
+		return history
+	}
+	return appendInboxMessage(history, mail.FormatInbox(inbox))
+}
+
+// applyWorkerWindow runs the shared compactor when the window says the
+// history crossed the budget; a failure keeps the history as is.
+func applyWorkerWindow(ctx context.Context, window WindowManager, history []models.Message, logger *zap.Logger) []models.Message {
+	if window == nil || !window.NeedsCompaction(history) {
+		return history
+	}
+	compacted, err := window.Compact(ctx, history)
+	if err != nil {
+		logger.Warn("worker compaction failed; continuing with the full history", zap.Error(err))
+		return history
+	}
+	if len(compacted) == 0 {
+		return history
+	}
+	return compacted
+}
+
+// recoverWorkerOverflow applies the bounded overflow recovery to a turn
+// that failed with a context-too-long error; retry is true when the caller
+// should resend with the recovered history.
+func recoverWorkerOverflow(err error, recovery *agent.ContextRecovery, history []models.Message, turn int, logger *zap.Logger) ([]models.Message, bool) {
+	if err == nil || !agent.IsContextTooLongError(err) || !recovery.CanRecoverContextOverflow() {
+		return history, false
+	}
+	recovered, ok := recovery.RecoverContextOverflow(history)
+	if !ok {
+		return history, false
+	}
+	logger.Warn("worker context overflow; compacted and retrying the turn", zap.Int("turn", turn+1), zap.Int("history", len(recovered)))
+	return recovered, true
+}
+
+// noteWorkerTurn journals what the turn appended (nil-safe).
+func noteWorkerTurn(window WindowManager, worker string, before, after []models.Message) {
+	if window == nil || len(after) <= len(before) {
+		return
+	}
+	window.NoteTurn(worker, after[len(before):])
 }
 
 // resolveWorkerMaxTurns resolves the effective turn budget for a worker:

--- a/cli/audit3_pr22_test.go
+++ b/cli/audit3_pr22_test.go
@@ -1,0 +1,54 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+func TestWorkerWindow_JournalsUnderTheParentWithoutPollutingIt(t *testing.T) {
+	t.Setenv("CHATCLI_ENCRYPTION_KEY", "")
+	path := filepath.Join(t.TempDir(), "tr-parent.jsonl")
+	j := &transcriptJournal{id: "tr-parent", path: path, seen: map[string]bool{}}
+	parent := []models.Message{{Role: "user", Content: "orchestrate"}, {Role: "assistant", Content: "dispatching"}}
+	if err := j.Sync(parent); err != nil {
+		t.Fatal(err)
+	}
+	c := &ChatCLI{logger: zap.NewNop(), transcript: j, historyCompactor: NewHistoryCompactor(zap.NewNop())}
+	w := &workerWindow{cli: c}
+	w.NoteTurn("researcher", []models.Message{{Role: "assistant", Content: "worker step"}, {Role: "tool", Content: "tool out"}})
+	w.NoteTurn("", []models.Message{{Role: "assistant", Content: "unnamed is dropped"}})
+	msgs, err := readTranscript(path)
+	if err != nil || len(msgs) != 2 {
+		t.Fatalf("parent history must not carry worker turns: %d %v", len(msgs), err)
+	}
+	workerEvents, _ := readWorkerTranscript(path)
+	if len(workerEvents) != 2 || workerEvents[0].Worker != "researcher" {
+		t.Fatalf("worker turns must be journaled under the parent: %+v", workerEvents)
+	}
+	// Reopening the journal rebuilds the parent's state from parent
+	// messages only.
+	j2 := &transcriptJournal{id: "tr-parent", path: path, seen: map[string]bool{}}
+	for _, m := range msgs { // what openTranscriptJournal seeds on reopen
+		j2.seen[messageHash(m)] = true
+	}
+	if err := j2.Sync(append(parent, models.Message{Role: "user", Content: "next"})); err != nil {
+		t.Fatal(err)
+	}
+	if msgs, _ := readTranscript(path); len(msgs) != 3 {
+		t.Fatalf("parent history after resync = %d", len(msgs))
+	}
+	if w.NeedsCompaction(nil) {
+		t.Fatal("empty history never needs compaction")
+	}
+	if (&workerWindow{}).NeedsCompaction(parent) || func() bool { _, err := (&workerWindow{}).Compact(t.Context(), parent); return err != nil }() {
+		t.Fatal("nil-safe")
+	}
+}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -945,6 +945,7 @@ func NewChatCLI(ctx context.Context, manager manager.LLMManager, logger *zap.Log
 	workers.RegisterCCRRecaller(cli.compressionLayer.Recall)
 	// Worker-loop microcompact archives dropped bytes into the same store.
 	workers.RegisterSquadCompressionLayer(cli.compressionLayer)
+	workers.RegisterWorkerWindow(&workerWindow{cli: cli})
 	// Read-only memory/session/knowledge views for workers that opt in
 	// (persona frontmatter tools: Memory, Session, Knowledge).
 	workers.RegisterContextToolRunner(cli.runWorkerContextTool)

--- a/cli/transcript_journal.go
+++ b/cli/transcript_journal.go
@@ -54,8 +54,12 @@ type transcriptEvent struct {
 	TS      time.Time       `json:"ts"`
 	Kind    string          `json:"kind"` // "msg" | "rewrite"
 	Message *models.Message `json:"message,omitempty"`
-	Before  int             `json:"before,omitempty"` // rewrite: messages before
-	After   int             `json:"after,omitempty"`  // rewrite: messages after
+	// Worker names the squad/taskgraph worker whose turn this is; worker
+	// events are journaled under the parent session for the record but
+	// never rebuilt into the parent's history.
+	Worker string `json:"worker,omitempty"`
+	Before int    `json:"before,omitempty"` // rewrite: messages before
+	After  int    `json:"after,omitempty"`  // rewrite: messages after
 	// Hashes (rewrite events) is the ordered hash list of the history the
 	// rewrite replaced, so the pre-rewrite conversation can be rebuilt
 	// from the journaled messages (/rewind compact after a resume).
@@ -223,6 +227,22 @@ func (j *transcriptJournal) Sync(history []models.Message) error {
 	return nil
 }
 
+// appendWorkerTurn journals one worker's turn under the parent session.
+func (j *transcriptJournal) appendWorkerTurn(worker string, turn []models.Message) error {
+	if j == nil || j.disabled || worker == "" || len(turn) == 0 {
+		return nil
+	}
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	now := time.Now()
+	events := make([]transcriptEvent, 0, len(turn))
+	for i := range turn {
+		m := turn[i]
+		events = append(events, transcriptEvent{TS: now, Kind: "msg", Worker: worker, Message: &m})
+	}
+	return j.appendEvents(events)
+}
+
 // appendEvents writes events as JSON lines (sealed when encryption at rest
 // is on) and fsyncs.
 func (j *transcriptJournal) appendEvents(events []transcriptEvent) error {
@@ -279,8 +299,24 @@ func readTranscript(path string) ([]models.Message, error) {
 	}
 	out := make([]models.Message, 0, len(events))
 	for _, ev := range events {
-		if ev.Kind == "msg" && ev.Message != nil {
+		if ev.Kind == "msg" && ev.Message != nil && ev.Worker == "" {
 			out = append(out, *ev.Message)
+		}
+	}
+	return out, nil
+}
+
+// readWorkerTranscript returns the worker turns journaled under the
+// parent session (worker name, message), in order.
+func readWorkerTranscript(path string) ([]transcriptEvent, error) {
+	events, err := readTranscriptEvents(path)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]transcriptEvent, 0, len(events))
+	for _, ev := range events {
+		if ev.Kind == "msg" && ev.Message != nil && ev.Worker != "" {
+			out = append(out, ev)
 		}
 	}
 	return out, nil
@@ -291,7 +327,7 @@ func readTranscript(path string) ([]models.Message, error) {
 func transcriptIndex(events []transcriptEvent) map[string]models.Message {
 	idx := make(map[string]models.Message, len(events))
 	for _, ev := range events {
-		if ev.Kind != "msg" || ev.Message == nil {
+		if ev.Kind != "msg" || ev.Message == nil || ev.Worker != "" {
 			continue
 		}
 		h := messageHash(*ev.Message)

--- a/cli/worker_window.go
+++ b/cli/worker_window.go
@@ -1,0 +1,57 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * The orchestrator's window management, shared with squad, taskgraph and
+ * delegate workers: the session compactor (with the active tenant's CCR)
+ * and the transcript journal. Workers used to have nothing beyond the L0
+ * microcompact — no compaction, no journal, no overflow recovery.
+ */
+package cli
+
+import (
+	"context"
+
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+// workerWindow implements workers.WindowManager over the live session.
+type workerWindow struct{ cli *ChatCLI }
+
+// NeedsCompaction applies the session's compaction budget to a worker
+// history (the worker's own system prompt counts as reserved prefix).
+func (w *workerWindow) NeedsCompaction(history []models.Message) bool {
+	if w == nil || w.cli == nil || w.cli.historyCompactor == nil {
+		return false
+	}
+	return w.cli.historyCompactor.NeedsCompaction(history, w.cli.compactConfig(w.cli.Provider, w.cli.Model))
+}
+
+// Compact runs the session compactor (Level 1 trim, Level 2 summary with
+// the configured summarizer, CCR archive through the tenant's layer).
+func (w *workerWindow) Compact(ctx context.Context, history []models.Message) ([]models.Message, error) {
+	if w == nil || w.cli == nil || w.cli.historyCompactor == nil {
+		return history, nil
+	}
+	cfg := w.cli.compactConfig(w.cli.Provider, w.cli.Model)
+	out, err := w.cli.historyCompactor.Compact(ctx, history, w.cli.getClient(), cfg)
+	if err != nil {
+		return history, err
+	}
+	if w.cli.costTracker != nil {
+		w.cli.costTracker.NoteExpectedCacheRebuild()
+	}
+	return out, nil
+}
+
+// NoteTurn journals the worker's turn under the parent session.
+func (w *workerWindow) NoteTurn(worker string, turn []models.Message) {
+	if w == nil || w.cli == nil || w.cli.transcript == nil {
+		return
+	}
+	if err := w.cli.transcript.appendWorkerTurn(worker, turn); err != nil && w.cli.logger != nil {
+		w.cli.logger.Debug("worker turn not journaled", zap.String("worker", worker), zap.Error(err))
+	}
+}


### PR DESCRIPTION
## Summary

Audit III, PR 22 (P2 CMP-14; info CAG-16). Worker window management.

- **Shared compactor (CMP-14).** `workers.WindowManager` (`NeedsCompaction`, `Compact`, `NoteTurn`) registered by the session (`workers.RegisterWorkerWindow`) like the squad CCR layer; `cli.workerWindow` implements it over the session's `HistoryCompactor` with `compactConfig` (Level 1 trim, Level 2 summary with the configured summarizer, CCR archive through the active tenant's layer) and notes the expected cache rebuild. The worker loop checks it at every turn boundary after the microcompact.
- **Overflow recovery (CMP-14).** A worker turn that fails with a context-overflow error runs `agent.ContextRecovery` (same levels, same bound) and retries instead of failing the task; a provider that always overflows still fails after the bounded attempts.
- **Journal under the parent (CMP-14).** `transcriptJournal.appendWorkerTurn` writes each worker turn tagged with the worker's name (`worker` field on the event); `readTranscript`, `transcriptIndex` and the reopen path ignore tagged events, so the parent history is never polluted, while `readWorkerTranscript` exposes them for the record.
- **Shared preamble (CAG-16).** Noted as future work; workers keep their own system prompt.

## Tests

`cli/agent/workers/audit3_pr22_test.go`: overflow then success completes the task with the shared compactor and journal called; always-overflow stays bounded. `cli/audit3_pr22_test.go`: worker turns journaled under the parent, excluded from the parent's history and from the reopen seed; nil-safety. golangci-lint and the local gates are green.