### PR TITLE
fix(llm): the effort a turn asks for reaches the request on every provider

### DIFF
--- a/llm/bedrock/bedrock_client.go
+++ b/llm/bedrock/bedrock_client.go
@@ -666,6 +666,17 @@ func extendedCacheTTLModel(model string) bool {
 }
 
 func supportsExtendedThinking(model string) bool {
+	if catalog.HasCapability(catalog.ProviderBedrock, model, "extended_thinking") {
+		return true
+	}
+	// A registered model without the flag takes no budget: that is what
+	// keeps a newer Claude on Bedrock from being handed the budgeted shape
+	// it answers with a 400.
+	if _, known := catalog.Resolve(catalog.ProviderBedrock, model); known {
+		return false
+	}
+	// Unknown id (cross-region profile, bare ARN): keep the historical
+	// name match so an unlisted model does not silently lose thinking.
 	m := strings.ToLower(model)
 	return strings.Contains(m, "opus-4") ||
 		strings.Contains(m, "sonnet-4") ||
@@ -695,12 +706,22 @@ func applyAnthropicThinkingForEffort(reqBody map[string]interface{}, model strin
 	if effort == client.EffortUnset {
 		return false
 	}
+	// Same lever as the first-party path: this builder feeds the native
+	// Anthropic messages body (InvokeModel and the Mantle endpoint), which
+	// carries output_config unchanged. The Converse and OpenAI families
+	// have their own request shapes and are not touched here.
+	if cfg := client.AnthropicOutputConfig(effort); cfg != nil &&
+		catalog.HasCapability(catalog.ProviderBedrock, model, "output_effort") {
+		reqBody["output_config"] = cfg
+	}
 	if catalog.HasCapability(catalog.ProviderBedrock, model, "adaptive_thinking") {
 		reqBody["thinking"] = map[string]interface{}{"type": "adaptive"}
 		return true
 	}
 	budget := client.ThinkingBudgetForEffort(effort)
 	if budget <= 0 || !supportsExtendedThinking(model) {
+		// The return value reports whether a thinking block was attached;
+		// output_config travels independently of it.
 		return false
 	}
 	required := budget + 1024

--- a/llm/bedrock/openai_family.go
+++ b/llm/bedrock/openai_family.go
@@ -41,6 +41,12 @@ func (c *BedrockClient) sendPromptOpenAI(ctx context.Context, prompt string, his
 		"messages":              messages,
 		"max_completion_tokens": effectiveMaxTokens,
 	}
+
+	// Per-turn effort: the OpenAI models served through Bedrock take the
+	// same reasoning_effort field as the first-party endpoint.
+	if eff := client.OpenAIReasoningEffort(c.model, client.EffortFromContext(ctx)); eff != "" {
+		reqBody["reasoning_effort"] = eff
+	}
 	if t := os.Getenv("BEDROCK_TEMPERATURE"); t != "" {
 		if f, err := strconv.ParseFloat(t, 64); err == nil {
 			reqBody["temperature"] = f

--- a/llm/catalog/catalog.go
+++ b/llm/catalog/catalog.go
@@ -322,7 +322,7 @@ var registry = []ModelMeta{
 		MaxOutputTokens: 64000,
 		PreferredAPI:    APIAnthropicMessages,
 		APIVersion:      config.ClaudeAIAPIVersionDefault,
-		Capabilities:    []string{"vision", "json_mode", "tools"},
+		Capabilities:    []string{"vision", "json_mode", "tools", "extended_thinking"},
 	},
 	{
 		// Sonnet 4.6: 1M context, 128K max output on the synchronous
@@ -338,7 +338,7 @@ var registry = []ModelMeta{
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
 		APIVersion:      config.ClaudeAIAPIVersionDefault,
-		Capabilities:    []string{"vision", "json_mode", "tools"},
+		Capabilities:    []string{"vision", "json_mode", "tools", "extended_thinking"},
 	},
 	{
 		// Haiku 4.5 (claude-haiku-4-5-20251001): 200K context, 64K max
@@ -389,7 +389,7 @@ var registry = []ModelMeta{
 		Capabilities: []string{
 			"vision",
 			"json_mode", "tools",
-			"adaptive_thinking", "mid_conversation_system",
+			"adaptive_thinking", "output_effort", "mid_conversation_system",
 		},
 	},
 	{
@@ -417,7 +417,7 @@ var registry = []ModelMeta{
 		Capabilities: []string{
 			"vision",
 			"json_mode", "tools",
-			"adaptive_thinking", "mid_conversation_system",
+			"adaptive_thinking", "output_effort", "mid_conversation_system",
 		},
 	},
 	{
@@ -440,7 +440,7 @@ var registry = []ModelMeta{
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
 		APIVersion:      config.ClaudeAIAPIVersionDefault,
-		Capabilities:    []string{"vision", "json_mode", "tools", "adaptive_thinking"},
+		Capabilities:    []string{"vision", "json_mode", "tools", "adaptive_thinking", "output_effort"},
 	},
 	{
 		// Sonnet 5 (claude-sonnet-5, Jun 2026): the Sonnet-tier successor —
@@ -462,14 +462,14 @@ var registry = []ModelMeta{
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
 		APIVersion:      config.ClaudeAIAPIVersionDefault,
-		Capabilities:    []string{"vision", "json_mode", "tools", "adaptive_thinking"},
+		Capabilities:    []string{"vision", "json_mode", "tools", "adaptive_thinking", "output_effort"},
 	},
 	{
 		// Opus 4.8 (claude-opus-4-8, May 28 2026): 1M context by default on
 		// the Claude API, 128K max output. Same API constraints as 4.7
 		// (no temperature/top_p/top_k; adaptive thinking only — extended
 		// thinking budgets return 400). New capabilities at launch:
-		//   - "adaptive_thinking": only supported thinking mode
+		//   - "adaptive_thinking", "output_effort": only supported thinking mode
 		//   - "fast_mode": research-preview "speed":"fast" for ~2.5x output
 		//     tokens per second at premium pricing
 		//   - "mid_conversation_system": role:"system" messages accepted
@@ -490,7 +490,7 @@ var registry = []ModelMeta{
 		Capabilities: []string{
 			"vision",
 			"json_mode", "tools",
-			"adaptive_thinking", "fast_mode",
+			"adaptive_thinking", "output_effort", "fast_mode",
 			"mid_conversation_system", "low_cache_minimum",
 		},
 	},
@@ -508,7 +508,7 @@ var registry = []ModelMeta{
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
 		APIVersion:      config.ClaudeAIAPIVersionDefault,
-		Capabilities:    []string{"vision", "json_mode", "tools", "adaptive_thinking"},
+		Capabilities:    []string{"vision", "json_mode", "tools", "adaptive_thinking", "output_effort"},
 	},
 	// There is no Sonnet 4.7: Anthropic went from Sonnet 4.6 straight to
 	// Sonnet 5. The forward-projected placeholder that used to sit here
@@ -525,7 +525,7 @@ var registry = []ModelMeta{
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
 		APIVersion:      config.ClaudeAIAPIVersionDefault,
-		Capabilities:    []string{"vision", "json_mode", "tools"},
+		Capabilities:    []string{"vision", "json_mode", "tools", "extended_thinking"},
 	},
 	{
 		// Opus 4.5 (claude-opus-4-5-20251101): 200K context, 64K max output.
@@ -537,7 +537,7 @@ var registry = []ModelMeta{
 		MaxOutputTokens: 64000,
 		PreferredAPI:    APIAnthropicMessages,
 		APIVersion:      config.ClaudeAIAPIVersionDefault,
-		Capabilities:    []string{"vision", "json_mode", "tools"},
+		Capabilities:    []string{"vision", "json_mode", "tools", "extended_thinking"},
 	},
 	// Opus 4.1 (retired Aug 5 2026), Opus 4 (Jun 15 2026) and the whole
 	// Claude 3.x line used to sit here — see the retirement note above
@@ -693,7 +693,7 @@ var registry = []ModelMeta{
 		ContextWindow:   200000,
 		MaxOutputTokens: 64000,
 		PreferredAPI:    APIChatCompletions,
-		Capabilities:    []string{"vision", "tools"},
+		Capabilities:    []string{"vision", "tools", "extended_thinking"},
 	},
 	{
 		ID:              "gemini-2.0-flash",
@@ -1229,7 +1229,7 @@ var registry = []ModelMeta{
 		ContextWindow:   200000,
 		MaxOutputTokens: 64000,
 		PreferredAPI:    APIChatCompletions,
-		Capabilities:    []string{"vision", "tools", "json_mode"},
+		Capabilities:    []string{"vision", "tools", "json_mode", "extended_thinking"},
 	},
 	{
 		ID:              "anthropic/claude-opus-4",
@@ -1239,7 +1239,7 @@ var registry = []ModelMeta{
 		ContextWindow:   200000,
 		MaxOutputTokens: 32000,
 		PreferredAPI:    APIChatCompletions,
-		Capabilities:    []string{"vision", "tools", "json_mode"},
+		Capabilities:    []string{"vision", "tools", "json_mode", "extended_thinking"},
 	},
 	{
 		ID:              "google/gemini-2.5-pro",
@@ -1330,7 +1330,7 @@ var registry = []ModelMeta{
 		ContextWindow:   1000000,
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking", "bedrock_mantle_only"},
+		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking", "output_effort", "bedrock_mantle_only"},
 	},
 	// Fable 5 (Jun 9 2026). Dateless ID per Anthropic's Bedrock docs —
 	// Fable 5, Opus 4.8 and Opus 4.7 have NO ARN-versioned model IDs on
@@ -1350,7 +1350,7 @@ var registry = []ModelMeta{
 		ContextWindow:   1000000,
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking", "bedrock_mantle_only"},
+		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking", "output_effort", "bedrock_mantle_only"},
 	},
 	// Opus 5 (Jul 2026). Like Sonnet 5 and Fable 5, served through the
 	// Claude-in-Amazon-Bedrock Messages endpoint (the models overview lists
@@ -1365,7 +1365,7 @@ var registry = []ModelMeta{
 		ContextWindow:   1000000,
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking", "bedrock_mantle_only"},
+		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking", "output_effort", "bedrock_mantle_only"},
 	},
 	// Sonnet 5 (Jun 2026). Served EXCLUSIVELY by the Claude-in-Amazon-
 	// Bedrock Messages endpoint (bedrock-mantle.{region}.api.aws) — it has
@@ -1380,7 +1380,7 @@ var registry = []ModelMeta{
 		ContextWindow:   1000000,
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking", "bedrock_mantle_only"},
+		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking", "output_effort", "bedrock_mantle_only"},
 	},
 	// Claude 4.8 (May 28 2026). Opus 4.8 = 1M / 128K per Anthropic.
 	// Canonical id is the global. inference profile: the bare dateless id
@@ -1403,7 +1403,7 @@ var registry = []ModelMeta{
 		PreferredAPI:    APIAnthropicMessages,
 		Capabilities: []string{
 			"tools", "vision", "json_mode",
-			"adaptive_thinking", "low_cache_minimum",
+			"adaptive_thinking", "output_effort", "low_cache_minimum",
 		},
 	},
 
@@ -1423,7 +1423,7 @@ var registry = []ModelMeta{
 		ContextWindow:   1000000,
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking"},
+		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking", "output_effort"},
 	},
 
 	// Claude 4.6 (abr 2026). Bedrock specs follow the AWS model cards:
@@ -1446,7 +1446,7 @@ var registry = []ModelMeta{
 		ContextWindow:   1000000,
 		MaxOutputTokens: 64000,
 		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode"},
+		Capabilities:    []string{"tools", "vision", "json_mode", "extended_thinking"},
 	},
 	{
 		ID: "global.anthropic.claude-opus-4-6-v1",
@@ -1460,7 +1460,7 @@ var registry = []ModelMeta{
 		ContextWindow:   1000000,
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode"},
+		Capabilities:    []string{"tools", "vision", "json_mode", "extended_thinking"},
 	},
 	{
 		ID:              "global.anthropic.claude-haiku-4-5-20251001-v1:0",
@@ -1482,7 +1482,7 @@ var registry = []ModelMeta{
 		ContextWindow:   200000,
 		MaxOutputTokens: 64000,
 		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode"},
+		Capabilities:    []string{"tools", "vision", "json_mode", "extended_thinking"},
 	},
 	{
 		ID:              "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
@@ -1492,7 +1492,7 @@ var registry = []ModelMeta{
 		ContextWindow:   200000,
 		MaxOutputTokens: 64000,
 		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode"},
+		Capabilities:    []string{"tools", "vision", "json_mode", "extended_thinking"},
 	},
 	{
 		// Opus 4.5 snapshot date is 20251101 (Bedrock model card and the
@@ -1505,7 +1505,7 @@ var registry = []ModelMeta{
 		ContextWindow:   200000,
 		MaxOutputTokens: 64000,
 		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode"},
+		Capabilities:    []string{"tools", "vision", "json_mode", "extended_thinking"},
 	},
 
 	// Claude 4 / 4.1. Sonnet 4 has a real global. inference profile (AWS
@@ -1522,7 +1522,7 @@ var registry = []ModelMeta{
 		ContextWindow:   200000,
 		MaxOutputTokens: 64000,
 		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode"},
+		Capabilities:    []string{"tools", "vision", "json_mode", "extended_thinking"},
 	},
 	{
 		ID:              "us.anthropic.claude-sonnet-4-20250514-v1:0",
@@ -1532,7 +1532,7 @@ var registry = []ModelMeta{
 		ContextWindow:   200000,
 		MaxOutputTokens: 64000,
 		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode"},
+		Capabilities:    []string{"tools", "vision", "json_mode", "extended_thinking"},
 	},
 	{
 		ID:              "eu.anthropic.claude-sonnet-4-20250514-v1:0",
@@ -1542,7 +1542,7 @@ var registry = []ModelMeta{
 		ContextWindow:   200000,
 		MaxOutputTokens: 64000,
 		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode"},
+		Capabilities:    []string{"tools", "vision", "json_mode", "extended_thinking"},
 	},
 	// Bedrock lifecycle (docs.aws.amazon.com/bedrock/latest/userguide/
 	// model-lifecycle.html, Sep 2 2026): Sonnet 4 is Legacy with EOL Oct
@@ -1557,7 +1557,7 @@ var registry = []ModelMeta{
 		ContextWindow:   200000,
 		MaxOutputTokens: 32000,
 		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode"},
+		Capabilities:    []string{"tools", "vision", "json_mode", "extended_thinking"},
 	},
 
 	// Claude 3.x on Bedrock — all gone (model-cards index + lifecycle

--- a/llm/claudeai/claude_client.go
+++ b/llm/claudeai/claude_client.go
@@ -200,6 +200,18 @@ func (c *ClaudeClient) getMaxTokens() int {
 // that dated variants (e.g. "claude-sonnet-4-5-20251001") and future 4.x
 // releases keep working without a catalog update.
 func supportsExtendedThinking(model string) bool {
+	if catalog.HasCapability(catalog.ProviderClaudeAI, model, "extended_thinking") {
+		return true
+	}
+	// The catalog is authoritative for every model it knows: a registered
+	// entry without the flag takes no budget, which is what stops a newer
+	// model from being handed the budgeted shape it rejects with a 400.
+	if _, known := catalog.Resolve(catalog.ProviderClaudeAI, model); known {
+		return false
+	}
+	// Unknown id (a dated snapshot, a gateway alias): fall back to the
+	// historical name match so an unlisted model keeps the thinking it
+	// has today rather than silently losing it.
 	m := strings.ToLower(model)
 	return strings.Contains(m, "opus-4") ||
 		strings.Contains(m, "sonnet-4") ||
@@ -229,6 +241,13 @@ func applyThinkingForEffort(reqBody map[string]interface{}, model string, ctx co
 	effort := client.EffortFromContext(ctx)
 	if effort == client.EffortUnset {
 		return false
+	}
+	// The level itself travels in output_config: the thinking block only
+	// says whether the model reasons, so without this every level from low
+	// to max produced the same request and the provider's default applied.
+	if cfg := client.AnthropicOutputConfig(effort); cfg != nil &&
+		catalog.HasCapability(catalog.ProviderClaudeAI, model, "output_effort") {
+		reqBody["output_config"] = cfg
 	}
 	if usesAdaptiveThinkingOnly(model) {
 		reqBody["thinking"] = map[string]interface{}{"type": "adaptive"}

--- a/llm/claudeai/effort_wire_test.go
+++ b/llm/claudeai/effort_wire_test.go
@@ -1,0 +1,84 @@
+package claudeai
+
+import (
+	"context"
+	"testing"
+
+	"github.com/diillson/chatcli/llm/client"
+)
+
+// The level is what decides how much the model thinks and spends. Before
+// this, every level produced the same request and the provider's default
+// applied, so low and max were indistinguishable on the wire.
+func TestEffortTravelsInOutputConfig(t *testing.T) {
+	cases := []struct {
+		model     string
+		effort    client.SkillEffort
+		wantLevel string
+		wantThink string // "adaptive", "budgeted" or ""
+	}{
+		{"claude-opus-5", client.EffortLow, "low", "adaptive"},
+		{"claude-opus-5", client.EffortXHigh, "xhigh", "adaptive"},
+		{"claude-opus-5", client.EffortMax, "max", "adaptive"},
+		{"claude-fable-5-1", client.EffortHigh, "high", "adaptive"},
+		// Budgeted generation: no output_config, the budget carries the level.
+		{"claude-sonnet-4-5", client.EffortHigh, "", "budgeted"},
+		// No hint: nothing is sent and the provider default applies.
+		{"claude-opus-5", client.EffortUnset, "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.model+"/"+string(tc.effort), func(t *testing.T) {
+			body := map[string]interface{}{"max_tokens": 4096}
+			ctx := context.Background()
+			if tc.effort != client.EffortUnset {
+				ctx = client.WithEffortHint(ctx, tc.effort)
+			}
+			applyThinkingForEffort(body, tc.model, ctx)
+
+			cfg, hasCfg := body["output_config"].(map[string]string)
+			if tc.wantLevel == "" {
+				if hasCfg {
+					t.Fatalf("output_config must not be sent: %+v", cfg)
+				}
+			} else {
+				if !hasCfg || cfg["effort"] != tc.wantLevel {
+					t.Fatalf("output_config = %+v, want effort %q", body["output_config"], tc.wantLevel)
+				}
+			}
+
+			think, hasThink := body["thinking"].(map[string]interface{})
+			switch tc.wantThink {
+			case "":
+				if hasThink {
+					t.Fatalf("thinking must not be sent: %+v", think)
+				}
+			case "adaptive":
+				if !hasThink || think["type"] != "adaptive" {
+					t.Fatalf("thinking = %+v, want adaptive", body["thinking"])
+				}
+			case "budgeted":
+				if !hasThink || think["type"] != "enabled" {
+					t.Fatalf("thinking = %+v, want budgeted", body["thinking"])
+				}
+			}
+		})
+	}
+}
+
+// The catalog is the single source of truth for a registered model; the
+// name match survives only for ids the catalog does not know, so an
+// unlisted snapshot keeps the thinking it has today.
+func TestExtendedThinkingComesFromTheCatalog(t *testing.T) {
+	if !supportsExtendedThinking("claude-sonnet-4-5") {
+		t.Error("a registered budgeted model must be recognized")
+	}
+	if supportsExtendedThinking("claude-opus-5") {
+		t.Error("a registered adaptive model must not take a token budget")
+	}
+	if !supportsExtendedThinking("claude-sonnet-4-5-20250929") {
+		t.Error("an unlisted snapshot must fall back to the name match")
+	}
+	if supportsExtendedThinking("gpt-5.6-terra") {
+		t.Error("a foreign model must not be treated as thinking-capable")
+	}
+}

--- a/llm/client/effort_wire.go
+++ b/llm/client/effort_wire.go
@@ -1,0 +1,83 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package client
+
+import "strings"
+
+// Per-turn effort on the wire, one mapping for every provider.
+//
+// The canonical level (skill frontmatter, /effort, a slash command's
+// routing) has to reach the request or it is only a preference. Each
+// family names the field differently — output_config.effort on Anthropic,
+// reasoning_effort on the OpenAI-compatible chat schema, reasoning.effort
+// on the Responses and OpenRouter schemas, a thinking budget on Gemini —
+// so the mapping lives here and every provider assigns the value into its
+// own body. Returning the value (instead of mutating a body map) keeps
+// the wire shape owned by the provider that knows it.
+//
+// Every helper returns a zero value when nothing should be sent, which is
+// also what an unset hint means: the provider's own default then applies,
+// exactly as before effort was wired.
+
+// SupportsOpenAIReasoningEffort reports whether a model on the
+// OpenAI-compatible chat schema accepts reasoning_effort. Shared by the
+// direct OpenAI client, the Responses client, Copilot, GitHub Models and
+// the Bedrock OpenAI family, which all speak the same dialect and used to
+// carry their own copy of this list (or none at all).
+func SupportsOpenAIReasoningEffort(model string) bool {
+	m := strings.ToLower(model)
+	return strings.HasPrefix(m, "o1") ||
+		strings.HasPrefix(m, "o3") ||
+		strings.HasPrefix(m, "o4") ||
+		strings.HasPrefix(m, "gpt-5") ||
+		strings.Contains(m, "gpt-oss") ||
+		strings.Contains(m, "-reasoning")
+}
+
+// OpenAIReasoningEffort is the value for reasoning_effort (or the effort
+// field of the Responses/OpenRouter reasoning object) on a given model.
+// Empty when the model does not take the field or the hint is unset.
+func OpenAIReasoningEffort(model string, e SkillEffort) string {
+	if !SupportsOpenAIReasoningEffort(model) {
+		return ""
+	}
+	return ReasoningEffortForOpenAI(e)
+}
+
+// XAIReasoningEffort is the value for grok's reasoning_effort, which
+// accepts only the two ends of the scale. Anything at or above high maps
+// to high; low and medium map to low, so a cheap turn stays cheap.
+func XAIReasoningEffort(model string, e SkillEffort) string {
+	m := strings.ToLower(model)
+	if !strings.Contains(m, "mini") && !strings.Contains(m, "reasoning") {
+		return ""
+	}
+	switch e {
+	case EffortLow, EffortMedium:
+		return "low"
+	case EffortHigh, EffortXHigh, EffortMax:
+		return "high"
+	}
+	return ""
+}
+
+// GeminiThinkingLevel is the value for
+// generationConfig.thinkingConfig.thinkingLevel. Gemini takes a named
+// level, not a token budget, and rejects a request that carries both the
+// level and the legacy budget — so this is the only thinking knob the
+// Gemini path sends. Empty means send nothing and let the model decide,
+// which is Gemini's own default.
+func GeminiThinkingLevel(e SkillEffort) string {
+	switch e {
+	case EffortLow:
+		return "low"
+	case EffortMedium:
+		return "medium"
+	case EffortHigh, EffortXHigh, EffortMax:
+		return "high"
+	}
+	return ""
+}

--- a/llm/client/effort_wire_test.go
+++ b/llm/client/effort_wire_test.go
@@ -1,0 +1,94 @@
+package client
+
+import "testing"
+
+func TestNormalizeEffortAcceptsXHigh(t *testing.T) {
+	for _, raw := range []string{"xhigh", "XHIGH", "x-high", "extra-high", "extra_high"} {
+		if got := NormalizeEffort(raw); got != EffortXHigh {
+			t.Errorf("NormalizeEffort(%q) = %q, want xhigh", raw, got)
+		}
+	}
+	if got := NormalizeEffort("nonsense"); got != EffortUnset {
+		t.Errorf("unknown level must stay unset, got %q", got)
+	}
+}
+
+// The level has to survive the trip to the wire on every family, or the
+// whole scale collapses into one request.
+func TestEffortReachesEveryFamily(t *testing.T) {
+	cases := []struct {
+		effort    SkillEffort
+		anthropic string
+		openai    string
+		xai       string
+		gemini    string
+	}{
+		{EffortUnset, "", "", "", ""},
+		{EffortLow, "low", "low", "low", "low"},
+		{EffortMedium, "medium", "medium", "low", "medium"},
+		{EffortHigh, "high", "high", "high", "high"},
+		{EffortXHigh, "xhigh", "high", "high", "high"},
+		{EffortMax, "max", "high", "high", "high"},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.effort), func(t *testing.T) {
+			if got := AnthropicEffortLevel(tc.effort); got != tc.anthropic {
+				t.Errorf("anthropic = %q, want %q", got, tc.anthropic)
+			}
+			if got := OpenAIReasoningEffort("gpt-5.6-terra", tc.effort); got != tc.openai {
+				t.Errorf("openai = %q, want %q", got, tc.openai)
+			}
+			if got := XAIReasoningEffort("grok-4-mini", tc.effort); got != tc.xai {
+				t.Errorf("xai = %q, want %q", got, tc.xai)
+			}
+			if got := GeminiThinkingLevel(tc.effort); got != tc.gemini {
+				t.Errorf("gemini = %q, want %q", got, tc.gemini)
+			}
+		})
+	}
+}
+
+func TestAnthropicOutputConfigShape(t *testing.T) {
+	if cfg := AnthropicOutputConfig(EffortUnset); cfg != nil {
+		t.Errorf("unset must send nothing, got %+v", cfg)
+	}
+	cfg := AnthropicOutputConfig(EffortXHigh)
+	if cfg == nil || cfg["effort"] != "xhigh" {
+		t.Fatalf("output_config = %+v", cfg)
+	}
+	if len(cfg) != 1 {
+		t.Errorf("output_config must carry only the effort field: %+v", cfg)
+	}
+}
+
+func TestOpenAIEffortOnlyForReasoningModels(t *testing.T) {
+	if got := OpenAIReasoningEffort("gpt-4.1", EffortHigh); got != "" {
+		t.Errorf("a non-reasoning model must not carry the field, got %q", got)
+	}
+	for _, m := range []string{"o1-preview", "o3-mini", "o4", "gpt-5.6-terra", "gpt-oss-120b", "custom-reasoning"} {
+		if !SupportsOpenAIReasoningEffort(m) {
+			t.Errorf("%s should take reasoning_effort", m)
+		}
+	}
+}
+
+// Grok exposes only the two ends of the scale, so the middle maps down:
+// a turn asked to be cheap must not become expensive on one provider.
+func TestXAIEffortOnlyForReasoningModels(t *testing.T) {
+	if got := XAIReasoningEffort("grok-4", EffortHigh); got != "" {
+		t.Errorf("a non-reasoning grok must not carry the field, got %q", got)
+	}
+}
+
+func TestThinkingBudgetOrderedByLevel(t *testing.T) {
+	low := ThinkingBudgetForEffort(EffortMedium)
+	high := ThinkingBudgetForEffort(EffortHigh)
+	xhigh := ThinkingBudgetForEffort(EffortXHigh)
+	max := ThinkingBudgetForEffort(EffortMax)
+	if !(low < high && high < xhigh && xhigh < max) {
+		t.Errorf("budgets must increase with the level: %d %d %d %d", low, high, xhigh, max)
+	}
+	if ThinkingBudgetForEffort(EffortLow) != 0 || ThinkingBudgetForEffort(EffortUnset) != 0 {
+		t.Error("low and unset must not enable budgeted thinking")
+	}
+}

--- a/llm/client/skill_hints.go
+++ b/llm/client/skill_hints.go
@@ -21,6 +21,7 @@ const (
 	EffortLow    SkillEffort = "low"
 	EffortMedium SkillEffort = "medium"
 	EffortHigh   SkillEffort = "high"
+	EffortXHigh  SkillEffort = "xhigh"
 	EffortMax    SkillEffort = "max"
 )
 
@@ -34,6 +35,8 @@ func NormalizeEffort(raw string) SkillEffort {
 		return EffortMedium
 	case "high", "High", "HIGH":
 		return EffortHigh
+	case "xhigh", "XHigh", "XHIGH", "x-high", "X-High", "extra-high", "extra_high":
+		return EffortXHigh
 	case "max", "Max", "MAX", "maximum", "Maximum", "MAXIMUM":
 		return EffortMax
 	}
@@ -73,6 +76,8 @@ func ThinkingBudgetForEffort(e SkillEffort) int {
 		return 4096
 	case EffortHigh:
 		return 16384
+	case EffortXHigh:
+		return 24576
 	case EffortMax:
 		return 32768
 	}
@@ -88,8 +93,44 @@ func ReasoningEffortForOpenAI(e SkillEffort) string {
 		return "low"
 	case EffortMedium:
 		return "medium"
-	case EffortHigh, EffortMax:
+	case EffortHigh, EffortXHigh, EffortMax:
 		return "high"
 	}
 	return ""
+}
+
+// AnthropicEffortLevel maps the canonical level to the string Anthropic's
+// output_config.effort accepts. Effort is the lever that decides how much
+// the model thinks and spends; the thinking block only says whether it
+// thinks at all, so a client that sends the block alone collapses every
+// level into one request.
+//
+// Returns "" when nothing should be sent, which is also what an unset hint
+// means: the provider's own default (high) then applies, unchanged from
+// the behavior before effort was wired.
+func AnthropicEffortLevel(e SkillEffort) string {
+	switch e {
+	case EffortLow:
+		return "low"
+	case EffortMedium:
+		return "medium"
+	case EffortHigh:
+		return "high"
+	case EffortXHigh:
+		return "xhigh"
+	case EffortMax:
+		return "max"
+	}
+	return ""
+}
+
+// AnthropicOutputConfig builds the output_config request block for one
+// effort level. Empty when the level carries nothing to send, so callers
+// can assign it without a nil check.
+func AnthropicOutputConfig(e SkillEffort) map[string]string {
+	level := AnthropicEffortLevel(e)
+	if level == "" {
+		return nil
+	}
+	return map[string]string{"effort": level}
 }

--- a/llm/copilot/copilot_client.go
+++ b/llm/copilot/copilot_client.go
@@ -133,6 +133,11 @@ func (c *Client) SendPrompt(ctx context.Context, prompt string, history []models
 		"store":    false, // Copilot API: don't store conversations
 	}
 
+	// Per-turn effort: same chat schema as OpenAI, same field.
+	if eff := client.OpenAIReasoningEffort(c.model, client.EffortFromContext(ctx)); eff != "" {
+		payload["reasoning_effort"] = eff
+	}
+
 	// Automatic prompt caching routing hint on OpenAI-compatible upstreams
 	// (ignored by those that do not route on it). See client.PromptCacheKey.
 	if key := client.PromptCacheKey(history); key != "" {

--- a/llm/githubmodels/github_models_client.go
+++ b/llm/githubmodels/github_models_client.go
@@ -127,6 +127,11 @@ func (c *GitHubModelsClient) SendPrompt(ctx context.Context, prompt string, hist
 		"max_tokens": effectiveMaxTokens,
 	}
 
+	// Per-turn effort: same chat schema as OpenAI, same field.
+	if eff := client.OpenAIReasoningEffort(c.model, client.EffortFromContext(ctx)); eff != "" {
+		payload["reasoning_effort"] = eff
+	}
+
 	jsonValue, err := json.Marshal(payload)
 	if err != nil {
 		return "", fmt.Errorf("%s: %w", i18n.T("llm.error.marshal_payload_for", "GitHub Models"), err)

--- a/llm/googleai/gemini_client.go
+++ b/llm/googleai/gemini_client.go
@@ -151,6 +151,12 @@ func (c *GeminiClient) SendPrompt(ctx context.Context, prompt string, history []
 		"topK":            40,
 		"maxOutputTokens": effectiveMaxTokens,
 	}
+	// Per-turn effort. Gemini takes a named level and rejects a request
+	// that also carries the legacy token budget, so the level is the only
+	// thinking knob this path sends.
+	if lvl := client.GeminiThinkingLevel(client.EffortFromContext(ctx)); lvl != "" {
+		generationConfig["thinkingConfig"] = map[string]interface{}{"thinkingLevel": lvl}
+	}
 
 	reqBody := map[string]interface{}{
 		"contents":         contents,

--- a/llm/openai/openai_client.go
+++ b/llm/openai/openai_client.go
@@ -80,12 +80,10 @@ func (c *OpenAIClient) getMaxTokens() int {
 // supportsOpenAIReasoningEffort reports whether the chat-completions model id
 // accepts the `reasoning_effort` field (o-series / GPT-5 reasoning models).
 func supportsOpenAIReasoningEffort(model string) bool {
-	m := strings.ToLower(model)
-	return strings.HasPrefix(m, "o1") ||
-		strings.HasPrefix(m, "o3") ||
-		strings.HasPrefix(m, "o4") ||
-		strings.HasPrefix(m, "gpt-5") ||
-		strings.Contains(m, "-reasoning")
+	// One list for the whole OpenAI-compatible family (see
+	// client.SupportsOpenAIReasoningEffort): this used to be duplicated
+	// per client and drifted.
+	return client.SupportsOpenAIReasoningEffort(model)
 }
 
 func (c *OpenAIClient) SendPrompt(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {

--- a/llm/openairesponses/openai_responses_client.go
+++ b/llm/openairesponses/openai_responses_client.go
@@ -86,12 +86,10 @@ func (c *OpenAIResponsesClient) getMaxTokens() int {
 // honors this field on the o-series reasoning models (o1, o3, o4, GPT-5).
 // Non-reasoning chat models (gpt-4o, gpt-4.1, etc.) reject unknown fields.
 func supportsReasoningEffort(model string) bool {
-	m := strings.ToLower(model)
-	return strings.HasPrefix(m, "o1") ||
-		strings.HasPrefix(m, "o3") ||
-		strings.HasPrefix(m, "o4") ||
-		strings.HasPrefix(m, "gpt-5") ||
-		strings.Contains(m, "-reasoning")
+	// One list for the whole OpenAI-compatible family (see
+	// client.SupportsOpenAIReasoningEffort): this used to be duplicated
+	// per client and drifted.
+	return client.SupportsOpenAIReasoningEffort(model)
 }
 
 func (c *OpenAIResponsesClient) SendPrompt(ctx context.Context, prompt string, history []models.Message, maxTokens int) (string, error) {

--- a/llm/openrouter/effort_wire_test.go
+++ b/llm/openrouter/effort_wire_test.go
@@ -1,0 +1,43 @@
+package openrouter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/diillson/chatcli/llm/client"
+	"go.uber.org/zap"
+)
+
+func TestOpenRouterCarriesEffortOnOfficialHost(t *testing.T) {
+	c := NewOpenRouterClient(testProvider("k"), "anthropic/claude-opus-5", zap.NewNop(), 1, 0)
+	ctx := client.WithEffortHint(context.Background(), client.EffortXHigh)
+	payload := c.buildPayload(ctx, nil, 100)
+	reasoning, ok := payload["reasoning"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("reasoning object missing: %+v", payload)
+	}
+	// OpenRouter normalizes across vendors onto the OpenAI scale.
+	if reasoning["effort"] != "high" {
+		t.Errorf("effort = %v, want high", reasoning["effort"])
+	}
+}
+
+func TestOpenRouterSendsNoEffortWithoutHint(t *testing.T) {
+	c := NewOpenRouterClient(testProvider("k"), "anthropic/claude-opus-5", zap.NewNop(), 1, 0)
+	payload := c.buildPayload(context.Background(), nil, 100)
+	if _, ok := payload["reasoning"]; ok {
+		t.Errorf("an unset hint must send nothing: %+v", payload)
+	}
+}
+
+// A generic OpenAI-compatible backend behind OPENROUTER_API_URL rejects
+// request fields it does not know, so the proprietary object stays off.
+func TestOpenRouterSkipsEffortOnCustomEndpoint(t *testing.T) {
+	t.Setenv("OPENROUTER_API_URL", "https://gateway.internal/v1/chat/completions")
+	c := NewOpenRouterClient(testProvider("k"), "anthropic/claude-opus-5", zap.NewNop(), 1, 0)
+	ctx := client.WithEffortHint(context.Background(), client.EffortHigh)
+	payload := c.buildPayload(ctx, nil, 100)
+	if _, ok := payload["reasoning"]; ok {
+		t.Errorf("custom endpoint must not receive the reasoning object: %+v", payload)
+	}
+}

--- a/llm/openrouter/openrouter_client.go
+++ b/llm/openrouter/openrouter_client.go
@@ -251,11 +251,22 @@ func capOpenRouterCacheMarkers(messages []map[string]interface{}, limit int) {
 }
 
 // buildPayload assembles the request payload with OpenRouter-specific options.
-func (c *OpenRouterClient) buildPayload(messages []map[string]interface{}, maxTokens int) map[string]interface{} {
+func (c *OpenRouterClient) buildPayload(ctx context.Context, messages []map[string]interface{}, maxTokens int) map[string]interface{} {
 	payload := map[string]interface{}{
 		"model":      c.model,
 		"messages":   messages,
 		"max_tokens": maxTokens,
+	}
+
+	// Per-turn effort. OpenRouter normalizes reasoning across vendors
+	// behind one object, so a single field carries the level whatever the
+	// upstream is. Gated to the official host for the same reason as the
+	// accounting field below: a strict OpenAI-compatible backend rejects
+	// request fields it does not know.
+	if !utils.IsCustomEndpoint(c.getAPIURL(), config.OpenRouterAPIURL) {
+		if eff := client.ReasoningEffortForOpenAI(client.EffortFromContext(ctx)); eff != "" {
+			payload["reasoning"] = map[string]interface{}{"effort": eff}
+		}
 	}
 
 	// Ask OpenRouter to attach accounting to the response: usage.cost is
@@ -352,7 +363,7 @@ func (c *OpenRouterClient) SendPrompt(ctx context.Context, prompt string, histor
 	}
 
 	messages := c.buildMessages(prompt, history)
-	payload := c.buildPayload(messages, effectiveMaxTokens)
+	payload := c.buildPayload(ctx, messages, effectiveMaxTokens)
 	if openRouterUsesPromptCacheKey(c.model) {
 		if key := client.PromptCacheKey(history); key != "" {
 			payload["prompt_cache_key"] = key

--- a/llm/xai/xai_client.go
+++ b/llm/xai/xai_client.go
@@ -100,6 +100,13 @@ func (c *XAIClient) SendPrompt(ctx context.Context, prompt string, history []mod
 		"max_tokens": effectiveMaxTokens,
 	}
 
+	// Per-turn effort. Grok's reasoning models accept only low and high,
+	// so the middle of the scale maps down rather than up: a cheap turn
+	// stays cheap.
+	if eff := client.XAIReasoningEffort(c.model, client.EffortFromContext(ctx)); eff != "" {
+		payload["reasoning_effort"] = eff
+	}
+
 	// Automatic prompt caching routing hint on OpenAI-compatible upstreams
 	// (ignored by those that do not route on it). See client.PromptCacheKey.
 	if key := client.PromptCacheKey(history); key != "" {


### PR DESCRIPTION
Audit IV, PR 2 of 8 — closes COST-1 (P0) and COST-4 (P2).

## The defect

The canonical effort level — skill frontmatter, a slash command's routing, the per-turn hint — was translated only into *whether* the model reasons.

- **Anthropic** (direct and Bedrock): any non-empty level produced the same `thinking: {type: "adaptive"}` block, so `low` and `max` generated byte-identical requests and the actual level was whatever the provider defaults to. `output_config` did not appear anywhere in the repository.
- **Copilot, GitHub Models, xAI, OpenRouter, Gemini, and the OpenAI models served through Bedrock**: the hint reached nothing at all.
- Only the two direct OpenAI paths carried it, and each kept its own copy of the "does this model take reasoning effort" list.

`xhigh` — the level between high and max that the field recommends for coding and agentic work — was not expressible at all.

## What changes

One mapping in `llm/client`, assigned by each provider into its own body, because every family names the field differently.

| Provider | Field | Status |
|---|---|---|
| claudeai | `output_config.effort` | new |
| bedrock (Anthropic schema) | `output_config.effort` | new |
| bedrock (OpenAI family) | `reasoning_effort` | new |
| copilot | `reasoning_effort` | new |
| githubmodels | `reasoning_effort` | new |
| xai | `reasoning_effort` (low/high only) | new |
| openrouter | `reasoning.effort` | new |
| googleai | `generationConfig.thinkingConfig.thinkingLevel` | new |
| openai | `reasoning_effort` | existed, now on the shared list |
| openairesponses | `reasoning.effort` | existed, now on the shared list |
| zai, moonshot | own thinking switch (`ZAI_THINKING`, `MOONSHOT_THINKING`) — no effort scale to map | n/a |
| minimax, ollama, stackspot, devin | no documented per-request effort field | n/a |

Details that matter:

- **Gemini** takes a named level and returns 400 if a request carries both the level and the legacy token budget, so the level is the only thinking knob that path sends.
- **Grok** accepts only the two ends of the scale, so the middle maps *down*: a turn asked to be cheap must not become expensive on one provider.
- **OpenRouter's** reasoning object is gated to the official host, matching the rule the file already applies to its other proprietary fields — a strict OpenAI-compatible backend rejects request fields it does not know.
- Every helper returns a zero value when nothing should be sent, so an **unset hint leaves every request exactly as it was**.

## Thinking capability stops being decided by name (COST-4)

`supportsExtendedThinking` matched `opus-4` / `sonnet-4` by substring, right next to a sibling that asked the catalog. A registered model now answers from the catalog — which is what keeps a future model from being handed the budgeted shape it rejects with a 400 — and the name match survives only for ids the catalog does not know, so an unlisted snapshot keeps the thinking it has today. The flag was added to exactly the entries the substring rule already covered, across every provider's mirrors, so behavior is unchanged for every model in the catalog.

## Portability

Request shaping only — no filesystem, no paths, no OS calls. Identical on Windows, Linux and macOS.

## No new environment variable

The lever already exists (`/effort`, skill frontmatter); this PR makes it arrive. Nothing new to configure.

## Verification

- `go build ./...`, full suite green, `golangci-lint --new-from-rev=main` clean, Floor 4 clean, Floor 13 clean.
- New tests: the level reaching each family across the whole scale, including the two clamping rules; `output_config` present on adaptive models and absent on budgeted ones; nothing sent for an unset hint; the OpenRouter object present on the official host and absent on a custom endpoint; catalog-driven thinking with the unlisted-snapshot fallback.
