### PR TITLE
fix(context): the provider engine reaches Bedrock and can summarize server-side

### DIFF
--- a/cli/config_env_defaults.go
+++ b/cli/config_env_defaults.go
@@ -153,7 +153,7 @@ var envDefaults = map[string]envDefault{
 	"CHATCLI_PROMPT_CACHE_TTL":             {Value: "5m", Source: "llm/client/cache_prefix.go (5m|1h|auto; auto = 1h in agent/coder turns)"},
 	"CHATCLI_MANAGED_CONFIG":               {Value: "(/etc/chatcli/managed.env · %ProgramData%\\chatcli\\managed.env)", Source: "config/managed.go (org defaults; !KEY=value locks)"},
 	"CHATCLI_PROMPT_CACHE_EXPLICIT":        {Value: "false", Source: "llm/client/cache_resources.go (Gemini cachedContents; bills storage per token-hour)"},
-	"CHATCLI_CONTEXT_ENGINE":               {Value: "builtin", Source: "extension_providers.go (builtin | provider — the model's server-side context editing | mcp:<server> with a context_compact tool)"},
+	"CHATCLI_CONTEXT_ENGINE":               {Value: "builtin", Source: "extension_providers.go (builtin | provider — the model's server-side context editing | provider-compact — editing plus server-side summarization | mcp:<server> with a context_compact tool)"},
 	"CHATCLI_MEMORY_PROVIDER":              {Value: "builtin", Source: "extension_providers.go (builtin | mcp:<server> alongside the embedded memory | mcp-only:<server> external only)"},
 	"CHATCLI_COMPACT_MODEL":                {Value: "(session client)", Source: "compact_config.go (PROVIDER:model for Level 2 summaries)"},
 	"CHATCLI_MICROCOMPACT_TRUNCATE_TURNS":  {Value: "2", Source: "agent.DefaultMicrocompactConfig"},

--- a/cli/extension_providers.go
+++ b/cli/extension_providers.go
@@ -16,6 +16,13 @@
  *     memory_store(messages[{role,content}], session) ← every turn's new
  *       messages, forwarded asynchronously and best-effort.
  *
+ *   CHATCLI_CONTEXT_ENGINE=provider-compact
+ *     the provider's own context editing plus its server-side
+ *     compaction — it summarizes the older conversation itself instead of
+ *     the client spending a turn on a summarizer. Opt-in and never the
+ *     default: what ChatCLI's own compaction cuts is archived and can be
+ *     recalled, and a server-side summary cannot.
+ *
  *   CHATCLI_CONTEXT_ENGINE=mcp:<server>
  *     context_compact(segment, budget_chars, instruction) → the summary
  *       that replaces the compacted segment (auto-compact and guided

--- a/llm/bedrock/bedrock_client.go
+++ b/llm/bedrock/bedrock_client.go
@@ -500,6 +500,13 @@ func (c *BedrockClient) sendPromptAnthropicModel(ctx context.Context, wireModel,
 	}
 
 	applyAnthropicThinkingForEffort(reqBody, wireModel, ctx)
+	// Provider context engine: the Anthropic models served here take the
+	// same context_management block as the first-party endpoint, and this
+	// path builds the native Anthropic body, so it travels unchanged.
+	// Audit III's PR 13 wired the response side and left this surface out.
+	if cm := client.AnthropicContextManagement(); cm != nil {
+		reqBody["context_management"] = cm
+	}
 
 	// Rolling conversation breakpoint. Bedrock accepts "ttl":"1h" in the
 	// cache_control object for Claude 4.5+ (docs.aws.amazon.com/bedrock/

--- a/llm/claudeai/claude_client.go
+++ b/llm/claudeai/claude_client.go
@@ -750,6 +750,9 @@ func applyExtendedCacheTTLBeta(req *http.Request) {
 	if client.ProviderContextEngine() {
 		addAnthropicBeta(req, client.ContextManagementBeta)
 	}
+	if client.ProviderCompactionEngine() {
+		addAnthropicBeta(req, client.CompactionBeta)
+	}
 }
 
 // addAnthropicBeta appends one beta flag to the anthropic-beta header
@@ -790,6 +793,9 @@ func applyOAuthHeaders(req *http.Request, token string) {
 	}
 	if client.ProviderContextEngine() {
 		betas = betas + "," + client.ContextManagementBeta
+		if client.ProviderCompactionEngine() {
+			betas = betas + "," + client.CompactionBeta
+		}
 	}
 	req.Header.Set("anthropic-beta", betas)
 	req.Header.Set("anthropic-version", "2023-06-01")

--- a/llm/client/cache_prefix.go
+++ b/llm/client/cache_prefix.go
@@ -34,9 +34,39 @@ const ContextEngineEnv = "CHATCLI_CONTEXT_ENGINE"
 // ContextManagementBeta is the Anthropic beta that enables context editing.
 const ContextManagementBeta = "context-management-2025-06-27"
 
-// ProviderContextEngine reports whether CHATCLI_CONTEXT_ENGINE=provider.
+// CompactionBeta is the Anthropic beta that enables server-side
+// compaction, where the API summarizes the older conversation itself
+// instead of the client spending a turn on a summarizer.
+const CompactionBeta = "compact-2026-01-12"
+
+// contextEngine returns the selected engine, lowercased and trimmed.
+func contextEngine() string {
+	return strings.ToLower(strings.TrimSpace(os.Getenv(ContextEngineEnv)))
+}
+
+// ProviderContextEngine reports whether the provider's own context
+// management is in play. Both provider values ask for it: the compaction
+// engine is the editing engine plus a summarizing edit, never a
+// replacement, so a prompt that outgrows the window is still trimmed of
+// stale tool results on the way there.
 func ProviderContextEngine() bool {
-	return strings.EqualFold(strings.TrimSpace(os.Getenv(ContextEngineEnv)), "provider")
+	switch contextEngine() {
+	case "provider", "provider-compact":
+		return true
+	}
+	return false
+}
+
+// ProviderCompactionEngine reports whether the provider should also
+// summarize the older conversation server-side
+// (CHATCLI_CONTEXT_ENGINE=provider-compact).
+//
+// Opt-in and never the default: ChatCLI's own compaction is recoverable —
+// what it cuts is archived and can be recalled — and a server-side summary
+// is not. The value exists for sessions that would rather not spend a turn
+// on a local summarizer.
+func ProviderCompactionEngine() bool {
+	return contextEngine() == "provider-compact"
 }
 
 // ContextThreshold is a typed amount in an Anthropic context edit
@@ -83,6 +113,16 @@ func AnthropicContextManagement() *ContextManagement {
 		Trigger: &ContextThreshold{Type: "input_tokens", Value: 100000},
 		Keep:    &ContextThreshold{Type: "thinking_turns", Value: 3},
 	})
+	// Server-side compaction summarizes what the two clearing edits could
+	// not free. It runs last on purpose: clearing stale tool results and
+	// old reasoning is lossless, summarizing is not, so the cheap edits
+	// get their chance first.
+	if ProviderCompactionEngine() {
+		edits = append(edits, ContextEdit{
+			Type:    "compact_20260112",
+			Trigger: &ContextThreshold{Type: "input_tokens", Value: 150000},
+		})
+	}
 	return &ContextManagement{Edits: edits}
 }
 

--- a/llm/client/thinking_test.go
+++ b/llm/client/thinking_test.go
@@ -99,3 +99,47 @@ func TestAnthropicContextManagementOffByDefault(t *testing.T) {
 		t.Errorf("builtin engine must send no context_management, got %+v", cm)
 	}
 }
+
+// The compaction engine is the editing engine plus a summarizing edit,
+// never a replacement: a prompt on its way to the window limit is still
+// trimmed of stale tool results and old reasoning first, because those
+// edits are lossless and a summary is not.
+func TestProviderCompactionEngineAddsCompactLast(t *testing.T) {
+	t.Setenv(ContextEngineEnv, "provider-compact")
+	if !ProviderContextEngine() {
+		t.Fatal("the compaction engine must also enable context editing")
+	}
+	if !ProviderCompactionEngine() {
+		t.Fatal("provider-compact must select server-side compaction")
+	}
+	cm := AnthropicContextManagement()
+	if cm == nil || len(cm.Edits) != 3 {
+		t.Fatalf("want three edits, got %+v", cm)
+	}
+	if cm.Edits[len(cm.Edits)-1].Type != "compact_20260112" {
+		t.Errorf("summarizing must run after the lossless edits: %+v", cm.Edits)
+	}
+}
+
+func TestProviderEngineWithoutCompaction(t *testing.T) {
+	t.Setenv(ContextEngineEnv, "provider")
+	if ProviderCompactionEngine() {
+		t.Error("plain provider must not ask the server to summarize")
+	}
+	cm := AnthropicContextManagement()
+	if cm == nil {
+		t.Fatal("plain provider still edits context")
+	}
+	for _, e := range cm.Edits {
+		if e.Type == "compact_20260112" {
+			t.Errorf("unexpected compaction edit: %+v", cm.Edits)
+		}
+	}
+}
+
+func TestBuiltinEngineSelectsNothing(t *testing.T) {
+	t.Setenv(ContextEngineEnv, "builtin")
+	if ProviderContextEngine() || ProviderCompactionEngine() {
+		t.Error("builtin must ask the provider for nothing")
+	}
+}


### PR DESCRIPTION
Audit IV, PR 6 of 8 — closes CAG-5 (P1) and CMP-3 (P1), and retires CAG-8 with evidence.

## CAG-5 — the engine was one code path

`AnthropicContextManagement()` had a single call site, on the first-party endpoint. The Bedrock path builds the same native Anthropic body and its Claude models accept the same block, but the request side was never wired — Audit III's PR 13 wired the response side (`ContextEdits`, `mirrorContextEdits`, calibration skip) and left this out. A Bedrock session selecting the provider engine got nothing.

The OAuth mode stays out, and now says so in code: native tools are disabled there (`SupportsNativeTools()` returns false), so there are no tool-use blocks for the engine to clear. That is a structural exclusion, not an open item.

## CMP-3 — the engine could only clear, never summarize

`CHATCLI_CONTEXT_ENGINE` gains a third value, `provider-compact`: the provider's context editing **plus** its server-side compaction, so the API summarizes the older conversation itself instead of the client spending a turn on a summarizer.

- **Opt-in, never the default.** What ChatCLI's own compaction cuts is archived and recallable; a server-side summary is not. That reversibility is the thing this product has and the field does not, so it stays the default.
- **The summarizing edit runs last.** Clearing stale tool results and old reasoning is lossless; summarizing is not. The cheap edits get their chance first.
- **Selecting it implies the editing engine**, so a prompt on its way to the limit is still trimmed on the way there.

## Retired: CAG-8 (cache diagnosis)

The finding said the miss threshold was "structural rather than measured". Reading the code, it is neither — `cacheMissMinTokens = 2000` and `cacheMissMinShare = 0.05` (`cli/cost_cache_telemetry.go:32-33`) are exactly the explicit definition the field publishes, already applied per provider schema. What ChatCLI still cannot do is name *where* the prefix diverged, and that needs an account-level beta plus a switch to turn it on. The accuracy problem the finding was raised for does not exist; the attribution nicety does not justify a beta header on every request. Retired with the line numbers rather than left open.

## No new environment variable

The engine selector already existed and gained a value. Registered in the env-default table and in the extension-provider documentation in the same commit.

## Portability

Request shaping only — identical on Windows, Linux and macOS.

## Verification

- Full suite green, `golangci-lint --new-from-rev=main` clean, Floor 4 clean.
- New tests: `provider-compact` enables both engines and places the summarizing edit last; plain `provider` never asks the server to summarize; `builtin` asks for nothing.
