### PR TITLE
fix(ui): footer shows used context apart from the answer reserve

### DIFF
--- a/cli/chat_pipeline.go
+++ b/cli/chat_pipeline.go
@@ -1013,10 +1013,15 @@ func (cli *ChatCLI) telemetryParts(usage *models.UsageInfo, costUSD float64, inc
 		// Prefer the projection for the NEXT request (current history plus
 		// the prefix that will front it): that is what decides whether the
 		// next turn compacts, and it may legitimately exceed 100%.
-		if proj, ok := cli.projectedContextPct(window); ok {
-			pct = proj
+		reserve := 0.0
+		if used, res, ok := cli.projectedContextParts(window); ok {
+			pct, reserve = used, res
 		}
-		parts = append(parts, i18n.T("chat.envelope.context_pct", roundPct(pct)))
+		if roundPct(reserve) > 0 {
+			parts = append(parts, i18n.T("chat.envelope.context_pct_reserve", roundPct(pct), roundPct(reserve)))
+		} else {
+			parts = append(parts, i18n.T("chat.envelope.context_pct", roundPct(pct)))
+		}
 	}
 	// Prompt-cache share of this turn's input, on every provider that
 	// reports cache tokens (Anthropic/Bedrock additive counts, OpenAI/
@@ -1060,10 +1065,25 @@ func (cli *ChatCLI) projectedContextPct(window int) (float64, bool) {
 	}
 	// One estimate for the footer, the compactor and /context status; the
 	// answer reserve is capped against the window the caller measures.
+	used, reserve, ok := cli.projectedContextParts(window)
+	return used + reserve, ok
+}
+
+// projectedContextParts splits the projection into what already occupies
+// the window (prefix, history, tool definitions) and the answer reserve
+// (max_tokens as sent, capped at a quarter of the window). The footer
+// shows them apart: a lone "ctx 16%" on an empty conversation read as a
+// capped window when it was only the reserve.
+func (cli *ChatCLI) projectedContextParts(window int) (used, reserve float64, ok bool) {
 	e := cli.contextEstimate()
 	e.Window = window
 	e.ReserveTokens = answerReserveTokens(cli.getMaxTokensForCurrentLLM(), window)
-	return e.Pct()
+	total, ok := e.Pct()
+	if !ok {
+		return 0, 0, false
+	}
+	reserve = float64(e.ReserveTokens) / float64(window) * 100
+	return total - reserve, reserve, true
 }
 
 // roundPct rounds a percentage to an int, floored at 0 and deliberately

--- a/cli/footer_ctx_reserve_test.go
+++ b/cli/footer_ctx_reserve_test.go
@@ -1,0 +1,42 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/i18n"
+	"github.com/diillson/chatcli/models"
+)
+
+func TestProjectedContextParts_SplitsUsedFromReserve(t *testing.T) {
+	cli := newTenantTestCLI(t)
+	cli.Provider, cli.Model = "CLAUDEAI", "claude-sonnet-5"
+	window := 1000
+	cli.history = []models.Message{{Role: "user", Content: strings.Repeat("x", 3000)}, {Role: "assistant", Content: strings.Repeat("y", 1000)}}
+	cli.promptBreakdowns.recordDegraded("chat", nil, []promptSection{{Name: "mode", Chars: 2000}})
+	used, reserve, ok := cli.projectedContextParts(window)
+	if !ok {
+		t.Fatal("projection must be available")
+	}
+	// (3000+1000+2000 chars) / 4 = 1500 tokens on a 1000 window = 150% used;
+	// the reserve rides apart (max_tokens capped at 25% of the window).
+	if used < 149 || used > 151 {
+		t.Fatalf("used = %.1f, want ≈150", used)
+	}
+	wantReserve := float64(answerReserveTokens(cli.getMaxTokensForCurrentLLM(), window)) / float64(window) * 100
+	if reserve < wantReserve-0.5 || reserve > wantReserve+0.5 {
+		t.Fatalf("reserve = %.1f, want ≈%.1f", reserve, wantReserve)
+	}
+	if total, _ := cli.projectedContextPct(window); total < used+reserve-1 || total > used+reserve+1 {
+		t.Fatalf("total = %.1f must be used + reserve", total)
+	}
+	line := i18n.T("chat.envelope.context_pct_reserve", roundPct(used), roundPct(reserve))
+	if !strings.Contains(line, "(+") || !strings.Contains(line, "150") {
+		t.Fatalf("footer line = %q", line)
+	}
+}

--- a/i18n/locales/en-US.footer-reserve.json
+++ b/i18n/locales/en-US.footer-reserve.json
@@ -1,0 +1,3 @@
+{
+  "chat.envelope.context_pct_reserve": "ctx %d%% (+%d%% reserve)"
+}

--- a/i18n/locales/en.footer-reserve.json
+++ b/i18n/locales/en.footer-reserve.json
@@ -1,0 +1,3 @@
+{
+  "chat.envelope.context_pct_reserve": "ctx %d%% (+%d%% reserve)"
+}

--- a/i18n/locales/pt-BR.footer-reserve.json
+++ b/i18n/locales/pt-BR.footer-reserve.json
@@ -1,0 +1,3 @@
+{
+  "chat.envelope.context_pct_reserve": "ctx %d%% (+%d%% reserva)"
+}


### PR DESCRIPTION
## Summary

Follow-up to #1485. The footer's `ctx %` folded the answer reserve (`max_tokens` as sent, capped at 25% of the window) into a single number, so a fresh conversation showed `ctx 16%` in chat and coder and read as a capped window. `projectedContextParts` splits the projection into what already occupies the window (prefix, history, tool definitions) and the reserve; the footer renders `ctx 2% (+14% reserve)` (locale fragment, pt-BR `reserva`). `projectedContextPct` keeps returning the sum for the compactor and `/context status`, which are unchanged.

## Tests

`cli/footer_ctx_reserve_test.go`: used and reserve split, the sum equals the previous projection, the footer line renders the reserve apart. golangci-lint and the local gates are green.