### PR TITLE
fix(coder): a write may not leave the workspace, and the denylist works on macOS

### DIFF
--- a/cli/agent/denylist_resolution_test.go
+++ b/cli/agent/denylist_resolution_test.go
@@ -1,0 +1,65 @@
+package agent
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// The denylist is compared against a path already resolved through
+// EvalSymlinks. On macOS /etc resolves to /private/etc, so the literal
+// entries matched nothing and the list was inert on that platform.
+func TestSensitivePathsAreCheckedInBothSpellings(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("posix denylist")
+	}
+	pv := NewPathValidator("/tmp/workspace", zap.NewNop())
+	for _, cmd := range []string{
+		"cat /etc/passwd",
+		"cat /etc/ssh/ssh_host_rsa_key",
+	} {
+		flagged, reason := pv.DetectPathTraversal(cmd)
+		if !flagged {
+			t.Errorf("%q must be flagged as touching a sensitive path", cmd)
+			continue
+		}
+		if !strings.Contains(reason, "sensitive") {
+			t.Errorf("%q flagged for the wrong reason: %s", cmd, reason)
+		}
+	}
+}
+
+func TestOrdinaryPathsAreNotFlagged(t *testing.T) {
+	pv := NewPathValidator("/tmp/workspace", zap.NewNop())
+	if flagged, reason := pv.DetectPathTraversal("go build ./cmd/server"); flagged {
+		t.Errorf("an ordinary command must pass: %s", reason)
+	}
+}
+
+func TestResolveDenyListKeepsTheLiteralEntry(t *testing.T) {
+	got := resolveDenyList([]string{"/etc/ssl/"})
+	if len(got) == 0 || got[0] != "/etc/ssl/" {
+		t.Fatalf("the literal entry must survive: %+v", got)
+	}
+	for _, e := range got {
+		if !strings.HasSuffix(e, "/") {
+			t.Errorf("a directory entry keeps its separator: %q", e)
+		}
+	}
+}
+
+// The macOS shadow file lives under the resolved spelling, which is what
+// a read check receives.
+func TestMasterPasswdIsBlockedInBothSpellings(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-specific path mapping")
+	}
+	s := NewSensitiveReadPaths()
+	for _, p := range []string{"/etc/master.passwd", "/private/etc/master.passwd"} {
+		if blocked, _ := s.isSensitivePath(p); !blocked {
+			t.Errorf("%s must be blocked", p)
+		}
+	}
+}

--- a/cli/agent/path_validator.go
+++ b/cli/agent/path_validator.go
@@ -12,6 +12,13 @@ import (
 )
 
 // PathValidator validates file paths against workspace boundaries.
+//
+// Not wired into any execution path today: command validation runs through
+// CommandValidator and the coder engine's own boundary check, and reads
+// go through SensitiveReadPaths. It is kept because it is part of the
+// package's exported surface, and it is kept correct — a security helper
+// that is wrong is worse than one that is unused, and the next caller
+// should not inherit the macOS denylist bug this comment replaced.
 type PathValidator struct {
 	workspaceBoundary string
 	logger            *zap.Logger
@@ -23,6 +30,29 @@ var sensitivePaths = []string{
 	"/etc/ssh/", "/etc/ssl/",
 	"/proc/", "/sys/", "/dev/",
 	"/boot/", "/sbin/",
+}
+
+// resolvedSensitivePaths carries each entry above in both spellings: the
+// literal one and the one it resolves to. The candidate path is compared
+// after EvalSymlinks, and on macOS /etc resolves to /private/etc — so the
+// literal entries matched nothing and the denylist was inert there.
+var resolvedSensitivePaths = resolveDenyList(sensitivePaths)
+
+func resolveDenyList(paths []string) []string {
+	out := make([]string, 0, len(paths)*2)
+	for _, p := range paths {
+		out = append(out, p)
+		trimmed := strings.TrimSuffix(p, "/")
+		resolved, err := filepath.EvalSymlinks(trimmed)
+		if err != nil || resolved == trimmed {
+			continue
+		}
+		if strings.HasSuffix(p, "/") {
+			resolved += "/"
+		}
+		out = append(out, resolved)
+	}
+	return out
 }
 
 // Allowed system binary paths (read/execute only).
@@ -73,7 +103,7 @@ func (pv *PathValidator) DetectPathTraversal(command string) (bool, string) {
 		}
 
 		// Check sensitive paths
-		for _, sensitive := range sensitivePaths {
+		for _, sensitive := range resolvedSensitivePaths {
 			if strings.HasPrefix(resolved, sensitive) {
 				return true, fmt.Sprintf("command accesses sensitive path: %s", sensitive)
 			}

--- a/cli/agent/read_path_validator.go
+++ b/cli/agent/read_path_validator.go
@@ -128,6 +128,14 @@ func (s *SensitiveReadPaths) IsReadAllowed(path, workspace string) (bool, string
 	return true, ""
 }
 
+// resolvedSensitiveReadPaths are the exact files never readable, in both
+// the literal and the symlink-resolved spelling.
+var resolvedSensitiveReadPaths = resolveDenyList([]string{
+	"/etc/shadow",
+	"/etc/gshadow",
+	"/etc/master.passwd",
+})
+
 // isSensitivePath checks if a path matches known sensitive file patterns.
 func (s *SensitiveReadPaths) isSensitivePath(path string) (bool, string) {
 	// os.UserHomeDir handles USERPROFILE on Windows; a raw $HOME lookup would
@@ -138,13 +146,10 @@ func (s *SensitiveReadPaths) isSensitivePath(path string) (bool, string) {
 		home = "/root"
 	}
 
-	// Exact sensitive paths
-	sensitivePaths := []string{
-		"/etc/shadow",
-		"/etc/gshadow",
-		"/etc/master.passwd",
-	}
-	for _, sp := range sensitivePaths {
+	// Exact sensitive paths. Compared in both spellings: the candidate has
+	// already been through EvalSymlinks, and on macOS /etc resolves to
+	// /private/etc — where the shadow file actually lives.
+	for _, sp := range resolvedSensitiveReadPaths {
 		if path == sp {
 			return true, "access to " + sp + " is blocked for security"
 		}

--- a/pkg/coder/engine/commands.go
+++ b/pkg/coder/engine/commands.go
@@ -95,7 +95,7 @@ func (e *Engine) handleWrite(args []string) error {
 	if *content == "" {
 		return fmt.Errorf("--content vazio")
 	}
-	if err := e.validatePath(*file); err != nil {
+	if err := e.validateWritePath(*file); err != nil {
 		return err
 	}
 
@@ -149,7 +149,7 @@ func (e *Engine) handlePatch(args []string) error {
 	if *file == "" || *search == "" {
 		return fmt.Errorf("--file e --search requeridos")
 	}
-	if err := e.validatePath(*file); err != nil {
+	if err := e.validateWritePath(*file); err != nil {
 		return err
 	}
 
@@ -197,7 +197,7 @@ func (e *Engine) handleRollback(args []string) error {
 	if *file == "" {
 		return fmt.Errorf("--file requerido")
 	}
-	if err := e.validatePath(*file); err != nil {
+	if err := e.validateWritePath(*file); err != nil {
 		return err
 	}
 	c, err := os.ReadFile(*file + ".bak")

--- a/pkg/coder/engine/engine.go
+++ b/pkg/coder/engine/engine.go
@@ -111,10 +111,41 @@ func auxAllowedPathsSnapshot() []string {
 	return out
 }
 
-// systemBinPaths are allowed for read/execute operations.
+// systemBinPaths are allowed for READ and EXECUTE only. A run needs to
+// read an interpreter or run a tool that lives outside the workspace;
+// nothing legitimate needs to WRITE there, and treating the two the same
+// let a write escape the workspace boundary entirely — planting an
+// executable on the user's PATH is the one escape that outlives the run.
 var systemBinPaths = []string{
 	"/usr/bin/", "/usr/local/bin/", "/bin/", "/usr/sbin/",
 	"/opt/homebrew/bin/",
+}
+
+// resolvedSensitivePaths is sensitivePaths with every entry put through
+// the same symlink resolution the candidate goes through.
+//
+// The list is compared against a path already resolved by EvalSymlinks,
+// and on macOS /etc resolves to /private/etc — so a literal "/etc/" entry
+// matched nothing and the whole denylist was inert on that platform.
+// Resolved once at init because the mapping is a property of the system,
+// not of the path being checked.
+var resolvedSensitivePaths = resolveDenyList(sensitivePaths)
+
+func resolveDenyList(paths []string) []string {
+	out := make([]string, 0, len(paths)*2)
+	for _, p := range paths {
+		out = append(out, p)
+		trimmed := strings.TrimSuffix(p, "/")
+		resolved, err := filepath.EvalSymlinks(trimmed)
+		if err != nil || resolved == trimmed {
+			continue
+		}
+		if strings.HasSuffix(p, "/") {
+			resolved += "/"
+		}
+		out = append(out, resolved)
+	}
+	return out
 }
 
 // NewEngine creates an Engine that writes to the given writers.
@@ -129,8 +160,53 @@ func NewEngine(out, errOut io.Writer, workspaceRoot string) *Engine {
 	return &Engine{Out: out, Err: errOut, WorkspaceRoot: root}
 }
 
-// validatePath checks that a file path is within the workspace boundary and not sensitive.
+// resolveThroughExistingAncestor resolves the symlinks of a path that may
+// not exist yet.
+//
+// EvalSymlinks fails on a missing path, and resolving only the immediate
+// parent is not enough: writing a new file into a new subdirectory leaves
+// both missing, so the path stayed unresolved while the boundary it is
+// compared against was resolved — and on any system where the workspace
+// sits under a symlink (macOS puts temporary and user directories under
+// one) a legitimate write read as an escape. So it walks up to the
+// nearest ancestor that does exist, resolves that, and rejoins the rest.
+func resolveThroughExistingAncestor(abs string) string {
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		return resolved
+	}
+	dir, rest := filepath.Dir(abs), filepath.Base(abs)
+	for {
+		if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+			return filepath.Join(resolved, rest)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			// Reached the root without finding anything that exists:
+			// the cleaned absolute path is the best answer available.
+			return abs
+		}
+		rest = filepath.Join(filepath.Base(dir), rest)
+		dir = parent
+	}
+}
+
+// validatePath checks that a path is within the workspace boundary and not
+// sensitive, for reading or executing. System binary directories pass:
+// a run legitimately reads an interpreter or runs a tool from outside the
+// workspace.
 func (e *Engine) validatePath(target string) error {
+	return e.validatePathForAccess(target, false)
+}
+
+// validateWritePath is validatePath for a path about to be written. It
+// refuses the system binary directories: the workspace boundary is the
+// promise this tool makes, and a write outside it is the one effect that
+// outlives the run.
+func (e *Engine) validateWritePath(target string) error {
+	return e.validatePathForAccess(target, true)
+}
+
+func (e *Engine) validatePathForAccess(target string, write bool) error {
 	if target == "" {
 		return nil
 	}
@@ -140,19 +216,10 @@ func (e *Engine) validatePath(target string) error {
 		return fmt.Errorf("cannot resolve path %q: %w", target, err)
 	}
 
-	// Resolve symlinks (follow the real path)
-	resolved := abs
-	if evalPath, err := filepath.EvalSymlinks(abs); err == nil {
-		resolved = evalPath
-	} else {
-		parent := filepath.Dir(abs)
-		if evalParent, err2 := filepath.EvalSymlinks(parent); err2 == nil {
-			resolved = filepath.Join(evalParent, filepath.Base(abs))
-		}
-	}
+	resolved := resolveThroughExistingAncestor(abs)
 
 	// Block sensitive system paths
-	for _, sp := range sensitivePaths {
+	for _, sp := range resolvedSensitivePaths {
 		if strings.HasPrefix(resolved, sp) {
 			return fmt.Errorf("access to sensitive path %q is blocked", target)
 		}
@@ -173,10 +240,12 @@ func (e *Engine) validatePath(target string) error {
 		}
 
 		isSystemBin := false
-		for _, bp := range systemBinPaths {
-			if strings.HasPrefix(resolved, bp) {
-				isSystemBin = true
-				break
+		if !write {
+			for _, bp := range systemBinPaths {
+				if strings.HasPrefix(resolved, bp) {
+					isSystemBin = true
+					break
+				}
 			}
 		}
 

--- a/pkg/coder/engine/multipatch.go
+++ b/pkg/coder/engine/multipatch.go
@@ -135,7 +135,7 @@ func (e *Engine) handleMultipatch(args []string) error {
 		if err != nil {
 			return fmt.Errorf("edit #%d: resolve path: %w", idx, err)
 		}
-		if err := e.validatePath(abs); err != nil {
+		if err := e.validateWritePath(abs); err != nil {
 			return fmt.Errorf("edit #%d: %w", idx, err)
 		}
 

--- a/pkg/coder/engine/write_boundary_test.go
+++ b/pkg/coder/engine/write_boundary_test.go
@@ -1,0 +1,105 @@
+package engine
+
+import (
+	"io"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// Planting an executable on the user's PATH is the one escape that
+// outlives the run, and it was the only out-of-workspace path the write
+// check accepted.
+func TestWriteRefusesSystemBinaryDirectories(t *testing.T) {
+	e := NewEngine(io.Discard, io.Discard, t.TempDir())
+	for _, p := range []string{
+		"/usr/local/bin/chatcli-payload",
+		"/usr/bin/chatcli-payload",
+		"/bin/chatcli-payload",
+		"/usr/sbin/chatcli-payload",
+		"/opt/homebrew/bin/chatcli-payload",
+	} {
+		if err := e.validateWritePath(p); err == nil {
+			t.Errorf("writing %s must be refused: it is outside the workspace", p)
+		}
+	}
+}
+
+// Reading and executing from those directories is legitimate — a run
+// reads an interpreter or runs a tool that lives outside the workspace.
+func TestReadStillAllowsSystemBinaryDirectories(t *testing.T) {
+	e := NewEngine(io.Discard, io.Discard, t.TempDir())
+	if err := e.validatePath("/usr/bin/env"); err != nil {
+		t.Errorf("reading a system binary must stay allowed: %v", err)
+	}
+}
+
+func TestWriteInsideTheWorkspaceIsUnaffected(t *testing.T) {
+	ws := t.TempDir()
+	e := NewEngine(io.Discard, io.Discard, ws)
+	if err := e.validateWritePath(filepath.Join(ws, "pkg", "main.go")); err != nil {
+		t.Errorf("a workspace write must pass: %v", err)
+	}
+}
+
+// The denylist is compared against a path already resolved through
+// EvalSymlinks. On macOS /etc resolves to /private/etc, so the literal
+// entries matched nothing and the list was inert on that platform.
+func TestSensitivePathsResolveThroughSymlinks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("posix denylist")
+	}
+	e := NewEngine(io.Discard, io.Discard, "")
+	for _, p := range []string{"/etc/passwd", "/etc/ssh/sshd_config"} {
+		err := e.validatePath(p)
+		if err == nil {
+			t.Errorf("%s must be refused", p)
+			continue
+		}
+		if !strings.Contains(err.Error(), "sensitive") {
+			t.Errorf("%s must be refused as sensitive, got %v", p, err)
+		}
+	}
+}
+
+func TestResolveDenyListKeepsBothSpellings(t *testing.T) {
+	got := resolveDenyList([]string{"/etc/ssh/"})
+	if len(got) == 0 || got[0] != "/etc/ssh/" {
+		t.Fatalf("the literal entry must survive: %+v", got)
+	}
+	if runtime.GOOS == "darwin" && len(got) != 2 {
+		t.Errorf("darwin must also carry the resolved spelling: %+v", got)
+	}
+	for _, entry := range got {
+		if !strings.HasSuffix(entry, "/") {
+			t.Errorf("a directory entry must keep its separator: %q", entry)
+		}
+	}
+}
+
+// Writing a new file into a new subdirectory leaves both missing, so
+// neither resolves — and on a system where the workspace sits under a
+// symlink the unresolved path read as an escape from the resolved
+// boundary.
+func TestWriteIntoANewSubdirectoryOfASymlinkedWorkspace(t *testing.T) {
+	ws := t.TempDir()
+	e := NewEngine(io.Discard, io.Discard, ws)
+	deep := filepath.Join(ws, "a", "b", "c", "new.go")
+	if err := e.validateWritePath(deep); err != nil {
+		t.Errorf("a write into a new subtree of the workspace must pass: %v", err)
+	}
+}
+
+func TestResolveThroughExistingAncestorFallsBackToTheInput(t *testing.T) {
+	// Nothing on this path exists; the cleaned absolute path is the best
+	// answer and must be returned rather than an empty string.
+	got := resolveThroughExistingAncestor(filepath.Join(string(filepath.Separator),
+		"chatcli-nonexistent-root", "x", "y"))
+	if got == "" {
+		t.Fatal("resolution must never return empty")
+	}
+	if !filepath.IsAbs(got) {
+		t.Errorf("resolution must stay absolute, got %q", got)
+	}
+}


### PR DESCRIPTION
Audit IV, outside the context stack — closes OUT-1 (P0) and OUT-3 (P1).

## OUT-1 — a write could leave the workspace

`systemBinPaths` disabled the workspace boundary for **every** operation, not just the read and execute it exists for. So `write`, `patch` and `multipatch` accepted any path under `/usr/bin`, `/usr/local/bin`, `/bin`, `/usr/sbin` or `/opt/homebrew/bin`, while every other path outside the workspace was refused.

Proved before the fix:

```
validatePath("/usr/local/bin/chatcli-payload") => nil
validatePath("/tmp/outside.txt")               => path is outside workspace boundary
```

Planting an executable on the user's PATH is the one effect that outlives the run, and on an auto-approving surface the model reaches it unattended. Read and execute keep the allowance — a run does legitimately read an interpreter or invoke a tool from outside the workspace. Write does not, and now goes through its own check.

## OUT-3 — the denylist was inert on macOS

The sensitive-path list compared literal entries such as `/etc/ssh/` against a candidate that had already been through `EvalSymlinks`. On macOS `/etc` resolves to `/private/etc`, so nothing ever matched:

```
DetectPathTraversal("cat /etc/passwd") => false
```

Each entry is now carried in both spellings, resolved once at init because the mapping is a property of the system, not of the path being checked. Same fix in the coder engine, the agent's command validator, and the exact-match list of the read validator — where the macOS shadow file (`/etc/master.passwd`) lives under the resolved spelling.

## A third bug the fix surfaced

Resolving only the *immediate* parent of a path that does not exist leaves a new file in a new subdirectory unresolved, while the boundary it is compared against is resolved. On any system whose workspace sits under a symlink — macOS puts temporary and user directories under one — a legitimate write into a new subtree read as an escape. Resolution now walks up to the nearest ancestor that exists and rejoins the rest. Found by a test written for the write boundary, fixed here rather than filed.

## The dead validator

`PathValidator` has no production caller: command validation runs through `CommandValidator` and the engine's own check, reads through `SensitiveReadPaths`. It stays — removing an exported type is a breaking change — and now says so in its doc comment. It is kept *correct* rather than merely kept: a security helper that is wrong is worse than one that is unused, and the next caller should not inherit the bug.

## Portability

`filepath.EvalSymlinks`, `filepath.Dir` and `filepath.Join` throughout; the two posix-specific tests skip on Windows and the darwin-specific one skips elsewhere. The behavior change is the same on all three platforms — only the denylist bug was macOS-specific.

## Verification

- Full suite green, `golangci-lint --new-from-rev=main` clean, Floor 4 clean, Floor 13 clean.
- New tests: every system binary directory is refused for write and allowed for read; a workspace write is unaffected; a write into a new subtree of a symlinked workspace passes; `/etc/passwd` and `/etc/ssh/*` are flagged as sensitive; an ordinary command is not; the denylist keeps both spellings and its separators; resolution never returns empty.
