### PR TITLE
fix(config): a reload keeps what the client provided and reaches the servers

### DIFF
--- a/cli/cli_config.go
+++ b/cli/cli_config.go
@@ -38,18 +38,20 @@ func (cli *ChatCLI) reconfigureLogger() {
 // reloadableEnvVars são as variáveis limpas do ambiente do processo antes do
 // godotenv.Overload em reloadConfiguration — sem constar aqui, um valor
 // removido do .env sobrevive ao /reload até o processo reiniciar. Toda env
-// nova de provider precisa entrar nesta lista. AWS_REGION/AWS_PROFILE ficam
-// de fora de propósito: são ambientais do SDK e podem vir do shell, não do
-// .env — unsetá-las derrubaria a cadeia de credenciais no reload
-// (TestReloadableEnvVarsCoverCriticalProviderVars trava isso). Use
-// BEDROCK_PROFILE/BEDROCK_REGION quando quiser um valor que o /reload
-// releia do arquivo.
+// nova de provider precisa entrar nesta lista.
 //
-// O que entra aqui é limpo mesmo quando NÃO veio do .env — o bloco env de
-// uma IDE/cliente MCP é a única fonte em superfícies não interativas. Por
-// isso reloadConfiguration chama config.RestoreBootEnv depois do Overload:
-// o arquivo continua mandando no que ele declara, e o que o shell/cliente
-// entregou no boot volta em vez de sumir.
+// AWS_PROFILE/AWS_REGION ficaram fora daqui por muito tempo com uma razão
+// legítima: são ambientais do SDK, costumam vir do shell e não do .env, e
+// unsetá-las derrubava a cadeia de credenciais no /reload. O que mudou é que
+// limpar deixou de significar perder — reloadConfiguration chama
+// config.RestoreBootEnv depois do Overload (devolve o que o shell ou o bloco
+// env da IDE/cliente MCP entregou no boot e que o arquivo não redefine) e
+// config.ReapplyProjectDotenv (devolve o que o .env do projeto contribuiu).
+// Com as duas redes no lugar, remover a variável do arquivo passa a valer
+// sem reiniciar, que é a razão de existir desta lista, sem que um valor de
+// fora do arquivo seja perdido. O contrato de comportamento está travado em
+// TestReload_KeepsClientProvidedVariables (pacote config) e no caso AWS de
+// TestReloadableEnvVarsCoverCriticalProviderVars.
 var reloadableEnvVars = []string{
 	"LOG_LEVEL", "ENV", "LLM_PROVIDER", "LOG_FILE", "LOG_MAX_SIZE", "HISTORY_MAX_SIZE",
 	"OPENAI_API_KEY", "OPENAI_MODEL", "OPENAI_ASSISTANT_MODEL",
@@ -67,6 +69,7 @@ var reloadableEnvVars = []string{
 	"COPILOT_MODEL", "COPILOT_MAX_TOKENS", "GITHUB_COPILOT_TOKEN",
 	"GITHUB_TOKEN", "GH_TOKEN", "GITHUB_MODELS_TOKEN", "GITHUB_MODELS_MODEL", "GITHUB_MODELS_API_URL",
 	"BEDROCK_PROVIDER", "BEDROCK_MODEL", "BEDROCK_MAX_TOKENS", "BEDROCK_REGION", "BEDROCK_PROFILE",
+	"AWS_PROFILE", "AWS_REGION", "AWS_DEFAULT_REGION",
 	"BEDROCK_BASE_URL", "BEDROCK_CONTROL_BASE_URL", "BEDROCK_MANTLE_BASE_URL",
 	"BEDROCK_ANTHROPIC_ENDPOINT", "BEDROCK_TEMPERATURE", "BEDROCK_TOP_P",
 	"OPENROUTER_API_KEY", "OPENROUTER_MODEL", "OPENROUTER_MAX_TOKENS", "OPENROUTER_API_URL",

--- a/cli/cli_config.go
+++ b/cli/cli_config.go
@@ -40,7 +40,16 @@ func (cli *ChatCLI) reconfigureLogger() {
 // removido do .env sobrevive ao /reload até o processo reiniciar. Toda env
 // nova de provider precisa entrar nesta lista. AWS_REGION/AWS_PROFILE ficam
 // de fora de propósito: são ambientais do SDK e podem vir do shell, não do
-// .env — unsetá-las derrubaria a cadeia de credenciais no reload.
+// .env — unsetá-las derrubaria a cadeia de credenciais no reload
+// (TestReloadableEnvVarsCoverCriticalProviderVars trava isso). Use
+// BEDROCK_PROFILE/BEDROCK_REGION quando quiser um valor que o /reload
+// releia do arquivo.
+//
+// O que entra aqui é limpo mesmo quando NÃO veio do .env — o bloco env de
+// uma IDE/cliente MCP é a única fonte em superfícies não interativas. Por
+// isso reloadConfiguration chama config.RestoreBootEnv depois do Overload:
+// o arquivo continua mandando no que ele declara, e o que o shell/cliente
+// entregou no boot volta em vez de sumir.
 var reloadableEnvVars = []string{
 	"LOG_LEVEL", "ENV", "LLM_PROVIDER", "LOG_FILE", "LOG_MAX_SIZE", "HISTORY_MAX_SIZE",
 	"OPENAI_API_KEY", "OPENAI_MODEL", "OPENAI_ASSISTANT_MODEL",
@@ -112,6 +121,20 @@ func (cli *ChatCLI) reloadConfiguration(ctx context.Context) {
 	if rep := config.ApplyManaged(); rep.Err != nil {
 		cli.logger.Warn("managed config unreadable; ignored", zap.String("path", rep.Path), zap.Error(rep.Err))
 	}
+	// Anything the file does NOT define falls back to what the shell — or an
+	// editor/MCP client's env block — provided at boot, instead of staying
+	// cleared. The file still wins for every variable it declares, so
+	// editing it remains the way to change a value; what this prevents is a
+	// single /reload silently dropping the provider, model or AWS profile
+	// pinned by a client that never writes an environment file.
+	if restored := config.RestoreBootEnv(reloadableEnvVars); len(restored) > 0 {
+		cli.logger.Info("reload: restored process-provided variables", zap.Strings("keys", restored))
+	}
+	// Same for the project overlay: it runs once per process, so without
+	// this the project's contribution would be gone after the first reload.
+	if reapplied := config.ReapplyProjectDotenv(); len(reapplied) > 0 {
+		cli.logger.Info("reload: re-applied project .env variables", zap.Strings("keys", reapplied))
+	}
 
 	// Slash-command catalog: force a re-scan so /reload picks up command
 	// files created or edited since boot (the stat fingerprint would catch
@@ -149,6 +172,9 @@ func (cli *ChatCLI) reloadConfiguration(ctx context.Context) {
 	}
 
 	cli.manager = manager
+	// Servers that cached the manager (MCP/ACP backend) must follow the
+	// rebuild, or a reload from the client changes nothing for them.
+	notifyManagerRebuilt(manager)
 
 	if prevProvider != "" && prevModel != "" {
 		if client, err := cli.manager.GetClient(prevProvider, prevModel); err == nil {

--- a/cli/cli_config_reload_test.go
+++ b/cli/cli_config_reload_test.go
@@ -2,12 +2,14 @@ package cli
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/diillson/chatcli/config"
 	"github.com/diillson/chatcli/i18n"
+	"github.com/joho/godotenv"
 )
 
 // TestReloadableEnvVarsCoverCriticalProviderVars trava na lista de reload as
@@ -34,10 +36,55 @@ func TestReloadableEnvVarsCoverCriticalProviderVars(t *testing.T) {
 			t.Errorf("reloadableEnvVars is missing %s", v)
 		}
 	}
-	for _, v := range []string{"AWS_REGION", "AWS_PROFILE"} {
-		if have[v] {
-			t.Errorf("reloadableEnvVars must not unset ambient AWS SDK var %s", v)
+	// As ambientais do SDK entraram na lista quando limpar deixou de
+	// significar perder: reloadConfiguration restaura, depois do Overload, o
+	// que o shell/cliente entregou no boot e o que o .env do projeto
+	// contribuiu. A exclusão anterior existia só para não derrubar a cadeia
+	// de credenciais — esse comportamento agora é garantido pelo teste
+	// abaixo, e não mais pela ausência delas aqui.
+	for _, v := range []string{"AWS_REGION", "AWS_PROFILE", "AWS_DEFAULT_REGION"} {
+		if !have[v] {
+			t.Errorf("reloadableEnvVars is missing ambient AWS SDK var %s", v)
 		}
+	}
+}
+
+// TestReloadKeepsShellProvidedAWSProfile trava o motivo pelo qual
+// AWS_PROFILE ficava fora da lista de reload: um profile vindo do shell (ou
+// do bloco env de uma IDE/cliente MCP), que o .env não repete, NÃO pode
+// sumir no /reload — era assim que a cadeia de credenciais caía. O ciclo
+// aqui é o mesmo de reloadConfiguration: limpa, relê o arquivo, restaura.
+func TestReloadKeepsShellProvidedAWSProfile(t *testing.T) {
+	config.ResetBootEnvForTest()
+	config.ResetProjectDotenvForTest()
+	t.Cleanup(func() {
+		config.ResetBootEnvForTest()
+		config.ResetProjectDotenvForTest()
+	})
+
+	dir := t.TempDir()
+	dotenv := filepath.Join(dir, ".env")
+	if err := os.WriteFile(dotenv, []byte("BEDROCK_MODEL=claude-sonnet-4-6\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CHATCLI_DOTENV", dotenv)
+	t.Setenv("AWS_PROFILE", "corp-sso") // do shell, ausente do arquivo
+	config.CaptureBootEnv()
+
+	for _, v := range reloadableEnvVars {
+		_ = os.Unsetenv(v)
+	}
+	if err := godotenv.Overload(dotenv); err != nil {
+		t.Fatal(err)
+	}
+	config.RestoreBootEnv(reloadableEnvVars)
+	config.ReapplyProjectDotenv()
+
+	if got := os.Getenv("AWS_PROFILE"); got != "corp-sso" {
+		t.Fatalf("AWS_PROFILE do shell precisa sobreviver ao /reload, got %q", got)
+	}
+	if got := os.Getenv("BEDROCK_MODEL"); got != "claude-sonnet-4-6" {
+		t.Fatalf("o arquivo precisa continuar valendo, got %q", got)
 	}
 }
 

--- a/cli/project_env.go
+++ b/cli/project_env.go
@@ -80,6 +80,7 @@ func (cli *ChatCLI) ApplyProjectEnv(dir string) (manager.LLMManager, config.Proj
 			return
 		}
 		cli.manager = rebuilt
+		notifyManagerRebuilt(rebuilt)
 		mgr = rebuilt
 		cli.adoptProviderAfterOverlay(rep)
 	})
@@ -109,6 +110,48 @@ func (cli *ChatCLI) adoptProviderAfterOverlay(rep config.ProjectDotenvReport) {
 		zap.String("provider", cli.Provider),
 		zap.String("model", cli.Model),
 		zap.String("source", strings.Join(rep.Applied, ",")))
+}
+
+// managerHooks are notified whenever the LLM manager is rebuilt (/reload,
+// /config reload, the project overlay). Long-lived servers hold their own
+// reference to the manager — the MCP/ACP backend does — and without this
+// they would keep serving the provider set the configuration had BEFORE the
+// reload. Delivered as a push instead of exposing the field: the readers
+// live on other goroutines, and each one stores the value behind its own
+// lock.
+var (
+	managerHooksMu sync.Mutex
+	managerHooks   []func(manager.LLMManager)
+)
+
+// OnManagerRebuild registers a hook fired after every manager rebuild.
+func (cli *ChatCLI) OnManagerRebuild(fn func(manager.LLMManager)) {
+	if fn == nil {
+		return
+	}
+	managerHooksMu.Lock()
+	defer managerHooksMu.Unlock()
+	managerHooks = append(managerHooks, fn)
+}
+
+// notifyManagerRebuilt fires the hooks with the new manager.
+func notifyManagerRebuilt(m manager.LLMManager) {
+	if m == nil {
+		return
+	}
+	managerHooksMu.Lock()
+	hooks := append([]func(manager.LLMManager){}, managerHooks...)
+	managerHooksMu.Unlock()
+	for _, fn := range hooks {
+		fn(m)
+	}
+}
+
+// ResetManagerHooksForTest clears the registered hooks. Test-only.
+func ResetManagerHooksForTest() {
+	managerHooksMu.Lock()
+	defer managerHooksMu.Unlock()
+	managerHooks = nil
 }
 
 // ResetProjectEnvOnceForTest re-arms the one-shot overlay. Test-only.

--- a/cli/project_env_test.go
+++ b/cli/project_env_test.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/diillson/chatcli/llm/manager"
+)
+
+// A server that cached the manager must follow every rebuild: without the
+// hook, a `/config reload` issued from an MCP/ACP client changes the
+// session's manager and leaves the server serving the previous provider set.
+func TestOnManagerRebuild_NotifiesRegisteredServers(t *testing.T) {
+	ResetManagerHooksForTest()
+	t.Cleanup(ResetManagerHooksForTest)
+
+	var got manager.LLMManager
+	calls := 0
+	(&ChatCLI{}).OnManagerRebuild(func(m manager.LLMManager) {
+		got = m
+		calls++
+	})
+
+	rebuilt := &manager.LLMManagerImpl{}
+	notifyManagerRebuilt(rebuilt)
+
+	if calls != 1 || got != manager.LLMManager(rebuilt) {
+		t.Fatalf("hook must receive the rebuilt manager: calls=%d got=%v", calls, got)
+	}
+
+	// A nil rebuild is a no-op — never hand a server a nil manager.
+	notifyManagerRebuilt(nil)
+	if calls != 1 {
+		t.Fatalf("nil must not fire the hook, calls=%d", calls)
+	}
+}
+
+func TestOnManagerRebuild_IgnoresNilHook(t *testing.T) {
+	ResetManagerHooksForTest()
+	t.Cleanup(ResetManagerHooksForTest)
+	(&ChatCLI{}).OnManagerRebuild(nil)
+	notifyManagerRebuilt(&manager.LLMManagerImpl{}) // must not panic
+}

--- a/cli/rpc_chat_test.go
+++ b/cli/rpc_chat_test.go
@@ -59,6 +59,11 @@ ZETA-SKILL-BODY
 	}
 
 	mgr := persona.NewManager(zap.NewNop())
+	// Skill activations are recorded asynchronously under HOME, which here
+	// is a t.TempDir: without draining them the write races the directory
+	// removal and fails the test with "directory not empty". Registered
+	// after the TempDir cleanups so it runs before them (LIFO).
+	t.Cleanup(mgr.WaitUsageFlush)
 	mgr.SetProjectDir(tmp)
 	if _, err := mgr.RefreshSkills(); err != nil {
 		t.Fatalf("RefreshSkills: %v", err)

--- a/cmd/rpcserve.go
+++ b/cmd/rpcserve.go
@@ -99,6 +99,8 @@ func runRPC(kind string, mgr manager.LLMManager, logger *zap.Logger) error {
 	}
 	if chatCLI != nil {
 		backend.store = chatCLI
+		// Follow every manager rebuild (project overlay, `/config reload`).
+		chatCLI.OnManagerRebuild(backend.setManager)
 		// Same bounded lifecycle the REPL applies on start: expire
 		// machine-created sessions (autosaves, mcp- mirrors) past their TTL.
 		// Background — boot never waits on disk.
@@ -285,6 +287,18 @@ func (b *rpcBackend) manager() manager.LLMManager {
 	return b.mgr
 }
 
+// setManager adopts a rebuilt manager (project overlay, or a `/config
+// reload` issued from the client): without it the server would keep serving
+// the provider set the configuration had before the reload.
+func (b *rpcBackend) setManager(m manager.LLMManager) {
+	if m == nil {
+		return
+	}
+	b.mgrMu.Lock()
+	b.mgr = m
+	b.mgrMu.Unlock()
+}
+
 // AdoptWorkspace implements rpcserve.ACPWorkspaceBackend: the editor told us
 // which project it opened, so layer that project's .env over the process
 // configuration (fill-only, once per process).
@@ -297,13 +311,9 @@ func (b *rpcBackend) AdoptWorkspace(dir string) {
 	if b.cli == nil {
 		return
 	}
-	rebuilt, _ := b.cli.ApplyProjectEnv(dir)
-	if rebuilt == nil {
-		return
-	}
-	b.mgrMu.Lock()
-	b.mgr = rebuilt
-	b.mgrMu.Unlock()
+	// The rebuilt manager arrives through the OnManagerRebuild hook, so the
+	// swap happens under the backend's own lock.
+	b.cli.ApplyProjectEnv(dir)
 }
 
 // HasLLM reports whether any LLM provider is configured. The MCP server

--- a/cmd/rpcserve_test.go
+++ b/cmd/rpcserve_test.go
@@ -361,3 +361,24 @@ func TestManageSession_Guards(t *testing.T) {
 		t.Error("delete without a store must fail")
 	}
 }
+
+// A rebuilt manager must reach the backend: the ACP/MCP server holds its own
+// reference, and a `/config reload` from the client that only swapped
+// ChatCLI's would leave every later prompt on the pre-reload provider set.
+func TestRPCBackend_SetManagerSwapsTheLiveManager(t *testing.T) {
+	first := &manager.LLMManagerImpl{}
+	second := &manager.LLMManagerImpl{}
+	b := &rpcBackend{mgr: first}
+
+	if b.manager() != manager.LLMManager(first) {
+		t.Fatal("backend must start on the manager it was built with")
+	}
+	b.setManager(second)
+	if b.manager() != manager.LLMManager(second) {
+		t.Fatal("setManager must swap the live manager")
+	}
+	b.setManager(nil)
+	if b.manager() != manager.LLMManager(second) {
+		t.Fatal("a nil rebuild must never blank the manager")
+	}
+}

--- a/config/dotenv.go
+++ b/config/dotenv.go
@@ -149,9 +149,13 @@ func ResolveDotenv() DotenvResolution {
 }
 
 var (
-	dotenvMu       sync.RWMutex
-	dotenvActive   DotenvResolution
-	dotenvOverlays []ProjectDotenvReport
+	dotenvMu     sync.RWMutex
+	dotenvActive DotenvResolution
+	// dotenvOverlays records the project files applied (for /config);
+	// dotenvOverlayApplied keeps their contributed values so a /reload can
+	// put them back — the overlay itself runs only once per process.
+	dotenvOverlays       []ProjectDotenvReport
+	dotenvOverlayApplied = map[string]string{}
 )
 
 // SetActiveDotenv records the resolution the process actually loaded, so
@@ -180,6 +184,7 @@ func ActiveDotenv() DotenvResolution {
 // godotenv.Load never overrides a variable already present in the process
 // environment, so a value exported by the shell keeps winning over the file.
 func LoadDotenv() (DotenvResolution, error) {
+	CaptureBootEnv()
 	res := ResolveDotenv()
 	SetActiveDotenv(res)
 	return res, godotenv.Load(res.Path)
@@ -306,6 +311,9 @@ func ApplyProjectDotenv(dir string) ProjectDotenvReport {
 		default:
 			_ = os.Setenv(key, value)
 			rep.Applied = append(rep.Applied, key)
+			dotenvMu.Lock()
+			dotenvOverlayApplied[key] = value
+			dotenvMu.Unlock()
 		}
 	}
 	sort.Strings(rep.Applied)
@@ -330,10 +338,109 @@ func ResetProjectDotenvForTest() {
 	dotenvMu.Lock()
 	defer dotenvMu.Unlock()
 	dotenvOverlays = nil
+	dotenvOverlayApplied = map[string]string{}
 	dotenvActive = DotenvResolution{}
 }
 
 func isEnvSet(key string) bool {
 	v, ok := os.LookupEnv(key)
 	return ok && v != ""
+}
+
+// ─── Boot environment snapshot ────────────────────────────────────────
+//
+// /reload clears every reloadable variable before re-reading the
+// environment file, so that a value REMOVED from the file stops applying
+// without a restart. That rule assumes the file is where those values came
+// from — true in a terminal, false for an editor-spawned `acp` or an
+// MCP client: there the client's own `env` block is often the only source,
+// and clearing it made a single /reload silently drop the provider, model
+// or AWS profile the client had pinned.
+//
+// CaptureBootEnv records the process environment BEFORE the environment
+// file is loaded, so it holds exactly what the shell or the client passed
+// in — never a value that came from the file. RestoreBootEnv puts those
+// back after the reload cycle, and only for variables the file did not
+// define, which keeps the file authoritative on /reload while a
+// client-provided value survives instead of vanishing.
+
+var (
+	bootEnvOnce sync.Once
+	bootEnvMu   sync.RWMutex
+	bootEnv     map[string]string
+)
+
+// CaptureBootEnv snapshots the process environment. It is idempotent: only
+// the first call (before any dotenv load) is recorded.
+func CaptureBootEnv() {
+	bootEnvOnce.Do(func() {
+		snapshot := make(map[string]string, len(os.Environ()))
+		for _, entry := range os.Environ() {
+			if key, value, ok := strings.Cut(entry, "="); ok {
+				snapshot[key] = value
+			}
+		}
+		bootEnvMu.Lock()
+		bootEnv = snapshot
+		bootEnvMu.Unlock()
+	})
+}
+
+// BootEnv returns the value a variable had when the process started.
+func BootEnv(key string) (string, bool) {
+	bootEnvMu.RLock()
+	defer bootEnvMu.RUnlock()
+	v, ok := bootEnv[key]
+	return v, ok
+}
+
+// RestoreBootEnv re-exports the given variables from the boot snapshot when
+// they are currently unset — i.e. the environment file did not define them
+// and the reload cycle cleared them. Returns the names actually restored.
+func RestoreBootEnv(keys []string) []string {
+	var restored []string
+	for _, key := range keys {
+		if isEnvSet(key) {
+			continue // the file, or a managed policy, owns it now
+		}
+		if value, ok := BootEnv(key); ok && value != "" {
+			_ = os.Setenv(key, value)
+			restored = append(restored, key)
+		}
+	}
+	sort.Strings(restored)
+	return restored
+}
+
+// ResetBootEnvForTest clears the snapshot so a test can take its own.
+func ResetBootEnvForTest() {
+	bootEnvOnce = sync.Once{}
+	bootEnvMu.Lock()
+	bootEnv = nil
+	bootEnvMu.Unlock()
+}
+
+// ReapplyProjectDotenv re-exports the variables that project overlays had
+// contributed and that are currently unset. A reload clears reloadable
+// variables and re-reads only the process-wide environment file, which
+// would otherwise drop the project's contribution for good — the overlay
+// itself runs once per process. Fill-only, like the original overlay.
+func ReapplyProjectDotenv() []string {
+	dotenvMu.RLock()
+	pending := make(map[string]string, len(dotenvOverlayApplied))
+	for key, value := range dotenvOverlayApplied {
+		pending[key] = value
+	}
+	dotenvMu.RUnlock()
+
+	var restored []string
+	for key, value := range pending {
+		if isEnvSet(key) {
+			continue
+		}
+		_ = os.Setenv(key, value)
+		restored = append(restored, key)
+	}
+	sort.Strings(restored)
+	return restored
 }

--- a/config/dotenv.go
+++ b/config/dotenv.go
@@ -398,7 +398,7 @@ func BootEnv(key string) (string, bool) {
 // they are currently unset — i.e. the environment file did not define them
 // and the reload cycle cleared them. Returns the names actually restored.
 func RestoreBootEnv(keys []string) []string {
-	var restored []string
+	restored := make([]string, 0, len(keys))
 	for _, key := range keys {
 		if isEnvSet(key) {
 			continue // the file, or a managed policy, owns it now
@@ -433,7 +433,7 @@ func ReapplyProjectDotenv() []string {
 	}
 	dotenvMu.RUnlock()
 
-	var restored []string
+	restored := make([]string, 0, len(pending))
 	for key, value := range pending {
 		if isEnvSet(key) {
 			continue

--- a/config/reload_env_test.go
+++ b/config/reload_env_test.go
@@ -1,0 +1,137 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/joho/godotenv"
+)
+
+// reloadCycle reproduces reloadConfiguration's sequence: clear the
+// reloadable variables, re-read the environment file, then restore what the
+// shell / client provided at boot and re-apply the project overlay.
+func reloadCycle(t *testing.T, reloadable []string) {
+	t.Helper()
+	for _, key := range reloadable {
+		_ = os.Unsetenv(key)
+	}
+	if err := godotenv.Overload(ResolveDotenv().Path); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("overload: %v", err)
+	}
+	RestoreBootEnv(reloadable)
+	ReapplyProjectDotenv()
+}
+
+func TestReload_KeepsClientProvidedVariables(t *testing.T) {
+	ResetBootEnvForTest()
+	ResetProjectDotenvForTest()
+	t.Cleanup(func() { ResetBootEnvForTest(); ResetProjectDotenvForTest() })
+
+	home := t.TempDir()
+	setHome(t, home)
+	t.Chdir(t.TempDir())
+	t.Setenv(DotenvEnv, "")
+	writeEnvFile(t, filepath.Join(home, ".env"), "BEDROCK_MODEL=claude-sonnet-4-6\n")
+
+	// What an editor's `env` block passes in — absent from the file.
+	t.Setenv("LLM_PROVIDER", "BEDROCK")
+	t.Setenv("BEDROCK_PROFILE", "work-sso")
+	CaptureBootEnv() // as the entrypoint does, before loading the file
+
+	reloadCycle(t, []string{"LLM_PROVIDER", "BEDROCK_PROFILE", "BEDROCK_MODEL"})
+
+	if got := os.Getenv("LLM_PROVIDER"); got != "BEDROCK" {
+		t.Errorf("a client-provided variable must survive /reload, got %q", got)
+	}
+	if got := os.Getenv("BEDROCK_PROFILE"); got != "work-sso" {
+		t.Errorf("the client's AWS profile must survive /reload, got %q", got)
+	}
+	if got := os.Getenv("BEDROCK_MODEL"); got != "claude-sonnet-4-6" {
+		t.Errorf("the file must still define its own variables, got %q", got)
+	}
+}
+
+func TestReload_FileStillWinsAndRemovalStillApplies(t *testing.T) {
+	ResetBootEnvForTest()
+	ResetProjectDotenvForTest()
+	t.Cleanup(func() { ResetBootEnvForTest(); ResetProjectDotenvForTest() })
+
+	home := t.TempDir()
+	setHome(t, home)
+	t.Chdir(t.TempDir())
+	t.Setenv(DotenvEnv, "")
+	dotenv := filepath.Join(home, ".env")
+	writeEnvFile(t, dotenv, "AWS_PROFILE=from-file\nBEDROCK_REGION=us-east-1\n")
+
+	// Boot: the file is loaded WITHOUT overriding the process, so the
+	// snapshot must be taken first and must not contain file values.
+	CaptureBootEnv()
+	if err := godotenv.Load(dotenv); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := BootEnv("AWS_PROFILE"); ok {
+		t.Fatal("a value coming from the file must never enter the boot snapshot")
+	}
+
+	// The user edits the file: profile changed, region removed.
+	writeEnvFile(t, dotenv, "AWS_PROFILE=edited\n")
+	reloadCycle(t, []string{"AWS_PROFILE", "BEDROCK_REGION"})
+
+	if got := os.Getenv("AWS_PROFILE"); got != "edited" {
+		t.Errorf("the edited file must win on /reload, got %q", got)
+	}
+	if got := os.Getenv("BEDROCK_REGION"); got != "" {
+		t.Errorf("a variable removed from the file must stop applying, got %q", got)
+	}
+}
+
+func TestReload_ReappliesProjectOverlay(t *testing.T) {
+	ResetBootEnvForTest()
+	ResetProjectDotenvForTest()
+	t.Cleanup(func() { ResetBootEnvForTest(); ResetProjectDotenvForTest() })
+
+	home := t.TempDir()
+	setHome(t, home)
+	t.Chdir(t.TempDir())
+	t.Setenv(DotenvEnv, "")
+	t.Setenv(ProjectDotenvEnv, "")
+	writeEnvFile(t, filepath.Join(home, ".env"), "LLM_PROVIDER=CLAUDEAI\n")
+	CaptureBootEnv()
+
+	project := t.TempDir()
+	writeEnvFile(t, filepath.Join(project, ".env"), "BEDROCK_PROFILE=project-sso\n")
+	os.Unsetenv("BEDROCK_PROFILE")
+	t.Cleanup(func() { os.Unsetenv("BEDROCK_PROFILE") })
+
+	if rep := ApplyProjectDotenv(project); len(rep.Applied) != 1 {
+		t.Fatalf("overlay should have contributed one variable: %+v", rep)
+	}
+
+	// The overlay runs once per process: without the re-apply step a single
+	// reload would drop the project's contribution for good.
+	reloadCycle(t, []string{"LLM_PROVIDER", "BEDROCK_PROFILE"})
+
+	if got := os.Getenv("BEDROCK_PROFILE"); got != "project-sso" {
+		t.Errorf("the project overlay must survive /reload, got %q", got)
+	}
+	if got := os.Getenv("LLM_PROVIDER"); got != "CLAUDEAI" {
+		t.Errorf("the environment file must still apply, got %q", got)
+	}
+}
+
+func TestRestoreBootEnv_NeverOverridesWhatIsAlreadySet(t *testing.T) {
+	ResetBootEnvForTest()
+	t.Cleanup(ResetBootEnvForTest)
+
+	t.Setenv("CHATCLI_TEST_KEY", "boot")
+	CaptureBootEnv()
+	t.Setenv("CHATCLI_TEST_KEY", "current")
+
+	if restored := RestoreBootEnv([]string{"CHATCLI_TEST_KEY"}); len(restored) != 0 {
+		t.Fatalf("a variable already in effect must not be rewritten: %v", restored)
+	}
+	if got := os.Getenv("CHATCLI_TEST_KEY"); got != "current" {
+		t.Fatalf("value changed to %q", got)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -78,6 +78,10 @@ func loadDotenvThenI18n() dotenvBootstrap {
 	// entrypoint: $CHATCLI_DOTENV, else ./.env, ~/.chatcli/.env, ~/.env.
 	// The home fallbacks are what keep `chatcli acp` / `mcp-server` working
 	// when an editor spawns them without the user's shell environment.
+	// Snapshot what the shell — or the editor/MCP client's env block — gave
+	// us, BEFORE the file is loaded: /reload restores from it so a
+	// client-provided variable is not lost when the file does not repeat it.
+	config.CaptureBootEnv()
 	res := config.ResolveDotenv()
 	config.SetActiveDotenv(res)
 	b := dotenvBootstrap{path: res.Path, expandErr: res.ExpandErr, resolution: res}


### PR DESCRIPTION
Follow-up do #1498, respondendo a "se eu der um `/reload`, tudo que foi ajustado continua valendo?". A resposta era **quase** — três buracos, todos só visíveis nas superfícies dirigidas por IDE/cliente MCP. Note que `/reload` está fora da allowlist do ACP, mas `/config` **está** — e `/config --reload` cai no mesmo `reloadConfiguration`.

## 1. O reload apagava o que veio do cliente

O ciclo limpa as `reloadableEnvVars` antes do `godotenv.Overload`, para que remover um valor do arquivo passe a valer sem reiniciar. Isso assume que o arquivo é a origem desses valores — verdade no terminal, **falso** numa IDE: lá o bloco `env` do cliente costuma ser a única fonte. Um `/config --reload` derrubava silenciosamente o provider, o modelo ou o `BEDROCK_PROFILE` fixado pelo cliente.

Provado antes de corrigir (teste temporário simulando o ciclo):

```
--- FAIL: TestProbe_ReloadDropsClientProvidedEnv
    LLM_PROVIDER vindo do cliente sumiu no reload: ""
    BEDROCK_PROFILE vindo do cliente sumiu no reload: ""
```

Agora o ambiente do processo é fotografado no boot **antes** do arquivo ser carregado (`config.CaptureBootEnv`) e restaurado depois do Overload apenas para variáveis que o arquivo não declara (`config.RestoreBootEnv`). O arquivo continua mandando no que ele declara; e como um valor vindo do arquivo nunca entra no snapshot, **remover do arquivo continua funcionando**.

## 2. O overlay de projeto morria no primeiro reload

O overlay roda uma vez por processo (`sync.Once`), então o reload limpava a contribuição dele e ninguém a repunha. Os valores aplicados passam a ser registrados e re-aplicados, fill-only, depois do reload.

## 3. O manager reconstruído não chegava nos servidores

O backend ACP/MCP guarda a própria referência do manager: um reload trocava o do `ChatCLI` e o servidor seguia respondendo com o conjunto de providers **anterior**. Rebuilds agora são empurrados por hook (`OnManagerRebuild`), que o backend registra e guarda sob o próprio lock — em vez de ler o campo da sessão de outra goroutine, o que seria data race com os requests JSON-RPC concorrentes.

## 4. `AWS_PROFILE`/`AWS_REGION` entram na lista de reload

Ficaram fora por anos com uma razão legítima: são ambientais do SDK, costumam vir do shell e não do `.env`, e limpá-las antes do Overload derrubava a cadeia de credenciais. **Limpar deixou de significar perder** com os itens 1 e 2 no lugar — então remover a variável do arquivo passa a valer sem reiniciar, que é a razão de existir da lista, sem que um valor de fora do arquivo se perca.

A asserção de formato que travava a exclusão (`reloadableEnvVars must not unset ambient AWS SDK var`) foi trocada pelo comportamento que ela realmente protegia: **um profile vindo do shell, que o arquivo não repete, precisa continuar setado depois de um ciclo completo de reload** (`TestReloadKeepsShellProvidedAWSProfile`).

## Boy-scout

`TestRunChatTurnRPC_FullPipelineParity` falhava de forma intermitente (4/4 na main limpa aqui) com `TempDir RemoveAll cleanup: directory not empty`: a gravação assíncrona de skill-usage corre com a remoção do HOME temporário. O `persona.Manager` já expõe `WaitUsageFlush` exatamente para isso — o teste só não drenava. 5/5 verde depois.

## Testes

- `config`: variável do cliente sobrevive ao reload; arquivo continua vencendo e remoção continua valendo; valor vindo do arquivo nunca entra no snapshot de boot; overlay de projeto re-aplicado; `RestoreBootEnv` nunca sobrescreve o que já está em efeito
- `cli`: profile do shell sobrevive ao ciclo completo de reload; a lista de reload cobre as ambientais AWS; hook de rebuild notifica com o manager novo, ignora `nil` e hook `nil`
- `cmd`: `setManager` troca o manager vivo e um rebuild `nil` nunca zera o backend

Suíte completa verde, `gofmt`/`go vet` limpos, `gosec` sem issues nos pacotes tocados.