### PR TITLE
fix(config): environment file discovery for editor-spawned servers and Bedrock profile parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ OPENAI_API_KEY=sk-xxx
 |---|---|---|---|
 | OpenAI | `OPENAI_API_KEY` | `OPENAI_MODEL` | `OPENAI_MAX_TOKENS`, `OPENAI_USE_RESPONSES`, `OPENAI_API_URL` |
 | Anthropic | `ANTHROPIC_API_KEY` | `ANTHROPIC_MODEL` | `ANTHROPIC_MAX_TOKENS` |
-| AWS Bedrock | IAM / Profile / credentials chain | `BEDROCK_MODEL` | `AWS_REGION`, `BEDROCK_CROSS_REGION` |
+| AWS Bedrock | IAM / SSO / `aws login` / credentials chain | `BEDROCK_MODEL` | `BEDROCK_PROFILE` or `AWS_PROFILE`, `BEDROCK_REGION` or `AWS_REGION`, `BEDROCK_CROSS_REGION` |
 | Google Gemini | `GOOGLEAI_API_KEY` | `GOOGLEAI_MODEL` | `GOOGLEAI_MAX_TOKENS` |
 | xAI | `XAI_API_KEY` | `XAI_MODEL` | `XAI_MAX_TOKENS` |
 | ZAI | `ZAI_API_KEY` | `ZAI_MODEL` | `ZAI_MAX_TOKENS`, `ZAI_USE_CODING_PLAN`, `ZAI_THINKING`, `ZAI_API_URL` |
@@ -137,6 +137,19 @@ OPENAI_API_KEY=sk-xxx
 | OpenRouter | `OPENROUTER_API_KEY` | — | `OPENROUTER_MAX_TOKENS`, `OPENROUTER_FALLBACK_MODELS`, `OPENROUTER_API_URL` |
 | Ollama | — | `OLLAMA_MODEL` | `OLLAMA_ENABLED=true`, `OLLAMA_BASE_URL` |
 | OpenAI (Responses API) | `OPENAI_API_KEY` | `OPENAI_MODEL` | `OPENAI_RESPONSES_API_URL` |
+
+#### Environment file (.env) discovery
+
+ChatCLI looks for its environment file in this order, and the **first file that exists wins**:
+
+1. `$CHATCLI_DOTENV` (explicit; honored even when missing, so a typo is reported instead of silently ignored)
+2. `./.env` — the working directory
+3. `~/.chatcli/.env`
+4. `~/.env`
+
+The home fallbacks matter for the **non-interactive surfaces**: an editor spawning `chatcli acp`, or an MCP client spawning `chatcli mcp-server`, does **not** run your shell profile — `CHATCLI_DOTENV` and any variable you export from `.zshrc`/`.bashrc` never reach the child process, and its working directory is the project, which usually has no `.env`. Before this fallback existed those servers ran with no environment file at all: providers keyed by an env var disappeared and `AWS_PROFILE` went missing, so Bedrock authenticated as the `default` profile instead of the account you logged into. Keep your file at `~/.chatcli/.env` (or `~/.env`) and every surface agrees. `/config` shows the file in effect, its origin, and the effective AWS profile.
+
+Per-project settings: the ACP server also layers the `.env` of the project the editor opened (`session/new`'s `cwd`) on top, **fill-only** — it can add variables you have not set, never override one already in effect, and only the first project announced applies. Because a project directory is untrusted input, `CHATCLI_PROJECT_ENV=safe` (the default) refuses credential and endpoint variables (`*_API_KEY`, `*_TOKEN`, `*_BASE_URL`, `*_API_URL`, …) from that file; `all` accepts everything, `off` disables the overlay.
 
 #### Custom endpoints and OpenAI-compatible gateways
 

--- a/README_PT.md
+++ b/README_PT.md
@@ -125,7 +125,7 @@ OPENAI_API_KEY=sk-xxx
 |---|---|---|---|
 | OpenAI | `OPENAI_API_KEY` | `OPENAI_MODEL` | `OPENAI_MAX_TOKENS`, `OPENAI_USE_RESPONSES`, `OPENAI_API_URL` |
 | Anthropic | `ANTHROPIC_API_KEY` | `ANTHROPIC_MODEL` | `ANTHROPIC_MAX_TOKENS` |
-| AWS Bedrock | IAM / Profile / credentials chain | `BEDROCK_MODEL` | `AWS_REGION`, `BEDROCK_CROSS_REGION` |
+| AWS Bedrock | IAM / SSO / `aws login` / credentials chain | `BEDROCK_MODEL` | `BEDROCK_PROFILE` or `AWS_PROFILE`, `BEDROCK_REGION` or `AWS_REGION`, `BEDROCK_CROSS_REGION` |
 | Google Gemini | `GOOGLEAI_API_KEY` | `GOOGLEAI_MODEL` | `GOOGLEAI_MAX_TOKENS` |
 | xAI | `XAI_API_KEY` | `XAI_MODEL` | `XAI_MAX_TOKENS` |
 | ZAI | `ZAI_API_KEY` | `ZAI_MODEL` | `ZAI_MAX_TOKENS`, `ZAI_USE_CODING_PLAN`, `ZAI_THINKING`, `ZAI_API_URL` |
@@ -137,6 +137,19 @@ OPENAI_API_KEY=sk-xxx
 | OpenRouter | `OPENROUTER_API_KEY` | — | `OPENROUTER_MAX_TOKENS`, `OPENROUTER_FALLBACK_MODELS`, `OPENROUTER_API_URL` |
 | Ollama | — | `OLLAMA_MODEL` | `OLLAMA_ENABLED=true`, `OLLAMA_BASE_URL` |
 | OpenAI (Responses API) | `OPENAI_API_KEY` | `OPENAI_MODEL` | `OPENAI_RESPONSES_API_URL` |
+
+#### Descoberta do arquivo de ambiente (.env)
+
+O ChatCLI procura o arquivo de ambiente nesta ordem, e o **primeiro que existir vence**:
+
+1. `$CHATCLI_DOTENV` (explícito; respeitado mesmo se não existir, para que um caminho errado seja avisado em vez de ignorado em silêncio)
+2. `./.env` — o diretório atual
+3. `~/.chatcli/.env`
+4. `~/.env`
+
+Os fallbacks no home existem por causa das **superfícies não interativas**: uma IDE que sobe `chatcli acp`, ou um cliente MCP que sobe `chatcli mcp-server`, **não** executa o seu shell profile — nem `CHATCLI_DOTENV` nem nada que você exporta no `.zshrc`/`.bashrc` chega no processo filho, e o diretório de trabalho é o projeto, que normalmente não tem `.env`. Sem esse fallback esses servidores rodavam sem nenhum arquivo de ambiente: providers configurados por env var sumiam e o `AWS_PROFILE` faltava, então o Bedrock autenticava com o profile `default` em vez da conta em que você fez login. Mantenha o arquivo em `~/.chatcli/.env` (ou `~/.env`) e todas as superfícies concordam. O `/config` mostra o arquivo em efeito, a origem dele e o profile AWS efetivo.
+
+Configuração por projeto: o servidor ACP também sobrepõe o `.env` do projeto aberto na IDE (o `cwd` do `session/new`), **somente preenchendo** — pode adicionar variáveis que você não definiu, nunca sobrescreve uma já em efeito, e só o primeiro projeto anunciado se aplica. Como o diretório do projeto é entrada não confiável, `CHATCLI_PROJECT_ENV=safe` (padrão) recusa variáveis de credencial e de endpoint (`*_API_KEY`, `*_TOKEN`, `*_BASE_URL`, `*_API_URL`, …) vindas desse arquivo; `all` aceita tudo e `off` desliga a sobreposição.
 
 #### Endpoints customizados e gateways compatíveis com OpenAI
 

--- a/cli/cli_config.go
+++ b/cli/cli_config.go
@@ -74,6 +74,7 @@ var reloadableEnvVars = []string{
 	// Security, sessions, memory, hub, telemetry: a value removed from
 	// .env must not survive /reload.
 	"CHATCLI_ENCRYPTION_KEY", "CHATCLI_AUDIT_LOG_PATH", "CHATCLI_ENV_REDACT_MODE", "CHATCLI_MANAGED_CONFIG",
+	"CHATCLI_PROJECT_ENV",
 	"CHATCLI_SESSION_TRANSCRIPT", "CHATCLI_SESSION_TTL", "CHATCLI_GATEWAY_MAX_TENANTS", "CHATCLI_HUB_TTL_HOURS",
 	"CHATCLI_MEMORY_MODE", "CHATCLI_MEMORY_ENABLED", "CHATCLI_MEMORY_AUTORECALL", "CHATCLI_SESSION_AUTORECALL",
 	"CHATCLI_MEMORY_FALLBACK_PROVIDERS", "CHATCLI_MEMORY_MAX_FACTS", "CHATCLI_MEMORY_MAX_SIZE",
@@ -90,16 +91,15 @@ func (cli *ChatCLI) reloadConfiguration(ctx context.Context) {
 	prevProvider := cli.Provider
 	prevModel := cli.Model
 
-	envFilePath := os.Getenv("CHATCLI_DOTENV")
-	if envFilePath == "" {
-		envFilePath = ".env"
-	} else {
-		if expanded, err := utils.ExpandPath(envFilePath); err == nil {
-			envFilePath = expanded
-		} else {
-			fmt.Println(i18n.T("main.warn_expand_path", envFilePath, err))
-		}
+	// Same discovery rule as boot (CHATCLI_DOTENV → ./.env → ~/.chatcli/.env
+	// → ~/.env), re-run here so /reload picks up a file created since boot
+	// and every later reader agrees on which file is in effect.
+	res := config.ResolveDotenv()
+	config.SetActiveDotenv(res)
+	if res.ExpandErr != nil {
+		fmt.Println(i18n.T("main.warn_expand_path", res.Path, res.ExpandErr))
 	}
+	envFilePath := res.Path
 	for _, variable := range reloadableEnvVars {
 		_ = os.Unsetenv(variable)
 	}
@@ -467,18 +467,29 @@ func firstNonEmptyEnvVal(names ...string) string {
 	return ""
 }
 
-// getEnvFilePath retorna o caminho do arquivo .env configurado (expandido).
+// getEnvFilePath retorna o caminho do arquivo .env em efeito (expandido),
+// pela mesma descoberta do boot — não apenas CHATCLI_DOTENV/"./.env".
 func (cli *ChatCLI) getEnvFilePath() string {
-	envFilePath := os.Getenv("CHATCLI_DOTENV")
-	if envFilePath == "" {
-		envFilePath = ".env"
+	res := config.ActiveDotenv()
+	if res.ExpandErr != nil {
+		cli.logger.Warn("Não foi possível expandir o caminho do .env", zap.Error(res.ExpandErr))
 	}
-	expanded, err := utils.ExpandPath(envFilePath)
-	if err != nil {
-		cli.logger.Warn("Não foi possível expandir o caminho do .env", zap.Error(err))
-		return envFilePath // Retorna o original se falhar
+	return res.Path
+}
+
+// dotenvOriginLabel descreve, em uma palavra, de onde veio o arquivo de
+// ambiente em efeito — a informação que separa "o .env não foi lido" de
+// "o .env foi lido e a variável não está lá".
+func (cli *ChatCLI) dotenvOriginLabel() string {
+	res := config.ActiveDotenv()
+	switch {
+	case !res.Exists && res.Origin == config.DotenvNotFound:
+		return i18n.T("cfg.dotenv.origin_none")
+	case !res.Exists:
+		return i18n.T("cfg.dotenv.origin_missing", string(res.Origin))
+	default:
+		return string(res.Origin)
 	}
-	return expanded
 }
 
 func (ch *CommandHandler) handleVersionCommand(ctx context.Context) {

--- a/cli/config_sections.go
+++ b/cli/config_sections.go
@@ -43,6 +43,7 @@ import (
 	"github.com/diillson/chatcli/cli/plugins"
 	"github.com/diillson/chatcli/config"
 	"github.com/diillson/chatcli/i18n"
+	"github.com/diillson/chatcli/llm/bedrock"
 	"github.com/diillson/chatcli/llm/catalog"
 	"github.com/diillson/chatcli/llm/imagegen"
 	"github.com/diillson/chatcli/llm/transcription"
@@ -489,7 +490,14 @@ func (cli *ChatCLI) showConfigGeneral() {
 	p := uiPrefix(ColorCyan)
 
 	kv(p, i18n.T("cfg.kv.dotenv_path"), cli.getEnvFilePath())
+	kv(p, i18n.T("cfg.kv.dotenv_origin"), cli.dotenvOriginLabel())
 	kv(p, "CHATCLI_DOTENV", envOr("CHATCLI_DOTENV"))
+	kv(p, "CHATCLI_PROJECT_ENV", string(config.ProjectDotenvPolicy()))
+	for _, overlay := range config.ProjectDotenvOverlays() {
+		kv(p, i18n.T("cfg.kv.dotenv_project"),
+			fmt.Sprintf("%s (%s: %s)", overlay.Path,
+				i18n.T("cfg.kv.dotenv_project_applied"), strings.Join(overlay.Applied, ", ")))
+	}
 	kv(p, "ENV", envOr("ENV"))
 	kv(p, "CHATCLI_ENV", envOr("CHATCLI_ENV"))
 	kv(p, "CHATCLI_DEBUG", envBool("CHATCLI_DEBUG"))
@@ -600,7 +608,13 @@ func (cli *ChatCLI) showConfigProviders() {
 	kv(p, "BEDROCK_MODEL", envOr("BEDROCK_MODEL"))
 	kv(p, "BEDROCK_REGION", envOr("BEDROCK_REGION"))
 	kv(p, "AWS_REGION", envOr("AWS_REGION"))
+	kv(p, "BEDROCK_PROFILE", envOr("BEDROCK_PROFILE"))
 	kv(p, "AWS_PROFILE", envOr("AWS_PROFILE"))
+	// The identity actually used, and which variable decided it: env vars
+	// alone do not tell the story once the value comes from the .env, and
+	// "which account is this?" is the first question when Bedrock answers
+	// from the wrong one.
+	kv(p, i18n.T("cfg.kv.aws_profile_effective"), effectiveAWSProfile())
 	kv(p, "BEDROCK_PROVIDER", envOr("BEDROCK_PROVIDER"))
 	kv(p, "BEDROCK_MAX_TOKENS", envOr("BEDROCK_MAX_TOKENS"))
 	kv(p, "BEDROCK_TEMPERATURE", envOr("BEDROCK_TEMPERATURE"))
@@ -1702,4 +1716,16 @@ func (cli *ChatCLI) renderCoderPolicy(p string) {
 	kv(p, i18n.T("cfg.kv.local_merge"), localMerge)
 	kv(p, i18n.T("cfg.kv.rule_count"), rulesCount)
 	kv(p, i18n.T("cfg.kv.last_match"), lastRule)
+}
+
+// effectiveAWSProfile renders the profile every Bedrock surface resolves to,
+// naming the variable it came from — "(none)" means the AWS SDK falls back
+// to its own `default` profile, which is exactly the state that makes an
+// editor-spawned acp/mcp-server answer from the wrong account.
+func effectiveAWSProfile() string {
+	profile, source := bedrock.ResolveProfile()
+	if profile == "" {
+		return i18n.T("cfg.kv.aws_profile_none")
+	}
+	return fmt.Sprintf("%s (%s)", profile, source)
 }

--- a/cli/project_env.go
+++ b/cli/project_env.go
@@ -1,0 +1,117 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+/*
+ * project_env.go
+ *
+ * Per-project environment overlay for surfaces that only learn about the
+ * user's project after boot — today the ACP server, which receives it as
+ * session/new's cwd.
+ *
+ * The overlay is FILL-ONLY (config.ApplyProjectDotenv): a project .env can
+ * add settings the user has not set, and can never take over one that is
+ * already in effect. It also runs at most once per process: the first
+ * project announced wins, so two editor windows can never fight over the
+ * process-wide environment.
+ */
+package cli
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/diillson/chatcli/config"
+	"github.com/diillson/chatcli/llm/manager"
+	"go.uber.org/zap"
+)
+
+// projectEnvOnce guards the overlay: applying it twice would be confusing
+// (the second project's values would be silently ignored anyway, since the
+// first pass already exported them) and would rebuild the manager under a
+// live session for nothing.
+var projectEnvOnce sync.Once
+
+// ApplyProjectEnv layers <dir>/.env over the process environment and, when
+// that actually contributed variables, rebuilds the LLM manager so providers
+// the project unlocked (a per-repository AWS_PROFILE, a provider key) become
+// available. Returns the rebuilt manager, or nil when nothing changed.
+//
+// It never runs while an operation is in flight: swapping the manager under a
+// running prompt would race the client it is already using.
+func (cli *ChatCLI) ApplyProjectEnv(dir string) (manager.LLMManager, config.ProjectDotenvReport) {
+	var (
+		mgr manager.LLMManager
+		rep config.ProjectDotenvReport
+	)
+	projectEnvOnce.Do(func() {
+		rep = config.ApplyProjectDotenv(dir)
+		if rep.Err != nil {
+			cli.logger.Warn("project .env ignored", zap.String("path", rep.Path), zap.Error(rep.Err))
+			return
+		}
+		if !rep.Present {
+			cli.logger.Debug("no project .env", zap.String("dir", rep.Dir))
+			return
+		}
+		cli.logger.Info("project .env applied",
+			zap.String("path", rep.Path),
+			zap.String("mode", string(rep.Mode)),
+			zap.Strings("applied", rep.Applied),
+			zap.Strings("already_set", rep.Skipped),
+			zap.Strings("refused", rep.Refused))
+		if len(rep.Applied) == 0 {
+			return
+		}
+		if cli.IsExecuting() {
+			// Values are exported already — the provider factories read the
+			// environment per call, so most of the overlay takes effect
+			// anyway. Only the manager rebuild is skipped.
+			cli.logger.Warn("project .env applied mid-operation; manager rebuild deferred",
+				zap.String("path", rep.Path))
+			return
+		}
+		config.Global.Reload(cli.logger)
+		rebuilt, err := manager.NewLLMManager(cli.logger)
+		if err != nil {
+			cli.logger.Error("failed to rebuild the LLM manager after the project .env", zap.Error(err))
+			return
+		}
+		cli.manager = rebuilt
+		mgr = rebuilt
+		cli.adoptProviderAfterOverlay(rep)
+	})
+	return mgr, rep
+}
+
+// adoptProviderAfterOverlay keeps the session on its current provider/model
+// when the rebuilt manager still serves them, and only re-resolves from the
+// environment when the overlay is what defined them (or the current pair no
+// longer resolves).
+func (cli *ChatCLI) adoptProviderAfterOverlay(rep config.ProjectDotenvReport) {
+	if cli.Provider != "" {
+		if client, err := cli.manager.GetClient(cli.Provider, cli.Model); err == nil {
+			cli.Client = client
+			return
+		}
+	}
+	cli.configureProviderAndModel()
+	client, err := cli.manager.GetClient(cli.Provider, cli.Model)
+	if err != nil {
+		cli.logger.Warn("no client after the project .env overlay",
+			zap.String("provider", cli.Provider), zap.String("model", cli.Model), zap.Error(err))
+		return
+	}
+	cli.Client = client
+	cli.logger.Info("provider re-resolved after the project .env overlay",
+		zap.String("provider", cli.Provider),
+		zap.String("model", cli.Model),
+		zap.String("source", strings.Join(rep.Applied, ",")))
+}
+
+// ResetProjectEnvOnceForTest re-arms the one-shot overlay. Test-only.
+func ResetProjectEnvOnceForTest() {
+	projectEnvOnce = sync.Once{}
+}

--- a/cli/rpcserve/acp.go
+++ b/cli/rpcserve/acp.go
@@ -61,6 +61,16 @@ type SlashCommandExpander interface {
 	ExpandSlashCommand(ctx context.Context, session, text string) (string, bool)
 }
 
+// ACPWorkspaceBackend is an OPTIONAL capability (type assertion, same
+// contract as ACPCommandBackend): backends that can adopt the client's
+// project directory get session/new's cwd. ChatCLI uses it to layer that
+// project's .env on top of its own configuration — fill-only, so a project
+// can add settings (a per-repository AWS_PROFILE or model) but never take
+// over one the user already set.
+type ACPWorkspaceBackend interface {
+	AdoptWorkspace(dir string)
+}
+
 // HistoryItem is one conversation message replayed to an ACP client on
 // session/load (system messages and empty content are filtered out upstream).
 type HistoryItem struct {
@@ -145,6 +155,17 @@ func (a *ACP) Handle(ctx context.Context, method string, params json.RawMessage)
 		}, nil
 	case "session/new":
 		id := uuid.NewString()
+		// cwd is the client's project directory. Editors spawn the agent
+		// without the user's shell environment, so this is often the only
+		// hint ChatCLI gets about which project it is serving.
+		if wb, ok := a.backend.(ACPWorkspaceBackend); ok && len(params) > 0 {
+			var p struct {
+				Cwd string `json:"cwd"`
+			}
+			if err := json.Unmarshal(params, &p); err == nil && strings.TrimSpace(p.Cwd) != "" {
+				wb.AdoptWorkspace(p.Cwd)
+			}
+		}
 		a.mu.Lock()
 		a.sessions[id] = &acpSession{mode: acpDefaultMode}
 		a.mu.Unlock()

--- a/cli/rpcserve/acp_workspace_test.go
+++ b/cli/rpcserve/acp_workspace_test.go
@@ -1,0 +1,56 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package rpcserve
+
+import (
+	"testing"
+)
+
+// workspaceBackend layers the ACPWorkspaceBackend capability on the base fake.
+type workspaceBackend struct {
+	*fakeBackend
+	adopted []string
+}
+
+func (w *workspaceBackend) AdoptWorkspace(dir string) {
+	w.adopted = append(w.adopted, dir)
+}
+
+func TestACP_SessionNewAdoptsClientCwd(t *testing.T) {
+	be := &workspaceBackend{fakeBackend: &fakeBackend{}}
+	a := NewACP(be, "1.0.0")
+
+	runLines(t, a.Handle,
+		`{"jsonrpc":"2.0","id":1,"method":"session/new","params":{"cwd":"/work/repo","mcpServers":[]}}`)
+
+	if len(be.adopted) != 1 || be.adopted[0] != "/work/repo" {
+		t.Fatalf("session/new must hand the client's cwd to the backend, got %v", be.adopted)
+	}
+}
+
+func TestACP_SessionNewWithoutCwdAdoptsNothing(t *testing.T) {
+	be := &workspaceBackend{fakeBackend: &fakeBackend{}}
+	a := NewACP(be, "1.0.0")
+
+	runLines(t, a.Handle,
+		`{"jsonrpc":"2.0","id":1,"method":"session/new","params":{}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"session/new","params":{"cwd":"   "}}`)
+
+	if len(be.adopted) != 0 {
+		t.Fatalf("an absent or blank cwd must not trigger an overlay, got %v", be.adopted)
+	}
+}
+
+func TestACP_SessionNewWithoutWorkspaceCapabilityStillWorks(t *testing.T) {
+	// The capability is optional: a backend that does not implement it must
+	// keep serving session/new exactly as before.
+	a := NewACP(&fakeBackend{}, "1.0.0")
+	pr := runLines(t, a.Handle,
+		`{"jsonrpc":"2.0","id":1,"method":"session/new","params":{"cwd":"/work/repo"}}`)
+	if len(pr) != 1 || pr[0].Error != nil {
+		t.Fatalf("session/new must succeed without the capability: %+v", pr)
+	}
+}

--- a/cli/update_command.go
+++ b/cli/update_command.go
@@ -26,7 +26,6 @@ import (
 	"github.com/diillson/chatcli/update"
 	"github.com/diillson/chatcli/utils"
 	"github.com/diillson/chatcli/version"
-	"github.com/joho/godotenv"
 	"go.uber.org/zap"
 )
 
@@ -61,13 +60,9 @@ func RunUpdateOneShot(ctx context.Context, logger *zap.Logger, checkOnly bool) e
 // contrato de exit code de RunUpdateSubcommand. Vive no pacote cli para boot
 // e contrato ficarem sob teste — no main resta apenas o os.Exit.
 func UpdateSubcommandMain(args []string) int {
-	envFilePath := os.Getenv("CHATCLI_DOTENV")
-	if envFilePath == "" {
-		envFilePath = ".env"
-	} else if expanded, err := utils.ExpandPath(envFilePath); err == nil {
-		envFilePath = expanded
-	}
-	_ = godotenv.Load(envFilePath)
+	// Mesma descoberta do boot: CHATCLI_DOTENV → ./.env → ~/.chatcli/.env →
+	// ~/.env (o canal/pin de update mora no arquivo de ambiente).
+	_, _ = config.LoadDotenv()
 	i18n.Init()
 	theme.InitFromEnv()
 

--- a/cmd/rpcserve.go
+++ b/cmd/rpcserve.go
@@ -66,7 +66,9 @@ func runRPC(kind string, mgr manager.LLMManager, logger *zap.Logger) error {
 	if err != nil {
 		logger.Warn("rpcserve: ChatCLI init failed; agent/coder/tools disabled", zap.Error(err))
 	}
-	chatCLI.SetAuditSurface("acp")
+	// The surface is the server actually running: labelling an
+	// `mcp-server` run as "acp" mislabels its audit trail and telemetry.
+	chatCLI.SetAuditSurface(kind)
 	if chatCLI != nil {
 		// stdin carries the JSON-RPC protocol: any interactive confirmation
 		// would consume protocol frames and hang the run. Unattended mode
@@ -205,6 +207,10 @@ type sessionStore interface {
 // rpcBackend implements rpcserve.MCPBackend (and thus Backend). Chat keeps a
 // per-session history; agent/coder/tools delegate to the ChatCLI.
 type rpcBackend struct {
+	// mgr is swapped when a project .env unlocks providers (AdoptWorkspace),
+	// so every read goes through manager() under mgrMu — JSON-RPC requests
+	// are served concurrently.
+	mgrMu    sync.RWMutex
 	mgr      manager.LLMManager
 	cli      *cli.ChatCLI
 	store    sessionStore // nil when ChatCLI failed to initialize
@@ -272,10 +278,38 @@ func trimDanglingToolPairs(hist []models.Message) []models.Message {
 	return hist[start:end]
 }
 
+// manager returns the live LLM manager.
+func (b *rpcBackend) manager() manager.LLMManager {
+	b.mgrMu.RLock()
+	defer b.mgrMu.RUnlock()
+	return b.mgr
+}
+
+// AdoptWorkspace implements rpcserve.ACPWorkspaceBackend: the editor told us
+// which project it opened, so layer that project's .env over the process
+// configuration (fill-only, once per process).
+//
+// This is also the recovery path for the environment an editor never passes
+// on: a client that spawns `chatcli acp` without the user's shell gets no
+// CHATCLI_DOTENV and no exported provider variables, and the project file is
+// then the only per-repository configuration ChatCLI can still see.
+func (b *rpcBackend) AdoptWorkspace(dir string) {
+	if b.cli == nil {
+		return
+	}
+	rebuilt, _ := b.cli.ApplyProjectEnv(dir)
+	if rebuilt == nil {
+		return
+	}
+	b.mgrMu.Lock()
+	b.mgr = rebuilt
+	b.mgrMu.Unlock()
+}
+
 // HasLLM reports whether any LLM provider is configured. The MCP server
 // hides the LLM-backed harness tools when this is false.
 func (b *rpcBackend) HasLLM() bool {
-	return len(b.mgr.GetAvailableProviders()) > 0
+	return len(b.manager().GetAvailableProviders()) > 0
 }
 
 // errNoLLM is the actionable no-provider error, sent in-band to the caller
@@ -337,7 +371,7 @@ func (b *rpcBackend) promptPlain(ctx context.Context, session, text string, hist
 	if model == "" {
 		model = b.model
 	}
-	client, err := b.mgr.GetClient(provider, model)
+	client, err := b.manager().GetClient(provider, model)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/rpcserve.go
+++ b/cmd/rpcserve.go
@@ -66,7 +66,7 @@ func runRPC(kind string, mgr manager.LLMManager, logger *zap.Logger) error {
 	if err != nil {
 		logger.Warn("rpcserve: ChatCLI init failed; agent/coder/tools disabled", zap.Error(err))
 	}
-	// The surface is the server actually running: labelling an
+	// The surface is the server actually running: labeling an
 	// `mcp-server` run as "acp" mislabels its audit trail and telemetry.
 	chatCLI.SetAuditSurface(kind)
 	if chatCLI != nil {

--- a/config/dotenv.go
+++ b/config/dotenv.go
@@ -90,6 +90,9 @@ func expandHome(path string) (string, error) {
 
 // fileExists reports whether path is an existing regular file.
 func fileExists(path string) bool {
+	// #nosec G703 -- the path is the operator's own configuration ($CHATCLI_DOTENV
+	// or a fixed candidate under the working directory / home); stat only, and
+	// pointing ChatCLI at your own file is the documented feature.
 	info, err := os.Stat(path)
 	return err == nil && info.Mode().IsRegular()
 }

--- a/config/dotenv.go
+++ b/config/dotenv.go
@@ -1,0 +1,336 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Dotenv discovery.
+ *
+ * Every entrypoint (REPL, one-shot, `acp`, `mcp-server`, `gateway`,
+ * `daemon`, `update`) used to resolve the environment file the same naive
+ * way: $CHATCLI_DOTENV, else the literal ".env" — relative to the process
+ * working directory. That silently breaks the moment ChatCLI is NOT started
+ * from a shell:
+ *
+ *   an editor spawning `chatcli acp` (or an MCP client spawning
+ *   `chatcli mcp-server`) does not run the user's shell profile, so
+ *   CHATCLI_DOTENV never reaches the child, and its working directory is the
+ *   project — where there is no .env. Result: not a single variable from the
+ *   user's environment file is loaded. Providers keyed by an env var vanish
+ *   (the run silently falls back to whatever OAuth/CLI provider survives),
+ *   and AWS_PROFILE goes missing, so Bedrock authenticates as the `default`
+ *   profile instead of the account the user logged into — the AWS credential
+ *   chain then exhausts into the confusing "no EC2 IMDS role found".
+ *
+ * ResolveDotenv is the single source of truth: an explicit CHATCLI_DOTENV
+ * always wins, and otherwise the file is looked up in the working directory
+ * first, then in the user's ChatCLI directory, then in the home directory.
+ * The resolution is recorded (ActiveDotenv) so /config can show which file is
+ * actually in effect and credential errors can say why a variable is missing.
+ */
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/joho/godotenv"
+)
+
+// DotenvEnv is the variable that pins the environment file explicitly.
+const DotenvEnv = "CHATCLI_DOTENV"
+
+// DotenvOrigin says where the effective environment file came from.
+type DotenvOrigin string
+
+const (
+	// DotenvFromEnvVar — pinned by $CHATCLI_DOTENV (honored even if missing).
+	DotenvFromEnvVar DotenvOrigin = "CHATCLI_DOTENV"
+	// DotenvFromWorkdir — ./.env in the process working directory.
+	DotenvFromWorkdir DotenvOrigin = "workdir"
+	// DotenvFromChatCLIDir — ~/.chatcli/.env.
+	DotenvFromChatCLIDir DotenvOrigin = "chatcli-dir"
+	// DotenvFromHome — ~/.env.
+	DotenvFromHome DotenvOrigin = "home"
+	// DotenvNotFound — no candidate exists; nothing was loaded.
+	DotenvNotFound DotenvOrigin = "none"
+)
+
+// DotenvResolution is the outcome of one discovery pass.
+type DotenvResolution struct {
+	Path       string       // file to load (kept even when missing, for the warning)
+	Origin     DotenvOrigin // where Path came from
+	Exists     bool         // the file is present and readable
+	ExpandErr  error        // $CHATCLI_DOTENV could not be expanded (path kept verbatim)
+	Candidates []string     // every path considered, in order
+}
+
+// expandHome expands a leading "~" like utils.ExpandPath does. It is
+// duplicated here on purpose: utils imports config, so config must not
+// import utils.
+func expandHome(path string) (string, error) {
+	if !strings.HasPrefix(path, "~") {
+		return path, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("could not resolve the home directory: %w", err)
+	}
+	if len(path) == 1 {
+		return home, nil
+	}
+	if path[1] == '/' || path[1] == filepath.Separator {
+		return filepath.Join(home, path[2:]), nil
+	}
+	return "", fmt.Errorf("~username expansion is not supported, only ~ for the current user's home directory")
+}
+
+// fileExists reports whether path is an existing regular file.
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Mode().IsRegular()
+}
+
+// ResolveDotenv finds the environment file to load.
+//
+// Precedence:
+//  1. $CHATCLI_DOTENV — explicit intent always wins, missing file included
+//     (the caller warns, exactly as before).
+//  2. ./.env — the historical behavior, so a project-local file still wins
+//     over the user-wide one.
+//  3. ~/.chatcli/.env — ChatCLI's own directory.
+//  4. ~/.env — the conventional location, and where users who export
+//     CHATCLI_DOTENV=~/.env from their shell profile already keep it.
+//
+// With no candidate present the result points at ".env" with Origin
+// DotenvNotFound, which keeps godotenv.Load's "not exist" path intact.
+func ResolveDotenv() DotenvResolution {
+	if raw := strings.TrimSpace(os.Getenv(DotenvEnv)); raw != "" {
+		res := DotenvResolution{Path: raw, Origin: DotenvFromEnvVar}
+		expanded, err := expandHome(raw)
+		if err != nil {
+			res.ExpandErr = err
+		} else {
+			res.Path = expanded
+		}
+		res.Candidates = []string{res.Path}
+		res.Exists = fileExists(res.Path)
+		return res
+	}
+
+	res := DotenvResolution{Path: ".env", Origin: DotenvNotFound}
+	type candidate struct {
+		path   string
+		origin DotenvOrigin
+	}
+	candidates := []candidate{{".env", DotenvFromWorkdir}}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		candidates = append(candidates,
+			candidate{filepath.Join(home, ".chatcli", ".env"), DotenvFromChatCLIDir},
+			candidate{filepath.Join(home, ".env"), DotenvFromHome},
+		)
+	}
+	for _, c := range candidates {
+		res.Candidates = append(res.Candidates, c.path)
+		if res.Exists {
+			continue // keep listing candidates for /config, first hit wins
+		}
+		if fileExists(c.path) {
+			res.Path, res.Origin, res.Exists = c.path, c.origin, true
+		}
+	}
+	return res
+}
+
+var (
+	dotenvMu       sync.RWMutex
+	dotenvActive   DotenvResolution
+	dotenvOverlays []ProjectDotenvReport
+)
+
+// SetActiveDotenv records the resolution the process actually loaded, so
+// every later reader (ConfigManager, /config, credential diagnostics) reports
+// the same file instead of re-deriving it from a working directory that may
+// have changed.
+func SetActiveDotenv(res DotenvResolution) {
+	dotenvMu.Lock()
+	defer dotenvMu.Unlock()
+	dotenvActive = res
+}
+
+// ActiveDotenv returns the recorded resolution, resolving on the fly when
+// the process never registered one (tests, library use).
+func ActiveDotenv() DotenvResolution {
+	dotenvMu.RLock()
+	res := dotenvActive
+	dotenvMu.RUnlock()
+	if res.Path != "" {
+		return res
+	}
+	return ResolveDotenv()
+}
+
+// LoadDotenv resolves, loads and records the environment file in one step.
+// godotenv.Load never overrides a variable already present in the process
+// environment, so a value exported by the shell keeps winning over the file.
+func LoadDotenv() (DotenvResolution, error) {
+	res := ResolveDotenv()
+	SetActiveDotenv(res)
+	return res, godotenv.Load(res.Path)
+}
+
+// ProjectDotenvMode is the policy for project-supplied environment files.
+type ProjectDotenvMode string
+
+const (
+	// ProjectDotenvSafe (default) applies a project .env except for
+	// credential and endpoint variables — see projectDotenvBlocked.
+	ProjectDotenvSafe ProjectDotenvMode = "safe"
+	// ProjectDotenvAll applies every key the project file declares.
+	ProjectDotenvAll ProjectDotenvMode = "all"
+	// ProjectDotenvOff ignores project files entirely.
+	ProjectDotenvOff ProjectDotenvMode = "off"
+)
+
+// ProjectDotenvEnv selects the policy above.
+const ProjectDotenvEnv = "CHATCLI_PROJECT_ENV"
+
+// ProjectDotenvPolicy reads the configured policy (default: safe).
+func ProjectDotenvPolicy() ProjectDotenvMode {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(ProjectDotenvEnv))) {
+	case "off", "false", "0", "no":
+		return ProjectDotenvOff
+	case "all", "true", "1", "yes":
+		return ProjectDotenvAll
+	default:
+		return ProjectDotenvSafe
+	}
+}
+
+// projectDotenvBlocked reports whether a key is refused in "safe" mode.
+//
+// A project directory is attacker-controlled input: cloning a repository and
+// opening it in an editor must not let its .env redirect ChatCLI's traffic
+// (a *_BASE_URL / *_API_URL pointing at an exfiltration host would carry the
+// user's own key with it) or inject credentials and encryption material.
+// Everything else — LLM_PROVIDER, LLM_MODEL, AWS_PROFILE, BEDROCK_REGION,
+// feature toggles — is per-project configuration and passes.
+func projectDotenvBlocked(key string) bool {
+	k := strings.ToUpper(strings.TrimSpace(key))
+	for _, suffix := range []string{
+		"_API_KEY", "_APIKEY", "_KEY", "_TOKEN", "_SECRET", "_PASSWORD",
+		"_BASE_URL", "_API_URL", "_ENDPOINT", "_ENDPOINT_URL", "_CREDENTIALS",
+	} {
+		if strings.HasSuffix(k, suffix) {
+			return true
+		}
+	}
+	switch k {
+	case "CLIENT_ID", "CLIENT_KEY", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY",
+		"AWS_SESSION_TOKEN", "AWS_WEB_IDENTITY_TOKEN_FILE", "AWS_CONFIG_FILE",
+		"AWS_SHARED_CREDENTIALS_FILE", "CHATCLI_DOTENV", "CHATCLI_MANAGED_CONFIG",
+		"CHATCLI_AUDIT_LOG_PATH", "CHATCLI_CA_BUNDLE", "CHATCLI_BEDROCK_CA_BUNDLE",
+		"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "PATH", "LD_PRELOAD":
+		return true
+	}
+	return false
+}
+
+// ProjectDotenvReport is the outcome of one project overlay.
+type ProjectDotenvReport struct {
+	Dir     string // directory the client announced
+	Path    string // <dir>/.env
+	Present bool   // the file exists
+	Mode    ProjectDotenvMode
+	Applied []string // keys that filled an unset variable
+	Skipped []string // keys already set in the process (never overridden)
+	Refused []string // keys blocked by the safe policy
+	Err     error    // read/parse failure (the file is then ignored)
+}
+
+// ApplyProjectDotenv loads <dir>/.env as a FILL-ONLY overlay: a variable
+// already present in the process (shell export, user .env, managed policy)
+// is never overridden, so the overlay can add per-project configuration but
+// can never take control of an existing setting. Applying the same directory
+// twice, or the file already loaded as the active dotenv, is a no-op.
+//
+// It exists for surfaces that learn about the user's project only after boot
+// — the ACP server receives it as session/new's cwd.
+func ApplyProjectDotenv(dir string) ProjectDotenvReport {
+	rep := ProjectDotenvReport{Dir: dir, Mode: ProjectDotenvPolicy()}
+	if strings.TrimSpace(dir) == "" || rep.Mode == ProjectDotenvOff {
+		return rep
+	}
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		rep.Err = err
+		return rep
+	}
+	rep.Dir = abs
+	rep.Path = filepath.Join(abs, ".env")
+	if !fileExists(rep.Path) {
+		return rep
+	}
+	rep.Present = true
+
+	active := ActiveDotenv()
+	if activeAbs, err := filepath.Abs(active.Path); err == nil && activeAbs == rep.Path {
+		return rep // already loaded as the process-wide environment file
+	}
+	dotenvMu.RLock()
+	for _, prev := range dotenvOverlays {
+		if prev.Path == rep.Path {
+			dotenvMu.RUnlock()
+			return rep
+		}
+	}
+	dotenvMu.RUnlock()
+
+	values, err := godotenv.Read(rep.Path)
+	if err != nil {
+		rep.Err = err
+		return rep
+	}
+	for key, value := range values {
+		switch {
+		case rep.Mode == ProjectDotenvSafe && projectDotenvBlocked(key):
+			rep.Refused = append(rep.Refused, key)
+		case isEnvSet(key):
+			rep.Skipped = append(rep.Skipped, key)
+		default:
+			_ = os.Setenv(key, value)
+			rep.Applied = append(rep.Applied, key)
+		}
+	}
+	sort.Strings(rep.Applied)
+	sort.Strings(rep.Skipped)
+	sort.Strings(rep.Refused)
+
+	dotenvMu.Lock()
+	dotenvOverlays = append(dotenvOverlays, rep)
+	dotenvMu.Unlock()
+	return rep
+}
+
+// ProjectDotenvOverlays returns the project files applied so far (for /config).
+func ProjectDotenvOverlays() []ProjectDotenvReport {
+	dotenvMu.RLock()
+	defer dotenvMu.RUnlock()
+	return append([]ProjectDotenvReport(nil), dotenvOverlays...)
+}
+
+// ResetProjectDotenvForTest clears the overlay bookkeeping. Test-only.
+func ResetProjectDotenvForTest() {
+	dotenvMu.Lock()
+	defer dotenvMu.Unlock()
+	dotenvOverlays = nil
+	dotenvActive = DotenvResolution{}
+}
+
+func isEnvSet(key string) bool {
+	v, ok := os.LookupEnv(key)
+	return ok && v != ""
+}

--- a/config/dotenv_test.go
+++ b/config/dotenv_test.go
@@ -1,0 +1,215 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// setHome points os.UserHomeDir at dir on every platform.
+func setHome(t *testing.T, dir string) {
+	t.Helper()
+	t.Setenv("HOME", dir)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", dir)
+	}
+}
+
+func writeEnvFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestResolveDotenv_ExplicitEnvVarWins(t *testing.T) {
+	home := t.TempDir()
+	setHome(t, home)
+	work := t.TempDir()
+	t.Chdir(work)
+	writeEnvFile(t, filepath.Join(work, ".env"), "A=1\n")
+	pinned := filepath.Join(home, "custom.env")
+	writeEnvFile(t, pinned, "A=2\n")
+	t.Setenv(DotenvEnv, pinned)
+
+	res := ResolveDotenv()
+	if res.Path != pinned || res.Origin != DotenvFromEnvVar || !res.Exists {
+		t.Fatalf("explicit CHATCLI_DOTENV must win: %+v", res)
+	}
+}
+
+func TestResolveDotenv_ExplicitMissingFileIsKept(t *testing.T) {
+	setHome(t, t.TempDir())
+	t.Chdir(t.TempDir())
+	t.Setenv(DotenvEnv, filepath.Join(t.TempDir(), "nope.env"))
+
+	res := ResolveDotenv()
+	if res.Origin != DotenvFromEnvVar || res.Exists {
+		t.Fatalf("a pinned but missing file must be reported as missing, not replaced: %+v", res)
+	}
+}
+
+func TestResolveDotenv_TildeIsExpanded(t *testing.T) {
+	home := t.TempDir()
+	setHome(t, home)
+	t.Chdir(t.TempDir())
+	writeEnvFile(t, filepath.Join(home, "shell.env"), "A=1\n")
+	t.Setenv(DotenvEnv, "~/shell.env")
+
+	res := ResolveDotenv()
+	if res.Path != filepath.Join(home, "shell.env") || !res.Exists {
+		t.Fatalf("~ must expand: %+v", res)
+	}
+}
+
+func TestResolveDotenv_FallbackOrder(t *testing.T) {
+	home := t.TempDir()
+	setHome(t, home)
+	work := t.TempDir()
+	t.Chdir(work)
+	t.Setenv(DotenvEnv, "")
+
+	homeEnv := filepath.Join(home, ".env")
+	chatcliEnv := filepath.Join(home, ".chatcli", ".env")
+	workEnv := filepath.Join(work, ".env")
+
+	// 1) Only ~/.env exists — this is the case an editor-spawned acp/mcp-server
+	// hits: no CHATCLI_DOTENV, project directory without a .env.
+	writeEnvFile(t, homeEnv, "A=1\n")
+	if res := ResolveDotenv(); res.Path != homeEnv || res.Origin != DotenvFromHome || !res.Exists {
+		t.Fatalf("~/.env fallback: %+v", res)
+	}
+
+	// 2) ~/.chatcli/.env outranks ~/.env.
+	writeEnvFile(t, chatcliEnv, "A=2\n")
+	if res := ResolveDotenv(); res.Path != chatcliEnv || res.Origin != DotenvFromChatCLIDir {
+		t.Fatalf("~/.chatcli/.env must outrank ~/.env: %+v", res)
+	}
+
+	// 3) The working directory still wins over both (historical behavior).
+	writeEnvFile(t, workEnv, "A=3\n")
+	if res := ResolveDotenv(); res.Origin != DotenvFromWorkdir {
+		t.Fatalf("./.env must win: %+v", res)
+	}
+}
+
+func TestResolveDotenv_NothingFound(t *testing.T) {
+	setHome(t, t.TempDir())
+	t.Chdir(t.TempDir())
+	t.Setenv(DotenvEnv, "")
+
+	res := ResolveDotenv()
+	if res.Exists || res.Origin != DotenvNotFound || res.Path != ".env" {
+		t.Fatalf("empty environment: %+v", res)
+	}
+	if len(res.Candidates) < 3 {
+		t.Fatalf("every candidate must be reported for diagnostics: %+v", res.Candidates)
+	}
+}
+
+func TestApplyProjectDotenv_FillOnly(t *testing.T) {
+	ResetProjectDotenvForTest()
+	t.Cleanup(ResetProjectDotenvForTest)
+	setHome(t, t.TempDir())
+	t.Setenv(ProjectDotenvEnv, "")
+
+	dir := t.TempDir()
+	writeEnvFile(t, filepath.Join(dir, ".env"), "AWS_PROFILE=project\nLLM_PROVIDER=BEDROCK\n")
+	t.Setenv("LLM_PROVIDER", "CLAUDEAI") // already set by the user
+	os.Unsetenv("AWS_PROFILE")
+	t.Cleanup(func() { os.Unsetenv("AWS_PROFILE") })
+
+	rep := ApplyProjectDotenv(dir)
+	if !rep.Present || rep.Err != nil {
+		t.Fatalf("overlay should have been read: %+v", rep)
+	}
+	if got := os.Getenv("AWS_PROFILE"); got != "project" {
+		t.Fatalf("unset variable must be filled, got %q", got)
+	}
+	if got := os.Getenv("LLM_PROVIDER"); got != "CLAUDEAI" {
+		t.Fatalf("a variable already in effect must never be overridden, got %q", got)
+	}
+	if len(rep.Applied) != 1 || rep.Applied[0] != "AWS_PROFILE" {
+		t.Fatalf("applied = %v", rep.Applied)
+	}
+	if len(rep.Skipped) != 1 || rep.Skipped[0] != "LLM_PROVIDER" {
+		t.Fatalf("skipped = %v", rep.Skipped)
+	}
+}
+
+func TestApplyProjectDotenv_SafeModeRefusesCredentialsAndEndpoints(t *testing.T) {
+	ResetProjectDotenvForTest()
+	t.Cleanup(ResetProjectDotenvForTest)
+	setHome(t, t.TempDir())
+	t.Setenv(ProjectDotenvEnv, "")
+
+	dir := t.TempDir()
+	writeEnvFile(t, filepath.Join(dir, ".env"),
+		"OPENAI_API_KEY=sk-hostile\nANTHROPIC_BASE_URL=https://evil.example\nBEDROCK_REGION=sa-east-1\n")
+	for _, k := range []string{"OPENAI_API_KEY", "ANTHROPIC_BASE_URL", "BEDROCK_REGION"} {
+		os.Unsetenv(k)
+	}
+	t.Cleanup(func() {
+		for _, k := range []string{"OPENAI_API_KEY", "ANTHROPIC_BASE_URL", "BEDROCK_REGION"} {
+			os.Unsetenv(k)
+		}
+	})
+
+	rep := ApplyProjectDotenv(dir)
+	if os.Getenv("OPENAI_API_KEY") != "" || os.Getenv("ANTHROPIC_BASE_URL") != "" {
+		t.Fatal("a project directory must not be able to inject credentials or redirect endpoints")
+	}
+	if os.Getenv("BEDROCK_REGION") != "sa-east-1" {
+		t.Fatal("plain per-project configuration must still apply")
+	}
+	if len(rep.Refused) != 2 {
+		t.Fatalf("refused = %v", rep.Refused)
+	}
+}
+
+func TestApplyProjectDotenv_ModesOffAndAll(t *testing.T) {
+	setHome(t, t.TempDir())
+	dir := t.TempDir()
+	writeEnvFile(t, filepath.Join(dir, ".env"), "OPENAI_API_KEY=sk-project\n")
+	os.Unsetenv("OPENAI_API_KEY")
+	t.Cleanup(func() { os.Unsetenv("OPENAI_API_KEY") })
+
+	ResetProjectDotenvForTest()
+	t.Setenv(ProjectDotenvEnv, "off")
+	if rep := ApplyProjectDotenv(dir); rep.Present || len(rep.Applied) != 0 {
+		t.Fatalf("off must ignore the file entirely: %+v", rep)
+	}
+
+	ResetProjectDotenvForTest()
+	t.Setenv(ProjectDotenvEnv, "all")
+	if rep := ApplyProjectDotenv(dir); len(rep.Applied) != 1 {
+		t.Fatalf("all must apply every key: %+v", rep)
+	}
+	if os.Getenv("OPENAI_API_KEY") != "sk-project" {
+		t.Fatal("all mode must export the key")
+	}
+	ResetProjectDotenvForTest()
+}
+
+func TestApplyProjectDotenv_SkipsTheActiveDotenvAndRepeats(t *testing.T) {
+	ResetProjectDotenvForTest()
+	t.Cleanup(ResetProjectDotenvForTest)
+	setHome(t, t.TempDir())
+	t.Setenv(ProjectDotenvEnv, "")
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".env")
+	writeEnvFile(t, path, "PROJECT_ONLY_KEY=1\n")
+	SetActiveDotenv(DotenvResolution{Path: path, Origin: DotenvFromWorkdir, Exists: true})
+
+	if rep := ApplyProjectDotenv(dir); len(rep.Applied) != 0 {
+		t.Fatalf("the file already loaded process-wide must not be applied twice: %+v", rep)
+	}
+	if len(ProjectDotenvOverlays()) != 0 {
+		t.Fatal("no overlay should have been recorded")
+	}
+}

--- a/config/manager.go
+++ b/config/manager.go
@@ -101,10 +101,22 @@ func (cm *ConfigManager) loadDefaults() {
 }
 
 // loadEnvFile carrega configurações do arquivo .env.
+//
+// O caminho vem de ActiveDotenv (CHATCLI_DOTENV → ./.env → ~/.chatcli/.env →
+// ~/.env), NUNCA do godotenv.Read() sem argumento: aquele lia sempre "./.env"
+// e ignorava CHATCLI_DOTENV, então o fallback ".env-sourced" que o manager de
+// LLM usa (config.Global.GetString("AWS_PROFILE"), modelos de boot, …) ficava
+// vazio sempre que o arquivo de ambiente não estava no diretório atual — o
+// caso normal de `chatcli acp`/`mcp-server` lançado por uma IDE.
 func (cm *ConfigManager) loadEnvFile() {
-	envMap, err := godotenv.Read() // Não sobrepõe vars de ambiente existentes
+	path := ActiveDotenv().Path
+	if path == "" {
+		path = ".env"
+	}
+	envMap, err := godotenv.Read(path) // Não sobrepõe vars de ambiente existentes
 	if err != nil {
-		cm.logger.Debug("Arquivo .env não encontrado ou erro na leitura", zap.Error(err))
+		cm.logger.Debug("Arquivo .env não encontrado ou erro na leitura",
+			zap.String("path", path), zap.Error(err))
 		return
 	}
 	for key, value := range envMap {

--- a/i18n/locales/en-US.env-discovery.json
+++ b/i18n/locales/en-US.env-discovery.json
@@ -1,0 +1,12 @@
+{
+  "cfg.kv.dotenv_origin": "Environment file origin",
+  "cfg.kv.dotenv_project": "Project .env",
+  "cfg.kv.dotenv_project_applied": "applied",
+  "cfg.dotenv.origin_none": "none (no .env found; only the process environment is in effect)",
+  "cfg.dotenv.origin_missing": "%s (file not found)",
+  "cfg.kv.aws_profile_effective": "Effective AWS profile",
+  "cfg.kv.aws_profile_none": "(none — the AWS SDK falls back to its 'default' profile)",
+  "llm.bedrock.creds_profile_none": "(none)",
+  "llm.bedrock.creds_dotenv_missing": "%s (not found)",
+  "llm.bedrock.creds_unresolved": "bedrock: could not resolve AWS credentials — profile %s (from %s), environment file %s (origin: %s). If ChatCLI was started by an editor or MCP client, it does not inherit your shell: set CHATCLI_DOTENV, BEDROCK_PROFILE or AWS_PROFILE in the client's env block, or keep your environment file at ~/.chatcli/.env. If the profile is correct, refresh the session with '%s'"
+}

--- a/i18n/locales/en.env-discovery.json
+++ b/i18n/locales/en.env-discovery.json
@@ -1,0 +1,12 @@
+{
+  "cfg.kv.dotenv_origin": "Environment file origin",
+  "cfg.kv.dotenv_project": "Project .env",
+  "cfg.kv.dotenv_project_applied": "applied",
+  "cfg.dotenv.origin_none": "none (no .env found; only the process environment is in effect)",
+  "cfg.dotenv.origin_missing": "%s (file not found)",
+  "cfg.kv.aws_profile_effective": "Effective AWS profile",
+  "cfg.kv.aws_profile_none": "(none — the AWS SDK falls back to its 'default' profile)",
+  "llm.bedrock.creds_profile_none": "(none)",
+  "llm.bedrock.creds_dotenv_missing": "%s (not found)",
+  "llm.bedrock.creds_unresolved": "bedrock: could not resolve AWS credentials — profile %s (from %s), environment file %s (origin: %s). If ChatCLI was started by an editor or MCP client, it does not inherit your shell: set CHATCLI_DOTENV, BEDROCK_PROFILE or AWS_PROFILE in the client's env block, or keep your environment file at ~/.chatcli/.env. If the profile is correct, refresh the session with '%s'"
+}

--- a/i18n/locales/pt-BR.env-discovery.json
+++ b/i18n/locales/pt-BR.env-discovery.json
@@ -1,0 +1,12 @@
+{
+  "cfg.kv.dotenv_origin": "Origem do arquivo de ambiente",
+  "cfg.kv.dotenv_project": ".env do projeto",
+  "cfg.kv.dotenv_project_applied": "aplicadas",
+  "cfg.dotenv.origin_none": "nenhuma (nenhum .env encontrado; só o ambiente do processo está em efeito)",
+  "cfg.dotenv.origin_missing": "%s (arquivo não encontrado)",
+  "cfg.kv.aws_profile_effective": "Profile AWS efetivo",
+  "cfg.kv.aws_profile_none": "(nenhum — o SDK da AWS cai no profile 'default')",
+  "llm.bedrock.creds_profile_none": "(nenhum)",
+  "llm.bedrock.creds_dotenv_missing": "%s (não encontrado)",
+  "llm.bedrock.creds_unresolved": "bedrock: não foi possível resolver as credenciais AWS — profile %s (de %s), arquivo de ambiente %s (origem: %s). Se o ChatCLI foi iniciado por uma IDE ou cliente MCP, ele NÃO herda o seu shell: defina CHATCLI_DOTENV, BEDROCK_PROFILE ou AWS_PROFILE no bloco env do cliente, ou mantenha o arquivo de ambiente em ~/.chatcli/.env. Se o profile estiver certo, renove a sessão com '%s'"
+}

--- a/llm/bedrock/bedrock_client.go
+++ b/llm/bedrock/bedrock_client.go
@@ -389,6 +389,16 @@ func (c *BedrockClient) maybeResolveProfileModel(ctx context.Context) {
 // model family (Anthropic Messages vs. OpenAI Chat Completions).
 // Retries are delegated to utils.Retry inside each family-specific path.
 func (c *BedrockClient) SendPrompt(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {
+	resp, err := c.sendPromptDispatch(ctx, prompt, history, maxTokens)
+	// A credential-chain failure reaches the user as "no EC2 IMDS role
+	// found", which explains nothing on a laptop. Annotate it with the
+	// profile in use and the environment file in effect (the error keeps its
+	// original chain for errors.As/Is).
+	return resp, ExplainCredentialError(err)
+}
+
+// sendPromptDispatch is SendPrompt without the credential-error annotation.
+func (c *BedrockClient) sendPromptDispatch(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {
 	// Clear per-call usage so an errored or usage-less response falls back
 	// to estimation instead of re-counting the previous call (see usage.go).
 	c.resetUsage()
@@ -818,7 +828,7 @@ func (c *BedrockClient) ListModels(ctx context.Context) ([]client.ModelInfo, err
 		ByOutputModality: bedrocktypes.ModelModalityText,
 	})
 	if err != nil {
-		c.logger.Warn("bedrock: ListFoundationModels failed", zap.Error(err),
+		c.logger.Warn("bedrock: ListFoundationModels failed", zap.Error(ExplainCredentialError(err)),
 			zap.String("hint", bedrockListEndpointHint))
 	} else {
 		for _, s := range fm.ModelSummaries {
@@ -870,7 +880,7 @@ func (c *BedrockClient) appendInferenceProfiles(ctx context.Context, profileType
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
-			c.logger.Warn("bedrock: ListInferenceProfiles failed", zap.Error(err),
+			c.logger.Warn("bedrock: ListInferenceProfiles failed", zap.Error(ExplainCredentialError(err)),
 				zap.String("type", string(profileType)),
 				zap.String("hint", bedrockListEndpointHint))
 			break

--- a/llm/bedrock/credentials.go
+++ b/llm/bedrock/credentials.go
@@ -1,0 +1,325 @@
+/*
+ * ChatCLI - AWS credential resolution and diagnostics for Bedrock.
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * One place decides WHICH AWS identity every Bedrock surface talks with —
+ * chat, agent/coder, model listing, embeddings and image generation — and
+ * one place explains what to do when that identity cannot be resolved.
+ *
+ * The split used to be silent and lossy: the chat client read AWS_PROFILE
+ * only, imagegen read BEDROCK_PROFILE first, and the registry factory read
+ * neither from the .env. So a BEDROCK_PROFILE documented in /config (it is
+ * listed in reloadableEnvVars) selected the account for images and was
+ * ignored for inference, and a profile that lived only in the environment
+ * file was invisible to any surface that did not export it to the process.
+ */
+package bedrock
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/diillson/chatcli/config"
+	"github.com/diillson/chatcli/i18n"
+)
+
+// ProfileEnvKeys are the variables that select the AWS profile, in
+// precedence order. BEDROCK_PROFILE scopes a profile to ChatCLI without
+// touching AWS_PROFILE for the rest of the shell.
+var ProfileEnvKeys = []string{"BEDROCK_PROFILE", "AWS_PROFILE"}
+
+// RegionEnvKeys are the variables that select the region, in precedence order.
+var RegionEnvKeys = []string{"BEDROCK_REGION", "AWS_REGION", "AWS_DEFAULT_REGION"}
+
+// envOrConfig reads a variable from the process environment first and from
+// the loaded environment file second. The second source matters because
+// godotenv only exports to the process when ChatCLI itself loaded the file;
+// values reaching ChatCLI through config.Global (managed policy, a file read
+// after boot) would otherwise be invisible to the AWS SDK.
+func envOrConfig(keys ...string) (value, key string) {
+	for _, k := range keys {
+		if v := strings.TrimSpace(os.Getenv(k)); v != "" {
+			return v, k
+		}
+	}
+	if config.Global != nil {
+		for _, k := range keys {
+			if v := strings.TrimSpace(config.Global.GetString(k)); v != "" {
+				return v, k
+			}
+		}
+	}
+	return "", ""
+}
+
+// ResolveProfile returns the AWS profile every Bedrock surface must use and
+// the variable it came from ("" when no profile is configured, which lets
+// the SDK fall back to its own default profile).
+func ResolveProfile() (profile, source string) {
+	return envOrConfig(ProfileEnvKeys...)
+}
+
+// ResolveRegion returns the configured region and its source, without
+// applying a default — callers decide their own fallback.
+func ResolveRegion() (region, source string) {
+	return envOrConfig(RegionEnvKeys...)
+}
+
+// awsConfigPath returns the shared config file path, honoring AWS_CONFIG_FILE.
+func awsConfigPath() string {
+	if v := strings.TrimSpace(os.Getenv("AWS_CONFIG_FILE")); v != "" {
+		return v
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".aws", "config")
+}
+
+// awsCredentialsPath returns the shared credentials file path, honoring
+// AWS_SHARED_CREDENTIALS_FILE.
+func awsCredentialsPath() string {
+	if v := strings.TrimSpace(os.Getenv("AWS_SHARED_CREDENTIALS_FILE")); v != "" {
+		return v
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".aws", "credentials")
+}
+
+// awsCacheDirs are the token caches written by an interactive AWS login:
+// ~/.aws/sso/cache for `aws sso login` and ~/.aws/login/cache for the newer
+// `aws login` flow (AWS CLI v2 "login_session" profiles, supported by the
+// SDK since aws-sdk-go-v2/config v1.33). A profile that authenticates that
+// way carries no key material in ~/.aws/credentials, so without looking
+// here ChatCLI concluded there were no AWS credentials at all and never
+// registered the Bedrock provider.
+func awsCacheDirs() []string {
+	if v := strings.TrimSpace(os.Getenv("AWS_LOGIN_CACHE_DIRECTORY")); v != "" {
+		return []string{v}
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	return []string{
+		filepath.Join(home, ".aws", "sso", "cache"),
+		filepath.Join(home, ".aws", "login", "cache"),
+	}
+}
+
+// HasCachedLoginToken reports whether an interactive AWS login left a token
+// cache behind (SSO or the newer `aws login`). An expired token still counts:
+// the SDK reports that precisely at call time, which is a far better error
+// than pretending the provider does not exist.
+func HasCachedLoginToken() bool {
+	for _, dir := range awsCacheDirs() {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if !e.IsDir() && strings.HasSuffix(e.Name(), ".json") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// credentialErrorMarkers are the SDK strings that mean "the credential chain
+// produced nothing usable" — as opposed to a genuine Bedrock API error.
+var credentialErrorMarkers = []string{
+	"failed to refresh cached credentials",
+	"no ec2 imds role found",
+	"ec2imds",
+	"get credentials:",
+	"get identity: get credentials",
+	"failed to get shared config profile",
+	"failed to load shared config",
+	"failed to retrieve credentials",
+	"no valid credential sources",
+	"sso session",
+	"sso token",
+	"token has expired",
+	"expiredtoken",
+	"invalidgrantexception",
+	"invalidclienttokenid",
+	"unrecognizedclientexception",
+	"security token included in the request is invalid",
+	"resolve aws credentials",
+}
+
+// IsCredentialError reports whether err is a credential-chain failure.
+// String matching is the pragmatic option: the SDK fmt-joins these chains
+// without stable sentinel types across credential providers.
+func IsCredentialError(err error) bool {
+	if err == nil {
+		return false
+	}
+	lower := strings.ToLower(err.Error())
+	for _, marker := range credentialErrorMarkers {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// ExplainCredentialError annotates an AWS credential failure with the state
+// that actually explains it: the profile in use and where it came from, and
+// the environment file in effect.
+//
+// Raw, the SDK says "no EC2 IMDS role found" — which reads like an EC2
+// problem and says nothing about the real cause on a developer machine: the
+// profile never reached the process. That is the normal outcome when an
+// editor or MCP client spawns `chatcli acp`/`chatcli mcp-server` without the
+// user's shell environment, so the message names that case explicitly.
+//
+// Non-credential errors are returned untouched.
+func ExplainCredentialError(err error) error {
+	if !IsCredentialError(err) {
+		return err
+	}
+	profile, source := ResolveProfile()
+	profileLabel := profile
+	if profile == "" {
+		profileLabel = i18n.T("llm.bedrock.creds_profile_none")
+		source = "-"
+	}
+	dotenv := config.ActiveDotenv()
+	dotenvLabel := dotenv.Path
+	if !dotenv.Exists {
+		dotenvLabel = i18n.T("llm.bedrock.creds_dotenv_missing", dotenv.Path)
+	}
+	loginHint := "aws sso login"
+	if profile != "" {
+		loginHint = "aws sso login --profile " + profile
+	}
+	// Wrapped, never replaced: errors.As/Is walks this chain (payload-cap
+	// recovery and the retry classifier both inspect it).
+	return fmt.Errorf("%s: %w", i18n.T("llm.bedrock.creds_unresolved",
+		profileLabel, source, dotenvLabel, string(dotenv.Origin), loginHint), err)
+}
+
+// CredentialsAvailable reports whether there is a credible signal that AWS
+// credentials are usable, so ChatCLI can register the Bedrock provider
+// without the AWS SDK falling through to IMDS (169.254.169.254) and hanging
+// with a confusing timeout on a machine that is not an EC2 instance.
+//
+// The mere existence of ~/.aws/config is deliberately NOT a signal (it may
+// hold only region/output metadata), and neither is an empty
+// ~/.aws/credentials.
+//
+// Accepted signals (any one is enough):
+//   - Static credentials in the environment (AWS_ACCESS_KEY_ID)
+//   - A profile selection (BEDROCK_PROFILE / AWS_PROFILE), from the process
+//     environment or the loaded .env — SSO, assume-role, credential_process
+//   - A Bedrock API key (AWS_BEARER_TOKEN_BEDROCK), used by the Mantle surface
+//   - Web identity / container roles (EKS / ECS)
+//   - A shared credentials file with a non-empty aws_access_key_id
+//   - A shared config declaring a usable profile: SSO (sso_start_url /
+//     sso_session), the newer `aws login` (login_session), assume-role
+//     (role_arn) or credential_process
+//   - A cached login token (~/.aws/sso/cache or ~/.aws/login/cache)
+func CredentialsAvailable() bool {
+	for _, key := range []string{
+		"AWS_ACCESS_KEY_ID",
+		"AWS_BEARER_TOKEN_BEDROCK",
+		"AWS_WEB_IDENTITY_TOKEN_FILE",
+		"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+		"AWS_CONTAINER_CREDENTIALS_FULL_URI",
+	} {
+		if strings.TrimSpace(os.Getenv(key)) != "" {
+			return true
+		}
+	}
+	// Profile from the environment OR from the loaded .env: godotenv exports
+	// to the process, but a value that only reached config.Global (managed
+	// policy) must count just the same.
+	if profile, _ := ResolveProfile(); profile != "" {
+		return true
+	}
+	if credentialsFileHasKey(awsCredentialsPath()) {
+		return true
+	}
+	if configFileHasUsableProfile(awsConfigPath()) {
+		return true
+	}
+	return HasCachedLoginToken()
+}
+
+// credentialsFileHasKey returns true only if the AWS shared credentials file
+// contains at least one non-empty aws_access_key_id entry. An empty or
+// region-only file is not enough to activate Bedrock.
+func credentialsFileHasKey(path string) bool {
+	if path == "" {
+		return false
+	}
+	data, err := os.ReadFile(filepath.Clean(path)) // #nosec G304 — path from AWS_SHARED_CREDENTIALS_FILE or os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, ";") {
+			continue
+		}
+		if strings.HasPrefix(strings.ToLower(trimmed), "aws_access_key_id") {
+			if idx := strings.Index(trimmed, "="); idx >= 0 {
+				if strings.TrimSpace(trimmed[idx+1:]) != "" {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// usableProfileKeys are the shared-config keys that can produce credentials
+// without IMDS. login_session is the newer `aws login` flow: a profile that
+// carries it has no key material anywhere else, so omitting it here made
+// ChatCLI declare "no AWS credentials" for a user who was, in fact, logged in.
+var usableProfileKeys = []string{
+	"sso_start_url",  // legacy SSO profile
+	"sso_session",    // new-style SSO (aws sso login)
+	"sso_account_id", // ditto
+	"login_session",  // aws login (AWS CLI v2 sign-in)
+	"role_arn",       // assume-role profile (source_profile / web identity)
+	"credential_process",
+}
+
+// configFileHasUsableProfile returns true if the shared config declares at
+// least one profile that can produce credentials without IMDS. A config that
+// only sets region/output does NOT count.
+func configFileHasUsableProfile(path string) bool {
+	if path == "" {
+		return false
+	}
+	data, err := os.ReadFile(filepath.Clean(path)) // #nosec G304 — path from AWS_CONFIG_FILE or os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, ";") {
+			continue
+		}
+		lower := strings.ToLower(trimmed)
+		for _, key := range usableProfileKeys {
+			if strings.HasPrefix(lower, key) {
+				if idx := strings.Index(trimmed, "="); idx >= 0 &&
+					strings.TrimSpace(trimmed[idx+1:]) != "" {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/llm/bedrock/credentials_test.go
+++ b/llm/bedrock/credentials_test.go
@@ -1,0 +1,184 @@
+package bedrock
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/config"
+	"go.uber.org/zap"
+)
+
+// isolateAWSEnv clears every variable that can decide the AWS identity and
+// points HOME at a scratch directory, so a test never inherits the machine's
+// real credentials.
+func isolateAWSEnv(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", home)
+	}
+	for _, k := range []string{
+		"BEDROCK_PROFILE", "AWS_PROFILE", "BEDROCK_REGION", "AWS_REGION", "AWS_DEFAULT_REGION",
+		"AWS_ACCESS_KEY_ID", "AWS_BEARER_TOKEN_BEDROCK", "AWS_WEB_IDENTITY_TOKEN_FILE",
+		"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+		"AWS_CONFIG_FILE", "AWS_SHARED_CREDENTIALS_FILE", "AWS_LOGIN_CACHE_DIRECTORY",
+	} {
+		t.Setenv(k, "")
+		os.Unsetenv(k)
+	}
+	config.ResetGlobalForTest(zap.NewNop())
+	return home
+}
+
+func writeFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func TestResolveProfile_Precedence(t *testing.T) {
+	isolateAWSEnv(t)
+
+	if p, src := ResolveProfile(); p != "" || src != "" {
+		t.Fatalf("no profile configured should resolve empty, got %q/%q", p, src)
+	}
+
+	// .env-only value (never exported to the process) must still be seen.
+	config.Global.Set("AWS_PROFILE", "from-dotenv")
+	if p, src := ResolveProfile(); p != "from-dotenv" || src != "AWS_PROFILE" {
+		t.Fatalf("dotenv profile: %q/%q", p, src)
+	}
+
+	// The process environment outranks the file.
+	t.Setenv("AWS_PROFILE", "from-env")
+	if p, _ := ResolveProfile(); p != "from-env" {
+		t.Fatalf("env must outrank the dotenv, got %q", p)
+	}
+
+	// BEDROCK_PROFILE scopes a profile to ChatCLI and outranks AWS_PROFILE —
+	// it was honored by image generation and ignored by inference before.
+	t.Setenv("BEDROCK_PROFILE", "bedrock-only")
+	if p, src := ResolveProfile(); p != "bedrock-only" || src != "BEDROCK_PROFILE" {
+		t.Fatalf("BEDROCK_PROFILE must win: %q/%q", p, src)
+	}
+}
+
+func TestResolveRegion_Precedence(t *testing.T) {
+	isolateAWSEnv(t)
+	config.Global.Set("AWS_REGION", "eu-west-1")
+	if r, _ := ResolveRegion(); r != "eu-west-1" {
+		t.Fatalf("dotenv region: %q", r)
+	}
+	t.Setenv("AWS_DEFAULT_REGION", "us-west-2")
+	if r, _ := ResolveRegion(); r != "us-west-2" {
+		t.Fatalf("process env must win: %q", r)
+	}
+	t.Setenv("BEDROCK_REGION", "sa-east-1")
+	if r, src := ResolveRegion(); r != "sa-east-1" || src != "BEDROCK_REGION" {
+		t.Fatalf("BEDROCK_REGION must win: %q/%q", r, src)
+	}
+}
+
+func TestCredentialsAvailable_Signals(t *testing.T) {
+	home := isolateAWSEnv(t)
+	if CredentialsAvailable() {
+		t.Fatal("an empty machine must not advertise Bedrock")
+	}
+
+	// A config file with only region/output is NOT a credential.
+	cfgPath := filepath.Join(home, ".aws", "config")
+	writeFile(t, cfgPath, "[default]\nregion = us-east-1\noutput = json\n")
+	if CredentialsAvailable() {
+		t.Fatal("region-only config must not count as a credential")
+	}
+
+	// An empty credentials file is not one either.
+	writeFile(t, filepath.Join(home, ".aws", "credentials"), "[default]\n")
+	if CredentialsAvailable() {
+		t.Fatal("empty credentials file must not count")
+	}
+
+	// `aws login` profile: no key material anywhere, only login_session.
+	writeFile(t, cfgPath, "[default]\nregion = us-east-1\nlogin_session = arn:aws:iam::123456789012:root\n")
+	if !CredentialsAvailable() {
+		t.Fatal("an `aws login` (login_session) profile must register Bedrock")
+	}
+}
+
+func TestCredentialsAvailable_LoginTokenCache(t *testing.T) {
+	home := isolateAWSEnv(t)
+	writeFile(t, filepath.Join(home, ".aws", "login", "cache", "token.json"), "{}")
+	if !CredentialsAvailable() {
+		t.Fatal("a cached `aws login` token must register Bedrock")
+	}
+}
+
+func TestCredentialsAvailable_DotenvProfile(t *testing.T) {
+	isolateAWSEnv(t)
+	config.Global.Set("BEDROCK_PROFILE", "work")
+	if !CredentialsAvailable() {
+		t.Fatal("a profile that lives only in the .env must register Bedrock")
+	}
+}
+
+func TestCredentialsAvailable_HonorsAWSConfigFileOverride(t *testing.T) {
+	isolateAWSEnv(t)
+	custom := filepath.Join(t.TempDir(), "aws.conf")
+	writeFile(t, custom, "[profile work]\nsso_session = corp\n")
+	t.Setenv("AWS_CONFIG_FILE", custom)
+	if !CredentialsAvailable() {
+		t.Fatal("AWS_CONFIG_FILE must be honored")
+	}
+}
+
+func TestIsCredentialError(t *testing.T) {
+	imds := errors.New(`operation error Bedrock Runtime: InvokeModel, get identity: get credentials: ` +
+		`failed to refresh cached credentials, no EC2 IMDS role found`)
+	if !IsCredentialError(imds) {
+		t.Fatal("the IMDS-exhaustion shape is the signature failure of a missing profile")
+	}
+	if IsCredentialError(errors.New("ValidationException: model not supported")) {
+		t.Fatal("a genuine API error must not be classified as a credential failure")
+	}
+	if IsCredentialError(nil) {
+		t.Fatal("nil is not an error")
+	}
+}
+
+func TestExplainCredentialError_AnnotatesAndPreservesChain(t *testing.T) {
+	isolateAWSEnv(t)
+	t.Setenv("AWS_PROFILE", "work")
+
+	sentinel := errors.New("failed to refresh cached credentials, no EC2 IMDS role found")
+	wrapped := fmt.Errorf("operation error Bedrock Runtime: %w", sentinel)
+
+	out := ExplainCredentialError(wrapped)
+	if !errors.Is(out, sentinel) {
+		t.Fatal("the original chain must survive for errors.Is/As")
+	}
+	msg := out.Error()
+	for _, want := range []string{"work", "aws sso login --profile work"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("message must name the profile and the fix; got %q", msg)
+		}
+	}
+
+	// Non-credential errors are returned untouched.
+	other := errors.New("ValidationException")
+	if got := ExplainCredentialError(other); got != other {
+		t.Fatalf("non-credential errors must pass through unchanged, got %v", got)
+	}
+	if ExplainCredentialError(nil) != nil {
+		t.Fatal("nil must stay nil")
+	}
+}

--- a/llm/bedrock/credentials_test.go
+++ b/llm/bedrock/credentials_test.go
@@ -175,7 +175,8 @@ func TestExplainCredentialError_AnnotatesAndPreservesChain(t *testing.T) {
 
 	// Non-credential errors are returned untouched.
 	other := errors.New("ValidationException")
-	if got := ExplainCredentialError(other); got != other {
+	got := ExplainCredentialError(other)
+	if !errors.Is(got, other) || got.Error() != other.Error() {
 		t.Fatalf("non-credential errors must pass through unchanged, got %v", got)
 	}
 	if ExplainCredentialError(nil) != nil {

--- a/llm/bedrock/register.go
+++ b/llm/bedrock/register.go
@@ -6,8 +6,6 @@
 package bedrock
 
 import (
-	"os"
-
 	"github.com/diillson/chatcli/config"
 	"github.com/diillson/chatcli/llm/client"
 	"github.com/diillson/chatcli/llm/registry"
@@ -18,21 +16,27 @@ func init() {
 		Name:         "BEDROCK",
 		DisplayName:  "AWS Bedrock (all text models available to your account)",
 		RequiresAuth: false, // Auth comes from AWS credential chain, not a string APIKey
-		EnvKeys:      []string{"BEDROCK_REGION", "AWS_REGION", "AWS_PROFILE"},
+		EnvKeys:      []string{"BEDROCK_REGION", "AWS_REGION", "BEDROCK_PROFILE", "AWS_PROFILE"},
 		Factory: func(cfg registry.ProviderConfig) (client.LLMClient, error) {
 			model := cfg.Model
 			if model == "" {
 				model = config.DefaultBedrockModel
 			}
+			// Same resolution the manager and every other Bedrock surface
+			// use (BEDROCK_* first, then AWS_*, then the loaded .env) — this
+			// factory used to read AWS_PROFILE from the process only, so a
+			// BEDROCK_PROFILE or an .env-only profile selected a different
+			// account here than in chat.
+			envRegion, _ := ResolveRegion()
 			region := firstNonEmpty(
 				cfg.ExtraConfig["region"],
-				os.Getenv("BEDROCK_REGION"),
-				os.Getenv("AWS_REGION"),
+				envRegion,
 				config.DefaultBedrockRegion,
 			)
+			envProfile, _ := ResolveProfile()
 			profile := firstNonEmpty(
 				cfg.ExtraConfig["profile"],
-				os.Getenv("AWS_PROFILE"),
+				envProfile,
 			)
 			return NewBedrockClient(model, region, profile, cfg.Logger, cfg.MaxRetries, cfg.Backoff), nil
 		},

--- a/llm/embedding/bedrock.go
+++ b/llm/embedding/bedrock.go
@@ -207,34 +207,13 @@ func profileHint(profile string) string {
 	return " --profile " + profile
 }
 
-// isAWSCredentialError matches the aws-sdk-go-v2 error chain shapes seen
-// when no usable credential source exists: expired SSO token cache, IMDS
-// disabled/absent, or an empty provider chain. String matching is the
-// pragmatic option — the SDK wraps these in fmt-joined chains without
-// stable sentinel types across providers.
+// isAWSCredentialError reports whether err is an AWS credential-chain
+// failure. The marker list lives in llm/bedrock (IsCredentialError) so chat,
+// listing and embeddings classify the same error identically — two copies
+// drifted apart is how an expired session tripped the breaker on one surface
+// and surfaced raw on another.
 func isAWSCredentialError(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := strings.ToLower(err.Error())
-	for _, marker := range []string{
-		"failed to refresh cached credentials",
-		"get credentials:",
-		"no ec2 imds role found",
-		"ec2imds",
-		"sso session",
-		"sso token",
-		"token has expired",
-		"expiredtoken",
-		"invalidclienttokenid",
-		"no valid credential sources",
-		"failed to retrieve credentials",
-	} {
-		if strings.Contains(msg, marker) {
-			return true
-		}
-	}
-	return false
+	return bedrock.IsCredentialError(err)
 }
 
 func (b *Bedrock) ensureRuntime(ctx context.Context) error {

--- a/llm/embedding/factory.go
+++ b/llm/embedding/factory.go
@@ -13,6 +13,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/diillson/chatcli/llm/bedrock"
 )
 
 // NewByName returns a provider by short name. Supported names: "voyage",
@@ -71,8 +73,11 @@ func NewByName(name string) (Provider, error) {
 				dim = n
 			}
 		}
-		region := firstNonEmpty(os.Getenv("BEDROCK_REGION"), os.Getenv("AWS_REGION"))
-		profile := os.Getenv("AWS_PROFILE")
+		// Shared resolution: BEDROCK_PROFILE/BEDROCK_REGION first, then the
+		// AWS_* pair, then the loaded .env — embeddings must land on the same
+		// account as chat.
+		region, _ := bedrock.ResolveRegion()
+		profile, _ := bedrock.ResolveProfile()
 		return NewBedrock(os.Getenv("CHATCLI_EMBED_MODEL"), region, profile, dim, nil)
 	default:
 		return nil, fmt.Errorf("%w: %q", ErrUnknownProvider, name)

--- a/llm/imagegen/bedrock.go
+++ b/llm/imagegen/bedrock.go
@@ -19,7 +19,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
@@ -230,19 +229,11 @@ func aspectRatio(w, h int) string {
 // bedrockImageRegion / bedrockImageProfile read the same env the chat Bedrock
 // provider uses.
 func bedrockImageRegion() string {
-	for _, k := range []string{"BEDROCK_REGION", "AWS_REGION", "AWS_DEFAULT_REGION"} {
-		if v := strings.TrimSpace(os.Getenv(k)); v != "" {
-			return v
-		}
-	}
-	return ""
+	region, _ := bedrock.ResolveRegion()
+	return region
 }
 
 func bedrockImageProfile() string {
-	for _, k := range []string{"BEDROCK_PROFILE", "AWS_PROFILE"} {
-		if v := strings.TrimSpace(os.Getenv(k)); v != "" {
-			return v
-		}
-	}
-	return ""
+	profile, _ := bedrock.ResolveProfile()
+	return profile
 }

--- a/llm/manager/llm_manager.go
+++ b/llm/manager/llm_manager.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -183,158 +182,30 @@ func NewLLMManager(logger *zap.Logger) (LLMManager, error) {
 // real das credenciais acontece apenas na primeira chamada (credentials chain
 // padrão: env → shared config → IAM role).
 func (m *LLMManagerImpl) configurarBedrockClient(maxRetries int, initialBackoff time.Duration) {
-	if !bedrockCredentialsAvailable() {
+	if !bedrock.CredentialsAvailable() {
 		m.logger.Warn(i18n.T("llm.warn.provider_not_available", "AWS credentials", "BEDROCK"))
 		return
 	}
-	m.logger.Info(i18n.T("llm.info.configuring_provider", "AWS Bedrock"))
+	profile, profileSource := bedrock.ResolveProfile()
+	// The effective identity is logged at boot on purpose: "Bedrock answered
+	// as the wrong account" is otherwise invisible until an API call fails,
+	// and on an editor-spawned acp/mcp-server the profile silently missing
+	// from the environment is exactly the bug this line exposes.
+	m.logger.Info(i18n.T("llm.info.configuring_provider", "AWS Bedrock"),
+		zap.String("profile", profile),
+		zap.String("profile_source", profileSource),
+		zap.String("dotenv", config.ActiveDotenv().Path))
 	m.clients["BEDROCK"] = func(model string) (client.LLMClient, error) {
 		if model == "" {
 			model = resolveBedrockModel()
 		}
-		region := firstNonEmptyEnv("BEDROCK_REGION", "AWS_REGION")
+		region, _ := bedrock.ResolveRegion()
 		if region == "" {
 			region = config.DefaultBedrockRegion
 		}
-		profile := resolveAWSProfile()
+		profile, _ := bedrock.ResolveProfile()
 		return bedrock.NewBedrockClient(model, region, profile, m.logger, maxRetries, initialBackoff), nil
 	}
-}
-
-// bedrockCredentialsAvailable reports whether there is a credible signal that
-// AWS credentials are usable. It intentionally does NOT treat the mere existence
-// of ~/.aws/config as a credential (that file may hold only region/profile
-// metadata), nor does it treat an empty ~/.aws/credentials as valid — otherwise
-// the AWS SDK falls through to IMDS (169.254.169.254) and hangs with a
-// confusing timeout on non-EC2 machines.
-//
-// Accepted signals (any one is enough):
-//   - Static creds via env (AWS_ACCESS_KEY_ID)
-//   - Profile selection (AWS_PROFILE) — SSO, assume-role, credential_process, etc.
-//   - Web identity / container roles (EKS / ECS)
-//   - ~/.aws/credentials with a non-empty aws_access_key_id
-//   - ~/.aws/config declaring a usable profile: SSO (sso_start_url / sso_session),
-//     assume-role (role_arn), or credential_process
-//   - An active SSO token cache in ~/.aws/sso/cache/
-func bedrockCredentialsAvailable() bool {
-	if os.Getenv("AWS_ACCESS_KEY_ID") != "" ||
-		os.Getenv("AWS_PROFILE") != "" ||
-		os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE") != "" ||
-		os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") != "" ||
-		os.Getenv("AWS_CONTAINER_CREDENTIALS_FULL_URI") != "" {
-		return true
-	}
-	// Also check .env-sourced config (godotenv doesn't export to os.Environ).
-	if config.Global != nil && config.Global.GetString("AWS_PROFILE") != "" {
-		return true
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return false
-	}
-	if credentialsFileHasKey(home + "/.aws/credentials") {
-		return true
-	}
-	if configFileHasUsableProfile(home + "/.aws/config") {
-		return true
-	}
-	return hasActiveSSOCache(home + "/.aws/sso/cache")
-}
-
-// credentialsFileHasKey returns true only if the AWS shared credentials file
-// contains at least one aws_access_key_id entry. An empty or region-only file
-// is not enough to activate Bedrock.
-func credentialsFileHasKey(path string) bool {
-	data, err := os.ReadFile(filepath.Clean(path)) // #nosec G304 — path built from os.UserHomeDir() + constant
-	if err != nil {
-		return false
-	}
-	for _, line := range strings.Split(string(data), "\n") {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, ";") {
-			continue
-		}
-		if strings.HasPrefix(strings.ToLower(trimmed), "aws_access_key_id") {
-			if idx := strings.Index(trimmed, "="); idx >= 0 {
-				if strings.TrimSpace(trimmed[idx+1:]) != "" {
-					return true
-				}
-			}
-		}
-	}
-	return false
-}
-
-// configFileHasUsableProfile returns true if ~/.aws/config declares at least
-// one profile that can produce credentials without IMDS: SSO, assume-role, or
-// credential_process. A config that only sets region/output does NOT count.
-func configFileHasUsableProfile(path string) bool {
-	data, err := os.ReadFile(filepath.Clean(path)) // #nosec G304 — path built from os.UserHomeDir() + constant
-	if err != nil {
-		return false
-	}
-	usableKeys := []string{
-		"sso_start_url",  // legacy SSO profile
-		"sso_session",    // new-style SSO (aws sso login)
-		"sso_account_id", // ditto
-		"role_arn",       // assume-role profile (source_profile / web identity)
-		"credential_process",
-	}
-	for _, line := range strings.Split(string(data), "\n") {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, ";") {
-			continue
-		}
-		lower := strings.ToLower(trimmed)
-		for _, key := range usableKeys {
-			if strings.HasPrefix(lower, key) {
-				if idx := strings.Index(trimmed, "="); idx >= 0 &&
-					strings.TrimSpace(trimmed[idx+1:]) != "" {
-					return true
-				}
-			}
-		}
-	}
-	return false
-}
-
-// hasActiveSSOCache returns true if ~/.aws/sso/cache contains any JSON token
-// file. A stale/expired token will still be caught later at SDK call time, but
-// its presence means the user has at least run `aws sso login` at some point.
-func hasActiveSSOCache(dir string) bool {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return false
-	}
-	for _, e := range entries {
-		if !e.IsDir() && strings.HasSuffix(e.Name(), ".json") {
-			return true
-		}
-	}
-	return false
-}
-
-// resolveAWSProfile returns the AWS profile name from the first available
-// source: env var AWS_PROFILE > .env file (via config.Global).
-func resolveAWSProfile() string {
-	if v := os.Getenv("AWS_PROFILE"); v != "" {
-		return v
-	}
-	if config.Global != nil {
-		if v := config.Global.GetString("AWS_PROFILE"); v != "" {
-			return v
-		}
-	}
-	return ""
-}
-
-func firstNonEmptyEnv(keys ...string) string {
-	for _, k := range keys {
-		if v := os.Getenv(k); v != "" {
-			return v
-		}
-	}
-	return ""
 }
 
 // resolveModelEnv returns the model to use when the caller did not pick
@@ -1018,11 +889,12 @@ func (m *LLMManagerImpl) CreateClientWithKey(provider, model, apiKey string) (cl
 		if model == "" {
 			model = resolveBedrockModel()
 		}
-		region := firstNonEmptyEnv("BEDROCK_REGION", "AWS_REGION")
+		region, _ := bedrock.ResolveRegion()
 		if region == "" {
 			region = config.DefaultBedrockRegion
 		}
-		return bedrock.NewBedrockClient(model, region, resolveAWSProfile(), m.logger, maxRetries, initialBackoff), nil
+		profile, _ := bedrock.ResolveProfile()
+		return bedrock.NewBedrockClient(model, region, profile, m.logger, maxRetries, initialBackoff), nil
 
 	default:
 		return nil, fmt.Errorf("%s", i18n.T("llm.manager.create_client_unsupported", provider))

--- a/llm/manager/llm_manager_test.go
+++ b/llm/manager/llm_manager_test.go
@@ -25,6 +25,10 @@ func setupTestEnv(t *testing.T, envs map[string]string) {
 		"OLLAMA_ENABLED", "OLLAMA_BASE_URL",
 		"STACKSPOT_REALM", "STACKSPOT_AGENT_ID",
 		"CHATCLI_AUTH_DIR",
+		// The environment file must not leak into provider assertions: with
+		// CHATCLI_DOTENV exported (a common developer setup) the resolver
+		// would load the real file and register every provider it configures.
+		"CHATCLI_DOTENV", "CHATCLI_PROJECT_ENV",
 		"AWS_ACCESS_KEY_ID", "AWS_PROFILE", "AWS_REGION", "BEDROCK_REGION",
 		"BEDROCK_MODEL",
 		"AWS_WEB_IDENTITY_TOKEN_FILE",

--- a/main.go
+++ b/main.go
@@ -61,10 +61,11 @@ func dispatchSubcommand() bool {
 // dotenvBootstrap carries the outcome of the pre-i18n environment load so
 // entrypoints can defer user-facing warnings until translations are up.
 type dotenvBootstrap struct {
-	path      string
-	expandErr error
-	loadErr   error
-	managed   config.ManagedReport
+	path       string
+	expandErr  error
+	loadErr    error
+	managed    config.ManagedReport
+	resolution config.DotenvResolution
 }
 
 // loadDotenvThenI18n resolves and loads the dotenv file and only then
@@ -73,14 +74,13 @@ type dotenvBootstrap struct {
 // init-first order silently ignored a dotenv-only CHATCLI_LANG, masked on
 // Unix by LANG but pinning Windows cmd/PowerShell (no LANG) to English.
 func loadDotenvThenI18n() dotenvBootstrap {
-	b := dotenvBootstrap{path: os.Getenv("CHATCLI_DOTENV")}
-	if b.path == "" {
-		b.path = ".env"
-	} else if expanded, err := utils.ExpandPath(b.path); err == nil {
-		b.path = expanded
-	} else {
-		b.expandErr = err
-	}
+	// config.ResolveDotenv is the single discovery rule shared by every
+	// entrypoint: $CHATCLI_DOTENV, else ./.env, ~/.chatcli/.env, ~/.env.
+	// The home fallbacks are what keep `chatcli acp` / `mcp-server` working
+	// when an editor spawns them without the user's shell environment.
+	res := config.ResolveDotenv()
+	config.SetActiveDotenv(res)
+	b := dotenvBootstrap{path: res.Path, expandErr: res.ExpandErr, resolution: res}
 	b.loadErr = godotenv.Load(b.path)
 	// Organization-managed defaults and locked policies (config/managed.go):
 	// after the user's .env so defaults fill only what is unset, and before
@@ -102,6 +102,25 @@ func reportDotenvBootstrap(b dotenvBootstrap) {
 	if b.managed.Err != nil {
 		fmt.Println(i18n.T("main.warn_managed_config", b.managed.Path, b.managed.Err))
 	}
+}
+
+// logDotenvResolution records which environment file the process actually
+// loaded, plus the candidates considered when none was found. It is the
+// first thing to check when an editor-spawned `acp`/`mcp-server` disagrees
+// with the terminal about available providers or the AWS profile in use.
+func logDotenvResolution(logger *zap.Logger) {
+	res := config.ActiveDotenv()
+	fields := []zap.Field{
+		zap.String("path", res.Path),
+		zap.String("origin", string(res.Origin)),
+		zap.Bool("exists", res.Exists),
+	}
+	if res.Exists {
+		logger.Info("dotenv loaded", fields...)
+		return
+	}
+	logger.Warn("no dotenv file found; only the process environment is in effect",
+		append(fields, zap.Strings("candidates", res.Candidates))...)
 }
 
 // printVersionInfo prints version details (including update check) and is used
@@ -211,6 +230,7 @@ func main() {
 
 	config.InitGlobal(logger)
 	config.Global.Load()
+	logDotenvResolution(logger)
 	utils.ApplyGlobalTLSTrust(logger)
 	utils.LogStartupInfo(logger)
 
@@ -288,6 +308,9 @@ func runSubcommand(subcmd string, args []string) {
 
 	config.InitGlobal(logger)
 	config.Global.Load()
+	// stdout carries the JSON-RPC protocol on `acp`/`mcp-server`: the dotenv
+	// outcome goes to the log, never to the wire.
+	logDotenvResolution(logger)
 	utils.ApplyGlobalTLSTrust(logger)
 
 	defer func() {
@@ -380,6 +403,7 @@ func runDaemonSubcommand(args []string) {
 
 	config.InitGlobal(logger)
 	config.Global.Load()
+	logDotenvResolution(logger)
 	utils.ApplyGlobalTLSTrust(logger)
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Problema

No ACP (e igualmente no MCP), o Bedrock deixou de usar a conta em que o usuário está logado. A causa não é do Bedrock: é o **arquivo de ambiente nunca ser carregado** quando o servidor é lançado por uma IDE/cliente MCP.

Todo entrypoint resolvia o dotenv como `$CHATCLI_DOTENV` senão `./.env` (relativo ao cwd). Uma IDE que sobe `chatcli acp` **não** executa o shell profile: `CHATCLI_DOTENV` e qualquer export do `.zshrc` não chegam no processo filho, e o cwd é o projeto — que normalmente não tem `.env`. Resultado: nenhuma variável do `.env` do usuário entra.

Reproduzido lado a lado no mesmo binário v1.196.0:

| provider | REPL no terminal | `chatcli acp` com `env -i` |
|---|---|---|
| GOOGLEAI / XAI / ZAI / MOONSHOT / OPENROUTER | configurados | **"not set" — sumiram** |
| BEDROCK | profile do `.env` | **sem `AWS_PROFILE` → profile `default`** |
| CLAUDEAI (OAuth), DEVIN (binário) | ok | ok — não dependem do `.env` |

Com o profile ausente a cadeia AWS esgota e o erro que chega ao usuário é `no EC2 IMDS role found`, que não diz nada sobre a causa real.

## O que muda

**Descoberta do dotenv (uma regra só, em todos os entrypoints):** `$CHATCLI_DOTENV` → `./.env` → `~/.chatcli/.env` → `~/.env`. A resolução é registrada, aparece no `/config` (caminho + origem) e no log de boot. O `ConfigManager` passa a honrá-la — ele chamava `godotenv.Read()` sem path, sempre lendo `./.env` e ignorando `CHATCLI_DOTENV`, o que deixava o fallback ".env-sourced" do LLM manager permanentemente vazio.

**Overlay por projeto (ACP):** o `cwd` do `session/new` era ignorado; agora o `.env` do projeto é sobreposto **fill-only** (nunca sobrescreve o que já está em efeito), uma vez por processo. Como diretório de projeto é entrada não confiável, o padrão `CHATCLI_PROJECT_ENV=safe` recusa variáveis de credencial e endpoint vindas dele (`*_API_KEY`, `*_TOKEN`, `*_BASE_URL`, `*_API_URL`, …); `all` aceita tudo, `off` desliga.

**Bedrock — paridade e diagnóstico:**
- resolução única de profile/região para chat, agent, listagem, embeddings e imagem, honrando `BEDROCK_PROFILE` (antes só o imagegen honrava), as variáveis AWS e o `.env` carregado
- reconhece o novo fluxo `aws login` (`login_session` + `~/.aws/login/cache`) — antes um usuário logado por ele era classificado como "sem credenciais AWS"
- honra `AWS_CONFIG_FILE` e `AWS_SHARED_CREDENTIALS_FILE`
- erro de credencial anotado com profile em uso, origem dele e arquivo de ambiente em efeito, **embrulhado** (a cadeia original sobrevive para `errors.Is`/`errors.As`)
- superfície de auditoria do `mcp-server` não é mais rotulada como `acp`

## Validação end-to-end

Com `env -i` (simulando o spawn da IDE), binário desta branch:

```
info dotenv loaded {path: /Users/…/.env, origin: home, exists: true}
info Configuring provider Google AI / xAI / ZAI / Moonshot / OpenRouter
info Configuring provider AWS Bedrock {profile: work-sso, profile_source: AWS_PROFILE, dotenv: /Users/…/.env}
info project .env applied {mode: safe, applied: [AWS_PROFILE], refused: [OPENAI_API_KEY]}
```

E o erro acionável quando o profile não resolve:

```
bedrock: could not resolve AWS credentials — profile work-sso (from AWS_PROFILE), environment file ~/.env (origin: home).
If ChatCLI was started by an editor or MCP client, it does not inherit your shell: set CHATCLI_DOTENV, BEDROCK_PROFILE
or AWS_PROFILE in the client's env block… If the profile is correct, refresh the session with 'aws sso login --profile work-sso'
```

## Testes

- `config`: precedência da descoberta (env var explícito, cwd, `~/.chatcli`, `~`), tilde, arquivo pinado inexistente, nada encontrado; overlay fill-only, denylist do modo safe, modos `off`/`all`, no-op quando o arquivo já é o dotenv ativo
- `llm/bedrock`: precedência de profile/região (env > `.env`, `BEDROCK_PROFILE` > `AWS_PROFILE`), sinais de credencial (config só com região não conta, `login_session` conta, cache de token conta, `AWS_CONFIG_FILE` honrado), classificação e anotação de erro preservando a cadeia
- `cli/rpcserve`: `session/new` entrega o `cwd` ao backend, `cwd` ausente/em branco não dispara nada, backend sem a capability continua funcionando
- `llm/manager`: teste de providers disponíveis ficou hermético (limpa `CHATCLI_DOTENV`) — antes passava por acidente, dependendo de o dotenv não ser encontrado

Suíte completa verde, `gofmt` e `go vet` limpos. Docs sincronizadas em EN e PT.