### PR TITLE
fix(workspace): instruction-file parity — import boundary and per-file cap, global always merged, local and override files, .claude/rules, watched-dir cap with .gitignore

### DIFF
--- a/cli/ctxmgr/audit3_pr25_test.go
+++ b/cli/ctxmgr/audit3_pr25_test.go
@@ -1,0 +1,42 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package ctxmgr
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWatchDirsForCapped_HonoursGitignoreAndTheCap(t *testing.T) {
+	root := t.TempDir()
+	for _, d := range []string{"src/a", "src/b", "build/out", "vendor2/x", "docs"} {
+		if err := os.MkdirAll(filepath.Join(root, d), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte("# noise\nbuild/\nvendor*\n!keep\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dirs, truncated := watchDirsForCapped([]string{root}, 0)
+	if truncated {
+		t.Fatal("no cap → not truncated")
+	}
+	joined := map[string]bool{}
+	for _, d := range dirs {
+		joined[d] = true
+	}
+	if joined[filepath.Join(root, "build")] || joined[filepath.Join(root, "build", "out")] || joined[filepath.Join(root, "vendor2")] {
+		t.Fatalf("gitignored directories must not be watched: %v", dirs)
+	}
+	if !joined[filepath.Join(root, "src", "a")] || !joined[filepath.Join(root, "docs")] {
+		t.Fatalf("ordinary directories must be watched: %v", dirs)
+	}
+	capped, truncated := watchDirsForCapped([]string{root}, 2)
+	if len(capped) != 2 || !truncated {
+		t.Fatalf("cap must stop the walk and report it: %d %v", len(capped), truncated)
+	}
+}

--- a/cli/ctxmgr/watch.go
+++ b/cli/ctxmgr/watch.go
@@ -15,9 +15,11 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/diillson/chatcli/i18n"
 	"github.com/diillson/chatcli/utils"
 	"github.com/fsnotify/fsnotify"
 	"go.uber.org/zap"
@@ -86,7 +88,7 @@ func (w *ContextWatcher) Watch(name string) error {
 	if err := w.ensureStarted(); err != nil {
 		return err
 	}
-	dirs := watchDirsFor(paths)
+	dirs, truncated := watchDirsForCapped(paths, maxWatchedDirs)
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if w.closed {
@@ -96,8 +98,10 @@ func (w *ContextWatcher) Watch(name string) error {
 		return nil
 	}
 	added := make([]string, 0, len(dirs))
+	failed := 0
 	for _, d := range dirs {
 		if err := w.watcher.Add(d); err != nil {
+			failed++
 			w.logger.Debug("context watch: cannot watch dir", zap.String("dir", d), zap.Error(err))
 			continue
 		}
@@ -105,6 +109,12 @@ func (w *ContextWatcher) Watch(name string) error {
 		added = append(added, d)
 	}
 	w.names[name] = added
+	if truncated || failed > 0 {
+		// The user believes the context is watched; say exactly how much of
+		// it is.
+		w.logger.Warn(i18n.T("context.watch.partial", name, len(added), failed, maxWatchedDirs),
+			zap.Bool("truncated", truncated), zap.Int("failed", failed))
+	}
 	return nil
 }
 
@@ -241,13 +251,32 @@ func (w *ContextWatcher) refresh(name string) {
 // watchDirsFor turns source paths into the directories to watch: a file's
 // parent, a directory and all its subdirectories (noise dirs skipped).
 func watchDirsFor(paths []string) []string {
+	dirs, _ := watchDirsForCapped(paths, maxWatchedDirs)
+	return dirs
+}
+
+// maxWatchedDirs bounds the directories one context may watch: every
+// watched directory costs a file descriptor (one per dir on kqueue), and
+// a monorepo used to exhaust them silently while the user believed the
+// context was watched.
+const maxWatchedDirs = 2000
+
+// watchDirsForCapped is watchDirsFor with an explicit cap; truncated
+// reports whether the walk stopped at it. Directories matched by the root's
+// .gitignore are skipped like the built-in noise directories.
+func watchDirsForCapped(paths []string, limit int) (dirs []string, truncated bool) {
 	seen := map[string]bool{}
 	var out []string
-	add := func(d string) {
-		if !seen[d] {
-			seen[d] = true
-			out = append(out, d)
+	add := func(d string) bool {
+		if seen[d] {
+			return true
 		}
+		if limit > 0 && len(out) >= limit {
+			return false
+		}
+		seen[d] = true
+		out = append(out, d)
+		return true
 	}
 	for _, p := range paths {
 		info, err := os.Stat(p)
@@ -255,19 +284,64 @@ func watchDirsFor(paths []string) []string {
 			continue
 		}
 		if !info.IsDir() {
-			add(filepath.Dir(p))
+			if !add(filepath.Dir(p)) {
+				truncated = true
+			}
 			continue
 		}
+		ignore := loadGitignoreDirs(p)
 		_ = filepath.WalkDir(p, func(path string, d os.DirEntry, err error) error {
 			if err != nil || !d.IsDir() {
 				return nil
 			}
-			if path != p && utils.ShouldSkipDir(d.Name()) {
+			if path != p && (utils.ShouldSkipDir(d.Name()) || ignore.matches(p, path)) {
 				return filepath.SkipDir
 			}
-			add(path)
+			if !add(path) {
+				truncated = true
+				return filepath.SkipAll
+			}
 			return nil
 		})
 	}
-	return out
+	return out, truncated
+}
+
+// gitignoreDirs is the subset of a .gitignore that names directories or
+// simple globs (no negation, no anchored multi-segment patterns).
+type gitignoreDirs struct{ patterns []string }
+
+// loadGitignoreDirs reads root/.gitignore; missing = empty.
+func loadGitignoreDirs(root string) gitignoreDirs {
+	data, err := os.ReadFile(filepath.Join(root, ".gitignore")) // #nosec G304 -- the watched root the user attached
+	if err != nil {
+		return gitignoreDirs{}
+	}
+	var g gitignoreDirs
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "!") {
+			continue
+		}
+		line = strings.TrimPrefix(strings.TrimSuffix(line, "/"), "/")
+		if line == "" || strings.Contains(line, "/") {
+			continue // multi-segment patterns are out of scope
+		}
+		g.patterns = append(g.patterns, line)
+	}
+	return g
+}
+
+// matches reports whether the directory at path (under root) is ignored.
+func (g gitignoreDirs) matches(root, path string) bool {
+	if len(g.patterns) == 0 {
+		return false
+	}
+	name := filepath.Base(path)
+	for _, p := range g.patterns {
+		if ok, _ := filepath.Match(p, name); ok {
+			return true
+		}
+	}
+	return false
 }

--- a/cli/workspace/audit3_pr25_test.go
+++ b/cli/workspace/audit3_pr25_test.go
@@ -1,0 +1,97 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func writeInstrFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestInstructions_ImportsStayInsideTheWorkspace(t *testing.T) {
+	ws := t.TempDir()
+	outside := t.TempDir()
+	global := t.TempDir()
+	writeInstrFile(t, filepath.Join(outside, "secret.md"), "SECRET NOTES")
+	writeInstrFile(t, filepath.Join(ws, "docs", "style.md"), "STYLE RULES")
+	_ = os.Symlink(filepath.Join(outside, "secret.md"), filepath.Join(ws, "link.md"))
+	writeInstrFile(t, filepath.Join(ws, "AGENTS.md"), "Project rules\n@docs/style.md\n@"+filepath.Join(outside, "secret.md")+"\n@link.md\n@~/nowhere.md\n")
+	bl := NewBootstrapLoader(ws, global, zap.NewNop())
+	doc, ok := bl.loadInstructionHierarchy()
+	if !ok {
+		t.Fatal("instructions must load")
+	}
+	if !strings.Contains(doc, "STYLE RULES") {
+		t.Fatal("in-tree import must expand")
+	}
+	if strings.Contains(doc, "SECRET NOTES") {
+		t.Fatal("out-of-tree imports (absolute or through a symlink) must be skipped")
+	}
+}
+
+func TestInstructions_OverrideLocalAndGlobalMerge(t *testing.T) {
+	ws := t.TempDir()
+	global := t.TempDir()
+	writeInstrFile(t, filepath.Join(global, "AGENTS.md"), "GLOBAL PREFS")
+	writeInstrFile(t, filepath.Join(ws, "AGENTS.md"), "SHARED PROJECT")
+	writeInstrFile(t, filepath.Join(ws, "AGENTS.local.md"), "MY LOCAL ADDITIONS")
+	bl := NewBootstrapLoader(ws, global, zap.NewNop())
+	doc, _ := bl.loadInstructionHierarchy()
+	for _, want := range []string{"GLOBAL PREFS", "SHARED PROJECT", "MY LOCAL ADDITIONS"} {
+		if !strings.Contains(doc, want) {
+			t.Fatalf("missing %q in %q", want, doc)
+		}
+	}
+	if strings.Index(doc, "GLOBAL PREFS") > strings.Index(doc, "SHARED PROJECT") {
+		t.Fatal("the global file merges first")
+	}
+	writeInstrFile(t, filepath.Join(ws, "AGENTS.override.md"), "OVERRIDE WINS")
+	bl2 := NewBootstrapLoader(ws, global, zap.NewNop())
+	doc2, _ := bl2.loadInstructionHierarchy()
+	if !strings.Contains(doc2, "OVERRIDE WINS") || strings.Contains(doc2, "SHARED PROJECT") {
+		t.Fatalf("AGENTS.override.md must replace AGENTS.md: %q", doc2)
+	}
+}
+
+func TestInstructions_PerFileImportCap(t *testing.T) {
+	ws := t.TempDir()
+	writeInstrFile(t, filepath.Join(ws, "big.md"), strings.Repeat("x", importFileMaxBytes*3))
+	writeInstrFile(t, filepath.Join(ws, "AGENTS.md"), "@big.md\n")
+	bl := NewBootstrapLoader(ws, "", zap.NewNop())
+	doc, _ := bl.loadInstructionHierarchy()
+	if len(doc) > importFileMaxBytes+512 {
+		t.Fatalf("one import must be capped on its own: %d bytes", len(doc))
+	}
+}
+
+func TestRules_ReadClaudeRulesToo(t *testing.T) {
+	ws := t.TempDir()
+	writeInstrFile(t, filepath.Join(ws, ".claude", "rules", "go.md"), "Use gofmt")
+	writeInstrFile(t, filepath.Join(ws, ".chatcli", "rules", "go.md"), "Use gofmt and govet")
+	rl := NewRulesLoader(ws, t.TempDir(), zap.NewNop())
+	out := rl.LoadMatchingRules(nil)
+	if !strings.Contains(out, "Use gofmt and govet") || strings.Contains(out, "Use gofmt\n") {
+		t.Fatalf(".chatcli/rules must win over .claude/rules of the same name: %q", out)
+	}
+	ws2 := t.TempDir()
+	writeInstrFile(t, filepath.Join(ws2, ".claude", "rules", "py.md"), "Use ruff")
+	if out := NewRulesLoader(ws2, t.TempDir(), zap.NewNop()).LoadMatchingRules(nil); !strings.Contains(out, "Use ruff") {
+		t.Fatalf(".claude/rules alone must load: %q", out)
+	}
+}

--- a/cli/workspace/instructions.go
+++ b/cli/workspace/instructions.go
@@ -18,6 +18,7 @@ package workspace
 
 import (
 	"fmt"
+	"go.uber.org/zap"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -34,6 +35,18 @@ const (
 
 // instructionFileNames are the per-directory candidates, in priority order.
 var instructionFileNames = []string{"AGENTS.md", "CHATCLI.md", "CLAUDE.md"}
+
+// instructionOverrideName replaces a directory's AGENTS.md when present
+// (the Codex convention: AGENTS.override.md wins over AGENTS.md).
+const instructionOverrideName = "AGENTS.override.md"
+
+// instructionLocalSuffix names the per-machine companion of an instruction
+// file (AGENTS.local.md, CLAUDE.local.md — gitignored, merged after it).
+const instructionLocalSuffix = ".local.md"
+
+// importFileMaxBytes caps ONE imported file; the whole hierarchy is still
+// capped by InstructionDocMaxBytes after the join.
+const importFileMaxBytes = 32 * 1024
 
 // importLine matches "@path/file.md", "@./file.md", "@~/file.md" or
 // "@import path" on a line of its own (Markdown files and plain text).
@@ -82,13 +95,30 @@ func (bl *BootstrapLoader) instructionDirs() []string {
 
 // instructionFileIn returns the first instruction file present in dir.
 func (bl *BootstrapLoader) instructionFileIn(dir string) (string, string, bool) {
+	// The override file replaces the directory's instructions outright.
+	if p := filepath.Join(dir, instructionOverrideName); p != "" {
+		if content, ok := bl.loadWithCache(p); ok {
+			return p, bl.withLocalCompanion(dir, "AGENTS.md", content), true
+		}
+	}
 	for _, name := range instructionFileNames {
 		p := filepath.Join(dir, name)
 		if content, ok := bl.loadWithCache(p); ok {
-			return p, content, true
+			return p, bl.withLocalCompanion(dir, name, content), true
 		}
 	}
 	return "", "", false
+}
+
+// withLocalCompanion appends <name>.local.md (per-machine, gitignored
+// additions) after the shared file's content when it exists.
+func (bl *BootstrapLoader) withLocalCompanion(dir, name, content string) string {
+	local := filepath.Join(dir, strings.TrimSuffix(name, ".md")+instructionLocalSuffix)
+	extra, ok := bl.loadWithCache(local)
+	if !ok || strings.TrimSpace(extra) == "" {
+		return content
+	}
+	return content + "\n\n<!-- " + filepath.Base(local) + " -->\n" + extra
 }
 
 // loadInstructionHierarchy assembles the project instruction files (root
@@ -96,6 +126,15 @@ func (bl *BootstrapLoader) instructionFileIn(dir string) (string, string, bool) 
 // Each file has its @imports expanded; the result is capped.
 func (bl *BootstrapLoader) loadInstructionHierarchy() (string, bool) {
 	parts := make([]string, 0, 4)
+	// The global file is always merged first (Claude Code merges global +
+	// project); it used to be a fallback only when the project had none.
+	globalUsed := false
+	if bl.globalDir != "" {
+		if path, content, ok := bl.instructionFileIn(bl.globalDir); ok {
+			parts = append(parts, "<!-- global "+filepath.Base(path)+" -->\n"+bl.expandImports(content, filepath.Dir(path), 1, map[string]bool{path: true}))
+			globalUsed = true
+		}
+	}
 	for _, dir := range bl.instructionDirs() {
 		path, content, ok := bl.instructionFileIn(dir)
 		if !ok {
@@ -111,15 +150,9 @@ func (bl *BootstrapLoader) loadInstructionHierarchy() (string, bool) {
 		}
 		parts = append(parts, content)
 	}
+	_ = globalUsed
 	if len(parts) == 0 {
-		if bl.globalDir == "" {
-			return "", false
-		}
-		path, content, ok := bl.instructionFileIn(bl.globalDir)
-		if !ok {
-			return "", false
-		}
-		parts = append(parts, bl.expandImports(content, filepath.Dir(path), 1, map[string]bool{path: true}))
+		return "", false
 	}
 	return capInstructionDoc(strings.Join(parts, "\n\n"), InstructionDocMaxBytes), true
 }
@@ -158,16 +191,52 @@ func (bl *BootstrapLoader) expandImports(content, baseDir string, hop int, visit
 			out = append(out, line)
 			continue
 		}
+		// Import boundary: symlinks resolved, then the file must live under
+		// the workspace or the global instruction directory. A cloned
+		// repository's instruction file cannot pull arbitrary files from
+		// the user's disk into the prompt.
+		if !bl.importAllowed(target) {
+			if bl.logger != nil {
+				bl.logger.Warn("instruction @import outside the workspace skipped", zap.String("target", target))
+			}
+			out = append(out, line)
+			continue
+		}
 		imported, ok := bl.loadWithCache(target)
 		if !ok {
 			out = append(out, line)
 			continue
+		}
+		if len(imported) > importFileMaxBytes {
+			imported = capInstructionDoc(imported, importFileMaxBytes)
 		}
 		visited[target] = true
 		out = append(out, fmt.Sprintf("<!-- import %s -->", filepath.Base(target)))
 		out = append(out, bl.expandImports(imported, filepath.Dir(target), hop+1, visited))
 	}
 	return strings.Join(out, "\n")
+}
+
+// importAllowed reports whether an @import target, symlinks resolved,
+// lives under the workspace or the global instruction directory.
+func (bl *BootstrapLoader) importAllowed(target string) bool {
+	resolved, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		return false
+	}
+	for _, root := range []string{bl.workspaceDir, bl.globalDir} {
+		if root == "" {
+			continue
+		}
+		r, err := filepath.EvalSymlinks(root)
+		if err != nil {
+			r = filepath.Clean(root)
+		}
+		if rel, err := filepath.Rel(r, resolved); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
 }
 
 // capInstructionDoc truncates at a line boundary with a visible note.

--- a/cli/workspace/instructions_test.go
+++ b/cli/workspace/instructions_test.go
@@ -41,8 +41,13 @@ func TestInstructionHierarchy_RootToCwdWithFallbacks(t *testing.T) {
 			t.Fatalf("missing %q in:\n%s", want, out)
 		}
 	}
-	if strings.Contains(out, "GLOBAL RULES") || strings.Contains(out, "must not win") {
-		t.Fatalf("project files must shadow the global one and CHATCLI.md must beat CLAUDE.md:\n%s", out)
+	if strings.Contains(out, "must not win") {
+		t.Fatalf("CHATCLI.md must beat CLAUDE.md:\n%s", out)
+	}
+	// The global file is always merged, first (Claude Code semantics); it
+	// used to be a fallback only when the project had none.
+	if !strings.Contains(out, "GLOBAL RULES") || strings.Index(out, "GLOBAL RULES") > strings.Index(out, "ROOT RULES") {
+		t.Fatalf("global file must merge first:\n%s", out)
 	}
 	if strings.Index(out, "ROOT RULES") > strings.Index(out, "API RULES") {
 		t.Fatal("root file must come first (least specific → most specific)")

--- a/cli/workspace/rules.go
+++ b/cli/workspace/rules.go
@@ -90,6 +90,10 @@ func (rl *RulesLoader) loadAllRules() []*Rule {
 	globalRulesDir := filepath.Join(rl.globalDir, "rules")
 	rl.scanRulesDir(globalRulesDir, seen)
 
+	// Claude Code's .claude/rules are honored too (lower priority than
+	// .chatcli/rules, which overwrites a rule of the same name).
+	rl.scanRulesDir(filepath.Join(rl.workspaceDir, ".claude", "rules"), seen)
+
 	// Load workspace rules (higher priority — overwrites global)
 	workspaceRulesDir := filepath.Join(rl.workspaceDir, ".chatcli", "rules")
 	rl.scanRulesDir(workspaceRulesDir, seen)

--- a/i18n/locales/en-US.context-watch.json
+++ b/i18n/locales/en-US.context-watch.json
@@ -1,0 +1,3 @@
+{
+  "context.watch.partial": "context watch %q is partial: %d directories watched, %d could not be watched, cap %d (large trees: attach a subdirectory, or add noise directories to .gitignore)"
+}

--- a/i18n/locales/en.context-watch.json
+++ b/i18n/locales/en.context-watch.json
@@ -1,0 +1,3 @@
+{
+  "context.watch.partial": "context watch %q is partial: %d directories watched, %d could not be watched, cap %d (large trees: attach a subdirectory, or add noise directories to .gitignore)"
+}

--- a/i18n/locales/pt-BR.context-watch.json
+++ b/i18n/locales/pt-BR.context-watch.json
@@ -1,0 +1,3 @@
+{
+  "context.watch.partial": "watch do contexto %q é parcial: %d diretórios observados, %d não puderam ser observados, teto %d (árvores grandes: anexe um subdiretório ou coloque diretórios de ruído no .gitignore)"
+}


### PR DESCRIPTION
## Summary

Audit III, PR 25 (P2 RAG-3, RAG-6; P3 RAG-10). Instruction files parity.

- **Import boundary (RAG-3).** `@import` targets are symlink-resolved and must live under the workspace or the global instruction directory (`importAllowed`); each imported file is capped at 32 KiB on its own before the hierarchy cap; an out-of-tree import is logged and left as text. A cloned repo's `AGENTS.md` can no longer pull `~/.ssh/notes.md` or any other file into the prompt (Claude Code prompts for trust; Codex confines to the repo — we confine).
- **Parity (RAG-10).** The global `AGENTS.md` is always merged first (Claude Code merges global + project; it used to be a fallback); `AGENTS.local.md` / `CLAUDE.local.md` / `CHATCLI.local.md` append to their shared file (gitignored per-machine additions); `AGENTS.override.md` replaces a directory's `AGENTS.md` (Codex); `.claude/rules` is read below `.chatcli/rules` (same-name rules in `.chatcli/rules` win).
- **Watcher (RAG-6).** `watchDirsForCapped` stops at 2000 directories and reports it; directory names matched by the root's `.gitignore` (simple patterns, no negation) are skipped like the built-in noise directories; when the watch is partial or some directories could not be watched the user gets a localized warning (`context.watch.partial`, locale fragment) instead of a silent Debug line.

## Tests

`cli/workspace/audit3_pr25_test.go`: in-tree import expands, absolute and symlinked out-of-tree imports are skipped; global merged first with local additions, override replaces; per-file import cap; `.claude/rules` read and shadowed by `.chatcli/rules`. `cli/ctxmgr/audit3_pr25_test.go`: gitignored directories skipped, cap stops the walk and reports. The existing hierarchy test is updated for the always-merged global file. golangci-lint and the local gates are green.