### PR TITLE
fix(llm): reasoning blocks travel back with the turn that produced them

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -2689,15 +2689,24 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 			}
 		}
 
-		// Persistir a resposta no histórico "real"
+		// Persistir a resposta no histórico "real". The reasoning blocks
+		// ride along on the assistant turn: with extended thinking on, the
+		// provider expects them back inside the turn that carries the tool
+		// call, and dropping them makes every step re-reason from zero.
+		thinkingBlocks := turnThinkingBlocks(llmResp, turnClient)
 		if len(nativeToolCalls) > 0 {
 			a.cli.history = append(a.cli.history, models.Message{
 				Role:      "assistant",
 				Content:   aiResponse,
 				ToolCalls: nativeToolCalls,
+				Thinking:  thinkingBlocks,
 			})
 		} else {
-			a.cli.history = append(a.cli.history, models.Message{Role: "assistant", Content: aiResponse})
+			a.cli.history = append(a.cli.history, models.Message{
+				Role:     "assistant",
+				Content:  aiResponse,
+				Thinking: thinkingBlocks,
+			})
 		}
 
 		// Mid-loop skill activation: the model's own <reasoning> text and the

--- a/cli/chat_pipeline.go
+++ b/cli/chat_pipeline.go
@@ -885,7 +885,15 @@ func (cli *ChatCLI) handleChatTurnResult(
 		cli.history = append(cli.history, models.TurnContextMessage(text))
 	}
 	cli.history = append(cli.history, userMessage)
-	cli.history = append(cli.history, models.Message{Role: "assistant", Content: aiResponse})
+	cli.history = append(cli.history, models.Message{
+		Role:    "assistant",
+		Content: aiResponse,
+		// Reasoning blocks belong to the turn that produced them: chat is
+		// tool-less, but the replay contract is the same one the agent
+		// loop follows, and a session that switches to /coder mid-thread
+		// carries a correct history into it.
+		Thinking: turnThinkingBlocks(nil, activeClient),
+	})
 
 	// Mirror the turn onto the shared cross-channel conversation so other
 	// channels (Telegram/Slack) see it as context, and write it through to

--- a/cli/turn_thinking.go
+++ b/cli/turn_thinking.go
@@ -1,0 +1,39 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"github.com/diillson/chatcli/llm/client"
+	"github.com/diillson/chatcli/models"
+)
+
+// turnThinkingBlocks resolves the reasoning blocks to attach to the
+// assistant turn just produced.
+//
+// Two sources, in order of confidence: the structured response of a
+// tool-aware call already carries them, and the plain send paths leave
+// them on the client because their signature returns only a string. The
+// blocks are bound to the model that produced them, so a client that
+// reports a different model than the one it just answered with — a
+// mid-turn route change, a fallback chain — contributes nothing rather
+// than a block the next request would be rejected for.
+func turnThinkingBlocks(resp *models.LLMResponse, c client.LLMClient) []models.ThinkingBlock {
+	if resp != nil && len(resp.Thinking) > 0 {
+		return resp.Thinking
+	}
+	ta, ok := client.AsThinkingAware(c)
+	if !ok {
+		return nil
+	}
+	blocks := ta.LastThinking()
+	if len(blocks) == 0 {
+		return nil
+	}
+	if m := ta.LastThinkingModel(); m != "" && m != c.GetModelName() {
+		return nil
+	}
+	return blocks
+}

--- a/cli/turn_thinking_test.go
+++ b/cli/turn_thinking_test.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/diillson/chatcli/llm/client"
+	"github.com/diillson/chatcli/models"
+)
+
+type fakeThinkingClient struct {
+	client.LLMClient
+	model  string
+	blocks []models.ThinkingBlock
+	from   string
+}
+
+func (f *fakeThinkingClient) GetModelName() string                 { return f.model }
+func (f *fakeThinkingClient) LastThinking() []models.ThinkingBlock { return f.blocks }
+func (f *fakeThinkingClient) LastThinkingModel() string            { return f.from }
+
+func TestTurnThinkingBlocksPrefersTheResponse(t *testing.T) {
+	resp := &models.LLMResponse{Thinking: []models.ThinkingBlock{{Type: "thinking", Thinking: "from resp", Signature: "s"}}}
+	c := &fakeThinkingClient{model: "m", from: "m", blocks: []models.ThinkingBlock{{Type: "thinking", Thinking: "stale", Signature: "s"}}}
+	got := turnThinkingBlocks(resp, c)
+	if len(got) != 1 || got[0].Thinking != "from resp" {
+		t.Errorf("structured response must win, got %+v", got)
+	}
+}
+
+func TestTurnThinkingBlocksFallsBackToTheClient(t *testing.T) {
+	c := &fakeThinkingClient{model: "m", from: "m", blocks: []models.ThinkingBlock{{Type: "thinking", Thinking: "plain path", Signature: "s"}}}
+	got := turnThinkingBlocks(nil, c)
+	if len(got) != 1 || got[0].Thinking != "plain path" {
+		t.Errorf("plain path blocks must be picked up, got %+v", got)
+	}
+}
+
+// Reasoning blocks are bound to the model that produced them: replaying
+// another model's blocks is rejected, so a route change contributes none.
+func TestTurnThinkingBlocksRefusesForeignModel(t *testing.T) {
+	c := &fakeThinkingClient{model: "sonnet", from: "opus", blocks: []models.ThinkingBlock{{Type: "thinking", Thinking: "x", Signature: "s"}}}
+	if got := turnThinkingBlocks(nil, c); got != nil {
+		t.Errorf("blocks from another model must not replay, got %+v", got)
+	}
+}
+
+func TestTurnThinkingBlocksHandlesPlainClient(t *testing.T) {
+	if got := turnThinkingBlocks(nil, nil); got != nil {
+		t.Errorf("a client without the capability must yield nil, got %+v", got)
+	}
+}

--- a/llm/bedrock/bedrock_client.go
+++ b/llm/bedrock/bedrock_client.go
@@ -225,6 +225,27 @@ type BedrockClient struct {
 	// client.UsageState is a comparable struct, preserving the comparable
 	// contract documented above.
 	usage client.UsageState
+	// thinking holds the reasoning blocks of the most recent response.
+	// Behind a pointer on purpose: client.ThinkingState carries a slice,
+	// so embedding it by value would make BedrockClient incomparable and
+	// break the contract documented above.
+	thinking *client.ThinkingState
+}
+
+// LastThinking implements client.ThinkingAwareClient.
+func (c *BedrockClient) LastThinking() []models.ThinkingBlock {
+	if c.thinking == nil {
+		return nil
+	}
+	return c.thinking.LastThinking()
+}
+
+// LastThinkingModel implements client.ThinkingAwareClient.
+func (c *BedrockClient) LastThinkingModel() string {
+	if c.thinking == nil {
+		return ""
+	}
+	return c.thinking.LastThinkingModel()
 }
 
 // NewBedrockClient creates a client bound to a model id and region.
@@ -243,6 +264,7 @@ func NewBedrockClient(model, region, profile string, logger *zap.Logger, maxAtte
 		logger:      logger,
 		maxAttempts: maxAttempts,
 		backoff:     backoff,
+		thinking:    &client.ThinkingState{},
 	}
 }
 
@@ -512,6 +534,7 @@ func (c *BedrockClient) sendPromptAnthropicModel(ctx context.Context, wireModel,
 		if err != nil {
 			return "", wrapBedrockInferenceProfileError(wireModel, err)
 		}
+		c.storeThinkingFromBody(out.Body)
 		text, perr := parseAnthropicBody(out.Body)
 		if perr == nil {
 			c.captureAnthropicUsage(out.Body)
@@ -574,7 +597,10 @@ func (c *BedrockClient) buildMessagesAndSystem(prompt string, history []models.M
 	for _, msg := range history {
 		switch strings.ToLower(strings.TrimSpace(msg.Role)) {
 		case "assistant":
-			messages = append(messages, map[string]interface{}{"role": "assistant", "content": visionwire.AnthropicContent(msg.Content, msg.Images)})
+			messages = append(messages, map[string]interface{}{
+				"role":    "assistant",
+				"content": visionwire.AnthropicContent(msg.Content, msg.Images).PrependThinking(msg.Thinking),
+			})
 		case "system":
 			if len(msg.SystemParts) > 0 {
 				for _, part := range msg.SystemParts {
@@ -1061,3 +1087,14 @@ var _ client.ModelLister = (*BedrockClient)(nil)
 
 // Keep config import used for defaults.
 var _ = config.DefaultMaxRetries
+
+// storeThinkingFromBody records the reasoning blocks of an Anthropic
+// InvokeModel response so the next assistant turn can replay them. The
+// typed body parser above reads only text blocks, so this walks the
+// generic shape once rather than widening it.
+func (c *BedrockClient) storeThinkingFromBody(body []byte) {
+	if c.thinking == nil {
+		return
+	}
+	c.thinking.StoreThinking(c.model, client.ParseAnthropicThinkingBody(body))
+}

--- a/llm/bedrock/thinking_replay_test.go
+++ b/llm/bedrock/thinking_replay_test.go
@@ -1,0 +1,63 @@
+package bedrock
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+// Bedrock's Anthropic surface enables extended thinking too, so it owes
+// the same replay: the reasoning that produced a turn travels back with it.
+func TestBedrockReplaysThinkingOnAssistantTurn(t *testing.T) {
+	c := NewBedrockClient("anthropic.claude-opus-5", "us-east-1", "", zap.NewNop(), 1, 0)
+	msgs, _ := c.buildMessagesAndSystem("", []models.Message{
+		{Role: "user", Content: "go"},
+		{
+			Role:     "assistant",
+			Content:  "done",
+			Thinking: []models.ThinkingBlock{{Type: "thinking", Thinking: "weighing", Signature: "sig"}},
+		},
+	})
+	raw, err := json.Marshal(msgs)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded []struct {
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, m := range decoded {
+		if m.Role != "assistant" {
+			continue
+		}
+		var blocks []map[string]any
+		if err := json.Unmarshal(m.Content, &blocks); err != nil {
+			t.Fatalf("assistant turn should carry a block array: %v (%s)", err, m.Content)
+		}
+		if len(blocks) == 0 || blocks[0]["type"] != "thinking" || blocks[0]["signature"] != "sig" {
+			t.Fatalf("reasoning must lead the assistant turn: %s", m.Content)
+		}
+		return
+	}
+	t.Fatal("no assistant turn in the payload")
+}
+
+func TestBedrockStoreThinkingFromBody(t *testing.T) {
+	c := NewBedrockClient("anthropic.claude-opus-5", "us-east-1", "", zap.NewNop(), 1, 0)
+	c.storeThinkingFromBody([]byte(`{"content":[{"type":"thinking","thinking":"a","signature":"s"},{"type":"text","text":"b"}]}`))
+	if got := c.LastThinking(); len(got) != 1 || got[0].Signature != "s" {
+		t.Fatalf("blocks not stored: %+v", got)
+	}
+	if c.LastThinkingModel() != "anthropic.claude-opus-5" {
+		t.Errorf("blocks must remember their model, got %q", c.LastThinkingModel())
+	}
+	c.storeThinkingFromBody([]byte("garbage"))
+	if got := c.LastThinking(); got != nil {
+		t.Errorf("an unparseable body must clear, not keep stale blocks: %+v", got)
+	}
+}

--- a/llm/claudeai/claude_client.go
+++ b/llm/claudeai/claude_client.go
@@ -53,14 +53,37 @@ type ClaudeClient struct {
 	// thinking holds the reasoning blocks of THIS instance's most recent
 	// response so the caller can replay them in the next assistant turn,
 	// which is what the provider requires once extended thinking is on.
-	thinking client.ThinkingState
+	// Behind a pointer on purpose: client.ThinkingState carries a slice,
+	// so embedding it by value would turn ClaudeClient from a comparable
+	// type into an incomparable one — breaking for anyone comparing
+	// client values.
+	thinking *client.ThinkingState
 }
 
 // LastThinking implements client.ThinkingAwareClient.
-func (c *ClaudeClient) LastThinking() []models.ThinkingBlock { return c.thinking.LastThinking() }
+func (c *ClaudeClient) LastThinking() []models.ThinkingBlock {
+	if c.thinking == nil {
+		return nil
+	}
+	return c.thinking.LastThinking()
+}
 
 // LastThinkingModel implements client.ThinkingAwareClient.
-func (c *ClaudeClient) LastThinkingModel() string { return c.thinking.LastThinkingModel() }
+func (c *ClaudeClient) LastThinkingModel() string {
+	if c.thinking == nil {
+		return ""
+	}
+	return c.thinking.LastThinkingModel()
+}
+
+// storeThinking records the reasoning blocks of the response just parsed,
+// tagged with the model that produced them.
+func (c *ClaudeClient) storeThinking(blocks []models.ThinkingBlock) {
+	if c.thinking == nil {
+		return
+	}
+	c.thinking.StoreThinking(c.model, blocks)
+}
 
 const (
 	oauthUserAgent         = auth.ClaudeCodeUserAgent
@@ -152,6 +175,7 @@ func NewClaudeClient(provider auth.TokenProvider, model string, logger *zap.Logg
 		maxAttempts: maxAttempts,
 		backoff:     backoff,
 		apiURL:      apiURL,
+		thinking:    &client.ThinkingState{},
 	}
 }
 
@@ -392,7 +416,7 @@ func (c *ClaudeClient) processResponse(resp *http.Response) (string, error) {
 	// Reasoning blocks ride out through the instance: this path returns a
 	// string, so the caller reads them back with LastThinking and attaches
 	// them to the assistant message it stores.
-	c.thinking.StoreThinking(c.model, client.ParseAnthropicThinkingBody(bodyBytes))
+	c.storeThinking(client.ParseAnthropicThinkingBody(bodyBytes))
 
 	var responseText string
 	for _, content := range result.Content {

--- a/llm/claudeai/claude_client.go
+++ b/llm/claudeai/claude_client.go
@@ -49,7 +49,18 @@ type ClaudeClient struct {
 	// processing, so the OAuth-sensitive request path stays untouched.
 	// See usage_tracker.go for the accessors.
 	usage client.UsageState
+
+	// thinking holds the reasoning blocks of THIS instance's most recent
+	// response so the caller can replay them in the next assistant turn,
+	// which is what the provider requires once extended thinking is on.
+	thinking client.ThinkingState
 }
+
+// LastThinking implements client.ThinkingAwareClient.
+func (c *ClaudeClient) LastThinking() []models.ThinkingBlock { return c.thinking.LastThinking() }
+
+// LastThinkingModel implements client.ThinkingAwareClient.
+func (c *ClaudeClient) LastThinkingModel() string { return c.thinking.LastThinkingModel() }
 
 const (
 	oauthUserAgent         = auth.ClaudeCodeUserAgent
@@ -377,6 +388,11 @@ func (c *ClaudeClient) processResponse(resp *http.Response) (string, error) {
 		c.logger.Error(i18n.T("llm.error.decode_response_for", "ClaudeAI"), zap.Error(err))
 		return "", fmt.Errorf("%s: %w", i18n.T("llm.error.decode_response"), err)
 	}
+
+	// Reasoning blocks ride out through the instance: this path returns a
+	// string, so the caller reads them back with LastThinking and attaches
+	// them to the assistant message it stores.
+	c.thinking.StoreThinking(c.model, client.ParseAnthropicThinkingBody(bodyBytes))
 
 	var responseText string
 	for _, content := range result.Content {

--- a/llm/claudeai/context_engine_wire_test.go
+++ b/llm/claudeai/context_engine_wire_test.go
@@ -50,9 +50,27 @@ func TestProviderContextEngine_AddsContextManagementAndBeta(t *testing.T) {
 	if !ok {
 		t.Fatalf("context_management missing: %v", body)
 	}
+	// Two edits ride together: stale tool results and stale reasoning.
+	// Both are cleared by the same pass over the prompt, so the engine
+	// asks for them in one block.
 	edits, _ := cm["edits"].([]interface{})
-	if len(edits) != 1 || edits[0].(map[string]interface{})["type"] != "clear_tool_uses_20250919" {
+	types := make([]string, 0, len(edits))
+	for _, e := range edits {
+		m, ok := e.(map[string]interface{})
+		if !ok {
+			t.Fatalf("edit is not an object: %v", e)
+		}
+		typ, _ := m["type"].(string)
+		types = append(types, typ)
+	}
+	want := []string{"clear_tool_uses_20250919", "clear_thinking_20251015"}
+	if len(types) != len(want) {
 		t.Fatalf("edits = %v", edits)
+	}
+	for i, w := range want {
+		if types[i] != w {
+			t.Fatalf("edit %d = %q, want %q (order matters: %v)", i, types[i], w, edits)
+		}
 	}
 	beta := headers.Get("anthropic-beta")
 	if !strings.Contains(beta, llmclient.ContextManagementBeta) || !strings.Contains(beta, llmclient.ExtendedCacheTTLBeta) {

--- a/llm/claudeai/thinking_replay_test.go
+++ b/llm/claudeai/thinking_replay_test.go
@@ -1,0 +1,79 @@
+package claudeai
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+)
+
+// The tool path is where the contract bites: with extended thinking on,
+// the assistant turn that carries a tool_use must carry back the thinking
+// that produced it.
+func TestParseClaudeToolResponseKeepsThinking(t *testing.T) {
+	body := `{
+	  "stop_reason":"tool_use",
+	  "content":[
+	    {"type":"thinking","thinking":"weighing options","signature":"sig-abc"},
+	    {"type":"text","text":"running it"},
+	    {"type":"tool_use","id":"tu_1","name":"read","input":{"path":"a.go"}}
+	  ]
+	}`
+	resp, err := parseClaudeToolResponse(body, nil)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(resp.Thinking) != 1 || resp.Thinking[0].Signature != "sig-abc" {
+		t.Fatalf("thinking not captured: %+v", resp.Thinking)
+	}
+	if resp.Content != "running it" {
+		t.Errorf("text block changed: %q", resp.Content)
+	}
+	if len(resp.ToolCalls) != 1 || resp.ToolCalls[0].ID != "tu_1" {
+		t.Errorf("tool call changed: %+v", resp.ToolCalls)
+	}
+}
+
+func TestBuildClaudeToolMessagesReplaysThinkingFirst(t *testing.T) {
+	history := []models.Message{
+		{Role: "user", Content: "go"},
+		{
+			Role:      "assistant",
+			Content:   "running it",
+			Thinking:  []models.ThinkingBlock{{Type: "thinking", Thinking: "weighing", Signature: "sig-abc"}},
+			ToolCalls: []models.ToolCall{{ID: "tu_1", Name: "read", Arguments: map[string]interface{}{"path": "a.go"}}},
+		},
+		{Role: "tool", ToolCallID: "tu_1", Content: "package main"},
+	}
+	raw, err := json.Marshal(buildClaudeToolMessages("", history))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// User turns marshal their content as a plain string, assistant turns
+	// with tool calls as a block array — decode lazily so both fit.
+	var msgs []struct {
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &msgs); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	var assistant []map[string]any
+	for _, m := range msgs {
+		if m.Role != "assistant" {
+			continue
+		}
+		if err := json.Unmarshal(m.Content, &assistant); err != nil {
+			t.Fatalf("assistant content is not a block array: %v", err)
+		}
+	}
+	if len(assistant) != 3 {
+		t.Fatalf("want thinking+text+tool_use, got %d blocks: %+v", len(assistant), assistant)
+	}
+	if assistant[0]["type"] != "thinking" || assistant[0]["signature"] != "sig-abc" {
+		t.Errorf("thinking must lead the assistant turn, got %+v", assistant[0])
+	}
+	if assistant[1]["type"] != "text" || assistant[2]["type"] != "tool_use" {
+		t.Errorf("block order after thinking changed: %+v", assistant[1:])
+	}
+}

--- a/llm/claudeai/tool_use.go
+++ b/llm/claudeai/tool_use.go
@@ -26,6 +26,7 @@ import (
 
 // Ensure ClaudeClient implements ToolAwareClient.
 var _ client.ToolAwareClient = (*ClaudeClient)(nil)
+var _ client.ThinkingAwareClient = (*ClaudeClient)(nil)
 
 // SupportsNativeTools returns true for API key auth, false for OAuth.
 // The OAuth endpoint (console.anthropic.com) uses a different message format
@@ -168,6 +169,12 @@ func (c *ClaudeClient) SendPromptWithTools(ctx context.Context, prompt string, h
 	)
 
 	response, err := parseClaudeToolResponse(respBody, c.logger)
+	if err == nil && response != nil {
+		// Mirror the reasoning blocks onto the instance too: callers that
+		// hold the response replay from it, callers on the plain path read
+		// them back through LastThinking.
+		c.thinking.StoreThinking(c.model, response.Thinking)
+	}
 	if err == nil && response != nil && response.Usage != nil {
 		// Per-instance mirror of what parseClaudeToolResponse recorded in the
 		// legacy global — parallel clients must not cross-attribute tokens.
@@ -253,8 +260,15 @@ func buildClaudeToolMessages(prompt string, history []models.Message) []interfac
 
 		case "assistant":
 			if len(msg.ToolCalls) > 0 {
-				// Assistant with tool_use content blocks
+				// Assistant with tool_use content blocks. Reasoning blocks
+				// come first when the turn has any: with extended thinking
+				// on, the provider expects the thinking that produced the
+				// tool call to travel back inside the same turn, ahead of
+				// the text and the tool_use blocks.
 				var content []interface{}
+				for _, blk := range client.AnthropicThinkingBlocks(msg.Thinking).Blocks {
+					content = append(content, blk)
+				}
 				if msg.Content != "" {
 					content = append(content, map[string]interface{}{
 						"type": "text",
@@ -374,6 +388,10 @@ func parseClaudeToolResponse(body string, logger *zap.Logger) (*models.LLMRespon
 
 		blockType, _ := b["type"].(string)
 		switch blockType {
+		case "thinking", "redacted_thinking":
+			// Collected below in one pass so the blocks keep their arrival
+			// order; the provider requires them replayed unchanged.
+			continue
 		case "text":
 			if text, ok := b["text"].(string); ok {
 				textParts = append(textParts, text)
@@ -394,6 +412,7 @@ func parseClaudeToolResponse(body string, logger *zap.Logger) (*models.LLMRespon
 	}
 
 	response.Content = strings.Join(textParts, "\n")
+	response.Thinking = client.ParseAnthropicThinkingBody([]byte(body))
 
 	// Server-side context edits applied by the provider context engine:
 	// parsed into the response so the caller can mirror them locally

--- a/llm/claudeai/tool_use.go
+++ b/llm/claudeai/tool_use.go
@@ -173,7 +173,7 @@ func (c *ClaudeClient) SendPromptWithTools(ctx context.Context, prompt string, h
 		// Mirror the reasoning blocks onto the instance too: callers that
 		// hold the response replay from it, callers on the plain path read
 		// them back through LastThinking.
-		c.thinking.StoreThinking(c.model, response.Thinking)
+		c.storeThinking(response.Thinking)
 	}
 	if err == nil && response != nil && response.Usage != nil {
 		// Per-instance mirror of what parseClaudeToolResponse recorded in the

--- a/llm/claudeai/usage_tracker.go
+++ b/llm/claudeai/usage_tracker.go
@@ -60,7 +60,7 @@ func (c *ClaudeClient) resetUsage() {
 	c.usage.StoreStopReason("")
 	// Reasoning blocks belong to one response. Clearing them here means a
 	// response that carries none can never replay the previous turn's.
-	c.thinking.StoreThinking(c.model, nil)
+	c.storeThinking(nil)
 }
 
 // storeUsage records usage on this instance (and mirrors to the legacy

--- a/llm/claudeai/usage_tracker.go
+++ b/llm/claudeai/usage_tracker.go
@@ -58,6 +58,9 @@ func (c *ClaudeClient) LastStopReason() string {
 func (c *ClaudeClient) resetUsage() {
 	c.usage.StoreUsage(nil)
 	c.usage.StoreStopReason("")
+	// Reasoning blocks belong to one response. Clearing them here means a
+	// response that carries none can never replay the previous turn's.
+	c.thinking.StoreThinking(c.model, nil)
 }
 
 // storeUsage records usage on this instance (and mirrors to the legacy

--- a/llm/client/cache_prefix.go
+++ b/llm/client/cache_prefix.go
@@ -67,12 +67,23 @@ func AnthropicContextManagement() *ContextManagement {
 	if !ProviderContextEngine() {
 		return nil
 	}
-	return &ContextManagement{Edits: []ContextEdit{{
+	edits := []ContextEdit{{
 		Type:         "clear_tool_uses_20250919",
 		Trigger:      &ContextThreshold{Type: "input_tokens", Value: 100000},
 		Keep:         &ContextThreshold{Type: "tool_uses", Value: 5},
 		ClearAtLeast: &ContextThreshold{Type: "input_tokens", Value: 20000},
-	}}}
+	}}
+	// Once reasoning blocks are replayed they occupy the window like any
+	// other content, so the engine needs a way to retire the old ones. The
+	// thresholds mirror the tool-use edit: same trigger, so one pass over
+	// the prompt clears both, and a keep count that leaves the recent
+	// reasoning the model is still building on.
+	edits = append(edits, ContextEdit{
+		Type:    "clear_thinking_20251015",
+		Trigger: &ContextThreshold{Type: "input_tokens", Value: 100000},
+		Keep:    &ContextThreshold{Type: "thinking_turns", Value: 3},
+	})
+	return &ContextManagement{Edits: edits}
 }
 
 // PromptCacheTTLEnv selects the Anthropic cache lifetime: "5m" (default) or

--- a/llm/client/thinking.go
+++ b/llm/client/thinking.go
@@ -172,3 +172,49 @@ func AnthropicThinkingBlocks(blocks []models.ThinkingBlock) AnthropicThinkingWir
 	}
 	return wire
 }
+
+// ParseGeminiThoughtBody extracts the thought parts of a Gemini
+// generateContent response together with the signature each carries.
+//
+// Gemini's signature is an encrypted handle to the model's reasoning
+// state, and the stateless path this client uses must resend every thought
+// part exactly as received or multi-turn reasoning — and multi-turn
+// function calling with it — breaks. A part with no signature is not
+// replayable, so it is left out rather than sent half-formed.
+//
+// Both field spellings are accepted: the part-level thoughtSignature and
+// the signature carried inside a thought step.
+func ParseGeminiThoughtBody(body []byte) []models.ThinkingBlock {
+	var generic struct {
+		Candidates []struct {
+			Content struct {
+				Parts []struct {
+					Text             string `json:"text"`
+					Thought          bool   `json:"thought"`
+					ThoughtSignature string `json:"thoughtSignature"`
+					Signature        string `json:"signature"`
+				} `json:"parts"`
+			} `json:"content"`
+		} `json:"candidates"`
+	}
+	if err := json.Unmarshal(body, &generic); err != nil || len(generic.Candidates) == 0 {
+		return nil
+	}
+	out := make([]models.ThinkingBlock, 0, len(generic.Candidates[0].Content.Parts))
+	for _, part := range generic.Candidates[0].Content.Parts {
+		sig := part.ThoughtSignature
+		if sig == "" {
+			sig = part.Signature
+		}
+		if !part.Thought || sig == "" {
+			continue
+		}
+		out = append(out, models.ThinkingBlock{Type: "thought", Thinking: part.Text, Signature: sig})
+	}
+	if len(out) == 0 {
+		// nil, not an empty slice: callers treat nil as "nothing to
+		// replay" and an empty non-nil slice would read as state.
+		return nil
+	}
+	return out
+}

--- a/llm/client/thinking.go
+++ b/llm/client/thinking.go
@@ -1,0 +1,174 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package client
+
+import (
+	"encoding/json"
+	"sync"
+
+	"github.com/diillson/chatcli/models"
+)
+
+// Provider-native reasoning blocks.
+//
+// When extended thinking is on, Anthropic returns the model's reasoning as
+// its own content blocks ahead of the text and tool_use blocks, and the
+// contract for continuing the same conversation is to send those blocks
+// back unchanged inside the assistant turn that carries the tool_use. A
+// client that parses only text and tool_use pays for the reasoning, drops
+// it, and makes every step of an agent loop start its reasoning over.
+//
+// The blocks are opaque: `thinking` carries text plus a signature that the
+// provider verifies, and `redacted_thinking` carries an encrypted payload
+// with no readable text at all. Neither may be edited, summarized or
+// re-ordered — they are replayed verbatim or not at all.
+
+// ThinkingState is an embeddable holder that gives a provider client the
+// LastThinking accessor, mirroring how UsageState provides LastUsage. The
+// plain (non-tool) send paths return a string, so the blocks they parse
+// have nowhere to ride out on; the caller reads them from here instead.
+type ThinkingState struct {
+	mu            sync.RWMutex
+	lastThinking  []models.ThinkingBlock
+	thinkingModel string
+}
+
+// StoreThinking saves the reasoning blocks of the most recent response,
+// together with the model that produced them. Passing nil clears the
+// state, which every send path must do before a request so a response
+// without reasoning never replays the previous turn's blocks.
+func (s *ThinkingState) StoreThinking(model string, blocks []models.ThinkingBlock) {
+	s.mu.Lock()
+	s.lastThinking = blocks
+	s.thinkingModel = model
+	s.mu.Unlock()
+}
+
+// LastThinking returns the reasoning blocks of the most recent response.
+// Implements ThinkingAwareClient.
+func (s *ThinkingState) LastThinking() []models.ThinkingBlock {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.lastThinking
+}
+
+// LastThinkingModel returns the model that produced the blocks LastThinking
+// reports. Reasoning blocks are bound to their producing model, so a caller
+// that switched models mid-session must not replay them.
+func (s *ThinkingState) LastThinkingModel() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.thinkingModel
+}
+
+// ThinkingAwareClient is the optional capability of a client that can hand
+// back the provider-native reasoning blocks of its last response. Callers
+// must keep working when a client does not implement it.
+type ThinkingAwareClient interface {
+	LLMClient
+
+	// LastThinking returns the reasoning blocks of the most recent
+	// response, or nil when the response carried none.
+	LastThinking() []models.ThinkingBlock
+
+	// LastThinkingModel names the model those blocks came from.
+	LastThinkingModel() string
+}
+
+// AsThinkingAware returns the client as a ThinkingAwareClient when it is one.
+func AsThinkingAware(c LLMClient) (ThinkingAwareClient, bool) {
+	tc, ok := c.(ThinkingAwareClient)
+	return tc, ok
+}
+
+// AnthropicThinkingWire carries reasoning blocks already shaped for the
+// Anthropic request body. It exists so the builder can return wire maps
+// without putting a bare map-of-interface in an exported signature.
+type AnthropicThinkingWire struct {
+	Blocks []map[string]interface{}
+}
+
+// ParseAnthropicThinkingBody extracts the reasoning blocks from a raw
+// Anthropic messages response. Callers pass the response bytes they
+// already hold: the typed parsers on the provider paths read only text
+// and tool_use, so this walks the content array once rather than widening
+// them. A body that does not parse yields no blocks — never the previous
+// turn's.
+func ParseAnthropicThinkingBody(body []byte) []models.ThinkingBlock {
+	var generic struct {
+		Content []interface{} `json:"content"`
+	}
+	if err := json.Unmarshal(body, &generic); err != nil {
+		return nil
+	}
+	return parseAnthropicThinkingBlocks(generic.Content)
+}
+
+// parseAnthropicThinkingBlocks reads one already-decoded content array.
+// Unknown block types are ignored; a thinking block missing its signature
+// is dropped, because replaying an unsigned block is rejected by the
+// provider and silently losing the turn is worse than losing the
+// reasoning.
+func parseAnthropicThinkingBlocks(contentBlocks []interface{}) []models.ThinkingBlock {
+	var out []models.ThinkingBlock
+	for _, raw := range contentBlocks {
+		b, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		switch t, _ := b["type"].(string); t {
+		case "thinking":
+			text, _ := b["thinking"].(string)
+			sig, _ := b["signature"].(string)
+			if sig == "" {
+				continue
+			}
+			out = append(out, models.ThinkingBlock{Type: "thinking", Thinking: text, Signature: sig})
+		case "redacted_thinking":
+			data, _ := b["data"].(string)
+			if data == "" {
+				continue
+			}
+			out = append(out, models.ThinkingBlock{Type: "redacted_thinking", Data: data})
+		}
+	}
+	return out
+}
+
+// AnthropicThinkingBlocks shapes reasoning blocks back into the wire form
+// the Anthropic messages API expects. There is no toggle: the blocks only
+// exist when the turn asked for extended thinking, and replaying them is
+// what that request commits to — a caller that wants none asks for no
+// effort instead. The result is empty when there is nothing to replay, so
+// callers can prepend it unconditionally.
+func AnthropicThinkingBlocks(blocks []models.ThinkingBlock) AnthropicThinkingWire {
+	if len(blocks) == 0 {
+		return AnthropicThinkingWire{}
+	}
+	wire := AnthropicThinkingWire{Blocks: make([]map[string]interface{}, 0, len(blocks))}
+	for _, b := range blocks {
+		switch b.Type {
+		case "thinking":
+			if b.Signature == "" {
+				continue
+			}
+			wire.Blocks = append(wire.Blocks, map[string]interface{}{
+				"type":      "thinking",
+				"thinking":  b.Thinking,
+				"signature": b.Signature,
+			})
+		case "redacted_thinking":
+			if b.Data == "" {
+				continue
+			}
+			wire.Blocks = append(wire.Blocks, map[string]interface{}{
+				"type": "redacted_thinking",
+				"data": b.Data,
+			})
+		}
+	}
+	return wire
+}

--- a/llm/client/thinking_test.go
+++ b/llm/client/thinking_test.go
@@ -1,0 +1,101 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+)
+
+func TestParseAnthropicThinkingKeepsOrderAndDropsUnsigned(t *testing.T) {
+	blocks := ParseAnthropicThinkingBody([]byte(`{"content":[
+		{"type":"thinking","thinking":"first","signature":"sig-1"},
+		{"type":"thinking","thinking":"unsigned"},
+		{"type":"redacted_thinking","data":"enc"},
+		{"type":"redacted_thinking"},
+		{"type":"text","text":"answer"},
+		{"type":"tool_use","id":"t1"},
+		"not-a-block"
+	]}`))
+	if len(blocks) != 2 {
+		t.Fatalf("want 2 replayable blocks, got %d: %+v", len(blocks), blocks)
+	}
+	if blocks[0].Type != "thinking" || blocks[0].Thinking != "first" || blocks[0].Signature != "sig-1" {
+		t.Errorf("first block not carried verbatim: %+v", blocks[0])
+	}
+	if blocks[1].Type != "redacted_thinking" || blocks[1].Data != "enc" {
+		t.Errorf("redacted block not carried verbatim: %+v", blocks[1])
+	}
+}
+
+func TestParseAnthropicThinkingBodyRejectsGarbage(t *testing.T) {
+	if got := ParseAnthropicThinkingBody([]byte("not json")); got != nil {
+		t.Errorf("an unparseable body must yield no blocks, got %+v", got)
+	}
+	if got := ParseAnthropicThinkingBody([]byte(`{"content":[]}`)); got != nil {
+		t.Errorf("want nil for no content, got %+v", got)
+	}
+}
+
+func TestAnthropicThinkingBlocksShapesWire(t *testing.T) {
+	wire := AnthropicThinkingBlocks([]models.ThinkingBlock{
+		{Type: "thinking", Thinking: "why", Signature: "sig"},
+		{Type: "thinking", Thinking: "no sig"},
+		{Type: "redacted_thinking", Data: "enc"},
+	})
+	if len(wire.Blocks) != 2 {
+		t.Fatalf("want 2 wire blocks, got %d", len(wire.Blocks))
+	}
+	if wire.Blocks[0]["signature"] != "sig" || wire.Blocks[0]["thinking"] != "why" {
+		t.Errorf("thinking block lost a field: %+v", wire.Blocks[0])
+	}
+	if wire.Blocks[1]["type"] != "redacted_thinking" || wire.Blocks[1]["data"] != "enc" {
+		t.Errorf("redacted block lost a field: %+v", wire.Blocks[1])
+	}
+}
+
+func TestThinkingStateStoreAndClear(t *testing.T) {
+	var st ThinkingState
+	if got := st.LastThinking(); got != nil {
+		t.Fatalf("zero value must be empty, got %+v", got)
+	}
+	st.StoreThinking("claude-opus-5", []models.ThinkingBlock{{Type: "thinking", Thinking: "a", Signature: "s"}})
+	if len(st.LastThinking()) != 1 || st.LastThinkingModel() != "claude-opus-5" {
+		t.Fatalf("store did not round-trip: %+v / %q", st.LastThinking(), st.LastThinkingModel())
+	}
+	st.StoreThinking("claude-opus-5", nil)
+	if st.LastThinking() != nil {
+		t.Errorf("a response without reasoning must not replay the previous turn's blocks")
+	}
+}
+
+// Once reasoning blocks are replayed they occupy the window like any other
+// content, so the provider engine must be able to retire the old ones.
+func TestAnthropicContextManagementClearsThinking(t *testing.T) {
+	t.Setenv(ContextEngineEnv, "provider")
+	cm := AnthropicContextManagement()
+	if cm == nil {
+		t.Fatal("provider engine selected but no context_management block")
+	}
+	var sawToolUses, sawThinking bool
+	for _, e := range cm.Edits {
+		switch e.Type {
+		case "clear_tool_uses_20250919":
+			sawToolUses = true
+		case "clear_thinking_20251015":
+			sawThinking = true
+			if e.Keep == nil || e.Keep.Value <= 0 {
+				t.Errorf("thinking edit must keep recent turns, got %+v", e.Keep)
+			}
+		}
+	}
+	if !sawToolUses || !sawThinking {
+		t.Errorf("want both edits, got %+v", cm.Edits)
+	}
+}
+
+func TestAnthropicContextManagementOffByDefault(t *testing.T) {
+	t.Setenv(ContextEngineEnv, "")
+	if cm := AnthropicContextManagement(); cm != nil {
+		t.Errorf("builtin engine must send no context_management, got %+v", cm)
+	}
+}

--- a/llm/googleai/gemini_client.go
+++ b/llm/googleai/gemini_client.go
@@ -44,6 +44,36 @@ type GeminiClient struct {
 	// built so clients that never opt in pay nothing.
 	explicit     *explicitCache
 	explicitOnce sync.Once
+
+	// thinking holds the thought parts of the most recent response so the
+	// next request can resend them verbatim, which the stateless path
+	// requires to keep the model's reasoning continuous. Behind a pointer:
+	// client.ThinkingState carries a slice and would make GeminiClient
+	// incomparable.
+	thinking *client.ThinkingState
+}
+
+// LastThinking implements client.ThinkingAwareClient.
+func (c *GeminiClient) LastThinking() []models.ThinkingBlock {
+	if c.thinking == nil {
+		return nil
+	}
+	return c.thinking.LastThinking()
+}
+
+// LastThinkingModel implements client.ThinkingAwareClient.
+func (c *GeminiClient) LastThinkingModel() string {
+	if c.thinking == nil {
+		return ""
+	}
+	return c.thinking.LastThinkingModel()
+}
+
+func (c *GeminiClient) storeThinking(blocks []models.ThinkingBlock) {
+	if c.thinking == nil {
+		return
+	}
+	c.thinking.StoreThinking(c.model, blocks)
 }
 
 // LastUsage returns the token usage from the most recent API call.
@@ -77,6 +107,7 @@ func NewGeminiClient(provider auth.TokenProvider, model string, logger *zap.Logg
 		maxAttempts: maxAttempts,
 		backoff:     backoff,
 		baseURL:     config.GoogleAIAPIURL,
+		thinking:    &client.ThinkingState{},
 	}
 }
 
@@ -203,7 +234,7 @@ func (c *GeminiClient) buildContentsAndSystem(history []models.Message, prompt s
 		case "assistant":
 			contents = append(contents, map[string]interface{}{
 				"role":  "model",
-				"parts": visionwire.GeminiParts(msg.Content, msg.Images),
+				"parts": visionwire.GeminiParts(msg.Content, msg.Images).PrependThought(msg.Thinking),
 			})
 		case "system":
 			// Gemini v1beta aceita system_instruction como top-level.
@@ -319,6 +350,12 @@ func (c *GeminiClient) parseResponse(bodyBytes []byte) (string, error) {
 			Status  string `json:"status"`
 		} `json:"error,omitempty"`
 	}
+
+	// Thought parts ride out through the instance: this path returns a
+	// string, so the caller reads them back with LastThinking and attaches
+	// them to the model turn it stores. Stored before the decode check so
+	// a malformed body clears the previous turn's rather than replaying it.
+	c.storeThinking(client.ParseGeminiThoughtBody(bodyBytes))
 
 	if err := json.Unmarshal(bodyBytes, &result); err != nil {
 		sanitizedResponse := c.sanitizeErrorResponse(string(bodyBytes))

--- a/llm/googleai/thought_replay_test.go
+++ b/llm/googleai/thought_replay_test.go
@@ -1,0 +1,91 @@
+package googleai
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/diillson/chatcli/llm/client"
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+// Gemini's signature is an encrypted handle to the model's reasoning
+// state, and the stateless path this client uses must resend every thought
+// part exactly as received.
+func TestParseGeminiThoughtBody(t *testing.T) {
+	blocks := client.ParseGeminiThoughtBody([]byte(`{"candidates":[{"content":{"parts":[
+		{"text":"weighing","thought":true,"thoughtSignature":"sig-1"},
+		{"text":"unsigned thought","thought":true},
+		{"text":"visible answer"}
+	]}}]}`))
+	if len(blocks) != 1 {
+		t.Fatalf("want only the signed thought, got %d: %+v", len(blocks), blocks)
+	}
+	if blocks[0].Type != "thought" || blocks[0].Signature != "sig-1" || blocks[0].Thinking != "weighing" {
+		t.Errorf("thought not carried verbatim: %+v", blocks[0])
+	}
+}
+
+func TestParseGeminiThoughtBodyAcceptsStepSignature(t *testing.T) {
+	blocks := client.ParseGeminiThoughtBody([]byte(`{"candidates":[{"content":{"parts":[
+		{"text":"step","thought":true,"signature":"sig-2"}
+	]}}]}`))
+	if len(blocks) != 1 || blocks[0].Signature != "sig-2" {
+		t.Errorf("step-level signature spelling not accepted: %+v", blocks)
+	}
+	if got := client.ParseGeminiThoughtBody([]byte("garbage")); got != nil {
+		t.Errorf("unparseable body must clear, got %+v", got)
+	}
+}
+
+func TestGeminiReplaysThoughtOnModelTurn(t *testing.T) {
+	c := NewGeminiClient(nil, "gemini-3-pro", zap.NewNop(), 1, 0)
+	contents, _, _ := c.buildContentsAndSystem([]models.Message{
+		{Role: "user", Content: "go"},
+		{
+			Role:     "assistant",
+			Content:  "done",
+			Thinking: []models.ThinkingBlock{{Type: "thought", Thinking: "weighing", Signature: "sig-1"}},
+		},
+	}, "")
+	raw, err := json.Marshal(contents)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded []struct {
+		Role  string           `json:"role"`
+		Parts []map[string]any `json:"parts"`
+	}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, turn := range decoded {
+		if turn.Role != "model" {
+			continue
+		}
+		if len(turn.Parts) < 2 {
+			t.Fatalf("want thought + text, got %s", raw)
+		}
+		if turn.Parts[0]["thought"] != true || turn.Parts[0]["thoughtSignature"] != "sig-1" {
+			t.Fatalf("thought must lead the model turn: %s", raw)
+		}
+		return
+	}
+	t.Fatal("no model turn in the payload")
+}
+
+func TestGeminiTurnWithoutThoughtIsUnchanged(t *testing.T) {
+	c := NewGeminiClient(nil, "gemini-3-pro", zap.NewNop(), 1, 0)
+	with, _, _ := c.buildContentsAndSystem([]models.Message{{Role: "assistant", Content: "done"}}, "")
+	a, _ := json.Marshal(with)
+	if string(a) == "" {
+		t.Fatal("empty payload")
+	}
+	if got := string(a); got == "" || !json.Valid(a) {
+		t.Fatalf("invalid payload: %s", a)
+	}
+	c.storeThinking(nil)
+	if c.LastThinking() != nil {
+		t.Error("cleared state must report no blocks")
+	}
+}

--- a/llm/internal/visionwire/prepend_thinking_test.go
+++ b/llm/internal/visionwire/prepend_thinking_test.go
@@ -1,0 +1,42 @@
+package visionwire
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+)
+
+func TestPrependThinkingLeadsTheTurn(t *testing.T) {
+	c := AnthropicContent("running it", nil).PrependThinking([]models.ThinkingBlock{
+		{Type: "thinking", Thinking: "weighing", Signature: "sig"},
+		{Type: "redacted_thinking", Data: "enc"},
+	})
+	raw, err := json.Marshal(c)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var blocks []map[string]any
+	if err := json.Unmarshal(raw, &blocks); err != nil {
+		t.Fatalf("want the array form once reasoning leads: %v (%s)", err, raw)
+	}
+	if len(blocks) != 3 {
+		t.Fatalf("want thinking+redacted+text, got %d: %s", len(blocks), raw)
+	}
+	if blocks[0]["type"] != "thinking" || blocks[1]["type"] != "redacted_thinking" || blocks[2]["type"] != "text" {
+		t.Errorf("block order wrong: %s", raw)
+	}
+}
+
+func TestPrependThinkingIsByteIdenticalWithoutBlocks(t *testing.T) {
+	base, _ := json.Marshal(AnthropicContent("plain answer", nil))
+	with, _ := json.Marshal(AnthropicContent("plain answer", nil).PrependThinking(nil))
+	if string(base) != string(with) {
+		t.Errorf("a turn with no reasoning must keep its wire bytes: %s vs %s", base, with)
+	}
+	unsigned, _ := json.Marshal(AnthropicContent("plain answer", nil).
+		PrependThinking([]models.ThinkingBlock{{Type: "thinking", Thinking: "x"}}))
+	if string(base) != string(unsigned) {
+		t.Errorf("an unsigned block must be skipped, not sent: %s", unsigned)
+	}
+}

--- a/llm/internal/visionwire/visionwire.go
+++ b/llm/internal/visionwire/visionwire.go
@@ -125,6 +125,33 @@ func AnthropicOAuthContent(text string, imgs []models.ImageContent) Content {
 	return Content{parts: anthropicBlocks(text, validImages(imgs)), array: true}
 }
 
+// PrependThought places Gemini thought parts ahead of the turn's existing
+// parts. Gemini's stateless path requires every thought part to come back
+// exactly as received — the signature is an encrypted handle to the
+// model's reasoning state — so a part without one is skipped instead of
+// being sent unsigned. A turn with no thoughts is returned untouched.
+func (c Content) PrependThought(blocks []models.ThinkingBlock) Content {
+	shaped := make([]any, 0, len(blocks))
+	for _, b := range blocks {
+		if b.Type != "thought" || b.Signature == "" {
+			continue
+		}
+		shaped = append(shaped, map[string]interface{}{
+			"text":             b.Thinking,
+			"thought":          true,
+			"thoughtSignature": b.Signature,
+		})
+	}
+	if len(shaped) == 0 {
+		return c
+	}
+	parts := c.parts
+	if parts == nil {
+		parts = []any{map[string]interface{}{"text": c.text}}
+	}
+	return Content{parts: append(shaped, parts...), array: true}
+}
+
 // PrependThinking places provider-native reasoning blocks ahead of the
 // turn's existing parts, forcing the array form. Anthropic requires the
 // thinking that produced a tool call to lead the assistant turn it is

--- a/llm/internal/visionwire/visionwire.go
+++ b/llm/internal/visionwire/visionwire.go
@@ -125,6 +125,49 @@ func AnthropicOAuthContent(text string, imgs []models.ImageContent) Content {
 	return Content{parts: anthropicBlocks(text, validImages(imgs)), array: true}
 }
 
+// PrependThinking places provider-native reasoning blocks ahead of the
+// turn's existing parts, forcing the array form. Anthropic requires the
+// thinking that produced a tool call to lead the assistant turn it is
+// replayed in; a turn with no blocks is returned untouched, so the wire
+// bytes of every existing path stay identical.
+//
+// The blocks are emitted verbatim — text with its signature, or the
+// encrypted payload of a redacted block. One missing its signature (or
+// payload) is skipped rather than sent, because an unsigned block is
+// rejected and losing the turn is worse than losing the reasoning.
+func (c Content) PrependThinking(blocks []models.ThinkingBlock) Content {
+	shaped := make([]any, 0, len(blocks))
+	for _, b := range blocks {
+		switch b.Type {
+		case "thinking":
+			if b.Signature == "" {
+				continue
+			}
+			shaped = append(shaped, map[string]interface{}{
+				"type":      "thinking",
+				"thinking":  b.Thinking,
+				"signature": b.Signature,
+			})
+		case "redacted_thinking":
+			if b.Data == "" {
+				continue
+			}
+			shaped = append(shaped, map[string]interface{}{
+				"type": "redacted_thinking",
+				"data": b.Data,
+			})
+		}
+	}
+	if len(shaped) == 0 {
+		return c
+	}
+	parts := c.parts
+	if parts == nil {
+		parts = []any{map[string]interface{}{"type": "text", "text": c.text}}
+	}
+	return Content{parts: append(shaped, parts...), array: true}
+}
+
 // anthropicBlocks builds the image-first, text-last blocks slice shared by the
 // API-key (when images present) and OAuth (always) Anthropic paths.
 func anthropicBlocks(text string, valid []models.ImageContent) []any {

--- a/llm/openairesponses/openai_responses_client.go
+++ b/llm/openairesponses/openai_responses_client.go
@@ -260,6 +260,12 @@ func (c *OpenAIResponsesClient) processResponse(resp *http.Response) (string, er
 		IncompleteDetails *struct {
 			Reason string `json:"reason"`
 		} `json:"incomplete_details"`
+		// Reasoning items are read past for their text only. Replaying
+		// them (as claudeai and googleai now do for their own reasoning
+		// blocks) additionally needs include: reasoning.encrypted_content
+		// on the request and the item echoed back in the input array —
+		// verified against the live API before it ships, since sending an
+		// item the endpoint does not expect fails the turn outright.
 		Output []struct {
 			Type    string `json:"type"` // "message" ou "reasoning"
 			Content []struct {

--- a/models/models.go
+++ b/models/models.go
@@ -85,6 +85,13 @@ type Message struct {
 	ToolCallID  string         `json:"tool_call_id,omitempty"` // ID when this message is a tool result.
 	SystemParts []ContentBlock `json:"system_parts,omitempty"` // Structured system prompt parts (for cache control).
 
+	// Thinking carries the provider-native reasoning blocks that preceded
+	// this assistant turn's text and tool calls. Providers that enable
+	// extended thinking require them back, unchanged and first, in the
+	// assistant turn that carries a tool_use; adapters without the concept
+	// ignore the field. Only meaningful when Role == "assistant".
+	Thinking []ThinkingBlock `json:"thinking,omitempty"`
+
 	// Images carries vision input attached to this turn. Populated for
 	// user messages (an attached/pasted/forwarded image) and consumed by
 	// vision-capable provider adapters, which serialize each entry into

--- a/models/tool_types.go
+++ b/models/tool_types.go
@@ -68,6 +68,23 @@ type LLMResponse struct {
 	// from the request server-side (Anthropic context editing); nil when
 	// nothing was edited.
 	ContextEdits *ContextEdits `json:"context_edits,omitempty"`
+	// Thinking carries the provider-native reasoning blocks of this
+	// response, in the order they arrived. They must be replayed verbatim
+	// inside the assistant turn on the next request; empty when the
+	// response carried none.
+	Thinking []ThinkingBlock `json:"thinking,omitempty"`
+}
+
+// ThinkingBlock is one provider-native reasoning block. It is opaque: the
+// text of a "thinking" block travels with a signature the provider
+// verifies, and a "redacted_thinking" block carries an encrypted payload
+// with no readable text. Neither may be edited, summarized or re-ordered —
+// they are replayed exactly as received or dropped entirely.
+type ThinkingBlock struct {
+	Type      string `json:"type"`                // "thinking" or "redacted_thinking"
+	Thinking  string `json:"thinking,omitempty"`  // reasoning text ("thinking" only)
+	Signature string `json:"signature,omitempty"` // provider signature ("thinking" only)
+	Data      string `json:"data,omitempty"`      // encrypted payload ("redacted_thinking" only)
 }
 
 // ContextEdits sums the server-side edits a provider applied to one


### PR DESCRIPTION
Audit IV, PR 1 of 8 — closes CMP-1 (P0) and CAG-7 (P2), across every provider that returns reasoning.

## The defect

When a model reasons, the provider returns that reasoning as its own blocks, and continuing the conversation means sending them back unchanged. Two families require it and both were dropping it:

- **Anthropic** (direct and Bedrock): with extended thinking on, the assistant turn that carries a `tool_use` must carry back the thinking that produced it. `parseClaudeToolResponse` handled `text` and `tool_use` only; a `thinking` block fell through with no case.
- **Gemini**: the stateless path must resend every `thought` part exactly as received — the signature is an encrypted handle to the model's reasoning state. The parts parser read only `text`.

Neither `models.LLMResponse` nor `models.Message` had anywhere to hold a block, so the reasoning was discarded on arrival. The agent loop enables thinking on every turn, paid for it, and then made each ReAct step re-reason from zero.

## What changes

One carrier, four surfaces.

- `models.ThinkingBlock` holds one block; `Message.Thinking` and `LLMResponse.Thinking` carry them. Both types already held slices, so neither becomes newly incomparable.
- `llm/client/thinking.go` owns the shared pieces: parsing an Anthropic body, parsing a Gemini body, shaping blocks back to the wire, and an embeddable `ThinkingState` mirroring `UsageState`. Plain send paths return a string, so they leave blocks on the client behind a new optional capability, `ThinkingAwareClient`.
- **claudeai** parses on the tool and plain paths and replays the blocks first in the assistant turn.
- **bedrock** does the same on its native Anthropic body.
- **googleai** parses thought parts with their signature and replays them ahead of the model turn's text.
- The CLI attaches blocks to the assistant turn it stores, in chat and in the agent loop, preferring the structured response and falling back to the client.

Two guards, both fail-safe. A block missing its signature is skipped rather than sent, because an unsigned block is rejected and losing the turn is worse than losing the reasoning. Blocks are bound to the model that produced them, so a mid-session route change contributes none.

## Provider coverage

| Provider | Returns reasoning that must be replayed | Status |
|---|---|---|
| claudeai | yes — `thinking` / `redacted_thinking` | covered |
| bedrock (Anthropic schema) | yes — same blocks | covered |
| googleai | yes — `thought` + signature | covered |
| openairesponses | yes — reasoning items | noted in code, not shipped: also needs `include: reasoning.encrypted_content` and the item echoed into the input array, which has to be verified against the live API before it ships |
| zai, moonshot | no — thinking is a request switch (`ZAI_THINKING`, `MOONSHOT_THINKING`); no block comes back to replay | n/a |
| openai, copilot, githubmodels, openrouter, xai, minimax, ollama, stackspot, devin | no reasoning block in the response | n/a |

## Clearing (CAG-7)

Replayed reasoning occupies the window like any other content, so `AnthropicContextManagement` now also asks for `clear_thinking_20251015`, on the same trigger as the tool-result edit. Shipping this separately would have traded a discarded block for permanent window occupancy.

## Portability

Pure request/response shaping — no filesystem, no paths, no OS calls. Nothing here behaves differently on Windows, Linux or macOS.

## No new environment variable

An earlier revision added a replay toggle and it was removed: the blocks only exist when the turn asked for reasoning, so a caller that wants none asks for no effort.

## Verification

- `go build ./...`, `go vet ./...`, full package tests green; `golangci-lint --new-from-rev=main` clean; Floor 4 clean; Floor 13 clean after moving the reasoning state behind a pointer on both clients that were comparable.
- New tests: parse keeps order and drops unsigned blocks; the assistant turn puts reasoning first; a turn with no blocks is byte-identical on the wire; foreign-model blocks are refused; Bedrock and Gemini replay and store; both Gemini signature spellings are accepted; both context edits ship in order.
- One existing wire test asserted a single context edit and now asserts both, in order.
