### PR TITLE
fix(cost): telemetry semconv and opt-in session series, embedding and daily-budget metrics, CSV export, spend finalized on every surface, park on hard stop

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -1623,6 +1623,13 @@ func (a *AgentMode) followUpRecallBlocks(ctx context.Context, userMsg string) st
 	return strings.Join(parts, "\n\n")
 }
 
+// nextLocalMidnight is when a daily budget resets: the park-on-hard-stop
+// resume time.
+func nextLocalMidnight() time.Time {
+	now := time.Now()
+	return time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, now.Location())
+}
+
 // RunCoderOnce executa o modo coder de forma não-interativa (one-shot),
 // mas mantendo o loop ReAct do AgentMode (com tool_calls/plugins).
 func (cli *ChatCLI) RunCoderOnce(ctx context.Context, input string) error {
@@ -2085,6 +2092,12 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 		// the session budget is exhausted and CHATCLI_BUDGET_HARD_STOP is on.
 		if err := a.cli.budgetBlockedErr(); err != nil {
 			fmt.Println(colorize("  "+err.Error(), ColorRed))
+			// Park instead of dying: the run resumes when the day rolls
+			// over (daily budget) or when /parked resume is issued after
+			// the budget was raised — the work done so far is not lost.
+			if perr := a.handleAgentPark(ctx, park.Request{Mode: park.ModeUntil, Until: nextLocalMidnight()}, "", ""); perr != nil {
+				return perr
+			}
 			return err
 		}
 

--- a/cli/audit3_pr24_test.go
+++ b/cli/audit3_pr24_test.go
@@ -1,0 +1,84 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+func TestTelemetry_SemconvAttrsAndOptInSession(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	c := &ChatCLI{logger: zap.NewNop(), costTracker: NewCostTracker()}
+	t.Cleanup(c.costTracker.FlushDailySpend)
+	c.costTracker.RecordUsage("OPENAI", "gpt-5.6", 1000, 100)
+	c.costTracker.RecordEmbeddingUsage("openai", 4000)
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.namespace=x")
+	metrics := c.telemetryMetrics()
+	var sawSemconv, sawSession, sawEmbedding, sawDaily bool
+	for _, m := range metrics {
+		for _, p := range m.Points {
+			if p.Attrs["gen_ai.provider.name"] == "OPENAI" && p.Attrs["gen_ai.request.model"] == "gpt-5.6" {
+				sawSemconv = true
+			}
+			if _, ok := p.Attrs["chatcli.session.id"]; ok {
+				sawSession = true
+			}
+		}
+		if strings.HasPrefix(m.Name, "chatcli.embedding.") {
+			sawEmbedding = true
+		}
+		if m.Name == "chatcli.budget.daily_spent" {
+			sawDaily = true
+		}
+	}
+	if !sawSemconv || sawSession || !sawEmbedding || !sawDaily {
+		t.Fatalf("semconv=%v session=%v embedding=%v daily=%v", sawSemconv, sawSession, sawEmbedding, sawDaily)
+	}
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.namespace=x, chatcli.session=attr")
+	for _, m := range c.telemetryMetrics() {
+		if m.Name == "chatcli.session.cost" && m.Points[0].Attrs["chatcli.session.id"] == "" {
+			t.Fatal("opt-in must attach the session id")
+		}
+	}
+	// Embedding spend accrues to the daily budget too.
+	if spent, _ := c.costTracker.DailySpend(); spent <= 0 {
+		t.Fatalf("embedding spend must count toward the day: %v", spent)
+	}
+}
+
+func TestCostExport_CSV(t *testing.T) {
+	ct := NewCostTracker()
+	ct.RecordUsage("CLAUDEAI", "claude-sonnet-5", 1000, 200)
+	out := string(costSnapshotCSV(ct.Snapshot()))
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 3 || !strings.HasPrefix(lines[0], "session_id,provider,model,requests") {
+		t.Fatalf("csv = %q", out)
+	}
+	if !strings.Contains(lines[1], "CLAUDEAI,claude-sonnet-5,1,1000,200") || !strings.Contains(lines[2], ",total,") {
+		t.Fatalf("rows = %q", lines[1:])
+	}
+}
+
+func TestFinalizeSpend_NilSafeAndPersists(t *testing.T) {
+	(*ChatCLI)(nil).finalizeSpend(context.Background())
+	(&ChatCLI{}).finalizeSpend(context.Background())
+	t.Setenv("HOME", t.TempDir())
+	ct := NewCostTracker()
+	ct.RecordUsage("OPENAI", "gpt-5.6", 10, 1)
+	c := &ChatCLI{logger: zap.NewNop(), costTracker: ct}
+	c.finalizeSpend(context.Background())
+	if _, err := LoadCostSnapshot(ct.Snapshot().SessionID); err != nil {
+		t.Fatalf("snapshot must be persisted on exit: %v", err)
+	}
+	if m := nextLocalMidnight(); !m.After(time.Now()) || m.Hour() != 0 || m.Minute() != 0 {
+		t.Fatalf("next midnight = %v", m)
+	}
+}

--- a/cli/audit3_pr24_test.go
+++ b/cli/audit3_pr24_test.go
@@ -68,13 +68,13 @@ func TestCostExport_CSV(t *testing.T) {
 }
 
 func TestFinalizeSpend_NilSafeAndPersists(t *testing.T) {
-	(*ChatCLI)(nil).finalizeSpend(context.Background())
-	(&ChatCLI{}).finalizeSpend(context.Background())
+	(*ChatCLI)(nil).settleSpendOnExit(context.Background())
+	(&ChatCLI{}).settleSpendOnExit(context.Background())
 	t.Setenv("HOME", t.TempDir())
 	ct := NewCostTracker()
 	ct.RecordUsage("OPENAI", "gpt-5.6", 10, 1)
 	c := &ChatCLI{logger: zap.NewNop(), costTracker: ct}
-	c.finalizeSpend(context.Background())
+	c.settleSpendOnExit(context.Background())
 	if _, err := LoadCostSnapshot(ct.Snapshot().SessionID); err != nil {
 		t.Fatalf("snapshot must be persisted on exit: %v", err)
 	}

--- a/cli/cost_command.go
+++ b/cli/cost_command.go
@@ -6,11 +6,14 @@
 package cli
 
 import (
+	"bytes"
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -124,17 +127,52 @@ func (cli *ChatCLI) handleCostSessions() {
 
 // handleCostExport writes the current session snapshot as JSON — to the
 // given path, or to the cost store with an -export suffix when omitted.
+// costSnapshotCSV renders the per-model rows of a snapshot as CSV (one
+// row per provider/model plus a total row) for spreadsheets and roll-ups.
+func costSnapshotCSV(snap SessionCostData) []byte {
+	var buf bytes.Buffer
+	w := csv.NewWriter(&buf)
+	_ = w.Write([]string{"session_id", "provider", "model", "requests", "prompt_tokens", "completion_tokens", "cache_read_tokens", "cache_write_tokens", "reasoning_tokens", "cost_usd"})
+	keys := make([]string, 0, len(snap.ModelUsage))
+	for k := range snap.ModelUsage {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		rec := snap.ModelUsage[k]
+		if rec == nil {
+			continue
+		}
+		_ = w.Write([]string{snap.SessionID, rec.Provider, rec.Model, strconv.Itoa(rec.Requests),
+			strconv.FormatInt(rec.PromptTokens, 10), strconv.FormatInt(rec.CompletionTokens, 10),
+			strconv.FormatInt(rec.CacheReadTokens, 10), strconv.FormatInt(rec.CacheCreationTokens, 10),
+			strconv.FormatInt(rec.ReasoningTokens, 10), strconv.FormatFloat(rec.TotalCostUSD, 'f', 6, 64)})
+	}
+	_ = w.Write([]string{snap.SessionID, "total", "", "", "", "", "", "", "", strconv.FormatFloat(snap.TotalCostUSD, 'f', 6, 64)})
+	w.Flush()
+	return buf.Bytes()
+}
+
 func (cli *ChatCLI) handleCostExport(path string) {
 	snap := cli.costTracker.Snapshot()
-	b, err := json.MarshalIndent(snap, "", "  ")
+	if path != "" {
+		if expanded, expErr := utils.ExpandPath(path); expErr == nil {
+			path = expanded
+		}
+	}
+	var b []byte
+	var err error
+	if strings.HasSuffix(strings.ToLower(path), ".csv") {
+		b = costSnapshotCSV(snap)
+	} else {
+		b, err = json.MarshalIndent(snap, "", "  ")
+	}
 	if err != nil {
 		fmt.Println(colorize("  "+i18n.T("cost.cmd.export_failed", err), ColorYellow))
 		return
 	}
 	if path == "" {
 		path = filepath.Join(costStoreDir(), snap.SessionID+"-export.json")
-	} else if expanded, expErr := utils.ExpandPath(path); expErr == nil {
-		path = expanded
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		fmt.Println(colorize("  "+i18n.T("cost.cmd.export_failed", err), ColorYellow))

--- a/cli/cost_daily.go
+++ b/cli/cost_daily.go
@@ -106,6 +106,17 @@ func (ct *CostTracker) saveDailySpendTo(path string) {
 	_ = utils.AtomicWriteFile(path, data, 0o600)
 }
 
+// DailySpend returns today's spend and the configured daily limit (0 when
+// unset).
+func (ct *CostTracker) DailySpend() (spent, limit float64) {
+	if ct == nil {
+		return 0, 0
+	}
+	ct.mu.RLock()
+	defer ct.mu.RUnlock()
+	return ct.dailySpentUSD, ct.dailyLimitUSD
+}
+
 // FlushDailySpend writes today's spend now (session end, tenant swap).
 func (ct *CostTracker) FlushDailySpend() {
 	if ct == nil {

--- a/cli/cost_embeddings.go
+++ b/cli/cost_embeddings.go
@@ -28,6 +28,8 @@ func (ct *CostTracker) RecordEmbeddingUsage(provider string, chars int) {
 	ct.embeddingTokens += tokens
 	ct.embeddingCostUSD += cost
 	ct.totalCostUSD += cost
+	// Embedding spend counts against the daily budget like any other.
+	ct.accrueDailyLocked()
 	ct.mu.Unlock()
 }
 

--- a/cli/gateway_command.go
+++ b/cli/gateway_command.go
@@ -312,6 +312,7 @@ func (cli *ChatCLI) runGateway(ctx context.Context, broker hub.Store) error {
 	runner.SetVoicePrefs(gateway.SharedVoicePrefs())
 	cli.maybeEnableVoiceReplies(runner)
 	cli.maybeEnableImageReplies(runner, imgOutbox)
+	defer cli.finalizeSpend(context.WithoutCancel(ctx))
 	return runner.Run(ctx)
 }
 

--- a/cli/gateway_command.go
+++ b/cli/gateway_command.go
@@ -312,7 +312,7 @@ func (cli *ChatCLI) runGateway(ctx context.Context, broker hub.Store) error {
 	runner.SetVoicePrefs(gateway.SharedVoicePrefs())
 	cli.maybeEnableVoiceReplies(runner)
 	cli.maybeEnableImageReplies(runner, imgOutbox)
-	defer cli.finalizeSpend(context.WithoutCancel(ctx))
+	defer cli.settleSpendOnExit(context.WithoutCancel(ctx))
 	return runner.Run(ctx)
 }
 

--- a/cli/oneshot_mode.go
+++ b/cli/oneshot_mode.go
@@ -49,6 +49,9 @@ func (cli *ChatCLI) HandleOneShotOrFatal(ctx context.Context, opts *Options) boo
 		return false
 	}
 	cli.SetAuditSurface("oneshot")
+	// -p exits right after its turn: persist spend and release paid caches
+	// like the REPL's cleanup does.
+	defer cli.finalizeSpend(context.WithoutCancel(ctx))
 
 	// Aplica overrides de provider/model
 	if err := cli.ApplyOverrides(ctx, cli.manager, opts.Provider, opts.Model); err != nil {

--- a/cli/oneshot_mode.go
+++ b/cli/oneshot_mode.go
@@ -51,7 +51,7 @@ func (cli *ChatCLI) HandleOneShotOrFatal(ctx context.Context, opts *Options) boo
 	cli.SetAuditSurface("oneshot")
 	// -p exits right after its turn: persist spend and release paid caches
 	// like the REPL's cleanup does.
-	defer cli.finalizeSpend(context.WithoutCancel(ctx))
+	defer cli.settleSpendOnExit(context.WithoutCancel(ctx))
 
 	// Aplica overrides de provider/model
 	if err := cli.ApplyOverrides(ctx, cli.manager, opts.Provider, opts.Model); err != nil {

--- a/cli/surface_shutdown.go
+++ b/cli/surface_shutdown.go
@@ -18,9 +18,9 @@ import (
 // and the MCP/ACP servers call it on their own exit so no surface leaves
 // spend unsaved or a paid cache lingering.
 // FinalizeSpend is finalizeSpend for the command layer (rpcserve exits).
-func (cli *ChatCLI) FinalizeSpend(ctx context.Context) { cli.finalizeSpend(ctx) }
+func (cli *ChatCLI) FinalizeSpend(ctx context.Context) { cli.settleSpendOnExit(ctx) }
 
-func (cli *ChatCLI) finalizeSpend(ctx context.Context) {
+func (cli *ChatCLI) settleSpendOnExit(ctx context.Context) {
 	if cli == nil {
 		return
 	}

--- a/cli/surface_shutdown.go
+++ b/cli/surface_shutdown.go
@@ -1,0 +1,36 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"context"
+
+	"github.com/diillson/chatcli/llm/client"
+	"go.uber.org/zap"
+)
+
+// finalizeSpend persists the session's cost snapshot and daily spend and
+// releases provider cache resources (Gemini explicit caches bill storage
+// per hour). The REPL runs it from cleanup; one-shot, the gateway daemon
+// and the MCP/ACP servers call it on their own exit so no surface leaves
+// spend unsaved or a paid cache lingering.
+// FinalizeSpend is finalizeSpend for the command layer (rpcserve exits).
+func (cli *ChatCLI) FinalizeSpend(ctx context.Context) { cli.finalizeSpend(ctx) }
+
+func (cli *ChatCLI) finalizeSpend(ctx context.Context) {
+	if cli == nil {
+		return
+	}
+	if cli.costTracker != nil {
+		if err := cli.costTracker.SaveSession(); err != nil && cli.logger != nil {
+			cli.logger.Debug("cost snapshot not saved on exit", zap.Error(err))
+		}
+		cli.costTracker.FlushDailySpend()
+	}
+	if n := client.ReleaseCacheResources(ctx); n > 0 && cli.logger != nil {
+		cli.logger.Info("released provider cache resources on exit", zap.Int("count", n))
+	}
+}

--- a/cli/telemetry_wiring.go
+++ b/cli/telemetry_wiring.go
@@ -12,7 +12,9 @@ package cli
 
 import (
 	"context"
+	"os"
 	"strconv"
+	"strings"
 
 	"github.com/diillson/chatcli/cli/telemetry"
 	"go.uber.org/zap"
@@ -41,6 +43,19 @@ func (cli *ChatCLI) initTelemetry(ctx context.Context, surface string) {
 	}
 }
 
+// telemetrySessionAttrOptIn reports whether OTEL_RESOURCE_ATTRIBUTES carries
+// chatcli.session=attr — the operator's explicit acceptance of one series
+// per session on the session cost metric.
+func telemetrySessionAttrOptIn() bool {
+	for _, kv := range strings.Split(os.Getenv("OTEL_RESOURCE_ATTRIBUTES"), ",") {
+		k, v, ok := strings.Cut(strings.TrimSpace(kv), "=")
+		if ok && strings.TrimSpace(k) == "chatcli.session" && strings.EqualFold(strings.TrimSpace(v), "attr") {
+			return true
+		}
+	}
+	return false
+}
+
 // telemetryMetrics renders the cost tracker as cumulative OTLP sums.
 func (cli *ChatCLI) telemetryMetrics() []telemetry.Metric {
 	ct := cli.costTracker
@@ -54,7 +69,8 @@ func (cli *ChatCLI) telemetryMetrics() []telemetry.Metric {
 		if rec == nil {
 			continue
 		}
-		base := map[string]string{"provider": rec.Provider, "model": rec.Model}
+		// OpenTelemetry GenAI semantic-convention attribute names.
+		base := map[string]string{"gen_ai.provider.name": rec.Provider, "gen_ai.request.model": rec.Model}
 		for kind, n := range map[string]int64{
 			"input": rec.PromptTokens, "output": rec.CompletionTokens,
 			"cache_read": rec.CacheReadTokens, "cache_write": rec.CacheCreationTokens, "reasoning": rec.ReasoningTokens,
@@ -88,7 +104,23 @@ func (cli *ChatCLI) telemetryMetrics() []telemetry.Metric {
 	if snap.CacheResources > 0 {
 		out = append(out, telemetry.Metric{Name: "chatcli.cache.storage_cost", Unit: "USD", Points: []telemetry.Point{{Value: snap.CacheStorageCostUSD}}})
 	}
-	out = append(out, telemetry.Metric{Name: "chatcli.session.cost", Unit: "USD", Points: []telemetry.Point{{Value: snap.TotalCostUSD, Attrs: map[string]string{"session": snap.SessionID}}}})
+	// The session id is unbounded cardinality: attached only when the
+	// operator opted in through OTEL_RESOURCE_ATTRIBUTES (chatcli.session=attr).
+	sessionAttrs := map[string]string(nil)
+	if telemetrySessionAttrOptIn() {
+		sessionAttrs = map[string]string{"chatcli.session.id": snap.SessionID}
+	}
+	out = append(out, telemetry.Metric{Name: "chatcli.session.cost", Unit: "USD", Points: []telemetry.Point{{Value: snap.TotalCostUSD, Attrs: sessionAttrs}}})
+	if calls, tokens, cost := ct.EmbeddingStats(); calls > 0 {
+		out = append(out, telemetry.Metric{Name: "chatcli.embedding.tokens", Unit: "{token}", Points: []telemetry.Point{{Value: float64(tokens)}}})
+		out = append(out, telemetry.Metric{Name: "chatcli.embedding.cost", Unit: "USD", Points: []telemetry.Point{{Value: cost}}})
+	}
+	if spent, limit := ct.DailySpend(); limit > 0 || spent > 0 {
+		out = append(out, telemetry.Metric{Name: "chatcli.budget.daily_spent", Unit: "USD", Points: []telemetry.Point{{Value: spent}}})
+		if limit > 0 {
+			out = append(out, telemetry.Metric{Name: "chatcli.budget.daily_limit", Unit: "USD", Points: []telemetry.Point{{Value: limit}}})
+		}
+	}
 	return out
 }
 

--- a/cmd/rpcserve.go
+++ b/cmd/rpcserve.go
@@ -104,6 +104,11 @@ func runRPC(kind string, mgr manager.LLMManager, logger *zap.Logger) error {
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	if chatCLI != nil {
+		// MCP/ACP servers exit with their client: persist spend and release
+		// paid caches like every other surface.
+		defer chatCLI.FinalizeSpend(context.WithoutCancel(ctx))
+	}
 	defer stop()
 
 	ver := version.GetCurrentVersion().Version


### PR DESCRIPTION
## Summary

Audit III, PR 24 (P3 COST-11, COST-12, COST-15; the release part of CAG-13).

- **Telemetry (COST-12).** Per-model points carry `gen_ai.provider.name` / `gen_ai.request.model` (OpenTelemetry GenAI semantic conventions). `chatcli.session.cost` no longer emits one series per session by default; the session id is attached only when `OTEL_RESOURCE_ATTRIBUTES` contains `chatcli.session=attr` (documented opt-in, no new env). New metrics: `chatcli.embedding.tokens` / `.cost`, `chatcli.budget.daily_spent` / `.daily_limit`. The six `OTEL_*` variables became reloadable in PR 28.
- **Every surface finalizes (COST-15, CAG-13).** `finalizeSpend` persists the cost snapshot and daily spend and releases provider cache resources (Gemini explicit caches bill storage); one-shot (`-p`), the gateway daemon and the MCP/ACP servers now call it on exit, as the REPL cleanup already did.
- **CSV export (COST-15).** `/cost export path.csv` writes one row per provider/model plus a total row.
- **Daily accrual (COST-11).** Embedding spend counts toward the daily budget.
- **Park on hard stop (COST-11).** When the budget hard stop trips inside the agent loop the run is parked (resume at the next local midnight, or `/parked resume` once the budget is raised) instead of dying with the work lost.

Not done here: feeding Prometheus from the cost tracker (the gRPC server already counts per request on its own path); left as a follow-up note.

## Tests

`cli/audit3_pr24_test.go`: semconv attributes, opt-in session series, embedding and daily metrics, embedding daily accrual, CSV shape, exit finalizer persists and is nil-safe, next-midnight helper. golangci-lint and the local gates are green.