### PR TITLE
fix(security): at-rest v2 — payloads bound to their store and tenant, passphrases stretched, fsync on reseal, 16-byte tenant digest, 0700 dirs

### DIFF
--- a/cli/ctxmgr/storage.go
+++ b/cli/ctxmgr/storage.go
@@ -31,7 +31,7 @@ var errContextCorrupt = errors.New("context file corrupt")
 // load, and a rename without fsync can survive a crash while the bytes it
 // points to do not.
 func atomicWrite(path string, data []byte) error {
-	sealed, err := atrest.Seal(data)
+	sealed, err := atrest.SealAt(path, data)
 	if err != nil {
 		return err
 	}
@@ -102,7 +102,7 @@ func (s *Storage) LoadContext(contextID string) (*FileContext, error) {
 
 	data, err := os.ReadFile(filePath) //#nosec G304 -- path supplied by user/agent through validated tool surface (boundary check upstream)
 	if err == nil {
-		data, err = atrest.Open(data)
+		data, err = atrest.OpenAt(filePath, data)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("erro ao ler contexto: %w", err)

--- a/cli/gateway_runtime_model.go
+++ b/cli/gateway_runtime_model.go
@@ -56,7 +56,7 @@ func (cli *ChatCLI) writeRuntimeModelState() {
 		return
 	}
 	path := runtimeModelStatePath()
-	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		cli.logger.Warn("gateway: could not create runtime-model state dir", zap.Error(err))
 		return
 	}

--- a/cli/journal_integrity_test.go
+++ b/cli/journal_integrity_test.go
@@ -122,5 +122,5 @@ func readJournalWithSkips(t *testing.T, path string) ([]transcriptEvent, int, er
 		return nil, 0, err
 	}
 	defer func() { _ = f.Close() }()
-	return decodeTranscriptEvents(f)
+	return decodeTranscriptEvents(f, path)
 }

--- a/cli/memory_pending.go
+++ b/cli/memory_pending.go
@@ -152,7 +152,7 @@ func (mw *memoryWorker) persistPending(messages []models.Message) (string, error
 	if dir == "" {
 		return "", fmt.Errorf("pending dir not configured")
 	}
-	if err := os.MkdirAll(dir, 0o750); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", err
 	}
 	// The queue holds raw conversation on disk until extraction runs:

--- a/cli/session_manager.go
+++ b/cli/session_manager.go
@@ -299,7 +299,7 @@ func (sm *SessionManager) SaveSessionV2(name string, sd *SessionData) error {
 	// before the write so every producer of this store — REPL save, exit
 	// autosave, MCP session mirrors, write-through — is covered by the one
 	// call. A no-op when no key is configured.
-	data, err = atrest.Seal(data)
+	data, err = atrest.SealAt(filePath, data)
 	if err != nil {
 		sm.logger.Error("Erro ao criptografar a sessão", zap.String("session", name), zap.Error(err))
 		return fmt.Errorf("%s: %w", i18n.T("session.encrypt_failed"), err)
@@ -374,7 +374,7 @@ func (sm *SessionManager) LoadSessionV2(name string) (*SessionData, error) {
 	// was configured) pass through and are sealed on their next save; an
 	// encrypted file with no key present is a clear error, never a silently
 	// empty or "corrupt" session.
-	data, err = atrest.Open(data)
+	data, err = atrest.OpenAt(filePath, data)
 	if err != nil {
 		sm.logger.Error("Erro ao decriptar a sessão", zap.String("session", name), zap.Error(err))
 		return nil, fmt.Errorf("%s: %w", i18n.T("session.decrypt_failed", name), err)

--- a/cli/tenant_scope.go
+++ b/cli/tenant_scope.go
@@ -121,7 +121,16 @@ func tenantRootFor(base, principal string) string {
 		safe = safe[:48]
 	}
 	sum := sha256.Sum256([]byte(principal))
-	return filepath.Join(base, "tenants", safe+"-"+hex.EncodeToString(sum[:4]))
+	root := filepath.Join(base, "tenants", safe+"-"+hex.EncodeToString(sum[:16]))
+	// Roots created by earlier builds carried a 32-bit digest; keep using
+	// them so a gateway upgrade never orphans a tenant's state.
+	legacy := filepath.Join(base, "tenants", safe+"-"+hex.EncodeToString(sum[:4]))
+	if _, err := os.Stat(root); err != nil {
+		if _, lerr := os.Stat(legacy); lerr == nil {
+			return legacy
+		}
+	}
+	return root
 }
 
 // captureStores snapshots the ChatCLI's current store handles and live

--- a/cli/tenant_scope_test.go
+++ b/cli/tenant_scope_test.go
@@ -7,6 +7,7 @@ package cli
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -28,7 +29,8 @@ func TestTenantRootFor_SafeAndDistinct(t *testing.T) {
 		t.Fatalf("unsafe characters in %s", a)
 	}
 	long := tenantRootFor("/base", strings.Repeat("x", 200))
-	if len(filepath.Base(long)) > 48+1+8 {
+	// 48-char slug + "-" + 16-byte digest as hex (32 chars).
+	if len(filepath.Base(long)) > 48+1+32 {
 		t.Fatalf("slug not capped: %s", filepath.Base(long))
 	}
 }
@@ -119,4 +121,21 @@ func TestEnterTenant_EvictsLeastRecentlyUsed(t *testing.T) {
 		t.Fatalf("rebuilt tenant store = %s", cli.sessionManager.sessionsDir)
 	}
 	leave()
+}
+
+func TestTenantRootFor_KeepsLegacyDigestRoots(t *testing.T) {
+	base := t.TempDir()
+	fresh := tenantRootFor(base, "slack:u1")
+	if len(filepath.Base(fresh)) != len("slack_u1-")+32 {
+		t.Fatalf("new roots carry the 16-byte digest: %s", filepath.Base(fresh))
+	}
+	// A root created by an earlier build (32-bit digest) keeps being used
+	// so an upgrade never orphans a tenant's state.
+	legacy := filepath.Join(base, "tenants", "slack_u1-"+filepath.Base(fresh)[len("slack_u1-"):len("slack_u1-")+8])
+	if err := os.MkdirAll(legacy, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if got := tenantRootFor(base, "slack:u1"); got != legacy {
+		t.Fatalf("legacy root must win while it exists: %s", got)
+	}
 }

--- a/cli/transcript_journal.go
+++ b/cli/transcript_journal.go
@@ -273,7 +273,7 @@ func (j *transcriptJournal) appendEvents(events []transcriptEvent) error {
 			return err
 		}
 		if atrest.Enabled() {
-			sealed, err := atrest.Seal(line)
+			sealed, err := atrest.SealAt(j.path, line)
 			if err != nil {
 				_ = f.Close()
 				return err
@@ -374,7 +374,7 @@ func readTranscriptEvents(path string) ([]transcriptEvent, error) {
 		return nil, err
 	}
 	defer func() { _ = f.Close() }()
-	events, _, err := decodeTranscriptEvents(f)
+	events, _, err := decodeTranscriptEvents(f, path)
 	return events, err
 }
 
@@ -384,7 +384,7 @@ func readTranscriptEvents(path string) ([]transcriptEvent, error) {
 // disable undo, checkpoints and export for the session). A sealed line
 // this process cannot open is an error: that is a key problem, not a
 // corrupt journal. Returns the events and how many lines were skipped.
-func decodeTranscriptEvents(r io.Reader) ([]transcriptEvent, int, error) {
+func decodeTranscriptEvents(r io.Reader, path string) ([]transcriptEvent, int, error) {
 	br := bufio.NewReaderSize(r, 1024*1024)
 	var out []transcriptEvent
 	skipped := 0
@@ -393,7 +393,7 @@ func decodeTranscriptEvents(r io.Reader) ([]transcriptEvent, int, error) {
 		torn := rerr != nil && len(line) > 0 // no trailing newline: partial write
 		line = bytes.TrimRight(line, "\r\n")
 		if len(line) > 0 && !torn {
-			ev, ok, oerr := decodeTranscriptLine(line)
+			ev, ok, oerr := decodeTranscriptLine(line, path)
 			if oerr != nil {
 				return out, skipped, oerr
 			}
@@ -416,13 +416,13 @@ func decodeTranscriptEvents(r io.Reader) ([]transcriptEvent, int, error) {
 
 // decodeTranscriptLine parses one line; ok is false for a line that is not
 // a journal event.
-func decodeTranscriptLine(line []byte) (transcriptEvent, bool, error) {
+func decodeTranscriptLine(line []byte, path string) (transcriptEvent, bool, error) {
 	if bytes.HasPrefix(line, []byte(sealedLinePrefix)) {
 		raw, err := base64.StdEncoding.DecodeString(string(line[len(sealedLinePrefix):]))
 		if err != nil {
 			return transcriptEvent{}, false, nil
 		}
-		plain, err := atrest.Open(raw)
+		plain, err := atrest.OpenAt(path, raw)
 		if err != nil {
 			return transcriptEvent{}, false, err
 		}

--- a/cli/workspace/memory/persist.go
+++ b/cli/workspace/memory/persist.go
@@ -35,7 +35,7 @@ import (
 // and an atomic rename (utils.AtomicWriteFile), so readers, crashes and power
 // loss only ever observe the old or the new content — never a torn write.
 func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
-	sealed, err := atrest.Seal(data)
+	sealed, err := atrest.SealAt(path, data)
 	if err != nil {
 		return err
 	}
@@ -53,7 +53,7 @@ func readStoreFile(path string) ([]byte, error) {
 		return nil, err
 	}
 	if atrest.IsEncrypted(data) {
-		plain, oerr := atrest.Open(data)
+		plain, oerr := atrest.OpenAt(path, data)
 		if oerr != nil {
 			return nil, &SealedStoreError{Path: path, Err: oerr}
 		}

--- a/pkg/atrest/atrest.go
+++ b/pkg/atrest/atrest.go
@@ -31,14 +31,29 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 
+	"github.com/diillson/chatcli/utils"
+	"golang.org/x/crypto/argon2"
 	"golang.org/x/crypto/hkdf"
 )
 
 const (
-	// Magic is the header every encrypted payload starts with.
+	// Magic is the header every version-1 encrypted payload starts with
+	// (no additional authenticated data).
 	Magic = "CHATCLI_ENC_v1\n"
+	// MagicV2 heads payloads bound to their store location: the AEAD's
+	// additional data is the store's relative path and tenant, so a file
+	// copied from one tenant's directory into another's (or renamed) no
+	// longer opens as if it belonged there. Version-1 payloads stay
+	// readable and are rewritten as v2 on their next save or reseal.
+	MagicV2 = "CHATCLI_ENC_v2\n"
+	// ShortSecretBytes is the length under which a secret is treated as a
+	// passphrase and stretched with Argon2id before key derivation; a
+	// random secret of at least this many bytes goes straight to HKDF.
+	ShortSecretBytes = 32
 	// EnvKey is the environment variable that opts a process into
 	// encryption at rest and supplies the master secret.
 	EnvKey = "CHATCLI_ENCRYPTION_KEY"
@@ -125,7 +140,7 @@ func (e *Encryptor) gcm() (cipher.AEAD, error) {
 
 // IsEncrypted reports whether data carries the encrypted-payload header.
 func IsEncrypted(data []byte) bool {
-	return len(data) >= len(Magic) && string(data[:len(Magic)]) == Magic
+	return (len(data) >= len(Magic) && string(data[:len(Magic)]) == Magic) || isV2(data)
 }
 
 // Enabled reports whether the process opted into encryption at rest.
@@ -133,16 +148,178 @@ func Enabled() bool {
 	return os.Getenv(EnvKey) != ""
 }
 
-// fromEnv builds the session-class Encryptor from CHATCLI_ENCRYPTION_KEY.
-// Re-derived per call: the derivation costs microseconds and reading the
-// environment each time keeps behavior consistent with a runtime reload.
+// fromEnv builds the version-1 Encryptor from CHATCLI_ENCRYPTION_KEY
+// (SHA-256 of the secret into HKDF). Re-derived per call: the derivation
+// costs microseconds and reading the environment each time keeps
+// behavior consistent with a runtime reload.
 func fromEnv() (*Encryptor, error) {
 	secret := os.Getenv(EnvKey)
 	if secret == "" {
 		return nil, ErrKeyMissing
 	}
+	return legacyEncryptor(secret)
+}
+
+// legacyEncryptor is the v1 derivation for a secret.
+func legacyEncryptor(secret string) (*Encryptor, error) {
 	master := sha256.Sum256([]byte(secret))
 	return NewFromMaster(master[:], SessionInfo)
+}
+
+// v2Encryptor derives the version-2 key: a random secret of at least
+// ShortSecretBytes goes to HKDF as before; a shorter one is a passphrase
+// and is stretched with Argon2id (64 MiB, 3 passes) first, cached per
+// secret because the stretch costs real time.
+func v2Encryptor(secret string) (*Encryptor, error) {
+	if len(secret) >= ShortSecretBytes {
+		master := sha256.Sum256([]byte(secret))
+		return NewFromMaster(master[:], SessionInfo)
+	}
+	stretchMu.Lock()
+	master, ok := stretched[secret]
+	stretchMu.Unlock()
+	if !ok {
+		master = argon2.IDKey([]byte(secret), []byte(argonSalt), 3, 64*1024, 4, 32)
+		stretchMu.Lock()
+		stretched[secret] = master
+		stretchMu.Unlock()
+	}
+	return NewFromMaster(master, SessionInfo)
+}
+
+// argonSalt is the fixed application salt for passphrase stretching (the
+// secret is per installation; the salt separates this use from any other
+// Argon2 use of the same passphrase).
+const argonSalt = "chatcli-atrest-v2-passphrase"
+
+var (
+	stretchMu sync.Mutex
+	stretched = map[string][]byte{}
+)
+
+// aadFor derives the additional authenticated data that binds a payload
+// to its store: the tenant slug and the last path components under the
+// state root. "" (no path) binds nothing — the v2 format without a
+// location, still stretched and authenticated.
+func aadFor(path string) []byte {
+	if path == "" {
+		return nil
+	}
+	clean := filepath.ToSlash(filepath.Clean(path))
+	tenant := ""
+	rel := clean
+	if i := strings.Index(clean, "/tenants/"); i >= 0 {
+		rest := clean[i+len("/tenants/"):]
+		if j := strings.IndexByte(rest, '/'); j > 0 {
+			tenant, rel = rest[:j], rest[j+1:]
+		}
+	} else if i := strings.Index(clean, "/.chatcli/"); i >= 0 {
+		rel = clean[i+len("/.chatcli/"):]
+	} else {
+		// Custom roots: bind to the store's own directory and name.
+		rel = filepath.ToSlash(filepath.Join(filepath.Base(filepath.Dir(clean)), filepath.Base(clean)))
+	}
+	return []byte("v2\x00" + rel + "\x00" + tenant)
+}
+
+// SealAt encrypts plaintext bound to the store at path (version 2). A
+// no-op when encryption at rest is off.
+func SealAt(path string, plaintext []byte) ([]byte, error) {
+	if !Enabled() {
+		return plaintext, nil
+	}
+	enc, err := v2Encryptor(os.Getenv(EnvKey))
+	if err != nil {
+		return nil, err
+	}
+	return enc.encryptV2(plaintext, aadFor(path))
+}
+
+// OpenAt decrypts a payload sealed for the store at path: version 2 with
+// the current or a retired key, version 1 through Open. Plaintext passes
+// through.
+func OpenAt(path string, data []byte) ([]byte, error) {
+	if !isV2(data) {
+		return Open(data)
+	}
+	secret := os.Getenv(EnvKey)
+	if secret == "" {
+		return nil, ErrKeyMissing
+	}
+	// Bound to this path first; a payload sealed without a location (Seal,
+	// or a store that has not been resealed at its path yet) carries no
+	// binding and opens with the empty AAD.
+	aads := [][]byte{aadFor(path)}
+	if path != "" {
+		aads = append(aads, nil)
+	}
+	enc, err := v2Encryptor(secret)
+	if err != nil {
+		return nil, err
+	}
+	var firstErr error
+	for _, aad := range aads {
+		plain, derr := enc.decryptV2(data, aad)
+		if derr == nil {
+			return plain, nil
+		}
+		if firstErr == nil {
+			firstErr = derr
+		}
+	}
+	for _, old := range previousSecrets() {
+		oe, derr := v2Encryptor(old)
+		if derr != nil {
+			continue
+		}
+		for _, aad := range aads {
+			if plain, perr := oe.decryptV2(data, aad); perr == nil {
+				return plain, nil
+			}
+		}
+	}
+	return nil, firstErr
+}
+
+func isV2(data []byte) bool {
+	return len(data) >= len(MagicV2) && string(data[:len(MagicV2)]) == MagicV2
+}
+
+// encryptV2 returns MagicV2 + nonce + ciphertext authenticated with aad.
+func (e *Encryptor) encryptV2(plaintext, aad []byte) ([]byte, error) {
+	gcm, err := e.gcm()
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("atrest: nonce generation failed: %w", err)
+	}
+	out := make([]byte, 0, len(MagicV2)+len(nonce)+len(plaintext)+gcm.Overhead())
+	out = append(out, MagicV2...)
+	out = append(out, nonce...)
+	return gcm.Seal(out, nonce, plaintext, aad), nil
+}
+
+// decryptV2 validates the v2 header and opens the payload with aad.
+func (e *Encryptor) decryptV2(data, aad []byte) ([]byte, error) {
+	if !isV2(data) {
+		return nil, errors.New("atrest: not a version-2 payload")
+	}
+	gcm, err := e.gcm()
+	if err != nil {
+		return nil, err
+	}
+	body := data[len(MagicV2):]
+	if len(body) < gcm.NonceSize() {
+		return nil, errors.New("atrest: payload too short for nonce")
+	}
+	nonce, ciphertext := body[:gcm.NonceSize()], body[gcm.NonceSize():]
+	plain, err := gcm.Open(nil, nonce, ciphertext, aad)
+	if err != nil {
+		return nil, fmt.Errorf("atrest: decryption failed (tampered, wrong key, or moved between stores): %w", err)
+	}
+	return plain, nil
 }
 
 // Seal encrypts plaintext when encryption at rest is enabled and returns it
@@ -151,11 +328,11 @@ func Seal(plaintext []byte) ([]byte, error) {
 	if !Enabled() {
 		return plaintext, nil
 	}
-	enc, err := fromEnv()
+	enc, err := v2Encryptor(os.Getenv(EnvKey))
 	if err != nil {
 		return nil, err
 	}
-	return enc.Encrypt(plaintext)
+	return enc.encryptV2(plaintext, nil)
 }
 
 // Open decrypts an encrypted payload and passes plaintext through untouched.
@@ -166,6 +343,9 @@ func Seal(plaintext []byte) ([]byte, error) {
 func Open(data []byte) ([]byte, error) {
 	if !IsEncrypted(data) {
 		return data, nil
+	}
+	if isV2(data) {
+		return OpenAt("", data)
 	}
 	enc, err := fromEnv()
 	if err != nil {
@@ -206,14 +386,20 @@ func previousSecrets() []string {
 // SealedWithCurrentKey reports whether data opens with the current key
 // alone (false for plaintext and for payloads only a retired key opens).
 func SealedWithCurrentKey(data []byte) bool {
-	if !IsEncrypted(data) {
+	return sealedWithCurrentKeyAt("", data)
+}
+
+// sealedWithCurrentKeyAt is SealedWithCurrentKey for a payload bound to
+// path; a version-1 payload is never "current" (it lacks the binding).
+func sealedWithCurrentKeyAt(path string, data []byte) bool {
+	if !isV2(data) {
 		return false
 	}
-	enc, err := fromEnv()
+	enc, err := v2Encryptor(os.Getenv(EnvKey))
 	if err != nil {
 		return false
 	}
-	_, err = enc.Decrypt(data)
+	_, err = enc.decryptV2(data, aadFor(path))
 	return err == nil
 }
 
@@ -240,14 +426,14 @@ func ResealFile(path string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if len(data) == 0 || SealedWithCurrentKey(data) {
+	if len(data) == 0 || sealedWithCurrentKeyAt(path, data) {
 		return false, nil
 	}
-	plain, err := Open(data)
+	plain, err := OpenAt(path, data)
 	if err != nil {
 		return false, err
 	}
-	sealed, err := Seal(plain)
+	sealed, err := SealAt(path, plain)
 	if err != nil {
 		return false, err
 	}
@@ -255,12 +441,9 @@ func ResealFile(path string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	tmp := path + ".reseal.tmp"
-	if err := os.WriteFile(tmp, sealed, info.Mode().Perm()); err != nil { // #nosec G304 G703 -- same operator-owned store path as the read above
-		return false, err
-	}
-	if err := os.Rename(tmp, path); err != nil { // #nosec G703 -- same operator-owned store path
-		_ = os.Remove(tmp)
+	// fsync'd temp + rename: a power loss between the write and the rename
+	// must never leave an empty store behind the old name.
+	if err := utils.AtomicWriteFile(path, sealed, info.Mode().Perm()); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -284,14 +467,14 @@ func ResealLines(path, linePrefix string) (int, error) {
 			continue
 		}
 		raw, err := base64.StdEncoding.DecodeString(line[len(linePrefix):])
-		if err != nil || SealedWithCurrentKey(raw) {
+		if err != nil || sealedWithCurrentKeyAt(path, raw) {
 			continue
 		}
-		plain, err := Open(raw)
+		plain, err := OpenAt(path, raw)
 		if err != nil {
 			return changed, fmt.Errorf("line %d: %w", i+1, err)
 		}
-		sealed, err := Seal(plain)
+		sealed, err := SealAt(path, plain)
 		if err != nil {
 			return changed, err
 		}
@@ -305,12 +488,7 @@ func ResealLines(path, linePrefix string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	tmp := path + ".reseal.tmp"
-	if err := os.WriteFile(tmp, []byte(strings.Join(lines, "\n")), info.Mode().Perm()); err != nil { // #nosec G304 G703 -- same operator-owned store path as the read above
-		return 0, err
-	}
-	if err := os.Rename(tmp, path); err != nil { // #nosec G703 -- same operator-owned store path
-		_ = os.Remove(tmp)
+	if err := utils.AtomicWriteFile(path, []byte(strings.Join(lines, "\n")), info.Mode().Perm()); err != nil {
 		return 0, err
 	}
 	return changed, nil

--- a/pkg/atrest/audit3_pr23_test.go
+++ b/pkg/atrest/audit3_pr23_test.go
@@ -1,0 +1,109 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package atrest
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSealAt_BindsThePayloadToItsStore(t *testing.T) {
+	t.Setenv(EnvKey, "0123456789abcdef0123456789abcdef-long-random-key")
+	a := "/home/u/.chatcli/tenants/alice-aaaa/sessions/work.json"
+	b := "/home/u/.chatcli/tenants/bob-bbbb/sessions/work.json"
+	sealed, err := SealAt(a, []byte(`{"secret":"alice"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isV2(sealed) || !IsEncrypted(sealed) {
+		t.Fatal("v2 header expected")
+	}
+	if plain, err := OpenAt(a, sealed); err != nil || string(plain) != `{"secret":"alice"}` {
+		t.Fatalf("own store must open: %v", err)
+	}
+	if _, err := OpenAt(b, sealed); err == nil {
+		t.Fatal("a file copied into another tenant's directory must not open")
+	}
+	if _, err := OpenAt(strings.Replace(a, "work.json", "other.json", 1), sealed); err == nil {
+		t.Fatal("a renamed store must not open")
+	}
+	// The unbound form (no path) round-trips and is v2 too.
+	unbound, _ := Seal([]byte("x"))
+	if plain, err := Open(unbound); err != nil || string(plain) != "x" {
+		t.Fatalf("unbound v2: %v", err)
+	}
+}
+
+func TestOpenAt_ReadsVersionOneAndRetiredKeys(t *testing.T) {
+	t.Setenv(EnvKey, "old-secret")
+	legacy, _ := legacyEncryptor("old-secret")
+	v1, err := legacy.Encrypt([]byte("legacy payload"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plain, err := OpenAt("/x/.chatcli/sessions/s.json", v1); err != nil || string(plain) != "legacy payload" {
+		t.Fatalf("v1 must still open: %v", err)
+	}
+	path := "/x/.chatcli/memory/facts.json"
+	v2, _ := SealAt(path, []byte("rotated"))
+	t.Setenv(EnvKey, "new-secret")
+	t.Setenv(EnvPreviousKeys, "old-secret")
+	if plain, err := OpenAt(path, v2); err != nil || string(plain) != "rotated" {
+		t.Fatalf("a retired key must still open v2: %v", err)
+	}
+	if sealedWithCurrentKeyAt(path, v2) {
+		t.Fatal("sealed with the retired key is not current")
+	}
+}
+
+func TestShortSecret_IsStretchedAndStillRoundTrips(t *testing.T) {
+	t.Setenv(EnvKey, "hunter2")
+	sealed, err := SealAt("/x/.chatcli/sessions/s.json", []byte("pw"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plain, err := OpenAt("/x/.chatcli/sessions/s.json", sealed); err != nil || string(plain) != "pw" {
+		t.Fatalf("short secret round trip: %v", err)
+	}
+	// The v2 key of a short secret is not the v1 key of the same secret.
+	short, _ := v2Encryptor("hunter2")
+	old, _ := legacyEncryptor("hunter2")
+	if string(short.key) == string(old.key) {
+		t.Fatal("passphrases must be stretched")
+	}
+	long := strings.Repeat("k", ShortSecretBytes)
+	a, _ := v2Encryptor(long)
+	b, _ := legacyEncryptor(long)
+	if string(a.key) != string(b.key) {
+		t.Fatal("a random key of full length keeps the HKDF derivation")
+	}
+}
+
+func TestResealFile_RewritesV1AsBoundV2(t *testing.T) {
+	t.Setenv(EnvKey, "0123456789abcdef0123456789abcdef-long-random-key")
+	dir := filepath.Join(t.TempDir(), ".chatcli", "sessions")
+	_ = os.MkdirAll(dir, 0o700)
+	path := filepath.Join(dir, "s.json")
+	legacy, _ := legacyEncryptor(os.Getenv(EnvKey))
+	v1, _ := legacy.Encrypt([]byte("data"))
+	_ = os.WriteFile(path, v1, 0o600)
+	changed, err := ResealFile(path)
+	if err != nil || !changed {
+		t.Fatalf("v1 must be resealed: %v %v", changed, err)
+	}
+	raw, _ := os.ReadFile(path)
+	if !isV2(raw) {
+		t.Fatal("resealed file must be v2")
+	}
+	if plain, err := OpenAt(path, raw); err != nil || string(plain) != "data" {
+		t.Fatalf("resealed opens at its path: %v", err)
+	}
+	if changed, _ := ResealFile(path); changed {
+		t.Fatal("already current: no rewrite")
+	}
+}

--- a/pkg/atrest/rotation_test.go
+++ b/pkg/atrest/rotation_test.go
@@ -50,7 +50,8 @@ func TestRotation_PreviousKeyOpensAndResealMigrates(t *testing.T) {
 		t.Fatalf("reseal: %v %v", err, changed)
 	}
 	data, _ := os.ReadFile(file)
-	if !SealedWithCurrentKey(data) {
+	// Resealed at its path: bound to the store, current key.
+	if !sealedWithCurrentKeyAt(file, data) {
 		t.Fatal("file must now be sealed with the current key")
 	}
 	if changed, _ := ResealFile(file); changed {
@@ -69,7 +70,7 @@ func TestRotation_PreviousKeyOpensAndResealMigrates(t *testing.T) {
 	}
 	// Retire the old key: everything still opens.
 	t.Setenv(EnvPreviousKeys, "")
-	if _, err := Open(mustRead(t, file)); err != nil {
+	if _, err := OpenAt(file, mustRead(t, file)); err != nil {
 		t.Fatal("resealed store must open with the current key alone")
 	}
 	t.Setenv(EnvKey, "")


### PR DESCRIPTION
## Summary

Audit III, PR 23 (P1 SEC-5; P3 SEC-12). Encryption at rest, version 2.

- **Store binding (SEC-5).** `atrest.SealAt(path, plaintext)` / `OpenAt(path, data)` write `CHATCLI_ENC_v2` payloads whose AEAD additional data is `v2 ‖ relative store path ‖ tenant slug` (the components under `~/.chatcli/` or under `tenants/<slug>/`; the store's directory and name for custom roots). A file copied from tenant A into tenant B, or renamed, no longer opens. The memory stores, sessions, contexts and the transcript journal seal at their path; `Seal`/`Open` (no path) produce and read unbound v2 payloads; `OpenAt` also accepts unbound v2 and v1, and the retired keys, so every existing file keeps loading and is rewritten bound on its next save or reseal.
- **Passphrases (SEC-5).** A secret shorter than 32 bytes is stretched with Argon2id (64 MiB, 3 passes, fixed application salt, cached per secret) before HKDF; a random key of full length keeps the HKDF derivation, so the documented ≥32-byte key is unchanged.
- **Reseal (SEC-12).** `ResealFile` / `ResealLines` write through the fsync'd atomic helper and rewrite v1 or unbound payloads as bound v2.
- **Tenant digest and dirs (SEC-12).** The tenant root digest is 16 bytes (32 hex); roots created with the 32-bit digest keep being used so an upgrade never orphans a tenant. The memory pending queue and the gateway runtime-model directories are created 0700.

## Tests

`pkg/atrest/audit3_pr23_test.go`: bound payload opens at its path, not in another tenant or under another name; unbound v2 round-trips; v1 and retired keys still open; short secrets are stretched and round-trip; reseal rewrites v1 as bound v2 and is idempotent. The rotation test and the tenant-root test are updated for the bound and longer-digest semantics; a new test covers the legacy-root fallback. golangci-lint and the local gates are green.