### PR TITLE
fix(memory): hygiene batch — rune-safe cuts, test-only helpers out of production, CCR skip surfaced, coder read line cap, transcript cap and plaintext notice, isolation refusal, external-only memory provider, worktree-aware projects

### DIFF
--- a/cli/audit3_pr27_test.go
+++ b/cli/audit3_pr27_test.go
@@ -1,0 +1,80 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/diillson/chatcli/cli/workspace/memory"
+)
+
+func TestRuneSafeCuts_MemoryPaths(t *testing.T) {
+	s := strings.Repeat("é", 700) // 1400 bytes of 2-byte runes
+	head := truncateRunesafe(s, 1200)
+	tail := tailRunesafe(s, 200)
+	if !utf8.ValidString(head) || !utf8.ValidString(tail) || len(head) > 1200+utf8.UTFMax || len(tail) > 200 {
+		t.Fatalf("head=%d tail=%d valid=%v/%v", len(head), len(tail), utf8.ValidString(head), utf8.ValidString(tail))
+	}
+	if tailRunesafe("short", 200) != "short" {
+		t.Fatal("short input untouched")
+	}
+}
+
+func TestMemoryProvider_ExclusiveValue(t *testing.T) {
+	if s, ok := extensionTarget("mcp-only:memsvc"); !ok || s != "memsvc" {
+		t.Fatalf("mcp-only must select the server: %q %v", s, ok)
+	}
+	if !memoryProviderExclusive("MCP-ONLY:memsvc") || memoryProviderExclusive("mcp:memsvc") {
+		t.Fatal("exclusive detection")
+	}
+	if extensionStatus("mcp-only:memsvc") != "mcp-only:memsvc" || extensionStatus("provider") != "provider" || extensionStatus("") != "builtin" {
+		t.Fatal("status rendering")
+	}
+}
+
+func TestSameProject_GitWorktreesAreOneProject(t *testing.T) {
+	root := t.TempDir()
+	main := filepath.Join(root, "repo")
+	common := filepath.Join(main, ".git")
+	if err := os.MkdirAll(filepath.Join(common, "worktrees", "feature"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	wt := filepath.Join(root, "repo-feature")
+	if err := os.MkdirAll(wt, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wt, ".git"), []byte("gitdir: "+filepath.Join(common, "worktrees", "feature")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !memory.SameProject(main, wt) {
+		t.Fatal("a git worktree and its main checkout are one project")
+	}
+	other := filepath.Join(root, "other")
+	_ = os.MkdirAll(filepath.Join(other, ".git"), 0o700)
+	if memory.SameProject(main, other) {
+		t.Fatal("distinct repositories stay distinct")
+	}
+}
+
+func TestBootstrapCard_RefreshesWhenItWasEmpty(t *testing.T) {
+	c := &ChatCLI{}
+	st := c.bootstrapCardState()
+	st.once.Do(func() {}) // computed empty (fresh install)
+	c.refreshBootstrapCard()
+	if c.bootstrapCard == st {
+		t.Fatal("an empty card must be rebuilt at the next boundary")
+	}
+	filled := c.bootstrapCardState()
+	filled.once.Do(func() { filled.chat = "card" })
+	c.refreshBootstrapCard()
+	if c.bootstrapCard != filled {
+		t.Fatal("a filled card is kept")
+	}
+}

--- a/cli/compaction_hooks.go
+++ b/cli/compaction_hooks.go
@@ -119,6 +119,7 @@ func (cli *ChatCLI) compactionEvent(typ hooks.EventType, trigger string) hooks.H
 // loop: cost record from the compactor's report, cache-rebuild note for
 // the cache telemetry, PostCompact hooks.
 func (cli *ChatCLI) noteCompactionApplied(ctx context.Context, trigger string) {
+	cli.refreshBootstrapCard()
 	if cli == nil {
 		return
 	}

--- a/cli/compress/layer.go
+++ b/cli/compress/layer.go
@@ -34,12 +34,13 @@ func isRecallTool(toolName string) bool {
 //
 // The zero Layer is not usable; build one with NewLayer or NewLayerFromEnv.
 type Layer struct {
-	router    atomic.Pointer[ContentRouter] // swapped whole on SetProfile
-	store     Store
-	mode      atomic.Int32 // holds a Mode; mutable at runtime via SetMode (/config compression)
-	profile   atomic.Int32 // holds a Profile; mutable at runtime via SetProfile
-	threshold atomic.Int64 // bytes; mutable at runtime via SetThreshold
-	metrics   *Metrics
+	archiveSkips atomic.Int64                  // archives refused by the store (per-entry cap)
+	router       atomic.Pointer[ContentRouter] // swapped whole on SetProfile
+	store        Store
+	mode         atomic.Int32 // holds a Mode; mutable at runtime via SetMode (/config compression)
+	profile      atomic.Int32 // holds a Profile; mutable at runtime via SetProfile
+	threshold    atomic.Int64 // bytes; mutable at runtime via SetThreshold
+	metrics      *Metrics
 
 	// storeFallbackErr records why the persistent CCR store could not be
 	// opened when the layer had to fall back to a bounded in-memory store.
@@ -294,9 +295,22 @@ func (l *Layer) Archive(content string) (string, bool) {
 	}
 	key, err := l.store.Put(content)
 	if err != nil {
+		// The largest cuts are exactly the ones that lose "recoverable via
+		// @recall" here; count it so the callers can say so instead of
+		// skipping silently (ArchiveSkips).
+		l.archiveSkips.Add(1)
 		return "", false
 	}
 	return key, true
+}
+
+// ArchiveSkips reports how many archives the store refused this session
+// (over the per-entry cap); surfaced by /cost and /context status.
+func (l *Layer) ArchiveSkips() int64 {
+	if l == nil {
+		return 0
+	}
+	return l.archiveSkips.Load()
 }
 
 // Recall returns the original content stored under a CCR key, or ok=false when

--- a/cli/config_env_defaults.go
+++ b/cli/config_env_defaults.go
@@ -154,7 +154,7 @@ var envDefaults = map[string]envDefault{
 	"CHATCLI_MANAGED_CONFIG":               {Value: "(/etc/chatcli/managed.env · %ProgramData%\\chatcli\\managed.env)", Source: "config/managed.go (org defaults; !KEY=value locks)"},
 	"CHATCLI_PROMPT_CACHE_EXPLICIT":        {Value: "false", Source: "llm/client/cache_resources.go (Gemini cachedContents; bills storage per token-hour)"},
 	"CHATCLI_CONTEXT_ENGINE":               {Value: "builtin", Source: "extension_providers.go (builtin | mcp:<server> with a context_compact tool)"},
-	"CHATCLI_MEMORY_PROVIDER":              {Value: "builtin", Source: "extension_providers.go (builtin | mcp:<server> with memory_recall/memory_store tools)"},
+	"CHATCLI_MEMORY_PROVIDER":              {Value: "builtin", Source: "extension_providers.go (builtin | mcp:<server> alongside the embedded memory | mcp-only:<server> external only)"},
 	"CHATCLI_COMPACT_MODEL":                {Value: "(session client)", Source: "compact_config.go (PROVIDER:model for Level 2 summaries)"},
 	"CHATCLI_MICROCOMPACT_TRUNCATE_TURNS":  {Value: "2", Source: "agent.DefaultMicrocompactConfig"},
 	"CHATCLI_MICROCOMPACT_SUMMARIZE_TURNS": {Value: "4", Source: "agent.DefaultMicrocompactConfig"},

--- a/cli/context_status.go
+++ b/cli/context_status.go
@@ -220,6 +220,9 @@ func (cli *ChatCLI) showContextStatus(ctx context.Context) {
 	if r.ReserveTokens > 0 {
 		fmt.Printf("    %s %s tok\n", kitPad(i18n.T("context.status.total_reserve")), formatTokenCount(int64(r.ReserveTokens)))
 	}
+	if skips := cli.compressionLayer.ArchiveSkips(); skips > 0 {
+		fmt.Printf("    %s\n", colorize(i18n.T("context.status.ccr_skips", skips), ColorYellow))
+	}
 	if edits, toolUses, tokens := cli.costTracker.ContextEditStats(); edits > 0 {
 		fmt.Printf("    %s\n", colorize(i18n.T("context.status.provider_edits", edits, toolUses, formatTokenCount(tokens)), ColorGray))
 	}

--- a/cli/extension_providers.go
+++ b/cli/extension_providers.go
@@ -67,10 +67,15 @@ func extensionTarget(raw string) (server string, ok bool) {
 	if v == "" || strings.EqualFold(v, "builtin") {
 		return "", false
 	}
-	if !strings.HasPrefix(strings.ToLower(v), "mcp:") {
+	lower := strings.ToLower(v)
+	switch {
+	case strings.HasPrefix(lower, "mcp-only:"):
+		server = strings.TrimSpace(v[len("mcp-only:"):])
+	case strings.HasPrefix(lower, "mcp:"):
+		server = strings.TrimSpace(v[4:])
+	default:
 		return "", false
 	}
-	server = strings.TrimSpace(v[4:])
 	return server, server != ""
 }
 
@@ -141,7 +146,7 @@ func (cli *ChatCLI) externalMemoryRecall(ctx context.Context, query string, hint
 		return ""
 	}
 	if len(text) > extRecallBudget {
-		text = text[:extRecallBudget] + "…"
+		text = truncateRunesafe(text, extRecallBudget) + "…"
 	}
 	return text
 }
@@ -264,7 +269,20 @@ func (cli *ChatCLI) forwardNewHistory(ctx context.Context, st *extForwardState, 
 // extensionStatus renders the configured extension points for /config.
 func extensionStatus(raw string) string {
 	if server, ok := extensionTarget(raw); ok {
+		if memoryProviderExclusive(raw) {
+			return "mcp-only:" + server
+		}
 		return "mcp:" + server
 	}
+	if strings.EqualFold(strings.TrimSpace(raw), "provider") {
+		return "provider"
+	}
 	return "builtin"
+}
+
+// memoryProviderExclusive reports whether raw selects the external memory
+// provider ALONE ("mcp-only:<server>"): the embedded recall block is not
+// built, only the provider's answer rides in the auto-recall block.
+func memoryProviderExclusive(raw string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(raw)), "mcp-only:")
 }

--- a/cli/memory_autorecall.go
+++ b/cli/memory_autorecall.go
@@ -118,7 +118,7 @@ func autoRecallEpisodeLine(e *memory.Episode) string {
 		text += " → " + strings.TrimSpace(e.Outcome)
 	}
 	if len(text) > autoRecallEpisodeLineMax {
-		text = text[:autoRecallEpisodeLineMax] + "…"
+		text = truncateRunesafe(text, autoRecallEpisodeLineMax) + "…"
 	}
 	return "- [episode " + e.Date.Format("2006-01-02") + "] " + text
 }
@@ -127,7 +127,10 @@ func (cli *ChatCLI) memoryAutoRecallBlockCtx(ctx context.Context, hints []string
 	if !memoryAutoRecallEnabled() || len(hints) == 0 {
 		return ""
 	}
-	block := cli.builtinAutoRecallBlock(ctx, hints, query)
+	block := ""
+	if !memoryProviderExclusive(os.Getenv(MemoryProviderEnv)) {
+		block = cli.builtinAutoRecallBlock(ctx, hints, query)
+	}
 	// External memory provider (CHATCLI_MEMORY_PROVIDER=mcp:<server>): its
 	// answer rides after the embedded block, bounded, never blocking.
 	if ext := cli.externalMemoryRecall(ctx, query, hints); ext != "" {

--- a/cli/memory_bootstrap.go
+++ b/cli/memory_bootstrap.go
@@ -83,6 +83,22 @@ const bootstrapCardChatDirective = "Never claim you have no memory of past sessi
 // computing the session-start snapshot on first use. Both are "" when every
 // memory surface is empty (a fresh install has nothing to navigate) or when
 // memory injection is off entirely.
+// bootstrapTitleMaxBytes caps a session title on the card.
+const bootstrapTitleMaxBytes = 80
+
+// refreshBootstrapCard lets the card be rebuilt at the next boundary
+// (compaction) when it was empty at session start — the first facts of a
+// fresh install used to stay invisible for the whole session.
+func (cli *ChatCLI) refreshBootstrapCard() {
+	if cli == nil || cli.bootstrapCard == nil {
+		return
+	}
+	st := cli.bootstrapCard
+	if st.chat == "" && st.agent == "" {
+		cli.bootstrapCard = &bootstrapCardState{}
+	}
+}
+
 func (cli *ChatCLI) memoryBootstrapCards() (chatCard, agentCard string) {
 	st := cli.bootstrapCardState()
 	st.once.Do(func() {
@@ -159,7 +175,7 @@ func (cli *ChatCLI) bootstrapSnapshotLines() []string {
 			if name, saved, title := cli.sessionManager.LatestSessionInfo(); name != "" {
 				line += fmt.Sprintf(" — latest: %q (%s", name, formatSessionAge(saved))
 				if title != "" {
-					line += fmt.Sprintf(", %q", title)
+					line += fmt.Sprintf(", %q", truncateRunesafe(title, bootstrapTitleMaxBytes))
 				}
 				line += ")"
 			}

--- a/cli/memory_worker.go
+++ b/cli/memory_worker.go
@@ -528,7 +528,7 @@ func buildExtractionSnippet(messages []models.Message) strings.Builder {
 		content := redactSecretsForLLM(msg.Content)
 		// Truncate very long messages to keep the extraction prompt small
 		if len(content) > 1500 {
-			content = content[:1200] + "\n... [truncated] ...\n" + content[len(content)-200:]
+			content = truncateRunesafe(content, 1200) + "\n... [truncated] ...\n" + tailRunesafe(content, 200)
 		}
 		sb.WriteString(fmt.Sprintf("[%s]: %s\n\n", msg.Role, content))
 	}
@@ -725,62 +725,6 @@ func (mw *memoryWorker) clearStatus() {
 // Deprecated: These are kept only for existing tests in memory_worker_test.go.
 // Production code uses memory.Manager.ProcessExtraction() with the enhanced parser.
 
-// parseMemoryResponse splits the LLM response into daily notes and long-term facts.
-//
-//nolint:unused // used by memory_worker_test; golangci run.tests=false hides the call site.
-func parseMemoryResponse(response string) (daily string, longTerm string) {
-	upper := strings.ToUpper(response)
-
-	dailyIdx := findSectionIndex(upper, "DAILY")
-	longTermIdx := findSectionIndex(upper, "LONGTERM")
-	if longTermIdx < 0 {
-		longTermIdx = findSectionIndex(upper, "LONG-TERM")
-	}
-	if longTermIdx < 0 {
-		longTermIdx = findSectionIndex(upper, "LONG_TERM")
-	}
-
-	extractAfter := func(idx int) string {
-		nlIdx := strings.Index(response[idx:], "\n")
-		if nlIdx < 0 {
-			return ""
-		}
-		return strings.TrimSpace(response[idx+nlIdx+1:])
-	}
-
-	switch {
-	case dailyIdx >= 0 && longTermIdx >= 0:
-		if dailyIdx < longTermIdx {
-			nlIdx := strings.Index(response[dailyIdx:], "\n")
-			if nlIdx >= 0 {
-				daily = strings.TrimSpace(response[dailyIdx+nlIdx+1 : longTermIdx])
-			}
-			longTerm = extractAfter(longTermIdx)
-		} else {
-			nlIdx := strings.Index(response[longTermIdx:], "\n")
-			if nlIdx >= 0 {
-				longTerm = strings.TrimSpace(response[longTermIdx+nlIdx+1 : dailyIdx])
-			}
-			daily = extractAfter(dailyIdx)
-		}
-	case dailyIdx >= 0:
-		daily = extractAfter(dailyIdx)
-	case longTermIdx >= 0:
-		longTerm = extractAfter(longTermIdx)
-	default:
-		daily = response
-	}
-
-	if isNothingNew(daily) {
-		daily = ""
-	}
-	if isNothingNew(longTerm) {
-		longTerm = ""
-	}
-
-	return daily, longTerm
-}
-
 // looksLikeExtraction reports whether a reply carries any of the section
 // markers the parser understands.
 func looksLikeExtraction(s string) bool {
@@ -802,22 +746,4 @@ func isNothingNew(s string) bool {
 		return true
 	}
 	return false
-}
-
-//nolint:unused // used by memory_worker_test via parseMemoryResponse.
-func findSectionIndex(upperResponse string, keyword string) int {
-	patterns := []string{
-		"## " + keyword,
-		"##" + keyword,
-		"# " + keyword,
-		"**" + keyword + "**",
-	}
-	best := -1
-	for _, p := range patterns {
-		idx := strings.Index(upperResponse, p)
-		if idx >= 0 && (best < 0 || idx < best) {
-			best = idx
-		}
-	}
-	return best
 }

--- a/cli/memory_worker_helpers_test.go
+++ b/cli/memory_worker_helpers_test.go
@@ -1,0 +1,82 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Test-only parsers that used to live in production code behind
+ * //nolint:unused directives.
+ */
+package cli
+
+import "strings"
+
+// parseMemoryResponse splits the LLM response into daily notes and long-term facts.
+func parseMemoryResponse(response string) (daily string, longTerm string) {
+	upper := strings.ToUpper(response)
+
+	dailyIdx := findSectionIndex(upper, "DAILY")
+	longTermIdx := findSectionIndex(upper, "LONGTERM")
+	if longTermIdx < 0 {
+		longTermIdx = findSectionIndex(upper, "LONG-TERM")
+	}
+	if longTermIdx < 0 {
+		longTermIdx = findSectionIndex(upper, "LONG_TERM")
+	}
+
+	extractAfter := func(idx int) string {
+		nlIdx := strings.Index(response[idx:], "\n")
+		if nlIdx < 0 {
+			return ""
+		}
+		return strings.TrimSpace(response[idx+nlIdx+1:])
+	}
+
+	switch {
+	case dailyIdx >= 0 && longTermIdx >= 0:
+		if dailyIdx < longTermIdx {
+			nlIdx := strings.Index(response[dailyIdx:], "\n")
+			if nlIdx >= 0 {
+				daily = strings.TrimSpace(response[dailyIdx+nlIdx+1 : longTermIdx])
+			}
+			longTerm = extractAfter(longTermIdx)
+		} else {
+			nlIdx := strings.Index(response[longTermIdx:], "\n")
+			if nlIdx >= 0 {
+				longTerm = strings.TrimSpace(response[longTermIdx+nlIdx+1 : dailyIdx])
+			}
+			daily = extractAfter(dailyIdx)
+		}
+	case dailyIdx >= 0:
+		daily = extractAfter(dailyIdx)
+	case longTermIdx >= 0:
+		longTerm = extractAfter(longTermIdx)
+	default:
+		daily = response
+	}
+
+	if isNothingNew(daily) {
+		daily = ""
+	}
+	if isNothingNew(longTerm) {
+		longTerm = ""
+	}
+
+	return daily, longTerm
+}
+
+func findSectionIndex(upperResponse string, keyword string) int {
+	patterns := []string{
+		"## " + keyword,
+		"##" + keyword,
+		"# " + keyword,
+		"**" + keyword + "**",
+	}
+	best := -1
+	for _, p := range patterns {
+		idx := strings.Index(upperResponse, p)
+		if idx >= 0 && (best < 0 || idx < best) {
+			best = idx
+		}
+	}
+	return best
+}

--- a/cli/rpcserve/mcp.go
+++ b/cli/rpcserve/mcp.go
@@ -6,12 +6,12 @@
 package rpcserve
 
 import (
-	"strings"
-	"os"
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 

--- a/cli/rpcserve/mcp.go
+++ b/cli/rpcserve/mcp.go
@@ -6,12 +6,12 @@
 package rpcserve
 
 import (
+	"strings"
+	"os"
 	"context"
 	"encoding/json"
 	"errors"
-	"os"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -640,6 +640,12 @@ func (m *MCP) callTool(ctx context.Context, params json.RawMessage) (interface{}
 		return m.result(m.backend.ProvidersJSON())
 	case "manage_session":
 		if sb, ok := m.backend.(SessionBackend); ok {
+			// The MCP/ACP surfaces have no principal: under hub isolation
+			// (CHATCLI_HUB_ISOLATE=true, multi-user gateway) they must not
+			// load, attach or delete the base user's sessions.
+			if hubIsolationOn() && (a.Action == "load" || a.Action == "attach" || a.Action == "delete") {
+				return nil, errf(CodeInvalidParams, "manage_session %s is refused under CHATCLI_HUB_ISOLATE=true: this surface has no principal (single-user surfaces only)", a.Action)
+			}
 			if a.Action == "" {
 				return nil, errf(CodeInvalidParams, "action is required (save, load, attach, detach, status, list, delete, clear, active, policy_mode%s)", m.sessionSearchActions())
 			}
@@ -901,4 +907,14 @@ func (m *MCP) result(text string, err error) (interface{}, *RPCError) {
 	return map[string]interface{}{
 		"content": []map[string]interface{}{{"type": "text", "text": text}},
 	}, nil
+}
+
+// hubIsolationOn reports whether the gateway hub runs in per-principal
+// isolation (CHATCLI_HUB_ISOLATE=true).
+func hubIsolationOn() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("CHATCLI_HUB_ISOLATE"))) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
 }

--- a/cli/session_adapter.go
+++ b/cli/session_adapter.go
@@ -182,6 +182,18 @@ func (a *sessionPluginAdapter) GetMessage(_ context.Context, name string, index 
 
 // truncateRunesafe cuts s at cap bytes, snapping back to a rune boundary so
 // the output stays valid UTF-8, and appends an ellipsis when it cut.
+// tailRunesafe returns the last capBytes of s without splitting a rune.
+func tailRunesafe(s string, capBytes int) string {
+	if len(s) <= capBytes {
+		return s
+	}
+	i := len(s) - capBytes
+	for i < len(s) && !utf8.RuneStart(s[i]) {
+		i++
+	}
+	return s[i:]
+}
+
 func truncateRunesafe(s string, capBytes int) string {
 	if len(s) <= capBytes {
 		return s

--- a/cli/session_transcript.go
+++ b/cli/session_transcript.go
@@ -23,16 +23,26 @@ import (
 	"github.com/diillson/chatcli/cli/ctxmgr"
 	"github.com/diillson/chatcli/i18n"
 	"github.com/diillson/chatcli/models"
+	"github.com/diillson/chatcli/pkg/atrest"
 )
 
 // transcriptSearchHits is how many hits /session transcript search prints.
 const transcriptSearchHits = 8
+
+// transcriptViewCap bounds how many journaled messages the transcript
+// commands load per call.
+const transcriptViewCap = 20_000
 
 // fullTranscript returns the journal's messages (source "journal") or the
 // live history (source "history") when the journal is unavailable.
 func (cli *ChatCLI) fullTranscript() ([]models.Message, string) {
 	if cli != nil && cli.transcript != nil && !cli.transcript.disabled && cli.transcript.path != "" {
 		if msgs, err := readTranscript(cli.transcript.path); err == nil && len(msgs) > 0 {
+			// Bounded view: a journal of a long-running session is read in
+			// full on every search/show/stats; keep the tail.
+			if len(msgs) > transcriptViewCap {
+				msgs = msgs[len(msgs)-transcriptViewCap:]
+			}
 			return msgs, "journal"
 		}
 	}
@@ -79,6 +89,10 @@ func (cli *ChatCLI) handleSessionExport(format, path string) {
 	} else {
 		_, err = f.WriteString(renderTranscriptMarkdown(msgs, cli.currentSessionName, cli.transcriptID()))
 		count = len(msgs)
+	}
+	if err == nil && atrest.Enabled() {
+		// The journal is sealed; the export is not.
+		fmt.Println(colorize("  "+i18n.T("session.export.plaintext_notice"), ColorYellow))
 	}
 	if cerr := f.Close(); err == nil {
 		err = cerr

--- a/cli/workspace/memory/export.go
+++ b/cli/workspace/memory/export.go
@@ -473,5 +473,44 @@ func SameProject(a, b string) bool {
 		return true
 	}
 	sep := string(filepath.Separator)
-	return strings.HasPrefix(a, b+sep) || strings.HasPrefix(b, a+sep)
+	if strings.HasPrefix(a, b+sep) || strings.HasPrefix(b, a+sep) {
+		return true
+	}
+	// Git worktrees of one repository are one project: their .git is a
+	// file pointing into the main checkout's .git/worktrees/<name>.
+	ca, cb := gitCommonDir(a), gitCommonDir(b)
+	return ca != "" && ca == cb
+}
+
+// gitCommonDir resolves the repository's common .git directory for a
+// worktree or a main checkout ("" when dir is not inside a git repo).
+func gitCommonDir(dir string) string {
+	for d := dir; ; d = filepath.Dir(d) {
+		dotGit := filepath.Join(d, ".git")
+		info, err := os.Stat(dotGit)
+		if err == nil {
+			if info.IsDir() {
+				return dotGit
+			}
+			data, rerr := os.ReadFile(dotGit) // #nosec G304 -- the .git file of a directory the user works in
+			if rerr != nil {
+				return ""
+			}
+			line := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(string(data)), "gitdir:"))
+			if line == "" {
+				return ""
+			}
+			if !filepath.IsAbs(line) {
+				line = filepath.Join(d, line)
+			}
+			// <common>/.git/worktrees/<name> → <common>/.git
+			if i := strings.Index(filepath.ToSlash(line), "/worktrees/"); i >= 0 {
+				return filepath.Clean(filepath.FromSlash(filepath.ToSlash(line)[:i]))
+			}
+			return filepath.Clean(line)
+		}
+		if parent := filepath.Dir(d); parent == d {
+			return ""
+		}
+	}
 }

--- a/i18n/locales/en-US.hygiene.json
+++ b/i18n/locales/en-US.hygiene.json
@@ -1,0 +1,5 @@
+{
+  "session.export.plaintext_notice": "Note: the journal is sealed at rest, but this export is plaintext — keep it where the content may live.",
+  "complete.root.rewind": "Rewind to a checkpoint; \"/rewind compact\" undoes the latest compaction",
+  "context.status.ccr_skips": "⚠ CCR archive refused %d oversized cut(s) this session — those originals are not recoverable via @recall (raise CHATCLI_COMPRESSION_CCR_MAX_MB)."
+}

--- a/i18n/locales/en.hygiene.json
+++ b/i18n/locales/en.hygiene.json
@@ -1,0 +1,5 @@
+{
+  "session.export.plaintext_notice": "Note: the journal is sealed at rest, but this export is plaintext — keep it where the content may live.",
+  "complete.root.rewind": "Rewind to a checkpoint; \"/rewind compact\" undoes the latest compaction",
+  "context.status.ccr_skips": "⚠ CCR archive refused %d oversized cut(s) this session — those originals are not recoverable via @recall (raise CHATCLI_COMPRESSION_CCR_MAX_MB)."
+}

--- a/i18n/locales/pt-BR.hygiene.json
+++ b/i18n/locales/pt-BR.hygiene.json
@@ -1,0 +1,5 @@
+{
+  "session.export.plaintext_notice": "Atenção: o journal fica selado em repouso, mas esta exportação é texto puro — guarde-a onde o conteúdo possa ficar.",
+  "complete.root.rewind": "Voltar a um checkpoint; \"/rewind compact\" desfaz a última compactação",
+  "context.status.ccr_skips": "⚠ O arquivo CCR recusou %d corte(s) grande(s) demais nesta sessão — esses originais não são recuperáveis via @recall (aumente CHATCLI_COMPRESSION_CCR_MAX_MB)."
+}

--- a/llm/claudeai/cache_planner.go
+++ b/llm/claudeai/cache_planner.go
@@ -84,9 +84,12 @@ func enforceCacheControlBudget(reqBody map[string]interface{}, maxMarkers int) {
 	var holders []map[string]interface{}
 
 	// Order matters: system is the outermost prefix, then tools, then
-	// messages. We collect in that order so the "earliest" markers we
-	// drop are correctly the system-block ones — those have the smallest
-	// covered prefix and are the cheapest to lose.
+	// messages. A marker caches everything BEFORE it, so a later marker
+	// already covers what an earlier one covers; an earlier marker only
+	// adds a partial-hit fallback for requests that diverge between the
+	// two. Collecting in request order makes the markers we drop first the
+	// earliest ones — the fallbacks — while the latest (largest) prefix
+	// stays cached.
 	if v, ok := reqBody["system"]; ok {
 		collectMarkerHolders(v, &holders)
 	}

--- a/pkg/coder/engine/commands.go
+++ b/pkg/coder/engine/commands.go
@@ -55,10 +55,21 @@ func (e *Engine) handleRead(args []string) error {
 			e.printf("❌ Range inválido para '%s'\n", f)
 			continue
 		}
+		// No range asked: a whole-file read is capped at DefaultMaxLines
+		// (the byte cap stays the ceiling), the way Claude Code pages
+		// reads — 200 KB in one read was ~50K tokens of a 200K window.
+		lineCapped := false
+		if *start == 0 && *end == 0 && *head == 0 && *tail == 0 && endIdx-startIdx > DefaultMaxLines {
+			endIdx = startIdx + DefaultMaxLines
+			lineCapped = true
+		}
 
 		e.printf("<<< INÍCIO DO ARQUIVO: %s >>>\n", f)
 		for i := startIdx; i < endIdx; i++ {
 			e.printf("%4d | %s\n", i+1, lines[i])
+		}
+		if lineCapped {
+			e.printf("... [%d de %d linhas; continue com --start %d] ...\n", DefaultMaxLines, len(lines), endIdx+1)
 		}
 		if truncated {
 			e.printf("... [TRUNCADO EM %d BYTES] ...\n", *maxBytes)

--- a/pkg/coder/engine/engine.go
+++ b/pkg/coder/engine/engine.go
@@ -20,6 +20,10 @@ const (
 	// DefaultMaxBytes is the default byte limit for file reads.
 	DefaultMaxBytes = 200_000
 
+	// DefaultMaxLines caps a read that asked for no range (the byte cap
+	// stays the ceiling); the model pages with --start/--end.
+	DefaultMaxLines = 2_000
+
 	// DefaultMaxEntries is the default entry limit for tree listings.
 	DefaultMaxEntries = 2_000
 )


### PR DESCRIPTION
## Summary

Audit III, PR 27 (P3 hygiene batch: CAG-11, CAG-14, CMP-17, CMP-20, CMP-21, MEM-13, MEM-14, MEM-16, MEM-17, RAG-15, SEC-11).

- **MEM-13** — the extraction snippet, the external recall text and the episode line cut rune-safe (`truncateRunesafe` / new `tailRunesafe`).
- **MEM-17** — `parseMemoryResponse` / `findSectionIndex` (only tests called them, hidden behind `//nolint:unused`) moved to `memory_worker_helpers_test.go`; no `nolint` left.
- **CMP-17** — `Layer.ArchiveSkips()` counts archives the store refused; `/context status` shows a yellow line naming what is not recoverable and how to raise the cap.
- **RAG-15** — coder `read` with no range is capped at `DefaultMaxLines` (2000) with a `--start` continuation hint; the byte cap stays the ceiling.
- **CMP-20** — transcript commands load at most 20 000 messages; an export prints a plaintext notice when the journal is sealed at rest.
- **SEC-11** — `manage_session load|attach|delete` is refused under `CHATCLI_HUB_ISOLATE=true` on the MCP/ACP surfaces (no principal there).
- **MEM-16** — `CHATCLI_MEMORY_PROVIDER=mcp-only:<server>` skips the embedded recall block; `/config` renders `mcp-only:<server>` and the `provider` context-engine value (**CAG-14**).
- **MEM-14** — the bootstrap card is rebuilt at the next compaction boundary when it was empty at start; session titles are capped at 80 bytes; `SameProject` treats git worktrees of one repository as one project.
- **CAG-11** — cache planner comments state the real drop rationale (behaviour unchanged). **CMP-21** — the `/rewind` completer help names `compact`.

## Tests

`cli/audit3_pr27_test.go`: rune-safe head/tail; exclusive provider parsing and status; worktree-aware `SameProject`; bootstrap card refresh semantics. Existing suites for rpcserve, the coder engine, compress and memory are green; golangci-lint and the local gates are green.