### PR TITLE
fix(context): the per-turn block stops repeating itself into the window

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -1045,7 +1045,7 @@ func (a *AgentMode) Run(ctx context.Context, query string, additionalContext str
 	//      context) — varies between runs but stable within one Run().
 	//   4. Skills injection (auto-activated + manual) + Orchestrator
 	//      catalog. Added further down after auto-activation is decided.
-	coreText := a.composeCoreText(isCoder, hasActivePersona)
+	coreText := a.withWorkspaceDirective(a.composeCoreText(isCoder, hasActivePersona))
 
 	a.isCoderMode = isCoder
 	// isOneShot is set by the caller before Run (false for the interactive
@@ -1324,7 +1324,14 @@ func (a *AgentMode) appendTurnContext(text string) {
 	if strings.TrimSpace(text) == "" {
 		return
 	}
-	a.cli.history = append(a.cli.history, models.TurnContextMessage(turnContextHeader+text))
+	full := turnContextHeader + text
+	// A block that would repeat the last one still in history is not
+	// appended: the model already read it, and a run of thirty turns used
+	// to carry thirty copies of the same date line into the window.
+	if turnContextIsRedundant(a.cli.history, full) {
+		return
+	}
+	a.cli.history = append(a.cli.history, models.TurnContextMessage(full))
 }
 
 // installAgentSystemMessage purges stale mode system messages and installs the
@@ -1352,6 +1359,22 @@ func (a *AgentMode) installAgentSystemMessage(sysMsg models.Message, currentMode
 // composeCoreText builds Block 1 of the agent system prompt (the stable core
 // behavior block): persona/coder/default base plus the language and gateway
 // directives. Split out of Run to keep its cyclomatic complexity in check.
+// withWorkspaceDirective appends the session-invariant workspace text to
+// the cached core. Where the run is rooted and how to read a relative path
+// against it never change during a session, so they belong in the prefix
+// the cache holds rather than in the per-turn context message that used to
+// repeat them.
+func (a *AgentMode) withWorkspaceDirective(coreText string) string {
+	if a.cli == nil || a.cli.contextBuilder == nil {
+		return coreText
+	}
+	dir := a.cli.contextBuilder.BuildWorkspaceDirective()
+	if dir == "" {
+		return coreText
+	}
+	return strings.TrimRight(coreText, "\n") + "\n\n" + dir
+}
+
 func (a *AgentMode) composeCoreText(isCoder, hasActivePersona bool) string {
 	var coreText string
 	if hasActivePersona {
@@ -2177,7 +2200,7 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 			// Same trigger surface for proactive recall: a follow-up asking
 			// about past work re-ranks memory/sessions against ITS words.
 			if rb := a.followUpRecallBlocks(ctx, userMsg); rb != "" {
-				a.cli.history = append(a.cli.history, models.TurnContextMessage(turnContextHeader+rb))
+				a.appendTurnContext(rb)
 			}
 		}
 
@@ -4172,7 +4195,7 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 				// Tagged like every other injected block: excluded from
 				// extraction, autosave indexing and session search, so the
 				// recall never feeds itself back into memory.
-				a.cli.history = append(a.cli.history, models.TurnContextMessage(turnContextHeader+rb))
+				a.appendTurnContext(rb)
 			}
 			continue
 		}

--- a/cli/chat_pipeline.go
+++ b/cli/chat_pipeline.go
@@ -235,6 +235,15 @@ func (cli *ChatCLI) modeAndLanguagePart() models.ContentBlock {
 	// Output-token reduction: the verbosity directive is a static string per
 	// level, so appending it keeps this Part 0 block cacheable.
 	text := ChatModeSystemHint + "\n" + i18n.T("ai.response_language") + verbosityDirectiveBlock()
+	// Where the session is rooted and how to read a relative path against
+	// it is fixed for the whole session, so it belongs in the cached
+	// prefix. It used to ride in the per-turn context message, which paid
+	// for the same paragraph again on every request.
+	if cli.contextBuilder != nil {
+		if dir := cli.contextBuilder.BuildWorkspaceDirective(); dir != "" {
+			text += "\n\n" + dir
+		}
+	}
 	if card := cli.memoryBootstrapCardChat(); card != "" {
 		text += "\n\n" + card
 	}

--- a/cli/cli_llm.go
+++ b/cli/cli_llm.go
@@ -54,8 +54,15 @@ func (cli *ChatCLI) processLLMRequest(parentCtx context.Context, in string) {
 	cli.compactHistoryIfNeeded(ctx)
 
 	assembly := cli.assembleChatSystemPrompt(ctx, userInput, additionalContext)
-	tempHistory := cli.buildChatTempHistoryWithContext(assembly.parts, assembly.turnContext, userInput, additionalContext, images)
-	cli.setPendingTurnContext(turnContextText(assembly.turnContext))
+	// A block that would repeat the last one still in history is not sent
+	// and not persisted: the model already read it, and adding it again
+	// only spends window. Anything that actually changed travels.
+	turnCtx := assembly.turnContext
+	if turnContextIsRedundant(cli.history, turnContextText(turnCtx)) {
+		turnCtx = nil
+	}
+	tempHistory := cli.buildChatTempHistoryWithContext(assembly.parts, turnCtx, userInput, additionalContext, images)
+	cli.setPendingTurnContext(turnContextText(turnCtx))
 	// What the wire carries this turn — the calibrator's chars side.
 	cli.lastPromptChars = promptCharsOf(tempHistory) + len(userInput+additionalContext)
 	userMessage := models.Message{Role: "user", Content: userInput + additionalContext, Images: images}

--- a/cli/history_compactor.go
+++ b/cli/history_compactor.go
@@ -347,6 +347,13 @@ func (hc *HistoryCompactor) Compact(
 	hc.emitStatus(CompactStageStart, i18n.T("compact.status.start",
 		beforeMsgs, FormatPayloadSize(before), FormatPayloadSize(budget)))
 
+	// LEVEL 0: superseded turn context. These are blocks ChatCLI injected
+	// itself — the date, an MCP channel push, a recall — and only the last
+	// one still says anything current. They are dropped rather than
+	// summarized: paying a summarizer to compress ChatCLI's own repeated
+	// preamble buys nothing, and the newest block stays untouched.
+	history = dropSupersededTurnContext(history)
+
 	// LEVEL 1: Near-lossless trimming — pure Go, no network
 	hc.emitStatus(CompactStageTrim, i18n.T("compact.status.trim"))
 	history = hc.trimmer.TrimHistory(history)

--- a/cli/turn_context.go
+++ b/cli/turn_context.go
@@ -14,8 +14,47 @@
  * as one flagged user-role message placed right before the user's turn,
  * persisted with the conversation so the next request replays identical
  * bytes; the system message is byte-stable for the session.
+ *
+ * Persisting them is what keeps the prefix cache alive — dropping a
+ * message the previous request sent moves every byte after it — but it
+ * also meant one block per turn accumulating in the window for the whole
+ * session, most of them repeating what the block before them already
+ * said. So the block is not injected at all when it would repeat the last
+ * one still in history: the conversation keeps growing by appends only,
+ * the cache holds, and the model reads the same information once instead
+ * of once per turn.
  */
 package cli
+
+import (
+	"strings"
+
+	"github.com/diillson/chatcli/models"
+)
+
+// lastTurnContextText returns the text of the most recent turn-context
+// message in the history, or "" when the history carries none.
+func lastTurnContextText(history []models.Message) string {
+	for i := len(history) - 1; i >= 0; i-- {
+		if history[i].IsTurnContext() {
+			return history[i].Content
+		}
+	}
+	return ""
+}
+
+// turnContextIsRedundant reports whether a block would tell the model
+// exactly what the last one already did.
+//
+// Comparison is on the whole text, so any real change — the day rolling
+// over, a new working directory, an MCP channel push, a recall block —
+// makes the block travel again. Only a byte-for-byte repeat is skipped.
+func turnContextIsRedundant(history []models.Message, text string) bool {
+	if strings.TrimSpace(text) == "" {
+		return true
+	}
+	return text == lastTurnContextText(history)
+}
 
 // setPendingTurnContext stashes the turn context text between assembly and
 // the commit of a successful chat turn.
@@ -34,4 +73,37 @@ func (cli *ChatCLI) takePendingTurnContext() string {
 	t := cli.pendingTurnContext
 	cli.pendingTurnContext = ""
 	return t
+}
+
+// dropSupersededTurnContext removes every turn-context message except the
+// most recent one.
+//
+// Compaction is the one moment where dropping them is free: the history is
+// being rewritten anyway, so the prefix cache is already being rebuilt and
+// nothing is lost by not carrying ChatCLI's own repeated preamble into the
+// summary. The newest block survives because it is the one still
+// describing the session the model is in.
+//
+// Returns the input unchanged when there is nothing to drop, so the caller
+// never pays a copy for the common case.
+func dropSupersededTurnContext(history []models.Message) []models.Message {
+	last := -1
+	count := 0
+	for i, m := range history {
+		if m.IsTurnContext() {
+			last = i
+			count++
+		}
+	}
+	if count < 2 {
+		return history
+	}
+	out := make([]models.Message, 0, len(history)-count+1)
+	for i, m := range history {
+		if m.IsTurnContext() && i != last {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
 }

--- a/cli/turn_context_dedup_test.go
+++ b/cli/turn_context_dedup_test.go
@@ -1,0 +1,119 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/cli/workspace"
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+func tc(text string) models.Message { return models.TurnContextMessage(text) }
+
+func TestTurnContextIsRedundantOnlyOnAnExactRepeat(t *testing.T) {
+	history := []models.Message{
+		{Role: "user", Content: "hi"},
+		tc("Current date: 2026-09-04"),
+		{Role: "assistant", Content: "hello"},
+	}
+	if !turnContextIsRedundant(history, "Current date: 2026-09-04") {
+		t.Error("an exact repeat must not be injected again")
+	}
+	// The day rolling over, a new working directory or a channel push all
+	// change the text, and the block must travel again.
+	if turnContextIsRedundant(history, "Current date: 2026-09-05") {
+		t.Error("a changed block must travel")
+	}
+	if !turnContextIsRedundant(history, "   ") {
+		t.Error("an empty block is nothing to say")
+	}
+	if turnContextIsRedundant(nil, "Current date: 2026-09-04") {
+		t.Error("the first block of a session must always travel")
+	}
+}
+
+func TestLastTurnContextTextReadsTheMostRecent(t *testing.T) {
+	history := []models.Message{
+		tc("first"),
+		{Role: "user", Content: "x"},
+		tc("second"),
+		{Role: "assistant", Content: "y"},
+	}
+	if got := lastTurnContextText(history); got != "second" {
+		t.Errorf("lastTurnContextText = %q, want the most recent", got)
+	}
+	if got := lastTurnContextText([]models.Message{{Role: "user", Content: "x"}}); got != "" {
+		t.Errorf("no turn context must read as empty, got %q", got)
+	}
+}
+
+func TestDropSupersededTurnContextKeepsTheNewest(t *testing.T) {
+	history := []models.Message{
+		{Role: "system", Content: "sys"},
+		tc("date 1"),
+		{Role: "user", Content: "a"},
+		{Role: "assistant", Content: "b"},
+		tc("date 2"),
+		{Role: "user", Content: "c"},
+		tc("date 3"),
+	}
+	got := dropSupersededTurnContext(history)
+	if len(got) != 5 {
+		t.Fatalf("want 5 messages left, got %d: %+v", len(got), got)
+	}
+	var kept []string
+	for _, m := range got {
+		if m.IsTurnContext() {
+			kept = append(kept, m.Content)
+		}
+	}
+	if len(kept) != 1 || kept[0] != "date 3" {
+		t.Errorf("only the newest block survives, kept %v", kept)
+	}
+	// Real conversation is untouched.
+	for _, want := range []string{"sys", "a", "b", "c"} {
+		found := false
+		for _, m := range got {
+			if m.Content == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("compaction dropped real content %q", want)
+		}
+	}
+}
+
+func TestDropSupersededTurnContextIsANoOpBelowTwo(t *testing.T) {
+	history := []models.Message{{Role: "user", Content: "a"}, tc("only")}
+	got := dropSupersededTurnContext(history)
+	if len(got) != len(history) {
+		t.Errorf("a single block must be left alone: %+v", got)
+	}
+	plain := []models.Message{{Role: "user", Content: "a"}}
+	if got := dropSupersededTurnContext(plain); len(got) != 1 {
+		t.Errorf("history without turn context must be untouched: %+v", got)
+	}
+}
+
+// The session-invariant half of the old block belongs in the cached
+// prefix; only the date is allowed to vary per turn.
+func TestWorkspaceDirectiveLeavesTheVolatileBlock(t *testing.T) {
+	dir := t.TempDir()
+	cb := workspace.NewContextBuilder(
+		workspace.NewBootstrapLoader(dir, dir, zap.NewNop()),
+		workspace.NewMemoryStore(dir, zap.NewNop()),
+		dir,
+	)
+	dyn := cb.BuildDynamicContext()
+	if got := cb.BuildWorkspaceDirective(); !strings.Contains(got, "working directory") {
+		t.Errorf("the directive must carry the working directory: %q", got)
+	}
+	if strings.Contains(dyn, "working directory") {
+		t.Errorf("the working directory must not ride in the per-turn block: %q", dyn)
+	}
+	if !strings.Contains(dyn, "Current date") {
+		t.Errorf("the per-turn block must still carry the date: %q", dyn)
+	}
+}

--- a/cli/workspace/context_builder.go
+++ b/cli/workspace/context_builder.go
@@ -2,7 +2,6 @@ package workspace
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -247,24 +246,40 @@ func appendMatchingRules(rules *RulesLoader, hints []string, parts []string) []s
 // BuildDynamicContext returns time-sensitive and session-aware context.
 // Includes current time, working directory, and disambiguation instructions
 // so the model never confuses paths from long-term memory with the current session.
+//
+// The block is split by lifetime, not by topic. What varies within a
+// session (the date) stays here, in the per-turn message; what is fixed
+// for the whole session (the working directory and the rule for resolving
+// relative paths against it) moved to BuildWorkspaceDirective, which the
+// caller places in the cached prefix. Both halves reach the model on every
+// turn as before; only one of them is paid for again each time.
 func (cb *ContextBuilder) BuildDynamicContext() string {
 	now := time.Now()
-	var parts []string
 	// Day resolution on purpose: this block rides in the per-turn context
 	// message, and a wall-clock second would make it differ on every
 	// request for nothing the model needs.
-	parts = append(parts, "Current date: "+now.Format("2006-01-02")+" ("+now.Weekday().String()+", "+now.Format("MST")+")")
+	return "Current date: " + now.Format("2006-01-02") + " (" + now.Weekday().String() + ", " + now.Format("MST") + ")"
+}
 
-	if cb.workspaceDir != "" {
-		parts = append(parts, fmt.Sprintf("Current working directory: %s", cb.workspaceDir))
-		parts = append(parts,
-			"IMPORTANT: When the user refers to \"here\", \"this project\", \"current directory\", "+
-				"or uses relative paths, ALWAYS resolve them against the current working directory above — "+
-				"NOT against paths from long-term memory or previous sessions. "+
-				"Memory may contain paths from other projects; treat those as historical context only.")
+// BuildWorkspaceDirective returns the session-invariant half of the
+// context above: where the session is rooted and how to read a relative
+// path against it. It belongs in the stable prefix — repeating it on every
+// turn cost the window a paragraph per turn and told the model nothing it
+// had not already been told.
+//
+// Empty when there is no workspace, so the caller can append it blind.
+func (cb *ContextBuilder) BuildWorkspaceDirective() string {
+	if cb.workspaceDir == "" {
+		return ""
 	}
-
-	return strings.Join(parts, "\n")
+	// Model-facing text, English on purpose — the same rule the mode
+	// banners follow. Translating a prompt directive changes how the model
+	// resolves paths, so it is not routed through i18n.
+	const directive = "IMPORTANT: When the user refers to \"here\", \"this project\", \"current directory\", " +
+		"or uses relative paths, ALWAYS resolve them against the current working directory above — " +
+		"NOT against paths from long-term memory or previous sessions. " +
+		"Memory may contain paths from other projects; treat those as historical context only."
+	return "Current working directory: " + cb.workspaceDir + "\n" + directive
 }
 
 // InvalidateCache forces rebuild on next call.

--- a/cli/workspace/context_builder_test.go
+++ b/cli/workspace/context_builder_test.go
@@ -69,15 +69,35 @@ func TestContextBuilder_DynamicContext(t *testing.T) {
 	wsDir := t.TempDir()
 	cb := NewContextBuilder(bl, ms, wsDir)
 
+	// Split by lifetime: the date is the only part that varies within a
+	// session, so it is the only part that rides in the per-turn block.
 	dyn := cb.BuildDynamicContext()
 	if !strings.Contains(dyn, "Current date: ") || strings.Contains(dyn, ":00") {
 		t.Errorf("expected dynamic context with date, got %q", dyn)
 	}
-	if !strings.Contains(dyn, "Current working directory: "+wsDir) {
-		t.Errorf("expected CWD in dynamic context, got %q", dyn)
+	if strings.Contains(dyn, "Current working directory") || strings.Contains(dyn, "IMPORTANT") {
+		t.Errorf("session-invariant text must not repeat per turn, got %q", dyn)
 	}
-	if !strings.Contains(dyn, "IMPORTANT") {
-		t.Errorf("expected disambiguation instruction in dynamic context, got %q", dyn)
+
+	// The invariant half still reaches the model — from the cached prefix.
+	dir := cb.BuildWorkspaceDirective()
+	if !strings.Contains(dir, "Current working directory: "+wsDir) {
+		t.Errorf("expected CWD in the workspace directive, got %q", dir)
+	}
+	if !strings.Contains(dir, "IMPORTANT") {
+		t.Errorf("expected disambiguation instruction in the workspace directive, got %q", dir)
+	}
+	if strings.Contains(dir, "Current date") {
+		t.Errorf("the directive must not carry the date, got %q", dir)
+	}
+}
+
+func TestContextBuilder_WorkspaceDirectiveEmptyWithoutWorkspace(t *testing.T) {
+	bl := NewBootstrapLoader(t.TempDir(), t.TempDir(), testLogger())
+	ms := NewMemoryStore(t.TempDir(), testLogger())
+	cb := NewContextBuilder(bl, ms, "")
+	if got := cb.BuildWorkspaceDirective(); got != "" {
+		t.Errorf("no workspace means no directive, got %q", got)
 	}
 }
 


### PR DESCRIPTION
Audit IV, PR 3 of 8 — closes CAG-1 (P0) and CMP-4 (P2).

## The defect

Every turn appends a context block to the history, and every later request carries all of them. That was a deliberate trade, and the code says so: dropping a message the previous request sent moves every byte after it, and the prefix cache misses at that position. The cost was the window. The block carried the date, the working directory and a paragraph on resolving relative paths — about 450 characters — and at turn sixty the conversation held sixty copies of it, fifty-nine of them stale, with compaction firing earlier to make room.

Naive pruning is not the fix: removing the older blocks at request time is exactly the cache miss the original design avoided.

## What changes

**Split by lifetime, not by topic.** The working directory and the relative-path rule never change within a session, so they move into the cached prefix — chat's Part 0 and the agent's cached core. They still reach the model on every turn; they are just paid for once. What stays in the per-turn block is the date, at day resolution.

**An identical block is not injected at all.** If what this turn would say repeats the last block still in history, it is neither sent nor persisted. The model already read it, the conversation still grows by appends only, and the cache holds exactly as before. Anything that really changed — the day rolling over, a new working directory, an MCP channel push, a recall block — differs in text and travels. The two mid-loop injections in the agent loop now route through the same gate instead of appending directly.

**Compaction gained a level zero** that drops superseded blocks instead of summarizing them (CMP-4). Compaction is the one moment where dropping is free, since the history is being rewritten anyway; paying a summarizer to compress ChatCLI's own repeated preamble buys nothing. The newest block survives because it is the one still describing the current session.

## Effect

A session that previously accumulated one block per turn now carries one per *change*. On a long coder run that is the difference between sixty copies of a date line and one.

## Provider and platform coverage

This changes what ChatCLI puts into the conversation, not how any provider is called, so all fifteen get the same window back with no per-provider work. No filesystem, path or OS surface is touched — identical on Windows, Linux and macOS.

## Still open, deliberately

CAG-2 — the `mid_conversation_system` capability, which would let the block render once and then stay cleared via `clear_at: "next_user_message"` — is not in this PR. The API places strict rules on where such a message may sit (it must follow a user turn and be last or followed by an assistant turn), while the block is injected *before* the user turn. Reordering it is a wire change worth making only against a verified live response, and the dedup above already removes the accumulation on every provider rather than one.

## Verification

- Full suite green, `golangci-lint --new-from-rev=main` clean, Floor 4 clean.
- New tests: an exact repeat is skipped and a changed block travels; the first block of a session always travels; only the newest block survives compaction and real conversation is untouched; the per-turn block no longer carries the invariant half and the directive carries it instead.
- One existing test asserted the old combined block and now asserts both halves in their new places.
