### PR TITLE
fix(cache): an advisable compaction waits while the prefix cache is warm

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -2342,7 +2342,11 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 					i18n.T("agent.preflight.warn_no_cap", FormatPayloadSize(totalHistoryChars)),
 					agent.ColorYellow))
 		}
-		if a.cli.historyCompactor.NeedsCompaction(a.cli.history, cfg) {
+		// A rewrite forces the provider to cache the whole prefix again,
+		// so an advisable pass waits while the prefix is warm and the
+		// history is only modestly over budget. A necessary one does not.
+		if a.cli.historyCompactor.NeedsCompaction(a.cli.history, cfg) &&
+			!a.cli.deferCompactionForWarmCache(a.cli.history, cfg) {
 			a.cli.flushMemoryBeforeCompaction(ctx)
 			// Emit live status during compaction so the terminal is never
 			// silent. Without this, Level 2 (LLM summarization) can block

--- a/cli/cli_llm.go
+++ b/cli/cli_llm.go
@@ -225,6 +225,14 @@ func (cli *ChatCLI) compactHistoryIfNeeded(ctx context.Context) {
 	if !cli.historyCompactor.NeedsCompaction(cli.history, cfg) {
 		return
 	}
+	// A rewrite forces the provider to cache the whole prefix again. While
+	// the prefix is still warm and the history is only modestly over
+	// budget, the turn is cheaper run against the cache it already paid
+	// for; the pass happens once that cache has gone cold anyway.
+	if cli.deferCompactionForWarmCache(cli.history, cfg) {
+		cli.logger.Debug("compaction deferred while the prefix cache is warm")
+		return
+	}
 	cli.historyCompactor.SetStatusCallback(func(stage CompactStage, msg string) {
 		fmt.Printf("\r\033[K  %s\n", msg)
 		_ = os.Stdout.Sync()

--- a/cli/compact_cache_aware.go
+++ b/cli/compact_cache_aware.go
@@ -1,0 +1,52 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import "github.com/diillson/chatcli/models"
+
+// Cache-aware compaction.
+//
+// Compaction rewrites the history, which moves every byte after the point
+// it edits and forces the provider to write the whole prefix into its
+// cache again. Deciding purely on size means a session can pay for that
+// rewrite one turn after paying to warm the cache, and then pay to warm
+// it again — the write costs more than the read it replaced.
+//
+// So a compaction that is merely *advisable* waits while the prefix is
+// still warm: the turn runs against the cache it already paid for, and the
+// pass happens once the cache has gone cold anyway. A compaction that is
+// *necessary* never waits, because overflowing the window is worse than
+// any cache write.
+
+// hardCeilingRatio is how far past the budget the history may drift while
+// a compaction is being deferred. Beyond it the pass runs regardless of
+// the cache: the margin exists to absorb one or two turns, not a run.
+const hardCeilingRatio = 1.15
+
+// deferCompactionForWarmCache reports whether this turn should skip an
+// otherwise-due compaction because the provider's prefix cache is still
+// warm and the history is only modestly over budget.
+//
+// Returns false whenever the answer is not clearly yes: no tracker, no
+// cache activity yet, a provider whose cache the session cannot observe,
+// or a history already past the hard ceiling.
+func (cli *ChatCLI) deferCompactionForWarmCache(history []models.Message, cfg CompactConfig) bool {
+	if cli == nil || cli.costTracker == nil || cli.historyCompactor == nil {
+		return false
+	}
+	stats := cli.costTracker.CacheStats()
+	// No request has reported cache tokens yet, so there is no warm prefix
+	// to protect and nothing to weigh against the rewrite.
+	if !stats.Warm || stats.Requests == 0 {
+		return false
+	}
+	budget := cli.historyCompactor.CharBudget(cfg)
+	if budget <= 0 {
+		return false
+	}
+	ceiling := int(float64(budget) * hardCeilingRatio)
+	return totalChars(history) <= ceiling
+}

--- a/cli/compact_cache_aware_test.go
+++ b/cli/compact_cache_aware_test.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+// warmCLI returns a CLI whose cost tracker has just seen a cached request,
+// so the prefix reads as warm.
+func warmCLI(t *testing.T) *ChatCLI {
+	t.Helper()
+	cli := &ChatCLI{
+		logger:           zap.NewNop(),
+		Provider:         "CLAUDEAI",
+		Model:            "claude-opus-5",
+		costTracker:      NewCostTrackerAt(t.TempDir()),
+		historyCompactor: NewHistoryCompactor(zap.NewNop()),
+	}
+	cli.costTracker.RecordRealUsage("CLAUDEAI", "claude-opus-5", &models.UsageInfo{
+		IsReal:               true,
+		PromptTokens:         10000,
+		CompletionTokens:     100,
+		CacheReadInputTokens: 9000,
+	})
+	return cli
+}
+
+func historyOf(chars int) []models.Message {
+	return []models.Message{{Role: "user", Content: strings.Repeat("x", chars)}}
+}
+
+// A rewrite forces the provider to cache the whole prefix again, so an
+// advisable pass waits while the cache it would throw away is still warm.
+func TestCompactionDefersWhileTheCacheIsWarm(t *testing.T) {
+	cli := warmCLI(t)
+	cfg := DefaultCompactConfig(cli.Provider, cli.Model)
+	budget := cli.historyCompactor.CharBudget(cfg)
+	if budget <= 0 {
+		t.Fatalf("unexpected budget %d", budget)
+	}
+	// Just over budget: worth doing eventually, not worth a cache rebuild now.
+	if !cli.deferCompactionForWarmCache(historyOf(budget+budget/100), cfg) {
+		t.Error("a modest overshoot with a warm cache should wait")
+	}
+}
+
+// Overflowing the window is worse than any cache write, so past the hard
+// ceiling the pass runs regardless.
+func TestCompactionNeverDefersPastTheCeiling(t *testing.T) {
+	cli := warmCLI(t)
+	cfg := DefaultCompactConfig(cli.Provider, cli.Model)
+	budget := cli.historyCompactor.CharBudget(cfg)
+	if cli.deferCompactionForWarmCache(historyOf(budget*2), cfg) {
+		t.Error("a history far past budget must compact even with a warm cache")
+	}
+}
+
+func TestCompactionDoesNotDeferWithoutAWarmCache(t *testing.T) {
+	cli := &ChatCLI{
+		logger:           zap.NewNop(),
+		Provider:         "CLAUDEAI",
+		Model:            "claude-opus-5",
+		costTracker:      NewCostTrackerAt(t.TempDir()),
+		historyCompactor: NewHistoryCompactor(zap.NewNop()),
+	}
+	cfg := DefaultCompactConfig(cli.Provider, cli.Model)
+	budget := cli.historyCompactor.CharBudget(cfg)
+	if cli.deferCompactionForWarmCache(historyOf(budget+1), cfg) {
+		t.Error("no cache activity means there is no warm prefix to protect")
+	}
+}
+
+func TestCompactionDeferralIsSafeWithoutATracker(t *testing.T) {
+	cli := &ChatCLI{logger: zap.NewNop(), historyCompactor: NewHistoryCompactor(zap.NewNop())}
+	if cli.deferCompactionForWarmCache(historyOf(100000), DefaultCompactConfig("CLAUDEAI", "claude-opus-5")) {
+		t.Error("a session without cost tracking must never defer")
+	}
+	var nilCLI *ChatCLI
+	if nilCLI.deferCompactionForWarmCache(nil, CompactConfig{}) {
+		t.Error("nil receiver must not defer")
+	}
+}

--- a/llm/bedrock/openai_family.go
+++ b/llm/bedrock/openai_family.go
@@ -42,6 +42,13 @@ func (c *BedrockClient) sendPromptOpenAI(ctx context.Context, prompt string, his
 		"max_completion_tokens": effectiveMaxTokens,
 	}
 
+	// Automatic prompt caching routing hint: the OpenAI models served
+	// through Bedrock speak the same chat schema as the first-party
+	// endpoint, so the same shard hint applies.
+	if key := client.PromptCacheKey(history); key != "" {
+		reqBody["prompt_cache_key"] = key
+	}
+
 	// Per-turn effort: the OpenAI models served through Bedrock take the
 	// same reasoning_effort field as the first-party endpoint.
 	if eff := client.OpenAIReasoningEffort(c.model, client.EffortFromContext(ctx)); eff != "" {

--- a/llm/bedrock/openai_family_cache_key_test.go
+++ b/llm/bedrock/openai_family_cache_key_test.go
@@ -1,0 +1,72 @@
+package bedrock
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+// The OpenAI models served through Bedrock speak the same chat schema as
+// the first-party endpoint, so they take the same automatic-caching shard
+// hint as the rest of that family.
+func TestSendPromptOpenAI_SendsPromptCacheKey(t *testing.T) {
+	var body map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
+	}))
+	defer srv.Close()
+
+	c := &BedrockClient{
+		model:       "openai.gpt-oss-120b-1:0",
+		region:      "us-east-1",
+		logger:      zap.NewNop(),
+		runtime:     newFakeEndpointRuntime(srv.URL),
+		maxAttempts: 1,
+		backoff:     time.Millisecond,
+	}
+
+	history := []models.Message{
+		{Role: "system", Content: "You are a careful assistant."},
+		{Role: "user", Content: "ping"},
+	}
+	if _, err := c.sendPromptOpenAI(t.Context(), "ping", history, 256); err != nil {
+		t.Fatalf("sendPromptOpenAI: %v", err)
+	}
+	if key, ok := body["prompt_cache_key"].(string); !ok || key == "" {
+		t.Fatalf("prompt_cache_key missing from the payload: %+v", body)
+	}
+}
+
+// No system message means no stable prefix to key on, so the field is
+// omitted rather than sent empty.
+func TestSendPromptOpenAI_OmitsCacheKeyWithoutASystemPrefix(t *testing.T) {
+	var body map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
+	}))
+	defer srv.Close()
+
+	c := &BedrockClient{
+		model:       "openai.gpt-oss-120b-1:0",
+		region:      "us-east-1",
+		logger:      zap.NewNop(),
+		runtime:     newFakeEndpointRuntime(srv.URL),
+		maxAttempts: 1,
+		backoff:     time.Millisecond,
+	}
+	if _, err := c.sendPromptOpenAI(t.Context(), "ping", []models.Message{{Role: "user", Content: "ping"}}, 256); err != nil {
+		t.Fatalf("sendPromptOpenAI: %v", err)
+	}
+	if _, ok := body["prompt_cache_key"]; ok {
+		t.Errorf("no stable prefix means no key: %+v", body)
+	}
+}

--- a/llm/githubmodels/cache_key_test.go
+++ b/llm/githubmodels/cache_key_test.go
@@ -1,0 +1,74 @@
+package githubmodels
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+// The automatic-caching routing hint steers requests that share a prefix
+// to the same shard. GitHub Models speaks the OpenAI chat schema, so it
+// takes the same field as the rest of that family.
+func TestGitHubModelsSendsPromptCacheKey(t *testing.T) {
+	var body map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("GITHUB_MODELS_API_URL", server.URL)
+	c := NewGitHubModelsClient(testProvider("ghp-test"), "gpt-5.6-terra", zap.NewNop(), 1, 0)
+
+	history := []models.Message{
+		{Role: "system", Content: "You are a careful assistant."},
+		{Role: "user", Content: "Hi"},
+	}
+	if _, err := c.SendPrompt(context.Background(), "Hi", history, 100); err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+	key, ok := body["prompt_cache_key"].(string)
+	if !ok || key == "" {
+		t.Fatalf("prompt_cache_key missing from the payload: %+v", body)
+	}
+
+	// The key is derived from the stable prefix, so a second turn of the
+	// same session lands on the same shard.
+	first := key
+	body = nil
+	history = append(history, models.Message{Role: "assistant", Content: "Hello"})
+	if _, err := c.SendPrompt(context.Background(), "again", history, 100); err != nil {
+		t.Fatalf("second SendPrompt: %v", err)
+	}
+	if body["prompt_cache_key"] != first {
+		t.Errorf("key changed between turns: %v vs %v", body["prompt_cache_key"], first)
+	}
+}
+
+// A conversation with no system message has no stable prefix to key on,
+// so the field is omitted rather than sent empty.
+func TestGitHubModelsOmitsCacheKeyWithoutASystemPrefix(t *testing.T) {
+	var body map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("GITHUB_MODELS_API_URL", server.URL)
+	c := NewGitHubModelsClient(testProvider("ghp-test"), "gpt-4o", zap.NewNop(), 1, 0)
+	if _, err := c.SendPrompt(context.Background(), "Hi", []models.Message{{Role: "user", Content: "Hi"}}, 100); err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+	if _, ok := body["prompt_cache_key"]; ok {
+		t.Errorf("no stable prefix means no key: %+v", body)
+	}
+}

--- a/llm/githubmodels/github_models_client.go
+++ b/llm/githubmodels/github_models_client.go
@@ -127,6 +127,12 @@ func (c *GitHubModelsClient) SendPrompt(ctx context.Context, prompt string, hist
 		"max_tokens": effectiveMaxTokens,
 	}
 
+	// Automatic prompt caching routing hint on OpenAI-compatible upstreams
+	// (ignored by those that do not route on it). See client.PromptCacheKey.
+	if key := client.PromptCacheKey(history); key != "" {
+		payload["prompt_cache_key"] = key
+	}
+
 	// Per-turn effort: same chat schema as OpenAI, same field.
 	if eff := client.OpenAIReasoningEffort(c.model, client.EffortFromContext(ctx)); eff != "" {
 		payload["reasoning_effort"] = eff


### PR DESCRIPTION
Audit IV, PR 5 of 8 — closes CAG-3 (P1) and CAG-6 (P2), and retires CAG-4 and CAG-9 with evidence.

## CAG-3 — compaction ignored the cache it was about to destroy

`NeedsCompaction` is one size comparison. Compaction rewrites the history, which moves every byte after the point it edits and makes the provider write the whole prefix into its cache again — so a session could pay to warm the cache, pay to rewrite it a turn later, and pay to warm it again. The only place that knew whether the prefix was still warm was the telemetry that reports it afterwards.

A pass that is merely **advisable** now waits while the prefix is warm and the history is only modestly over budget: the turn runs against the cache it already paid for, and the pass happens once that cache has gone cold anyway. A pass that is **necessary** never waits — a hard ceiling above the budget runs it regardless, because overflowing the window is worse than any cache write.

The deferral answers no whenever the answer is not clearly yes: no cost tracker, no cache activity yet, or a history already past the ceiling. Both loops (chat and agent) go through the same decision.

This needs nothing from the provider beyond the cache accounting the cost tracker already collects, so every provider that reports cache tokens benefits — no per-provider work.

## CAG-6 — two surfaces still missing the routing hint

GitHub Models and the OpenAI family served through Bedrock speak the same chat schema as the first-party endpoint and now send the same `prompt_cache_key`. That was the last of the list named in Audit III's CAG-6.

## Retired: CAG-4 (heartbeat keep-warm)

The audit asked for a pre-warm request placed just under the cache TTL. On inspection it does not earn its place: it sends billable requests the user did not ask for, it pays a cache write on every beat, and it only ever pays off for a session that goes idle past the TTL *and then resumes*. A feature that spends money on a bet about future behavior needs the user to make that bet explicitly, which means a switch — and the switch is worth less than the complexity. Recorded here rather than left open.

## Retired: CAG-9 (shared worker preamble)

The audit's premise — "every worker turn is a cold cache write" — is wrong. Worker turns build a single `system` message, and the Anthropic client already marks a single system message `cache_control: ephemeral` (`llm/claudeai/tool_use.go:211-216`), so workers of the same type already share a cache entry. Sharing the *orchestrator's* core instead would make it worse: a 5K-token preamble read at cache prices costs more than the worker's own prompt. Retired with the measurement rather than implemented.

## Portability

No filesystem, path or OS surface — identical on Windows, Linux and macOS.

## Verification

- Full suite green, `golangci-lint --new-from-rev=main` clean, full-module gocyclo clean, Floor 4 clean.
- New tests: a modest overshoot with a warm cache waits; a history far past budget compacts anyway; no cache activity means no deferral; a session without cost tracking and a nil receiver never defer.
