### PR TITLE
fix(cost): long-context tiers per call, Amazon Nova rows, Copilot as a subscription

### DIFF
--- a/cli/audit3_pr26_test.go
+++ b/cli/audit3_pr26_test.go
@@ -1,0 +1,65 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"math"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+)
+
+func TestNovaPricing_RowsAndUnverifiedNova2(t *testing.T) {
+	in, out, ok := lookupModelPricing("BEDROCK", "amazon.nova-pro-v1:0")
+	if !ok || in != 0.80 || out != 3.20 {
+		t.Fatalf("nova pro = %v %v %v", in, out, ok)
+	}
+	if in, out, ok := lookupModelPricing("BEDROCK", "us.amazon.nova-micro-v1:0"); !ok || in != 0.035 || out != 0.14 {
+		t.Fatalf("nova micro = %v %v %v", in, out, ok)
+	}
+	if _, _, ok := lookupModelPricing("BEDROCK", "amazon.nova-2-lite-v1:0"); ok {
+		t.Fatal("Nova 2 stays unpriced until its list price is verified (never a guess)")
+	}
+}
+
+func TestCopilot_IsASubscriptionNotPerToken(t *testing.T) {
+	in, out, ok := lookupModelPricing("COPILOT", "gpt-5.6")
+	if !ok || in != 0 || out != 0 {
+		t.Fatalf("copilot = %v %v %v", in, out, ok)
+	}
+}
+
+func TestLongContextTiers_PerCall(t *testing.T) {
+	if in, out := longContextMultipliers("CLAUDEAI", "claude-sonnet-5", 250_000); in != 2 || out != 1.5 {
+		t.Fatalf("anthropic tier = %v %v", in, out)
+	}
+	if in, out := longContextMultipliers("CLAUDEAI", "claude-sonnet-5", 150_000); in != 1 || out != 1 {
+		t.Fatal("under the threshold: no tier")
+	}
+	if in, out := longContextMultipliers("GOOGLEAI", "gemini-2.5-pro", 300_000); in != 2 || out != 1.5 {
+		t.Fatalf("gemini tier = %v %v", in, out)
+	}
+	if in, out := longContextMultipliers("XAI", "grok-4", 200_000); in != 2 || out != 2 {
+		t.Fatalf("grok tier = %v %v", in, out)
+	}
+	if in, out := longContextMultipliers("OPENAI", "gpt-5.6", 500_000); in != 1 || out != 1 {
+		t.Fatal("openai has no tier")
+	}
+	small := &models.UsageInfo{PromptTokens: 100_000, CompletionTokens: 1000, IsReal: true}
+	big := &models.UsageInfo{PromptTokens: 300_000, CompletionTokens: 1000, IsReal: true}
+	base := estimateTurnCostUSD("CLAUDEAI", "claude-sonnet-5", small)
+	tiered := estimateTurnCostUSD("CLAUDEAI", "claude-sonnet-5", big)
+	// 3× the prompt at 2× the price, output at 1.5×: strictly more than 3× base.
+	if base <= 0 || tiered <= base*3 {
+		t.Fatalf("tier must raise the per-turn estimate: base=%v tiered=%v", base, tiered)
+	}
+	// The session tracker books the tiered call as a billed amount.
+	ct := NewCostTracker()
+	ct.RecordRealUsage("CLAUDEAI", "claude-sonnet-5", big)
+	if math.Abs(ct.TotalCost()-tiered) > 1e-9 {
+		t.Fatalf("tracker total %v != tiered %v", ct.TotalCost(), tiered)
+	}
+}

--- a/cli/cost_cache_telemetry_test.go
+++ b/cli/cost_cache_telemetry_test.go
@@ -146,18 +146,20 @@ func TestCacheWrite1hPricing(t *testing.T) {
 	if !known || input <= 0 {
 		t.Skip("pricing table entry missing")
 	}
-	u := &models.UsageInfo{PromptTokens: 0, CacheCreationInputTokens: 1_000_000, CacheCreation1hInputTokens: 1_000_000, IsReal: true}
+	// 100K tokens: under the 200K long-context tier, so only the TTL
+	// multiplier applies (a 1M write would also be long-context priced).
+	u := &models.UsageInfo{PromptTokens: 0, CacheCreationInputTokens: 100_000, CacheCreation1hInputTokens: 100_000, IsReal: true}
 	got := estimateTurnCostUSD("CLAUDEAI", "claude-sonnet-5", u)
-	if math.Abs(got-input*2.0) > 1e-9 {
-		t.Fatalf("1h write cost = %.6f, want %.6f (2x input)", got, input*2.0)
+	if math.Abs(got-input*2.0*0.1) > 1e-9 {
+		t.Fatalf("1h write cost = %.6f, want %.6f (2x input)", got, input*2.0*0.1)
 	}
-	u5 := &models.UsageInfo{CacheCreationInputTokens: 1_000_000, IsReal: true}
-	if got := estimateTurnCostUSD("CLAUDEAI", "claude-sonnet-5", u5); math.Abs(got-input*1.25) > 1e-9 {
-		t.Fatalf("5m write cost = %.6f, want %.6f (1.25x input)", got, input*1.25)
+	u5 := &models.UsageInfo{CacheCreationInputTokens: 100_000, IsReal: true}
+	if got := estimateTurnCostUSD("CLAUDEAI", "claude-sonnet-5", u5); math.Abs(got-input*1.25*0.1) > 1e-9 {
+		t.Fatalf("5m write cost = %.6f, want %.6f (1.25x input)", got, input*1.25*0.1)
 	}
 	ct := NewCostTracker()
 	ct.RecordRealUsage("CLAUDEAI", "claude-sonnet-5", u)
-	if s := ct.TotalCost(); math.Abs(s-input*2.0) > 1e-9 {
-		t.Fatalf("session cost = %.6f, want %.6f", s, input*2.0)
+	if s := ct.TotalCost(); math.Abs(s-input*2.0*0.1) > 1e-9 {
+		t.Fatalf("session cost = %.6f, want %.6f", s, input*2.0*0.1)
 	}
 }

--- a/cli/cost_tracker.go
+++ b/cli/cost_tracker.go
@@ -313,6 +313,14 @@ func (ct *CostTracker) RecordRealUsage(provider, model string, usage *models.Usa
 	if usage == nil {
 		return
 	}
+	// Long-context tiers are per call (the record only knows totals): a
+	// call past the provider's threshold is booked at its tier price as a
+	// billed amount, so the table math never averages it away.
+	if tiered := tieredCallCostUSD(provider, model, usage); tiered > 0 {
+		u := *usage
+		u.CostUSD = tiered
+		usage = &u
+	}
 	ct.mu.Lock()
 
 	key := modelKey(provider, model)
@@ -937,6 +945,9 @@ func estimateTurnCostUSD(provider, model string, usage *models.UsageInfo) float6
 	if usage.CostUSD > 0 {
 		return usage.CostUSD
 	}
+	if tiered := tieredCallCostUSD(provider, model, usage); tiered > 0 {
+		return tiered
+	}
 	// Single source of truth: run the turn through the exact record math the
 	// session tracker applies — a second hand-rolled formula here is how the
 	// footer and /cost drift apart.
@@ -996,6 +1007,12 @@ func lookupModelPricing(provider, model string) (inputCost, outputCost float64, 
 	if strings.Contains(provider, "zai") && zai.CodingPlanActive() {
 		return 0, 0, true
 	}
+	// GitHub Copilot is a subscription: requests debit the plan's premium
+	// request allowance, not a per-token invoice — before the model-name
+	// heuristics, which would price gpt-*/claude-* at API rates.
+	if strings.Contains(provider, "copilot") {
+		return 0, 0, true
+	}
 
 	for _, fn := range []func(string) (float64, float64, bool){
 		claudePricing,
@@ -1004,6 +1021,7 @@ func lookupModelPricing(provider, model string) (inputCost, outputCost float64, 
 		grokPricing,
 		deepseekPricing,
 		zaiPricing,
+		novaPricing,
 	} {
 		if in, out, ok := fn(model); ok {
 			return in, out, true
@@ -1310,7 +1328,10 @@ func providerFallbackPricing(provider, model string) (float64, float64, bool) {
 		// Cobre também kimi-k2.7-code ($0.95/$4.00 — mesmo tier do K2.6).
 		return 0.95, 4.00, true
 	case strings.Contains(provider, "copilot"):
-		return 2.50, 10.0, true
+		// GitHub Copilot is a subscription: requests debit the plan's
+		// premium-request allowance, not a per-token invoice. Known-zero
+		// like Devin/Ollama/StackSpot; /cost labels it as such.
+		return 0, 0, true
 	case strings.Contains(provider, "openrouter"):
 		return getOpenRouterModelPricing(model)
 	case strings.Contains(provider, "ollama"), strings.Contains(provider, "stackspot"),
@@ -1321,6 +1342,82 @@ func providerFallbackPricing(provider, model string) (float64, float64, bool) {
 		return 0, 0, true
 	}
 	return 0, 0, false
+}
+
+// novaPricing prices the Amazon Nova family on Bedrock (on-demand, us-east-1
+// list prices per 1M tokens: Micro $0.035/$0.14, Lite $0.06/$0.24, Pro
+// $0.80/$3.20, Premier $2.50/$12.50). Nova 2 generations are reported as
+// unpriced until their list price is verified — never a guess.
+func novaPricing(model string) (float64, float64, bool) {
+	if !strings.Contains(model, "nova") {
+		return 0, 0, false
+	}
+	switch {
+	case strings.Contains(model, "nova-2"):
+		return 0, 0, false
+	case strings.Contains(model, "nova-micro"):
+		return 0.035, 0.14, true
+	case strings.Contains(model, "nova-lite"):
+		return 0.06, 0.24, true
+	case strings.Contains(model, "nova-pro"):
+		return 0.80, 3.20, true
+	case strings.Contains(model, "nova-premier"):
+		return 2.50, 12.50, true
+	}
+	return 0, 0, false
+}
+
+// longContextThresholdTokens is the prompt size above which the providers
+// below switch to their long-context tier.
+const (
+	longContextAnthropicTokens = 200_000
+	longContextGeminiTokens    = 200_000
+	longContextGrokTokens      = 128_000
+)
+
+// longContextMultipliers returns the input and output price multipliers a
+// call with promptTokens of context pays: Anthropic (Claude 4+ with the
+// 1M window) and Gemini 2.5 Pro bill 2× input and 1.5× output past 200K;
+// xAI Grok 4 bills 2× both past 128K. 1/1 elsewhere.
+func longContextMultipliers(provider, model string, promptTokens int) (in, out float64) {
+	p, m := strings.ToLower(provider), strings.ToLower(model)
+	switch {
+	case strings.Contains(m, "claude") && promptTokens > longContextAnthropicTokens:
+		return 2, 1.5
+	case strings.Contains(m, "gemini-2.5-pro") && promptTokens > longContextGeminiTokens:
+		return 2, 1.5
+	case (strings.Contains(p, "xai") || strings.HasPrefix(m, "grok-4")) && strings.HasPrefix(m, "grok-4") && promptTokens > longContextGrokTokens:
+		return 2, 2
+	}
+	return 1, 1
+}
+
+// tieredCallCostUSD prices one call with its long-context tier applied; 0
+// when the call is not in a tier (the record math prices it normally).
+func tieredCallCostUSD(provider, model string, usage *models.UsageInfo) float64 {
+	if usage == nil || usage.CostUSD > 0 {
+		return 0
+	}
+	context := usage.PromptTokens + usage.CacheReadInputTokens + usage.CacheCreationInputTokens
+	in, out := longContextMultipliers(provider, model, context)
+	if in == 1 && out == 1 {
+		return 0
+	}
+	rec := &ModelUsageRecord{
+		ReasoningTokens:       int64(usage.ReasoningTokens),
+		Provider:              provider,
+		Model:                 model,
+		PromptTokens:          int64(usage.PromptTokens),
+		CompletionTokens:      int64(usage.CompletionTokens),
+		CacheReadTokens:       int64(usage.CacheReadInputTokens),
+		CacheCreationTokens:   int64(usage.CacheCreationInputTokens),
+		CacheCreation1hTokens: int64(usage.CacheCreation1hInputTokens),
+	}
+	recomputeRecordCost(rec)
+	if !rec.PricingKnown {
+		return 0
+	}
+	return (rec.InputCostUSD+rec.CacheCostUSD)*in + rec.OutputCostUSD*out
 }
 
 // cacheTokensAdditive reports whether the usage payload counts cache tokens

--- a/cli/cost_tracker_overhaul_test.go
+++ b/cli/cost_tracker_overhaul_test.go
@@ -93,15 +93,17 @@ func TestRecomputeCostCacheSubsetSemantics(t *testing.T) {
 
 	// Anthropic reports cache tokens ALONGSIDE input_tokens — additive.
 	ct2 := NewCostTracker()
+	// 100K + 40K: under the 200K long-context tier, so the additive
+	// semantics are what is measured (1.4M would be tier-priced).
 	ct2.RecordRealUsage("CLAUDEAI", "claude-sonnet-5", &models.UsageInfo{
-		PromptTokens:         1_000_000,
-		CacheReadInputTokens: 400_000,
+		PromptTokens:         100_000,
+		CacheReadInputTokens: 40_000,
 		IsReal:               true,
 	})
 	rec2 := ct2.modelUsage[modelKey("CLAUDEAI", "claude-sonnet-5")]
-	// 1M at $2.00 + 400K at $0.20 = 2.00 + 0.08
-	if !almostEqual(rec2.TotalCostUSD, 2.08) {
-		t.Fatalf("additive cache cost = %v, want 2.08", rec2.TotalCostUSD)
+	// 100K at $2.00 + 40K at $0.20 = 0.20 + 0.008
+	if !almostEqual(rec2.TotalCostUSD, 0.208) {
+		t.Fatalf("additive cache cost = %v, want 0.208", rec2.TotalCostUSD)
 	}
 }
 

--- a/cli/cost_tracker_pricing_test.go
+++ b/cli/cost_tracker_pricing_test.go
@@ -167,7 +167,7 @@ func TestGetModelPricing(t *testing.T) {
 		{"kimi-k2.5 retired keeps generic tier", "MOONSHOT", "kimi-k2.5", 0.95, 4.00},
 		{"moonshot-v1 retired keeps generic tier", "MOONSHOT", "moonshot-v1-128k", 0.95, 4.00},
 
-		{"copilot", "COPILOT", "gpt-4o", 2.50, 10.0},
+		{"copilot", "COPILOT", "gpt-4o", 0, 0}, // subscription: known-zero
 		{"ollama zero", "OLLAMA", "llama3", 0.0, 0.0},
 		// Devin CLI: o binário não reporta tokens e o custo é da assinatura
 		// Cognition — sempre zero, qualquer que seja o modelo roteado.


### PR DESCRIPTION
## Summary

Audit III, PR 26 (P2 COST-10; P3 COST-14 partial). Pricing tiers.

- **Long-context tiers per call (COST-10).** `longContextMultipliers` returns the input/output multipliers a call pays past the provider threshold: Claude over 200K context (2× input, 1.5× output), Gemini 2.5 Pro over 200K (2× / 1.5×), Grok 4 over 128K (2× / 2×); no tier elsewhere. `tieredCallCostUSD` prices such a call with the record math and the multipliers; `RecordRealUsage` books it as a billed amount (the record only knows totals, so a per-call tier cannot live in the aggregate), and `estimateTurnCostUSD` (footer and `/cost` agree) applies the same rule.
- **Amazon Nova rows (COST-10).** `novaPricing`: Micro $0.035/$0.14, Lite $0.06/$0.24, Pro $0.80/$3.20, Premier $2.50/$12.50 per 1M (on-demand list). Nova 2 generations are reported as unpriced on purpose: the list price could not be verified from the pricing page in this session, and a guessed rate is worse than "unknown" in a cost tool.
- **Copilot is a subscription (COST-10).** Requests debit the plan's premium-request allowance; the provider is short-circuited to known-zero before the model-name heuristics (which priced `gpt-*`/`claude-*` at API rates).
- The existing 1h cache-write test now uses 100K tokens so it exercises the TTL multiplier without crossing the long-context tier it did not mean to test.

## Tests

`cli/audit3_pr26_test.go`: Nova rows and Nova 2 unpriced; Copilot zero; tier multipliers per provider and threshold; tiered per-turn estimate and tracker total agree. golangci-lint and the local gates are green.