### PR TITLE
fix(agent): tool schemas stop traveling once they crowd out the conversation

### DIFF
--- a/cli/agent/workers/tool_defer.go
+++ b/cli/agent/workers/tool_defer.go
@@ -1,0 +1,191 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package workers
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+
+	"github.com/diillson/chatcli/cli/ctxmgr"
+	"github.com/diillson/chatcli/models"
+)
+
+// Deferred tool definitions.
+//
+// Every request carries the full JSON schema of every tool the run can
+// call. For the built-in set that is a bounded cost, but MCP servers are
+// unbounded: a handful of servers puts tens of thousands of tokens of
+// schema in front of the model on every turn, cached at best, and the
+// compaction budget can only reserve room for it — nothing shrinks it.
+//
+// So the schemas stop traveling by default once they are large enough to
+// matter. What travels instead is a one-line index — name and summary,
+// small enough to live in the cached prefix — plus one tool the model
+// calls to pull the full schema of whatever it actually needs. Tools it
+// asks for stay loaded for the rest of the run.
+//
+// The mechanism is deliberately client-side. Anthropic serves a
+// server-side equivalent for its own models; doing the selection here
+// means every provider gets it, including the ones that will never have
+// such an endpoint.
+
+// FindToolsName is the tool the model calls to load deferred schemas.
+const FindToolsName = "find_tools"
+
+// deferFloorChars is the payload below which nothing is deferred. A small
+// tool set costs less than the round trip a search would add, so the
+// behavior of a plain install is unchanged.
+const deferFloorChars = 8000
+
+// DeferThresholdChars is the payload above which deferrable schemas stop
+// traveling, derived from the model's context window so a large window
+// tolerates a larger tool set. Never below the floor.
+func DeferThresholdChars(windowTokens, charsPerToken int) int {
+	if windowTokens <= 0 || charsPerToken <= 0 {
+		return deferFloorChars
+	}
+	// A twentieth of the window: past that, tool schemas are competing
+	// with the conversation rather than describing it.
+	limit := windowTokens * charsPerToken / 20
+	if limit < deferFloorChars {
+		return deferFloorChars
+	}
+	return limit
+}
+
+// ToolPlan is what one turn ships and what it advertises instead.
+type ToolPlan struct {
+	// Defs are the definitions that travel on the wire this turn.
+	Defs []models.ToolDefinition
+	// Index is the one-line-per-tool catalog of everything deferred,
+	// for the cached prefix. Empty when nothing was deferred.
+	Index string
+	// Deferred counts the schemas left out of the request.
+	Deferred int
+}
+
+// PlanToolDefs decides what a turn ships.
+//
+// core always travels — the loop cannot work without it. deferrable
+// travels too while the whole payload stays under the threshold; past it
+// only the tools the model already asked for (activated) travel, next to
+// the search tool, and the rest are advertised through the index.
+func PlanToolDefs(core, deferrable []models.ToolDefinition, activated map[string]bool, threshold int) ToolPlan {
+	all := append(append([]models.ToolDefinition{}, core...), deferrable...)
+	if len(deferrable) == 0 || serializedChars(all) <= threshold {
+		return ToolPlan{Defs: all}
+	}
+
+	plan := ToolPlan{Defs: append([]models.ToolDefinition{}, core...)}
+	indexed := make([]models.ToolDefinition, 0, len(deferrable))
+	for _, d := range deferrable {
+		if activated[d.Function.Name] {
+			plan.Defs = append(plan.Defs, d)
+			continue
+		}
+		indexed = append(indexed, d)
+	}
+	if len(indexed) == 0 {
+		return plan
+	}
+	plan.Defs = append(plan.Defs, FindToolsDefinition())
+	plan.Index = ToolIndex(indexed)
+	plan.Deferred = len(indexed)
+	return plan
+}
+
+// FindToolsDefinition is the definition of the search tool itself. It is
+// never deferred — a model that cannot ask for tools cannot recover any.
+func FindToolsDefinition() models.ToolDefinition {
+	return models.ToolDefinition{
+		Type: "function",
+		Function: models.ToolFunctionDef{
+			Name: FindToolsName,
+			Description: "Load the full definition of tools that are listed in the available-tools index but not yet loaded. " +
+				"Call this before using any tool from that index; the tools it returns stay available for the rest of the session.",
+			Parameters: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"query": map[string]interface{}{
+						"type":        "string",
+						"description": "What the tool should do, or its exact name from the index.",
+					},
+				},
+				"required": []string{"query"},
+			},
+		},
+	}
+}
+
+// ToolIndex renders the deferred set as one line per tool: the name the
+// model must ask for, and enough of the description to choose by.
+func ToolIndex(defs []models.ToolDefinition) string {
+	if len(defs) == 0 {
+		return ""
+	}
+	lines := make([]string, 0, len(defs))
+	for _, d := range defs {
+		lines = append(lines, "- "+d.Function.Name+": "+firstSentence(d.Function.Description))
+	}
+	sort.Strings(lines)
+	return "AVAILABLE TOOLS (definitions not loaded — call " + FindToolsName +
+		" with what you need before using one):\n" + strings.Join(lines, "\n")
+}
+
+// SearchToolDefs ranks the deferred set against a query. An exact name
+// match wins outright, because a model quoting a name from the index is
+// asking for that tool and not for something like it.
+func SearchToolDefs(defs []models.ToolDefinition, query string, k int) []models.ToolDefinition {
+	q := strings.TrimSpace(query)
+	if q == "" || len(defs) == 0 {
+		return nil
+	}
+	for _, d := range defs {
+		if strings.EqualFold(d.Function.Name, q) {
+			return []models.ToolDefinition{d}
+		}
+	}
+	docs := make([]string, 0, len(defs))
+	for _, d := range defs {
+		docs = append(docs, d.Function.Name+" "+d.Function.Description)
+	}
+	hits := ctxmgr.RankDocsBM25(docs, q, k)
+	out := make([]models.ToolDefinition, 0, len(hits))
+	for _, h := range hits {
+		if h.Index >= 0 && h.Index < len(defs) {
+			out = append(out, defs[h.Index])
+		}
+	}
+	return out
+}
+
+// firstSentence keeps an index line short without cutting mid-word.
+func firstSentence(s string) string {
+	s = strings.TrimSpace(strings.ReplaceAll(s, "\n", " "))
+	if i := strings.Index(s, ". "); i > 0 && i < 200 {
+		return s[:i+1]
+	}
+	if len(s) <= 200 {
+		return s
+	}
+	cut := s[:200]
+	if i := strings.LastIndex(cut, " "); i > 0 {
+		cut = cut[:i]
+	}
+	return cut + "…"
+}
+
+func serializedChars(defs []models.ToolDefinition) int {
+	if len(defs) == 0 {
+		return 0
+	}
+	raw, err := json.Marshal(defs)
+	if err != nil {
+		return 0
+	}
+	return len(raw)
+}

--- a/cli/agent/workers/tool_defer_test.go
+++ b/cli/agent/workers/tool_defer_test.go
@@ -1,0 +1,146 @@
+package workers
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+)
+
+func mcpTool(name, desc string) models.ToolDefinition {
+	return models.ToolDefinition{
+		Type: "function",
+		Function: models.ToolFunctionDef{
+			Name:        name,
+			Description: desc,
+			Parameters: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"padding": map[string]interface{}{"type": "string", "description": strings.Repeat("x", 400)},
+				},
+			},
+		},
+	}
+}
+
+// A small tool set costs less than the round trip a search would add, so
+// a plain install must be untouched.
+func TestSmallToolSetIsNotDeferred(t *testing.T) {
+	core := CoderToolDefinitions(nil)
+	plan := PlanToolDefs(core, []models.ToolDefinition{mcpTool("jira_issue", "Fetch a Jira issue")}, nil, 1<<20)
+	if plan.Deferred != 0 || plan.Index != "" {
+		t.Fatalf("nothing should be deferred below the threshold: %+v", plan)
+	}
+	if len(plan.Defs) != len(core)+1 {
+		t.Errorf("every definition must travel, got %d", len(plan.Defs))
+	}
+}
+
+func TestLargeToolSetDefersAndAdvertises(t *testing.T) {
+	core := CoderToolDefinitions(nil)
+	var deferrable []models.ToolDefinition
+	for _, n := range []string{"jira_issue", "grafana_query", "pagerduty_ack", "s3_list"} {
+		deferrable = append(deferrable, mcpTool(n, "Does "+n+" things"))
+	}
+	plan := PlanToolDefs(core, deferrable, nil, 1000)
+	if plan.Deferred != len(deferrable) {
+		t.Fatalf("want every deferrable tool deferred, got %d", plan.Deferred)
+	}
+	// The core still travels, plus exactly one tool to recover the rest.
+	names := map[string]bool{}
+	for _, d := range plan.Defs {
+		names[d.Function.Name] = true
+	}
+	if !names[FindToolsName] {
+		t.Error("the search tool must travel or nothing is recoverable")
+	}
+	for _, d := range core {
+		if !names[d.Function.Name] {
+			t.Errorf("core tool %q must always travel", d.Function.Name)
+		}
+	}
+	for _, d := range deferrable {
+		if names[d.Function.Name] {
+			t.Errorf("deferred tool %q must not be on the wire", d.Function.Name)
+		}
+		if !strings.Contains(plan.Index, d.Function.Name) {
+			t.Errorf("deferred tool %q must be in the index", d.Function.Name)
+		}
+	}
+	// The index has to be far cheaper than the schemas it replaces.
+	full, _ := json.Marshal(deferrable)
+	if len(plan.Index) >= len(full)/2 {
+		t.Errorf("index (%d) should be much smaller than the schemas (%d)", len(plan.Index), len(full))
+	}
+}
+
+func TestActivatedToolsTravelAgain(t *testing.T) {
+	core := CoderToolDefinitions(nil)
+	deferrable := []models.ToolDefinition{
+		mcpTool("jira_issue", "Fetch a Jira issue"),
+		mcpTool("s3_list", "List S3 objects"),
+	}
+	plan := PlanToolDefs(core, deferrable, map[string]bool{"jira_issue": true}, 1000)
+	var found bool
+	for _, d := range plan.Defs {
+		if d.Function.Name == "jira_issue" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("a tool the model already asked for must stay loaded")
+	}
+	if strings.Contains(plan.Index, "jira_issue") {
+		t.Error("an activated tool must not still be advertised as deferred")
+	}
+}
+
+func TestSearchToolDefsPrefersTheExactName(t *testing.T) {
+	defs := []models.ToolDefinition{
+		mcpTool("s3_list", "List objects in a bucket"),
+		mcpTool("list_files", "List files in a directory, similar to listing objects"),
+	}
+	got := SearchToolDefs(defs, "s3_list", 5)
+	if len(got) != 1 || got[0].Function.Name != "s3_list" {
+		t.Fatalf("an exact name must win outright, got %+v", got)
+	}
+	got = SearchToolDefs(defs, "bucket objects", 5)
+	if len(got) == 0 || got[0].Function.Name != "s3_list" {
+		t.Errorf("description search failed: %+v", got)
+	}
+	if got := SearchToolDefs(defs, "  ", 5); got != nil {
+		t.Errorf("an empty query returns nothing, got %+v", got)
+	}
+}
+
+func TestDeferThresholdScalesWithTheWindow(t *testing.T) {
+	small := DeferThresholdChars(0, 0)
+	big := DeferThresholdChars(1000000, 4)
+	if small != deferFloorChars {
+		t.Errorf("unknown window must fall back to the floor, got %d", small)
+	}
+	if big <= small {
+		t.Errorf("a large window must tolerate a larger tool set: %d vs %d", big, small)
+	}
+	if DeferThresholdChars(1000, 4) != deferFloorChars {
+		t.Error("the floor must hold for a tiny window")
+	}
+}
+
+func TestToolIndexIsStableAndReadable(t *testing.T) {
+	defs := []models.ToolDefinition{
+		mcpTool("b_tool", "Second. With more text after the first sentence."),
+		mcpTool("a_tool", "First tool."),
+	}
+	idx := ToolIndex(defs)
+	if strings.Index(idx, "a_tool") > strings.Index(idx, "b_tool") {
+		t.Error("index must be sorted so the cached prefix is stable across reconnects")
+	}
+	if strings.Contains(idx, "With more text") {
+		t.Error("index lines must stop at the first sentence")
+	}
+	if ToolIndex(nil) != "" {
+		t.Error("no deferred tools means no index")
+	}
+}

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -56,7 +56,15 @@ type AgentMode struct {
 	// toolDefsChars is the serialized size of this run's native tool
 	// definitions — request weight outside the history that the compaction
 	// budget must still reserve (CompactConfig.ReservedChars).
-	toolDefsChars       int
+	toolDefsChars int
+	// activatedTools names the deferred tools the model asked for. They
+	// travel on every later turn of the run: a tool it needed once is
+	// usually needed again, and re-searching for it would cost a round
+	// trip each time.
+	activatedTools map[string]bool
+	// deferrableTools is the set the index advertises, kept so a
+	// find_tools call can be answered without rebuilding it.
+	deferrableTools     []models.ToolDefinition
 	cli                 *ChatCLI
 	logger              *zap.Logger
 	executor            *agent.CommandExecutor
@@ -1097,6 +1105,13 @@ func (a *AgentMode) Run(ctx context.Context, query string, additionalContext str
 	// builds the knowledge it lacks instead of guessing or stalling. Cheap,
 	// deterministic, and rides in the same cacheable block.
 	toolsText += "\n\n" + contextPipelineHint()
+	// The deferred-tool index is part of the cached prefix: it is fixed
+	// for the run, while which schemas travel changes only when the model
+	// asks for one. Building it here (not per turn) keeps the prefix
+	// stable even as tools are activated.
+	if idx := a.prepareDeferredTools(); idx != "" {
+		toolsText += "\n\n" + idx
+	}
 	// Pilar 1A: nudge proactive in-turn skill authoring/evolution (cacheable,
 	// empty when self-evolution is off).
 	if sh := skillAuthoringHint(); sh != "" {
@@ -2410,13 +2425,17 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 		// than relying on text-only XML dispatch.
 		var nativeToolDefs []models.ToolDefinition
 		if canUseNativeTools {
+			var core []models.ToolDefinition
 			if a.isCoderMode {
-				nativeToolDefs = workers.CoderToolDefinitions(nil)
+				core = workers.CoderToolDefinitions(nil)
 			}
-			nativeToolDefs = append(nativeToolDefs, workers.PluginToolDefinitions()...)
-			if a.cli.mcpManager != nil && a.cli.mcpManager.ToolCount() > 0 {
-				nativeToolDefs = append(nativeToolDefs, a.cli.mcpManager.GetTools()...)
-			}
+			core = append(core, workers.PluginToolDefinitions()...)
+			// MCP is the unbounded half. Past the threshold its schemas
+			// stop traveling and are advertised through the index built
+			// once for this run; the model pulls what it needs and keeps
+			// it for the rest of the run.
+			plan := workers.PlanToolDefs(core, a.deferrableTools, a.activatedTools, a.toolDeferThreshold())
+			nativeToolDefs = plan.Defs
 		}
 
 		// Chamada à LLM (native tools or text)
@@ -2731,6 +2750,16 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 			// Plugin tools (web_search, web_fetch) map to their respective plugins.
 			// Coder tools (read_file, write_file, etc.) map to @coder.
 			for _, ntc := range nativeToolCalls {
+				// The tool-search call is answered here: it loads schemas
+				// this run deferred and never leaves the process.
+				if result, handled := a.handleFindTools(ntc); handled {
+					a.cli.history = append(a.cli.history, models.Message{
+						Role:       "tool",
+						ToolCallID: ntc.ID,
+						Content:    result,
+					})
+					continue
+				}
 				if pluginName, pluginArgs, isPlugin := workers.ResolveNativePluginTool(ntc.Name, ntc.Arguments); isPlugin {
 					// Plugin tool: map to the plugin's CLI args format
 					argsStr := strings.Join(pluginArgs, " ")
@@ -4701,14 +4730,19 @@ func extractDelegateArgs(argsJSON string) (map[string]interface{}, string) {
 // part of the history slice, so the compaction budget reserves them
 // explicitly instead of discovering the overflow at the provider.
 func (a *AgentMode) estimateToolDefsChars() int {
-	var defs []models.ToolDefinition
+	var core []models.ToolDefinition
 	if a.isCoderMode {
-		defs = workers.CoderToolDefinitions(nil)
+		core = workers.CoderToolDefinitions(nil)
 	}
-	defs = append(defs, workers.PluginToolDefinitions()...)
+	core = append(core, workers.PluginToolDefinitions()...)
+	var deferrable []models.ToolDefinition
 	if a.cli != nil && a.cli.mcpManager != nil && a.cli.mcpManager.ToolCount() > 0 {
-		defs = append(defs, a.cli.mcpManager.GetTools()...)
+		deferrable = a.cli.mcpManager.GetTools()
 	}
+	// Measure what the turn actually ships, not what it could: reserving
+	// room for schemas that are deferred would take the space back from
+	// the conversation the deferral just freed it for.
+	defs := workers.PlanToolDefs(core, deferrable, a.activatedTools, a.toolDeferThreshold()).Defs
 	if len(defs) == 0 {
 		return 0
 	}

--- a/cli/agent_tool_defer.go
+++ b/cli/agent_tool_defer.go
@@ -1,0 +1,108 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"github.com/diillson/chatcli/cli/agent/workers"
+	"github.com/diillson/chatcli/llm/catalog"
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+// Deferred tool definitions, CLI side.
+//
+// workers.PlanToolDefs decides what a turn ships; this file supplies the
+// threshold it decides against and answers the search call the model makes
+// when it wants a schema the turn did not carry.
+
+// toolDeferThreshold is the serialized tool payload this run tolerates
+// before deferring, derived from the model's context window so a large
+// window keeps more tools loaded.
+func (a *AgentMode) toolDeferThreshold() int {
+	window := 0
+	if a.cli != nil {
+		window = catalog.GetContextWindow(a.cli.Provider, a.cli.Model)
+	}
+	charsPerToken := int(defaultCharsPerToken)
+	if a.cli != nil {
+		if cpt, samples := a.cli.calibrator().CharsPerToken(a.cli.Provider, a.cli.Model); samples > 0 && cpt > 0 {
+			charsPerToken = int(cpt)
+		}
+	}
+	return workers.DeferThresholdChars(window, charsPerToken)
+}
+
+// handleFindTools answers a find_tools call: it resolves the query against
+// the tools this run deferred, marks the matches as activated so they
+// travel on every later turn, and returns their definitions as the tool
+// result.
+//
+// Returns ok=false when the call is not find_tools, so the caller can fall
+// through to its normal dispatch.
+func (a *AgentMode) handleFindTools(call models.ToolCall) (string, bool) {
+	if call.Name != workers.FindToolsName {
+		return "", false
+	}
+	query, _ := call.Arguments["query"].(string)
+	matches := workers.SearchToolDefs(a.deferrableTools, query, 5)
+	if len(matches) == 0 {
+		// An empty result is a real answer, not an error: the model asked
+		// for something the index does not hold and should stop looking.
+		return "No tool in the index matches " + strconv.Quote(strings.TrimSpace(query)) +
+			". Use the tools already loaded, or tell the user what is missing.", true
+	}
+	if a.activatedTools == nil {
+		a.activatedTools = map[string]bool{}
+	}
+	names := make([]string, 0, len(matches))
+	for _, m := range matches {
+		a.activatedTools[m.Function.Name] = true
+		names = append(names, m.Function.Name)
+	}
+	payload, err := json.Marshal(matches)
+	if err != nil {
+		return "Loaded: " + strings.Join(names, ", "), true
+	}
+	a.logger.Info("tool search loaded deferred definitions",
+		zap.Strings("tools", names),
+		zap.Int("deferred_remaining", len(a.deferrableTools)-len(a.activatedTools)))
+	return "Loaded and now callable: " + strings.Join(names, ", ") + "\n" + string(payload), true
+}
+
+// prepareDeferredTools captures the run's deferrable set and returns the
+// index to advertise, or "" when the payload is small enough that every
+// schema travels as before.
+//
+// Called once while the cached prompt is assembled, so the index is fixed
+// for the run: activating a tool changes which schemas travel, never the
+// prefix the cache is keyed on.
+func (a *AgentMode) prepareDeferredTools() string {
+	a.activatedTools = map[string]bool{}
+	a.deferrableTools = nil
+	if a.cli == nil || a.cli.mcpManager == nil || a.cli.mcpManager.ToolCount() == 0 {
+		return ""
+	}
+	var core []models.ToolDefinition
+	if a.isCoderMode {
+		core = workers.CoderToolDefinitions(nil)
+	}
+	core = append(core, workers.PluginToolDefinitions()...)
+
+	deferrable := a.cli.mcpManager.GetTools()
+	plan := workers.PlanToolDefs(core, deferrable, nil, a.toolDeferThreshold())
+	if plan.Deferred == 0 {
+		return ""
+	}
+	a.deferrableTools = deferrable
+	a.logger.Info("deferring tool definitions behind a searchable index",
+		zap.Int("deferred", plan.Deferred),
+		zap.Int("loaded", len(plan.Defs)))
+	return plan.Index
+}

--- a/cli/agent_tool_defer_test.go
+++ b/cli/agent_tool_defer_test.go
@@ -1,0 +1,115 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/cli/agent/workers"
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+func deferAgent(t *testing.T) *AgentMode {
+	t.Helper()
+	return &AgentMode{
+		logger: zap.NewNop(),
+		cli: &ChatCLI{
+			logger:   zap.NewNop(),
+			Provider: "CLAUDEAI",
+			Model:    "claude-opus-5",
+		},
+	}
+}
+
+func deferrable(name, desc string) models.ToolDefinition {
+	return models.ToolDefinition{
+		Type:     "function",
+		Function: models.ToolFunctionDef{Name: name, Description: desc},
+	}
+}
+
+func TestHandleFindToolsIgnoresOtherCalls(t *testing.T) {
+	a := deferAgent(t)
+	if _, handled := a.handleFindTools(models.ToolCall{Name: "read_file"}); handled {
+		t.Error("a normal tool call must fall through to the usual dispatch")
+	}
+}
+
+// A tool the model pulls stays loaded for the rest of the run: needing it
+// once usually means needing it again.
+func TestHandleFindToolsLoadsAndActivates(t *testing.T) {
+	a := deferAgent(t)
+	a.deferrableTools = []models.ToolDefinition{
+		deferrable("jira_issue", "Fetch a Jira issue by key"),
+		deferrable("s3_list", "List objects in an S3 bucket"),
+	}
+	result, handled := a.handleFindTools(models.ToolCall{
+		Name:      workers.FindToolsName,
+		Arguments: map[string]interface{}{"query": "jira_issue"},
+	})
+	if !handled {
+		t.Fatal("the search call must be answered in-process")
+	}
+	if !strings.Contains(result, "jira_issue") {
+		t.Errorf("result must name the loaded tool: %q", result)
+	}
+	if !strings.Contains(result, "description") && !strings.Contains(result, "Fetch a Jira issue") {
+		t.Errorf("result must carry the definition, not just the name: %q", result)
+	}
+	if !a.activatedTools["jira_issue"] {
+		t.Error("a pulled tool must stay activated for the run")
+	}
+	if a.activatedTools["s3_list"] {
+		t.Error("only the matched tool is activated")
+	}
+}
+
+// An empty result is a real answer: the index does not hold what the model
+// asked for and it should stop looking rather than retry.
+func TestHandleFindToolsAnswersOnNoMatch(t *testing.T) {
+	a := deferAgent(t)
+	a.deferrableTools = []models.ToolDefinition{deferrable("jira_issue", "Fetch a Jira issue")}
+	result, handled := a.handleFindTools(models.ToolCall{
+		Name:      workers.FindToolsName,
+		Arguments: map[string]interface{}{"query": "quantum teleportation"},
+	})
+	if !handled {
+		t.Fatal("the search call must still be answered")
+	}
+	if !strings.Contains(strings.ToLower(result), "no tool") {
+		t.Errorf("the model must be told nothing matched: %q", result)
+	}
+	if len(a.activatedTools) != 0 {
+		t.Errorf("a miss must activate nothing: %+v", a.activatedTools)
+	}
+}
+
+func TestToolDeferThresholdNeverBelowTheFloor(t *testing.T) {
+	a := deferAgent(t)
+	got := a.toolDeferThreshold()
+	if got < workers.DeferThresholdChars(0, 0) {
+		t.Errorf("threshold %d fell below the floor", got)
+	}
+	// A model with a large window tolerates a larger tool set than the floor.
+	if got <= 0 {
+		t.Errorf("threshold must be positive, got %d", got)
+	}
+	// No CLI at all still answers with the floor rather than zero.
+	bare := &AgentMode{logger: zap.NewNop()}
+	if bare.toolDeferThreshold() <= 0 {
+		t.Error("a bare agent must still get the floor")
+	}
+}
+
+func TestPrepareDeferredToolsWithoutMCP(t *testing.T) {
+	a := deferAgent(t)
+	if idx := a.prepareDeferredTools(); idx != "" {
+		t.Errorf("no MCP server means nothing to defer, got %q", idx)
+	}
+	if a.activatedTools == nil {
+		t.Error("the activation set must be initialized for the run")
+	}
+	if a.deferrableTools != nil {
+		t.Errorf("nothing deferrable, got %+v", a.deferrableTools)
+	}
+}


### PR DESCRIPTION
Audit IV, PR 4 of 8 — closes CMP-2 (P1).

## The defect

Every native-tool request carried the full JSON schema of every tool the run can call. The built-in set is bounded — 21 definitions, about 12,900 bytes, measured — but MCP servers are not: a handful of them puts tens of thousands of tokens of schema in front of the model on every turn.

The only lever the codebase had was `estimateToolDefsChars`, which *reserved* room for that payload in the compaction budget. Nothing shrank it. The text-mode path had already solved this — `GetToolsSummary` sends name and description only and defers the schemas — and the native path never got the same treatment.

## What changes

Past a threshold derived from the model's context window (a twentieth of it, never below 8 KB), MCP schemas stop traveling. What travels instead:

- a **one-line index** — name and summary per tool — small enough to live in the cached prefix;
- **one tool**, `find_tools`, that the model calls to pull the definitions it actually needs.

Tools the model asks for stay loaded for the rest of the run: a tool needed once is usually needed again, and re-searching would cost a round trip each time.

Three properties worth calling out:

- **Below the threshold nothing changes.** A small tool set costs less than the round trip a search would add, so a plain install is byte-identical on the wire.
- **The index is built once**, while the cached prompt is assembled. Activating a tool changes which schemas travel, never the prefix the cache is keyed on.
- **Search matches an exact name outright** — a model quoting a name from the index wants that tool, not something like it — and otherwise ranks by BM25 over name and description, reusing `ctxmgr.RankDocsBM25`.

The budget reservation now measures what a turn actually ships rather than what it could, so the space the deferral frees reaches the conversation instead of being reserved back.

## Provider and platform coverage

The selection is client-side on purpose. Anthropic serves a server-side equivalent for its own models; deciding here means **every provider with native tool calling** gets it — claudeai, openai, zai, moonshot, minimax today, and anything that implements the capability tomorrow. The providers on the text path already had the lightweight catalog through `GetToolsSummary`, so this closes the gap rather than opening a second mechanism.

No filesystem, path or OS surface — identical on Windows, Linux and macOS.

## No new environment variable

The threshold comes from the model's context window and the existing chars-per-token calibrator. Nothing new to configure.

## Verification

- Full suite green, `golangci-lint --new-from-rev=main` clean, Floor 4 clean, Floor 13 clean.
- New tests: a small set is not deferred and every definition travels; a large set defers everything and advertises it, with the core and the search tool still on the wire; the index is far smaller than the schemas it replaces; an activated tool travels again and leaves the index; exact-name search wins over description search; an empty query returns nothing; the threshold scales with the window and holds its floor; the index is sorted so the prefix is stable across server reconnects.
