### PR TITLE
fix(cost): the calibration sample measures what the request actually sent

### DIFF
--- a/cli/agent_calibration_chars_test.go
+++ b/cli/agent_calibration_chars_test.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+// The provider counts the tool definitions it was sent, so a sample that
+// measures only the history reports fewer chars against the same tokens —
+// and the ratio it teaches makes the budget compact too early.
+func TestCalibrationCharsIncludeToolDefinitions(t *testing.T) {
+	history := []models.Message{
+		{Role: "system", Content: strings.Repeat("s", 500)},
+		{Role: "user", Content: strings.Repeat("u", 1500)},
+	}
+	a := &AgentMode{logger: zap.NewNop(), toolDefsChars: 12911}
+
+	got := a.calibrationChars(history)
+	want := promptCharsOf(history) + 12911
+	if got != want {
+		t.Fatalf("calibrationChars = %d, want %d", got, want)
+	}
+	if got <= promptCharsOf(history) {
+		t.Error("the tool catalog must widen the sample, not be ignored")
+	}
+}
+
+func TestCalibrationCharsWithoutToolDefinitions(t *testing.T) {
+	history := []models.Message{{Role: "user", Content: "hi"}}
+	a := &AgentMode{logger: zap.NewNop()}
+	if got, want := a.calibrationChars(history), promptCharsOf(history); got != want {
+		t.Errorf("a run with no tool catalog must measure the history alone: %d vs %d", got, want)
+	}
+}
+
+// Only a real usage report teaches the ratio: an estimate would train it
+// on the ratio it was derived from.
+func TestObserveCalibrationIgnoresEstimates(t *testing.T) {
+	cli := &ChatCLI{logger: zap.NewNop(), stateRoot: t.TempDir()}
+	a := &AgentMode{logger: zap.NewNop(), cli: cli, toolDefsChars: 4000}
+	history := []models.Message{{Role: "user", Content: strings.Repeat("u", 4000)}}
+
+	a.observeCalibration("CLAUDEAI", "claude-opus-5", history, nil)
+	if _, samples := cli.calibrator().CharsPerToken("CLAUDEAI", "claude-opus-5"); samples != 0 {
+		t.Fatalf("a nil usage must teach nothing, got %d samples", samples)
+	}
+	a.observeCalibration("CLAUDEAI", "claude-opus-5", history,
+		&models.UsageInfo{PromptTokens: 2000, CompletionTokens: 10})
+	if _, samples := cli.calibrator().CharsPerToken("CLAUDEAI", "claude-opus-5"); samples != 0 {
+		t.Fatalf("an estimate must teach nothing, got %d samples", samples)
+	}
+
+	a.observeCalibration("CLAUDEAI", "claude-opus-5", history,
+		&models.UsageInfo{IsReal: true, PromptTokens: 2000, CompletionTokens: 10})
+	ratio, samples := cli.calibrator().CharsPerToken("CLAUDEAI", "claude-opus-5")
+	if samples == 0 {
+		t.Fatal("a real usage report must produce a sample")
+	}
+	// The sample carries the tool catalog, so the ratio is wider than the
+	// history alone would have taught.
+	historyOnly := float64(promptCharsOf(history)) / 2000.0
+	if ratio <= historyOnly {
+		t.Errorf("ratio %.2f should exceed the history-only ratio %.2f", ratio, historyOnly)
+	}
+}
+
+func TestObserveCalibrationWithoutCLI(t *testing.T) {
+	a := &AgentMode{logger: zap.NewNop()}
+	a.observeCalibration("CLAUDEAI", "claude-opus-5", nil, &models.UsageInfo{IsReal: true, PromptTokens: 1})
+}

--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -2517,8 +2517,8 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 			}
 			// Learn the real chars-per-token ratio for this provider/model
 			// from what was actually sent and what the API counted.
-			if turnUsage != nil && turnUsage.IsReal && !edited {
-				a.cli.calibrator().Observe(effProvider, effModel, promptCharsOf(turnHistory), contextTokens(effProvider, effModel, turnUsage))
+			if !edited {
+				a.observeCalibration(effProvider, effModel, turnHistory, turnUsage)
 			}
 			a.cli.maybeAnnounceBudget()
 			a.cli.maybeAnnounceCacheMisses()
@@ -4750,6 +4750,30 @@ func extractDelegateArgs(argsJSON string) (map[string]interface{}, string) {
 		return inner, string(outer.Args)
 	}
 	return nil, string(outer.Args)
+}
+
+// observeCalibration feeds one turn into the chars-per-token calibrator.
+// Only a real usage report teaches anything: an estimate would train the
+// ratio on the ratio it was derived from.
+func (a *AgentMode) observeCalibration(provider, model string, turnHistory []models.Message, usage *models.UsageInfo) {
+	if usage == nil || !usage.IsReal || a.cli == nil {
+		return
+	}
+	a.cli.calibrator().Observe(provider, model,
+		a.calibrationChars(turnHistory), contextTokens(provider, model, usage))
+}
+
+// calibrationChars is the chars side of one calibration sample: what the
+// request actually put on the wire.
+//
+// The tokens side comes from the provider's own count, which includes the
+// tool definitions the request shipped. Measuring the history alone made
+// the learned ratio read low on exactly the surface that carries a tool
+// catalog, and a low chars-per-token ratio makes the compaction budget
+// treat the same text as more tokens than it costs — compacting earlier
+// than it needs to.
+func (a *AgentMode) calibrationChars(turnHistory []models.Message) int {
+	return promptCharsOf(turnHistory) + a.toolDefsChars
 }
 
 // estimateToolDefsChars measures the native tool definitions this run ships

--- a/llm/openairesponses/openai_responses_client.go
+++ b/llm/openairesponses/openai_responses_client.go
@@ -126,6 +126,7 @@ func (c *OpenAIResponsesClient) SendPrompt(ctx context.Context, prompt string, h
 			"instructions":      instructions,
 			"input":             conversationInput,
 			"max_output_tokens": effectiveMaxTokens,
+			"store":             false,
 		}
 	} else {
 		input := buildTextFromHistory(history, "")
@@ -143,6 +144,11 @@ func (c *OpenAIResponsesClient) SendPrompt(ctx context.Context, prompt string, h
 			"model":             c.model,
 			"input":             input,
 			"max_output_tokens": effectiveMaxTokens,
+			// Explicit, like the OAuth path: the endpoint retains
+			// responses by default, and ChatCLI never reads them back —
+			// it resends the conversation every turn. Leaving the field
+			// unset paid the retention without taking the benefit.
+			"store": false,
 		}
 	}
 

--- a/llm/openairesponses/store_test.go
+++ b/llm/openairesponses/store_test.go
@@ -1,0 +1,45 @@
+package openairesponses
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/diillson/chatcli/auth"
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+// The endpoint retains responses by default and ChatCLI never reads them
+// back — it resends the conversation every turn. Leaving the field unset
+// paid the retention without taking the benefit, so both paths now say so.
+func TestResponsesSendsStoreFalse(t *testing.T) {
+	var body map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("OPENAI_RESPONSES_API_URL", server.URL)
+	c := NewOpenAIResponsesClient(
+		auth.NewStaticTokenProvider("sk-test", auth.AuthModeAPIKey, auth.ProviderOpenAI),
+		"gpt-5.6-terra", zap.NewNop(), 1, 0)
+
+	if _, err := c.SendPrompt(context.Background(), "hi",
+		[]models.Message{{Role: "user", Content: "hi"}}, 100); err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+	store, ok := body["store"]
+	if !ok {
+		t.Fatalf("store must be explicit, payload: %+v", body)
+	}
+	if store != false {
+		t.Errorf("store = %v, want false", store)
+	}
+}


### PR DESCRIPTION
Audit IV, PR 7 of 8 — closes COST-2 (P1) and COST-3 (P1), and retires CMP-5 with reasoning.

## COST-2 — the calibrator was taught a mismatched pair

The agent loop samples the chars-per-token calibrator with `promptCharsOf(turnHistory)` against the provider's real input token count. Those two do not measure the same request: the token count includes the tool definitions that travelled, the char count does not. Every agent and coder turn was short by the whole serialized catalog — about 12,900 bytes in coder mode, measured in PR 4.

A ratio learned low makes the compaction budget convert the same text into *more* tokens than it costs, so the surface with the most window pressure was the one compacting earliest. The sample now includes the catalog, in a named helper so the two halves are visibly the same request.

This is the half of Audit III's COST-7 that PR 14 did not land — the alias-normalized keys and the scoped store did, the tool-definition chars did not.

## COST-3 — the Responses path paid retention and took no benefit

The OAuth path sent `store: false` explicitly; the API-key path sent nothing, so the endpoint's default applied and responses were retained server-side. ChatCLI never reads them back — it re-serializes the whole conversation every turn — so that was the worst of both. The field is now explicit on both paths.

Server-side threading with `previous_response_id`, which is what would make retention *worth* paying for, is deliberately not added: it changes where the conversation lives, which is a decision the user should make rather than inherit, and that means a switch. The local-first default stays.

## Retired: CMP-5 (per-tool result caps)

The finding asked for per-tool ceilings instead of the two global constants. Reading the code, `EnforceToolResultBudget` already persists an oversized result to disk and leaves a preview with a file reference the model can read — truncation is recoverable, not lossy. What per-tool ceilings would add is tuning *where* that spill happens, and the numbers to tune with do not exist: picking multipliers per tool without data is guesswork that risks cutting useful output. Retired rather than guessed. The global cap remains overridable.

## Portability

No filesystem, path or OS surface — identical on Windows, Linux and macOS.

## Verification

- Full suite green, `golangci-lint --new-from-rev=main` clean, Floor 4 clean.
- New tests: the calibration sample widens by the tool catalog and equals the history alone when there is none; the Responses payload carries an explicit `store: false`.
