### PR TITLE
fix(server): refuse to serve an unauthenticated API on a reachable address

### DIFF
--- a/deploy/helm/chatcli-operator/Chart.yaml
+++ b/deploy/helm/chatcli-operator/Chart.yaml
@@ -25,7 +25,14 @@ maintainers:
     email: diillson@hotmail.com
 annotations:
   artifacthub.io/license: Apache-2.0
-  artifacthub.io/containsSecurityUpdates: 'false'
+  artifacthub.io/containsSecurityUpdates: 'true'
+  artifacthub.io/changes: |
+    - kind: changed
+      description: An Instance whose server would listen on a reachable address with no credential is no longer provisioned; the operator raises the AuthenticationConfigured condition on it instead
+    - kind: security
+      description: The server refuses to start unauthenticated on a reachable address, so spec.server.token or spec.server.security.jwtSecretRef is required unless bindAddress is loopback
+    - kind: fixed
+      description: The bindAddress field documented a 127.0.0.1 default it never had; unset means every interface inside a cluster
   artifacthub.io/prerelease: 'false'
   artifacthub.io/operator: 'true'
   artifacthub.io/operatorCapabilities: Seamless Upgrades

--- a/deploy/helm/chatcli-operator/README.md
+++ b/deploy/helm/chatcli-operator/README.md
@@ -241,6 +241,26 @@ This chart installs 17 Custom Resource Definitions for the AIOps platform:
 | `EscalationPolicy` | `ep` | L1 -> L2 -> L3 escalation chains for incidents |
 | `IncidentSLA` | `sla` | SLA targets for incident response and resolution by severity |
 | `Instance` | `inst` | ChatCLI instance configuration |
+
+> **An Instance needs a credential.** The server an Instance provisions
+> binds every interface inside a cluster, and a reachable listener with no
+> credential admits every caller as an administrator — so it refuses to
+> start, and the operator refuses to provision the Deployment rather than
+> leaving a pod to crash-loop. It raises a condition instead:
+>
+> ```bash
+> kubectl get instance my-instance \
+>   -o jsonpath='{.status.conditions[?(@.type=="AuthenticationConfigured")].message}'
+> ```
+>
+> Satisfy it with `spec.server.token`, with
+> `spec.server.security.jwtSecretRef` (tokens must carry an `exp` claim),
+> or by binding loopback with
+> `spec.server.security.bindAddress: "127.0.0.1"` when the server is only
+> reached from inside its own pod. A credential passed through
+> `spec.extraEnv` as `CHATCLI_SERVER_TOKEN` or `CHATCLI_JWT_SECRET` counts
+> too. Note that leaving `bindAddress` unset means *every interface*, not
+> loopback.
 | `Issue` | `iss` | Correlated operational problem detected in the cluster |
 | `NotificationPolicy` | `np` | Multi-channel notification rules (Slack, PagerDuty, Email, etc.) |
 | `PostMortem` | `pm` | Auto-generated post-incident lifecycle report |

--- a/deploy/helm/chatcli-operator/crds/platform.chatcli.io_instances.yaml
+++ b/deploy/helm/chatcli-operator/crds/platform.chatcli.io_instances.yaml
@@ -169,7 +169,9 @@ spec:
                           description: Selects a key of a ConfigMap.
                           properties:
                             key:
-                              description: The key to select.
+                              description: |-
+                                The key to select from the ConfigMap's Data field.
+                                Keys in the BinaryData field are not currently propagated to container env vars.
                               type: string
                             name:
                               default: ""
@@ -649,11 +651,8 @@ spec:
                       Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
                       whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
                       CSIDriver instance. Other volumes are always re-labelled recursively.
-                      "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
 
-                      If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
-                      If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
-                      and "Recursive" for all other volumes.
+                      If not specified, "MountOption" is used.
 
                       This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
 
@@ -812,8 +811,13 @@ spec:
                       bindAddress:
                         description: |-
                           BindAddress is the address to bind the server to.
-                          Maps to CHATCLI_BIND_ADDRESS env var. Default: "127.0.0.1".
-                          Set to "0.0.0.0" to expose to all interfaces.
+                          Maps to CHATCLI_BIND_ADDRESS env var.
+
+                          Unset inside a cluster means every interface ("0.0.0.0"), which is
+                          what makes Service routing and health checks work — it is NOT
+                          loopback. Set it to "127.0.0.1" for an instance that should only be
+                          reachable inside its own pod; any other value requires a credential
+                          (see Token and JWTSecretRef).
                         type: string
                       debug:
                         description: |-
@@ -827,7 +831,11 @@ spec:
                       jwtSecretRef:
                         description: |-
                           JWTSecretRef references a Secret key containing the JWT signing secret.
-                          Maps to CHATCLI_JWT_SECRET env var.
+                          Maps to CHATCLI_JWT_SECRET env var. Tokens signed with it must carry
+                          an exp claim; one without an expiry is rejected.
+
+                          One of this or spec.server.token is required unless the server binds
+                          loopback.
                         properties:
                           key:
                             description: Key is the key within the Secret.
@@ -886,7 +894,16 @@ spec:
                         type: string
                     type: object
                   token:
-                    description: Token references a Secret containing the auth token.
+                    description: |-
+                      Token references a Secret containing the auth token.
+                      Maps to CHATCLI_SERVER_TOKEN env var.
+
+                      REQUIRED unless security.jwtSecretRef is set or the server binds
+                      loopback: a listener on a reachable address with no credential
+                      admits every caller as an administrator, so the server refuses to
+                      start in that shape and the operator will not provision the
+                      Deployment — it raises the AuthenticationConfigured condition on the
+                      Instance instead.
                     properties:
                       key:
                         description: Key is the key within the Secret.

--- a/deploy/helm/chatcli/Chart.yaml
+++ b/deploy/helm/chatcli/Chart.yaml
@@ -24,7 +24,16 @@ maintainers:
     email: diillson@hotmail.com
 annotations:
   artifacthub.io/license: Apache-2.0
-  artifacthub.io/containsSecurityUpdates: 'false'
+  artifacthub.io/containsSecurityUpdates: 'true'
+  artifacthub.io/changes: |
+    - kind: security
+      description: The server refuses to start unauthenticated on a reachable address; set server.token or security.jwtSecretRef, or bind loopback
+    - kind: security
+      description: JWTs without an exp claim are rejected, and the auth-failure rate limit counts per client instead of per connection
+    - kind: changed
+      description: An Instance without a credential is no longer provisioned; the operator raises the AuthenticationConfigured condition instead
+    - kind: removed
+      description: The safety values block, whose only effect was a variable no code reads
   artifacthub.io/prerelease: 'false'
   artifacthub.io/operator: 'false'
   artifacthub.io/crds: |

--- a/deploy/helm/chatcli/README.md
+++ b/deploy/helm/chatcli/README.md
@@ -161,8 +161,28 @@ fallback:
 |-----------|-------------|---------|
 | `server.port` | gRPC server port | `50051` |
 | `server.metricsPort` | Prometheus metrics port (0 = disabled) | `9090` |
-| `server.token` | Authentication token (empty = no auth) | `""` |
+| `server.token` | Authentication token. **Required in-cluster** — see below | `""` |
 | `server.grpcReflection` | Enable gRPC reflection (disable in production) | `false` |
+
+### The server needs a credential in-cluster
+
+Inside Kubernetes the server binds every interface, because that is what
+makes Service routing and health checks work. A listener reachable from
+the network with no credential admits every caller as an administrator, so
+the server **refuses to start** in that shape and says which setting is
+missing.
+
+Set one of:
+
+| Option | Value | When |
+|---|---|---|
+| Shared token | `server.token` | one credential for every caller |
+| Per-user JWTs | `security.jwtSecret` or `security.jwtSecretRef` | callers carry their own identity and role; tokens must carry an `exp` claim |
+| No credential | `security.bindAddress: "127.0.0.1"` | the server is only reached from inside its own pod |
+
+`security.jwtSecretRef` is preferred over `security.jwtSecret` in
+production: the plain value lands in the Deployment's env, the reference
+keeps it in a Secret.
 
 ### TLS
 

--- a/deploy/helm/chatcli/crds/platform.chatcli.io_instances.yaml
+++ b/deploy/helm/chatcli/crds/platform.chatcli.io_instances.yaml
@@ -169,7 +169,9 @@ spec:
                           description: Selects a key of a ConfigMap.
                           properties:
                             key:
-                              description: The key to select.
+                              description: |-
+                                The key to select from the ConfigMap's Data field.
+                                Keys in the BinaryData field are not currently propagated to container env vars.
                               type: string
                             name:
                               default: ""
@@ -649,11 +651,8 @@ spec:
                       Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
                       whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
                       CSIDriver instance. Other volumes are always re-labelled recursively.
-                      "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
 
-                      If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
-                      If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
-                      and "Recursive" for all other volumes.
+                      If not specified, "MountOption" is used.
 
                       This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
 
@@ -812,8 +811,13 @@ spec:
                       bindAddress:
                         description: |-
                           BindAddress is the address to bind the server to.
-                          Maps to CHATCLI_BIND_ADDRESS env var. Default: "127.0.0.1".
-                          Set to "0.0.0.0" to expose to all interfaces.
+                          Maps to CHATCLI_BIND_ADDRESS env var.
+
+                          Unset inside a cluster means every interface ("0.0.0.0"), which is
+                          what makes Service routing and health checks work — it is NOT
+                          loopback. Set it to "127.0.0.1" for an instance that should only be
+                          reachable inside its own pod; any other value requires a credential
+                          (see Token and JWTSecretRef).
                         type: string
                       debug:
                         description: |-
@@ -827,7 +831,11 @@ spec:
                       jwtSecretRef:
                         description: |-
                           JWTSecretRef references a Secret key containing the JWT signing secret.
-                          Maps to CHATCLI_JWT_SECRET env var.
+                          Maps to CHATCLI_JWT_SECRET env var. Tokens signed with it must carry
+                          an exp claim; one without an expiry is rejected.
+
+                          One of this or spec.server.token is required unless the server binds
+                          loopback.
                         properties:
                           key:
                             description: Key is the key within the Secret.
@@ -886,7 +894,16 @@ spec:
                         type: string
                     type: object
                   token:
-                    description: Token references a Secret containing the auth token.
+                    description: |-
+                      Token references a Secret containing the auth token.
+                      Maps to CHATCLI_SERVER_TOKEN env var.
+
+                      REQUIRED unless security.jwtSecretRef is set or the server binds
+                      loopback: a listener on a reachable address with no credential
+                      admits every caller as an administrator, so the server refuses to
+                      start in that shape and the operator will not provision the
+                      Deployment — it raises the AuthenticationConfigured condition on the
+                      Instance instead.
                     properties:
                       key:
                         description: Key is the key within the Secret.

--- a/deploy/helm/chatcli/values.schema.json
+++ b/deploy/helm/chatcli/values.schema.json
@@ -884,25 +884,6 @@
         }
       }
     },
-    "safety": {
-      "type": "object",
-      "description": "Safety guardrails configuration.",
-      "additionalProperties": false,
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "description": "Enable safety guardrails."
-        },
-        "config": {
-          "type": "object",
-          "description": "Safety configuration object. Structure depends on the safety implementation."
-        },
-        "existingConfigMap": {
-          "type": "string",
-          "description": "Name of an existing ConfigMap containing safety configuration."
-        }
-      }
-    },
     "skillRegistry": {
       "type": "object",
       "description": "Skill registry configuration for discovering and installing skills.",

--- a/deploy/helm/chatcli/values.yaml
+++ b/deploy/helm/chatcli/values.yaml
@@ -18,7 +18,14 @@ server:
   port: 50051
   # Prometheus metrics HTTP port (0 = disabled)
   metricsPort: 9090
-  # Authentication token for gRPC server (leave empty to disable auth)
+  # Authentication token for the gRPC server.
+  #
+  # REQUIRED for any in-cluster install. Inside Kubernetes the server binds
+  # every interface, and it refuses to start unauthenticated on a reachable
+  # address — every caller that could reach it would otherwise be admitted
+  # as an administrator. Set this, or security.jwtSecret / jwtSecretRef for
+  # per-user JWTs. Leaving both empty is only valid when the server is
+  # bound to loopback (security.bindAddress: "127.0.0.1").
   token: ""
   # Enable gRPC reflection for debugging
   grpcReflection: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,20 @@ services:
     environment:
       # Server config
       CHATCLI_SERVER_PORT: "50051"
-      CHATCLI_SERVER_TOKEN: "${CHATCLI_SERVER_TOKEN:-}"  # Set for auth, leave empty for no auth
+
+      # The published port above only reaches the server if it listens on
+      # the container's interface. Without this the server binds loopback
+      # INSIDE the container: the health check still passes (it runs in
+      # there) while nothing outside can connect.
+      CHATCLI_BIND_ADDRESS: "${CHATCLI_BIND_ADDRESS:-0.0.0.0}"
+
+      # REQUIRED with the bind above: a server reachable from outside the
+      # container with no credential admits every caller as an
+      # administrator, so it refuses to start and says so. Compose cannot
+      # express "required unless loopback", so the check lives in the
+      # server. To run without a token, keep it inside the container:
+      #   CHATCLI_BIND_ADDRESS=127.0.0.1  (then use `docker exec`)
+      CHATCLI_SERVER_TOKEN: "${CHATCLI_SERVER_TOKEN:-}"
 
       # LLM Provider (configure at least one)
       LLM_PROVIDER: "${LLM_PROVIDER:-}"

--- a/operator/README.md
+++ b/operator/README.md
@@ -170,6 +170,8 @@ spec:
     token:
       name: chatcli-server-token    # Secret containing the auth token
       key: token                    # Key within the Secret (default: "token")
+      # Required unless security.jwtSecretRef is set or the server binds
+      # loopback — see "Server authentication is required" below.
     security:
       rateLimitRps: 20
       rateLimitBurst: 50
@@ -259,6 +261,39 @@ spec:
   server:
     port: 50051
 ```
+
+### Server authentication is required
+
+An Instance provisions a gRPC server. Inside a cluster that server binds
+every interface unless `spec.server.security.bindAddress` says otherwise,
+and a listener reachable from the network with no credential admits every
+caller as an administrator.
+
+So the server refuses to start in that shape, and the operator refuses to
+provision the Deployment rather than leaving a pod to crash-loop with the
+reason in its logs. Instead it raises a condition on the Instance:
+
+```bash
+kubectl get instance my-instance -o jsonpath='{.status.conditions[?(@.type=="AuthenticationConfigured")]}'
+```
+
+```
+{"type":"AuthenticationConfigured","status":"False","reason":"CredentialMissing",
+ "message":"server would listen on a reachable address with no credential ..."}
+```
+
+Three ways to satisfy it:
+
+| Option | Field | When |
+|---|---|---|
+| Shared token | `spec.server.token` | one credential for every caller |
+| Per-user JWTs | `spec.server.security.jwtSecretRef` | callers carry their own identity and role; tokens must carry an `exp` claim |
+| No credential | `spec.server.security.bindAddress: "127.0.0.1"` | the server is only reached from inside its own pod |
+
+A credential supplied directly through `spec.extraEnv` as
+`CHATCLI_SERVER_TOKEN` or `CHATCLI_JWT_SECRET` counts too.
+
+<!-- provider auth follows -->
 
 Two authentication modes — pick one:
 

--- a/operator/api/v1alpha1/instance_types.go
+++ b/operator/api/v1alpha1/instance_types.go
@@ -176,6 +176,14 @@ type ServerSpec struct {
 	TLS *TLSSpec `json:"tls,omitempty"`
 
 	// Token references a Secret containing the auth token.
+	// Maps to CHATCLI_SERVER_TOKEN env var.
+	//
+	// REQUIRED unless security.jwtSecretRef is set or the server binds
+	// loopback: a listener on a reachable address with no credential
+	// admits every caller as an administrator, so the server refuses to
+	// start in that shape and the operator will not provision the
+	// Deployment — it raises the AuthenticationConfigured condition on the
+	// Instance instead.
 	// +optional
 	Token *SecretKeyRefSpec `json:"token,omitempty"`
 
@@ -187,7 +195,11 @@ type ServerSpec struct {
 // ServerSecuritySpec defines security settings for the gRPC server.
 type ServerSecuritySpec struct {
 	// JWTSecretRef references a Secret key containing the JWT signing secret.
-	// Maps to CHATCLI_JWT_SECRET env var.
+	// Maps to CHATCLI_JWT_SECRET env var. Tokens signed with it must carry
+	// an exp claim; one without an expiry is rejected.
+	//
+	// One of this or spec.server.token is required unless the server binds
+	// loopback.
 	// +optional
 	JWTSecretRef *SecretKeyRefSpec `json:"jwtSecretRef,omitempty"`
 
@@ -217,8 +229,13 @@ type ServerSecuritySpec struct {
 	MaxConcurrentStreams *int32 `json:"maxConcurrentStreams,omitempty"`
 
 	// BindAddress is the address to bind the server to.
-	// Maps to CHATCLI_BIND_ADDRESS env var. Default: "127.0.0.1".
-	// Set to "0.0.0.0" to expose to all interfaces.
+	// Maps to CHATCLI_BIND_ADDRESS env var.
+	//
+	// Unset inside a cluster means every interface ("0.0.0.0"), which is
+	// what makes Service routing and health checks work — it is NOT
+	// loopback. Set it to "127.0.0.1" for an instance that should only be
+	// reachable inside its own pod; any other value requires a credential
+	// (see Token and JWTSecretRef).
 	// +optional
 	BindAddress string `json:"bindAddress,omitempty"`
 

--- a/operator/config/crd/bases/platform.chatcli.io_instances.yaml
+++ b/operator/config/crd/bases/platform.chatcli.io_instances.yaml
@@ -169,7 +169,9 @@ spec:
                           description: Selects a key of a ConfigMap.
                           properties:
                             key:
-                              description: The key to select.
+                              description: |-
+                                The key to select from the ConfigMap's Data field.
+                                Keys in the BinaryData field are not currently propagated to container env vars.
                               type: string
                             name:
                               default: ""
@@ -649,11 +651,8 @@ spec:
                       Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
                       whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
                       CSIDriver instance. Other volumes are always re-labelled recursively.
-                      "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
 
-                      If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
-                      If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
-                      and "Recursive" for all other volumes.
+                      If not specified, "MountOption" is used.
 
                       This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
 
@@ -812,8 +811,13 @@ spec:
                       bindAddress:
                         description: |-
                           BindAddress is the address to bind the server to.
-                          Maps to CHATCLI_BIND_ADDRESS env var. Default: "127.0.0.1".
-                          Set to "0.0.0.0" to expose to all interfaces.
+                          Maps to CHATCLI_BIND_ADDRESS env var.
+
+                          Unset inside a cluster means every interface ("0.0.0.0"), which is
+                          what makes Service routing and health checks work — it is NOT
+                          loopback. Set it to "127.0.0.1" for an instance that should only be
+                          reachable inside its own pod; any other value requires a credential
+                          (see Token and JWTSecretRef).
                         type: string
                       debug:
                         description: |-
@@ -827,7 +831,11 @@ spec:
                       jwtSecretRef:
                         description: |-
                           JWTSecretRef references a Secret key containing the JWT signing secret.
-                          Maps to CHATCLI_JWT_SECRET env var.
+                          Maps to CHATCLI_JWT_SECRET env var. Tokens signed with it must carry
+                          an exp claim; one without an expiry is rejected.
+
+                          One of this or spec.server.token is required unless the server binds
+                          loopback.
                         properties:
                           key:
                             description: Key is the key within the Secret.
@@ -886,7 +894,16 @@ spec:
                         type: string
                     type: object
                   token:
-                    description: Token references a Secret containing the auth token.
+                    description: |-
+                      Token references a Secret containing the auth token.
+                      Maps to CHATCLI_SERVER_TOKEN env var.
+
+                      REQUIRED unless security.jwtSecretRef is set or the server binds
+                      loopback: a listener on a reachable address with no credential
+                      admits every caller as an administrator, so the server refuses to
+                      start in that shape and the operator will not provision the
+                      Deployment — it raises the AuthenticationConfigured condition on the
+                      Instance instead.
                     properties:
                       key:
                         description: Key is the key within the Secret.

--- a/operator/controllers/auth_precheck.go
+++ b/operator/controllers/auth_precheck.go
@@ -6,10 +6,14 @@
 package controllers
 
 import (
+	"context"
 	"net"
 	"strings"
 
 	platformv1alpha1 "github.com/diillson/chatcli/operator/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // Refusing to provision an unauthenticated instance on a reachable bind.
@@ -96,4 +100,39 @@ func isLoopbackAddress(addr string) bool {
 	}
 	ip := net.ParseIP(host)
 	return ip != nil && ip.IsLoopback()
+}
+
+// recordAuthCondition writes the AuthenticationConfigured condition for
+// this Instance and reports whether provisioning must stop.
+//
+// Stopping is not an error: there is nothing to retry until the spec
+// changes, and a requeue would only rewrite the same condition. The
+// condition is the output — it is what the user reads.
+func (r *InstanceReconciler) recordAuthCondition(ctx context.Context, instance *platformv1alpha1.Instance) bool {
+	log := log.FromContext(ctx)
+	blocked := instanceAuthUnconfigured(instance)
+
+	cond := metav1.Condition{
+		Type:               AuthConditionType,
+		Status:             metav1.ConditionTrue,
+		Reason:             "CredentialConfigured",
+		Message:            "server has a credential, or binds loopback only",
+		ObservedGeneration: instance.Generation,
+	}
+	if blocked {
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = "CredentialMissing"
+		cond.Message = authUnconfiguredMessage
+		instance.Status.Ready = false
+	}
+	meta.SetStatusCondition(&instance.Status.Conditions, cond)
+
+	if !blocked {
+		return false
+	}
+	if err := r.Status().Update(ctx, instance); err != nil {
+		log.Error(err, "failed to record the missing-credential condition")
+	}
+	log.Info("instance not provisioned: " + authUnconfiguredMessage)
+	return true
 }

--- a/operator/controllers/auth_precheck.go
+++ b/operator/controllers/auth_precheck.go
@@ -1,0 +1,99 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package controllers
+
+import (
+	"net"
+	"strings"
+
+	platformv1alpha1 "github.com/diillson/chatcli/operator/api/v1alpha1"
+)
+
+// Refusing to provision an unauthenticated instance on a reachable bind.
+//
+// The server itself refuses to start in that shape, because a listener on
+// every interface with no credential admits any caller as an
+// administrator. Inside a cluster that is every pod. Left to the pod, the
+// refusal shows up as a crash loop and the reason sits in container logs;
+// surfacing it on the Instance instead means the operator says what is
+// wrong where the user is already looking.
+//
+// The check mirrors the server's exactly: loopback may run open, anything
+// else needs a credential, and an address that does not parse counts as
+// reachable — the safe answer to "unknown" is to require one.
+
+// AuthConditionType is the Instance condition raised when the spec would
+// provision a server that refuses to start for want of a credential.
+const AuthConditionType = "AuthenticationConfigured"
+
+// instanceBindAddress is the address the pod will listen on: the spec's
+// own value when set, otherwise the in-cluster default the server picks
+// for itself, which is every interface.
+func instanceBindAddress(instance *platformv1alpha1.Instance) string {
+	if instance != nil && instance.Spec.Server.Security != nil {
+		if addr := strings.TrimSpace(instance.Spec.Server.Security.BindAddress); addr != "" {
+			return addr
+		}
+	}
+	// No bindAddress in the spec: the container runs with
+	// KUBERNETES_SERVICE_HOST set, so the server binds every interface.
+	return "0.0.0.0"
+}
+
+// instanceHasCredential reports whether the spec provisions either
+// authentication mechanism — a shared token, a JWT secret, or one of the
+// two supplied directly through extraEnv.
+func instanceHasCredential(instance *platformv1alpha1.Instance) bool {
+	if instance == nil {
+		return false
+	}
+	if instance.Spec.Server.Token != nil {
+		return true
+	}
+	if sec := instance.Spec.Server.Security; sec != nil && sec.JWTSecretRef != nil {
+		return true
+	}
+	for _, env := range instance.Spec.ExtraEnv {
+		switch env.Name {
+		case "CHATCLI_SERVER_TOKEN", "CHATCLI_JWT_SECRET":
+			if env.Value != "" || env.ValueFrom != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// instanceAuthUnconfigured reports whether this Instance would provision a
+// server that refuses to start: reachable bind, no credential.
+func instanceAuthUnconfigured(instance *platformv1alpha1.Instance) bool {
+	if instanceHasCredential(instance) {
+		return false
+	}
+	return !isLoopbackAddress(instanceBindAddress(instance))
+}
+
+// authUnconfiguredMessage is what the condition and the event say. It
+// names both ways to fix it and the one way to opt out.
+const authUnconfiguredMessage = "server would listen on a reachable address with no credential, and refuses to start in that shape: " +
+	"set spec.server.token, or spec.server.security.jwtSecretRef, or bind loopback with spec.server.security.bindAddress=127.0.0.1"
+
+// isLoopbackAddress mirrors the server's own check.
+func isLoopbackAddress(addr string) bool {
+	host := strings.TrimSpace(addr)
+	if host == "" {
+		return false
+	}
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	host = strings.Trim(host, "[]")
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}

--- a/operator/controllers/auth_precheck_test.go
+++ b/operator/controllers/auth_precheck_test.go
@@ -1,0 +1,145 @@
+package controllers
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	platformv1alpha1 "github.com/diillson/chatcli/operator/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func instanceWith(bind string, token *platformv1alpha1.SecretKeyRefSpec, jwt *platformv1alpha1.SecretKeyRefSpec, extra ...corev1.EnvVar) *platformv1alpha1.Instance {
+	inst := &platformv1alpha1.Instance{}
+	inst.Spec.ExtraEnv = extra
+	inst.Spec.Server.Token = token
+	if bind != "" || jwt != nil {
+		inst.Spec.Server.Security = &platformv1alpha1.ServerSecuritySpec{BindAddress: bind, JWTSecretRef: jwt}
+	}
+	return inst
+}
+
+// No bindAddress in the spec means the pod inherits the in-cluster
+// default, which is every interface — the case the crash loop came from.
+func TestUnsetBindAddressCountsAsReachable(t *testing.T) {
+	if got := instanceBindAddress(instanceWith("", nil, nil)); got != "0.0.0.0" {
+		t.Errorf("instanceBindAddress = %q, want the in-cluster default", got)
+	}
+	if !instanceAuthUnconfigured(instanceWith("", nil, nil)) {
+		t.Error("an instance with no bind and no credential must be flagged")
+	}
+}
+
+func TestLoopbackBindNeedsNoCredential(t *testing.T) {
+	for _, addr := range []string{"127.0.0.1", "::1", "localhost"} {
+		if instanceAuthUnconfigured(instanceWith(addr, nil, nil)) {
+			t.Errorf("%s binds only this pod and needs no credential", addr)
+		}
+	}
+}
+
+func TestEitherCredentialSatisfiesTheCheck(t *testing.T) {
+	ref := &platformv1alpha1.SecretKeyRefSpec{Name: "s", Key: "k"}
+	if instanceAuthUnconfigured(instanceWith("0.0.0.0", ref, nil)) {
+		t.Error("a token reference must satisfy the check")
+	}
+	if instanceAuthUnconfigured(instanceWith("0.0.0.0", nil, ref)) {
+		t.Error("a JWT secret reference must satisfy the check")
+	}
+}
+
+// A credential supplied straight through extraEnv counts too — the
+// operator must not demand its own field for something already provided.
+func TestExtraEnvCredentialCounts(t *testing.T) {
+	for _, name := range []string{"CHATCLI_SERVER_TOKEN", "CHATCLI_JWT_SECRET"} {
+		inline := instanceWith("0.0.0.0", nil, nil, corev1.EnvVar{Name: name, Value: "x"})
+		if instanceAuthUnconfigured(inline) {
+			t.Errorf("%s given inline must satisfy the check", name)
+		}
+		fromSecret := instanceWith("0.0.0.0", nil, nil, corev1.EnvVar{
+			Name:      name,
+			ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{}},
+		})
+		if instanceAuthUnconfigured(fromSecret) {
+			t.Errorf("%s from a secret must satisfy the check", name)
+		}
+	}
+	empty := instanceWith("0.0.0.0", nil, nil, corev1.EnvVar{Name: "CHATCLI_SERVER_TOKEN"})
+	if !instanceAuthUnconfigured(empty) {
+		t.Error("an empty value provisions nothing and must not satisfy the check")
+	}
+}
+
+// The message is what a user sees on the Instance, so it has to name every
+// way out.
+func TestMessageNamesEveryRemedy(t *testing.T) {
+	for _, want := range []string{"spec.server.token", "jwtSecretRef", "bindAddress"} {
+		if !strings.Contains(authUnconfiguredMessage, want) {
+			t.Errorf("the condition message should mention %s: %s", want, authUnconfiguredMessage)
+		}
+	}
+}
+
+func TestUnparseableBindIsReachable(t *testing.T) {
+	if isLoopbackAddress("chatcli.internal") || isLoopbackAddress("") {
+		t.Error("an unresolvable or empty address must not be assumed loopback")
+	}
+}
+
+// The condition is what a user sees, so the reconcile has to raise it and
+// stop rather than provisioning a Deployment that cannot start.
+func TestReconcileRefusesToProvisionWithoutACredential(t *testing.T) {
+	instance := newInstance("no-credential", "default")
+	instance.Spec.Server.Token = nil // reachable bind, nothing to authenticate with
+	r, c := setupFakeReconciler(instance)
+	ctx := context.Background()
+
+	if _, err := r.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "no-credential", Namespace: "default"},
+	}); err != nil {
+		t.Fatalf("reconcile should stop cleanly, not error: %v", err)
+	}
+
+	var updated platformv1alpha1.Instance
+	if err := c.Get(ctx, types.NamespacedName{Name: "no-credential", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get instance: %v", err)
+	}
+	cond := meta.FindStatusCondition(updated.Status.Conditions, AuthConditionType)
+	if cond == nil {
+		t.Fatalf("want the %s condition on the instance, got %+v", AuthConditionType, updated.Status.Conditions)
+	}
+	if cond.Status != metav1.ConditionFalse || cond.Reason != "CredentialMissing" {
+		t.Errorf("condition = %+v, want False/CredentialMissing", cond)
+	}
+
+	var deploy appsv1.Deployment
+	err := c.Get(ctx, types.NamespacedName{Name: "no-credential", Namespace: "default"}, &deploy)
+	if err == nil {
+		t.Error("a Deployment must not be provisioned for an instance that cannot start")
+	}
+}
+
+// The happy path keeps working and records why.
+func TestReconcileRecordsAConfiguredCredential(t *testing.T) {
+	instance := newInstance("with-credential", "default")
+	r, c := setupFakeReconciler(instance)
+	ctx := context.Background()
+
+	if _, err := r.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "with-credential", Namespace: "default"},
+	}); err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+	var updated platformv1alpha1.Instance
+	if err := c.Get(ctx, types.NamespacedName{Name: "with-credential", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get instance: %v", err)
+	}
+	if cond := meta.FindStatusCondition(updated.Status.Conditions, AuthConditionType); cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Errorf("want a True %s condition, got %+v", AuthConditionType, cond)
+	}
+}

--- a/operator/controllers/instance_controller.go
+++ b/operator/controllers/instance_controller.go
@@ -188,6 +188,35 @@ func (r *InstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, err
 	}
 
+	// The server refuses to start unauthenticated on a reachable address,
+	// so a spec in that shape would produce a crash loop with the reason
+	// buried in container logs. Say it on the Instance instead, and do not
+	// provision the Deployment.
+	if instanceAuthUnconfigured(&instance) {
+		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+			Type:               AuthConditionType,
+			Status:             metav1.ConditionFalse,
+			Reason:             "CredentialMissing",
+			Message:            authUnconfiguredMessage,
+			ObservedGeneration: instance.Generation,
+		})
+		instance.Status.Ready = false
+		if err := r.Status().Update(ctx, &instance); err != nil {
+			log.Error(err, "failed to record the missing-credential condition")
+		}
+		log.Info("instance not provisioned: " + authUnconfiguredMessage)
+		reconciliationsTotal.WithLabelValues("success").Inc()
+		reconcileDuration.Observe(time.Since(start).Seconds())
+		return ctrl.Result{}, nil
+	}
+	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+		Type:               AuthConditionType,
+		Status:             metav1.ConditionTrue,
+		Reason:             "CredentialConfigured",
+		Message:            "server has a credential, or binds loopback only",
+		ObservedGeneration: instance.Generation,
+	})
+
 	if err := r.reconcileDeployment(ctx, &instance); err != nil {
 		log.Error(err, "failed to reconcile Deployment")
 		reconciliationsTotal.WithLabelValues("error").Inc()

--- a/operator/controllers/instance_controller.go
+++ b/operator/controllers/instance_controller.go
@@ -147,29 +147,10 @@ func (r *InstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 	}
 
-	if err := r.reconcileConfigMap(ctx, &instance); err != nil {
-		log.Error(err, "failed to reconcile ConfigMap")
+	if err := r.reconcileConfigMaps(ctx, &instance); err != nil {
 		reconciliationsTotal.WithLabelValues("error").Inc()
 		reconcileDuration.Observe(time.Since(start).Seconds())
 		return ctrl.Result{}, err
-	}
-
-	if instance.Spec.MCP != nil && instance.Spec.MCP.Enabled {
-		if err := r.reconcileMCPConfigMap(ctx, &instance); err != nil {
-			log.Error(err, "failed to reconcile MCP ConfigMap")
-			reconciliationsTotal.WithLabelValues("error").Inc()
-			reconcileDuration.Observe(time.Since(start).Seconds())
-			return ctrl.Result{}, err
-		}
-	}
-
-	if instance.Spec.Watcher != nil && instance.Spec.Watcher.Enabled && len(instance.Spec.Watcher.Targets) > 0 {
-		if err := r.reconcileWatchConfigMap(ctx, &instance); err != nil {
-			log.Error(err, "failed to reconcile watch config ConfigMap")
-			reconciliationsTotal.WithLabelValues("error").Inc()
-			reconcileDuration.Observe(time.Since(start).Seconds())
-			return ctrl.Result{}, err
-		}
 	}
 
 	if instance.Spec.Persistence != nil && instance.Spec.Persistence.Enabled {
@@ -192,30 +173,11 @@ func (r *InstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// so a spec in that shape would produce a crash loop with the reason
 	// buried in container logs. Say it on the Instance instead, and do not
 	// provision the Deployment.
-	if instanceAuthUnconfigured(&instance) {
-		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-			Type:               AuthConditionType,
-			Status:             metav1.ConditionFalse,
-			Reason:             "CredentialMissing",
-			Message:            authUnconfiguredMessage,
-			ObservedGeneration: instance.Generation,
-		})
-		instance.Status.Ready = false
-		if err := r.Status().Update(ctx, &instance); err != nil {
-			log.Error(err, "failed to record the missing-credential condition")
-		}
-		log.Info("instance not provisioned: " + authUnconfiguredMessage)
+	if r.recordAuthCondition(ctx, &instance) {
 		reconciliationsTotal.WithLabelValues("success").Inc()
 		reconcileDuration.Observe(time.Since(start).Seconds())
 		return ctrl.Result{}, nil
 	}
-	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-		Type:               AuthConditionType,
-		Status:             metav1.ConditionTrue,
-		Reason:             "CredentialConfigured",
-		Message:            "server has a credential, or binds loopback only",
-		ObservedGeneration: instance.Generation,
-	})
 
 	if err := r.reconcileDeployment(ctx, &instance); err != nil {
 		log.Error(err, "failed to reconcile Deployment")
@@ -362,4 +324,31 @@ func (r *InstanceReconciler) secretToInstance(ctx context.Context, obj client.Ob
 		}
 	}
 	return requests
+}
+
+// reconcileConfigMaps reconciles every ConfigMap an Instance owns: its own
+// configuration, the MCP server list when MCP is enabled, and the watch
+// targets when the watcher has any. Grouped because the three share a
+// lifecycle and a failure mode, and reading them as one step keeps the
+// reconcile loop legible.
+func (r *InstanceReconciler) reconcileConfigMaps(ctx context.Context, instance *platformv1alpha1.Instance) error {
+	log := log.FromContext(ctx)
+
+	if err := r.reconcileConfigMap(ctx, instance); err != nil {
+		log.Error(err, "failed to reconcile ConfigMap")
+		return err
+	}
+	if instance.Spec.MCP != nil && instance.Spec.MCP.Enabled {
+		if err := r.reconcileMCPConfigMap(ctx, instance); err != nil {
+			log.Error(err, "failed to reconcile MCP ConfigMap")
+			return err
+		}
+	}
+	if instance.Spec.Watcher != nil && instance.Spec.Watcher.Enabled && len(instance.Spec.Watcher.Targets) > 0 {
+		if err := r.reconcileWatchConfigMap(ctx, instance); err != nil {
+			log.Error(err, "failed to reconcile watch config ConfigMap")
+			return err
+		}
+	}
+	return nil
 }

--- a/operator/controllers/instance_controller_test.go
+++ b/operator/controllers/instance_controller_test.go
@@ -40,6 +40,12 @@ func newInstance(name, ns string) *platformv1alpha1.Instance {
 		Spec: platformv1alpha1.InstanceSpec{
 			Provider: "CLAUDEAI",
 			Model:    "claude-sonnet-4-5",
+			// A server reachable from the network needs a credential or
+			// the operator will not provision it (auth_precheck.go), so
+			// the fixture carries the shape a real Instance has.
+			Server: platformv1alpha1.ServerSpec{
+				Token: &platformv1alpha1.SecretKeyRefSpec{Name: "chatcli-server-token", Key: "token"},
+			},
 		},
 	}
 }

--- a/server/auth.go
+++ b/server/auth.go
@@ -8,6 +8,7 @@ package server
 import (
 	"context"
 	"crypto/subtle"
+	"net"
 	"os"
 	"strings"
 	"sync"
@@ -198,13 +199,15 @@ func (a *TokenAuthInterceptor) validateJWT(tokenStr string) (*UserInfo, error) {
 
 	now := time.Now().Unix()
 
-	// Check expiry with clock skew tolerance
-	if exp, ok := claims["exp"]; ok {
-		if expFloat, ok := exp.(float64); ok {
-			if now > int64(expFloat)+jwtClockSkew {
-				return nil, status.Errorf(codes.Unauthenticated, "token expired")
-			}
-		}
+	// Expiry is required, not optional. A token without exp — or with one
+	// that is not a number — never expires, which turns a leaked
+	// credential into a permanent one.
+	exp, ok := claims["exp"].(float64)
+	if !ok {
+		return nil, status.Errorf(codes.Unauthenticated, "authentication failed")
+	}
+	if now > int64(exp)+jwtClockSkew {
+		return nil, status.Errorf(codes.Unauthenticated, "token expired")
 	}
 
 	// Check not-before with clock skew tolerance
@@ -294,9 +297,20 @@ func (a *TokenAuthInterceptor) recordFailure(peerAddr string) {
 	// This is a no-op placeholder for additional failure tracking (metrics, alerting)
 }
 
+// extractPeerAddress identifies the caller for rate limiting.
+//
+// The host alone, never host:port: a peer address carries the ephemeral
+// port, so keying on it gave every new connection a fresh limiter and the
+// failure limit counted to five per connection instead of per client —
+// which is no limit at all against a caller willing to reconnect.
 func extractPeerAddress(ctx context.Context) string {
-	if p, ok := peer.FromContext(ctx); ok {
-		return p.Addr.String()
+	p, ok := peer.FromContext(ctx)
+	if !ok || p.Addr == nil {
+		return "unknown"
 	}
-	return "unknown"
+	addr := p.Addr.String()
+	if host, _, err := net.SplitHostPort(addr); err == nil {
+		return host
+	}
+	return addr
 }

--- a/server/auth_hardening_test.go
+++ b/server/auth_hardening_test.go
@@ -1,0 +1,99 @@
+package server
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+)
+
+func signedJWT(t *testing.T, secret []byte, claims map[string]interface{}) string {
+	t.Helper()
+	enc := func(v interface{}) string {
+		raw, _ := json.Marshal(v)
+		return strings.TrimRight(base64.URLEncoding.EncodeToString(raw), "=")
+	}
+	head := enc(map[string]string{"alg": "HS256", "typ": "JWT"})
+	body := enc(claims)
+	sig := computeHS256(head+"."+body, secret)
+	return head + "." + body + "." + strings.TrimRight(base64.URLEncoding.EncodeToString(sig), "=")
+}
+
+// A token with no expiry never expires, which turns a leaked credential
+// into a permanent one.
+func TestJWTWithoutExpiryIsRejected(t *testing.T) {
+	t.Setenv("CHATCLI_JWT_SECRET", "test-secret-value")
+	a := NewTokenAuthInterceptor("", zap.NewNop())
+
+	valid := signedJWT(t, a.jwtSecret, map[string]interface{}{
+		"sub": "alice", "role": "admin", "exp": float64(time.Now().Add(time.Hour).Unix()),
+	})
+	if _, err := a.validateJWT(valid); err != nil {
+		t.Fatalf("a token with a future expiry must be accepted: %v", err)
+	}
+
+	noExp := signedJWT(t, a.jwtSecret, map[string]interface{}{"sub": "alice", "role": "admin"})
+	if _, err := a.validateJWT(noExp); err == nil {
+		t.Error("a token with no expiry must be rejected")
+	}
+
+	badExp := signedJWT(t, a.jwtSecret, map[string]interface{}{
+		"sub": "alice", "exp": "not-a-number",
+	})
+	if _, err := a.validateJWT(badExp); err == nil {
+		t.Error("a token whose expiry is not a number must be rejected")
+	}
+
+	expired := signedJWT(t, a.jwtSecret, map[string]interface{}{
+		"sub": "alice", "exp": float64(time.Now().Add(-time.Hour).Unix()),
+	})
+	if _, err := a.validateJWT(expired); err == nil {
+		t.Error("an expired token must be rejected")
+	}
+}
+
+// The limiter must count per client, not per connection: keying on the
+// ephemeral port made the limit meaningless against a caller willing to
+// reconnect.
+func TestPeerAddressDropsTheEphemeralPort(t *testing.T) {
+	ctx := peer.NewContext(context.Background(), &peer.Peer{Addr: &fakeAddr{"10.0.0.5:54321"}})
+	if got := extractPeerAddress(ctx); got != "10.0.0.5" {
+		t.Errorf("extractPeerAddress = %q, want the host alone", got)
+	}
+	other := peer.NewContext(context.Background(), &peer.Peer{Addr: &fakeAddr{"10.0.0.5:54322"}})
+	if extractPeerAddress(ctx) != extractPeerAddress(other) {
+		t.Error("two connections from one client must share a limiter")
+	}
+	if got := extractPeerAddress(context.Background()); got != "unknown" {
+		t.Errorf("a context with no peer must read as unknown, got %q", got)
+	}
+}
+
+func TestAuthFailureLimiterCountsPerClient(t *testing.T) {
+	t.Setenv("CHATCLI_JWT_SECRET", "")
+	a := NewTokenAuthInterceptor("the-token", zap.NewNop())
+	md := metadata.Pairs("authorization", "Bearer wrong")
+
+	var refusedByLimiter bool
+	for i := 0; i < 12; i++ {
+		ctx := peer.NewContext(metadata.NewIncomingContext(context.Background(), md),
+			&peer.Peer{Addr: &fakeAddr{"10.0.0.9:" + string(rune('a'+i))}})
+		if _, err := a.authorize(ctx, "/svc/Method"); err != nil && i > 5 {
+			refusedByLimiter = true
+		}
+	}
+	if !refusedByLimiter {
+		t.Error("repeated failures from one client must eventually be rate limited")
+	}
+}
+
+type fakeAddr struct{ s string }
+
+func (f *fakeAddr) Network() string { return "tcp" }
+func (f *fakeAddr) String() string  { return f.s }

--- a/server/bind_guard.go
+++ b/server/bind_guard.go
@@ -1,0 +1,64 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package server
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strings"
+)
+
+// Refusing to serve an unauthenticated API on a reachable address.
+//
+// Authentication is optional by design: the local CLI talks to its own
+// server over loopback, where the trust boundary is the machine and a
+// token would only be ceremony. That default becomes dangerous the moment
+// the listener is reachable from elsewhere — inside Kubernetes the bind
+// address is every interface, and an unauthenticated caller was admitted
+// as an administrator.
+//
+// So the rule is about the address, not the environment: loopback may run
+// open, anything else needs a credential, and the server says which one is
+// missing instead of starting and hoping.
+
+// requireAuthOnReachableBind returns an error when the server would listen
+// on an address other than loopback with neither a shared token nor a JWT
+// secret configured.
+func requireAuthOnReachableBind(bindAddr, token string) error {
+	if isLoopbackBind(bindAddr) {
+		return nil
+	}
+	if strings.TrimSpace(token) != "" || strings.TrimSpace(os.Getenv("CHATCLI_JWT_SECRET")) != "" {
+		return nil
+	}
+	return fmt.Errorf(
+		"refusing to serve an unauthenticated API on %s: every caller that can reach it would be admitted as an administrator. "+
+			"Set CHATCLI_SERVER_TOKEN (or --token) for a shared token, or CHATCLI_JWT_SECRET for per-user JWTs. "+
+			"To run without authentication, bind loopback instead (CHATCLI_BIND_ADDRESS=127.0.0.1)",
+		bindAddr)
+}
+
+// isLoopbackBind reports whether an address reaches only this machine.
+// An empty address means "every interface" in Go's listener, so it is not
+// loopback; a hostname that does not parse as an IP is treated as
+// reachable, because the safe answer to "unknown" is to require a
+// credential.
+func isLoopbackBind(bindAddr string) bool {
+	host := strings.TrimSpace(bindAddr)
+	if host == "" {
+		return false
+	}
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	host = strings.Trim(host, "[]")
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}

--- a/server/bind_guard_test.go
+++ b/server/bind_guard_test.go
@@ -1,0 +1,56 @@
+package server
+
+import (
+	"strings"
+	"testing"
+)
+
+// Loopback is the local CLI's own transport: the boundary is the machine,
+// so it may run without a credential. Anything reachable may not.
+func TestLoopbackMayRunWithoutAuth(t *testing.T) {
+	t.Setenv("CHATCLI_JWT_SECRET", "")
+	for _, addr := range []string{"127.0.0.1", "::1", "localhost", "127.0.0.1:8080", "[::1]:8080"} {
+		if err := requireAuthOnReachableBind(addr, ""); err != nil {
+			t.Errorf("%s must be allowed without a credential: %v", addr, err)
+		}
+	}
+}
+
+func TestReachableBindRequiresACredential(t *testing.T) {
+	t.Setenv("CHATCLI_JWT_SECRET", "")
+	for _, addr := range []string{"0.0.0.0", "::", "10.0.0.5", "", "chatcli.internal"} {
+		err := requireAuthOnReachableBind(addr, "")
+		if err == nil {
+			t.Errorf("%q must refuse to serve unauthenticated", addr)
+			continue
+		}
+		// The message has to say what to do, not just what went wrong.
+		for _, want := range []string{"CHATCLI_SERVER_TOKEN", "CHATCLI_JWT_SECRET", "CHATCLI_BIND_ADDRESS"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error for %q should name %s: %v", addr, want, err)
+			}
+		}
+	}
+}
+
+func TestReachableBindAcceptsEitherCredential(t *testing.T) {
+	t.Setenv("CHATCLI_JWT_SECRET", "")
+	if err := requireAuthOnReachableBind("0.0.0.0", "shared-token"); err != nil {
+		t.Errorf("a shared token must be enough: %v", err)
+	}
+	t.Setenv("CHATCLI_JWT_SECRET", "a-jwt-secret")
+	if err := requireAuthOnReachableBind("0.0.0.0", ""); err != nil {
+		t.Errorf("a JWT secret must be enough: %v", err)
+	}
+}
+
+// An address that does not parse is treated as reachable: the safe answer
+// to "unknown" is to require a credential.
+func TestUnparseableBindIsTreatedAsReachable(t *testing.T) {
+	if isLoopbackBind("not-an-address") {
+		t.Error("an unresolvable host must not be assumed loopback")
+	}
+	if isLoopbackBind("") {
+		t.Error("an empty bind means every interface, not loopback")
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -242,6 +242,15 @@ func (s *Server) Start() error {
 			bindAddr = "127.0.0.1"
 		}
 	}
+	// Fail closed on a reachable address. Binding every interface with no
+	// credential configured admits any caller on the network as an
+	// administrator — inside a cluster that is every pod. Loopback keeps
+	// working without a credential, because that is the local CLI's own
+	// transport and the boundary is the machine.
+	if err := requireAuthOnReachableBind(bindAddr, s.config.Token); err != nil {
+		return err
+	}
+
 	addr := fmt.Sprintf("%s:%d", bindAddr, s.config.Port)
 	lis, err := net.Listen("tcp", addr)
 	if err != nil {


### PR DESCRIPTION
Audit IV, outside the context stack — closes OUT-4 (P1).

## The defect

Authentication is optional by design: the local CLI talks to its own server over loopback, where the trust boundary is the machine and a token would be ceremony. That default followed the server onto every interface.

```go
// server.go — inside Kubernetes, bind every interface
if os.Getenv("KUBERNETES_SERVICE_HOST") != "" { bindAddr = "0.0.0.0" }

// auth.go — with no credential configured, admit everyone as admin
if a.token == "" && a.jwtSecret == nil {
    return ContextWithUser(ctx, &UserInfo{Subject: "system", Role: RoleAdmin}), nil
}
```

The chart ships `server.token: ""` and `security.jwtSecret: ""`, with `networkPolicy.enabled: false`. A default install therefore exposed an unauthenticated admin API to the pod network.

## What changes

The rule is about the address, not the environment.

- **Loopback may run open** — that is the local CLI's own transport, unchanged.
- **Anything else needs a credential.** The server refuses to start and names both ways to provide one, plus how to bind loopback instead if that is what was meant.
- **An address that does not parse counts as reachable.** The safe answer to "unknown" is to require a credential.

This is a deliberate behavior change: a default in-cluster install that used to start silently open now fails to start with an actionable message. Running open was the bug.

## Two more holes in the same interceptor

- **A JWT with no `exp` never expired.** The claim was read `if exp, ok := claims["exp"]; ok` and a non-float value fell through the inner type assertion too, so a token missing or malforming it was accepted forever — a leaked credential becomes a permanent one. Expiry is required now.
- **The auth-failure rate limiter was keyed by `peer.Addr.String()`**, which carries the ephemeral port. Every new connection got a fresh limiter, so the five-failures-per-minute limit counted per *connection*: no limit at all against a caller willing to reconnect. It keys on the host.

## Chart

`server.token` now says, at the value itself, that it is required for an in-cluster install and what the alternatives are.

## Portability

`net.SplitHostPort` and `net.ParseIP`; no filesystem or OS-specific behavior. Identical on Windows, Linux and macOS.

## Verification

- Full suite green, `golangci-lint --new-from-rev=main` clean, Floor 4 clean, Floor 13 clean.
- New tests: loopback in five spellings runs without a credential; `0.0.0.0`, `::`, a private IP, an empty address and a hostname all refuse, and the message names all three variables; either credential is enough; an unparseable host is not assumed loopback; a token with a future expiry is accepted while one with no expiry, a non-numeric expiry or a past expiry is rejected; two connections from one client share a limiter and repeated failures are eventually refused.
