### PR TITLE
feat(knowledge): a passage carries where it came from into the index

### DIFF
--- a/cli/ctxmgr/lexical.go
+++ b/cli/ctxmgr/lexical.go
@@ -49,7 +49,10 @@ func newLexicalIndex(segs []Segment) *lexicalIndex {
 	}
 	var total int
 	for i, s := range segs {
-		terms := tokenizeLexicalMode(s.Content, idx.mode)
+		// The situating header is indexed with the passage: a query that
+		// names the file or the function it is about must be able to match
+		// on it, which is the whole point of deriving it.
+		terms := tokenizeLexicalMode(s.IndexText(), idx.mode)
 		idx.docLen[i] = len(terms)
 		total += len(terms)
 		for _, t := range terms {

--- a/cli/ctxmgr/manager.go
+++ b/cli/ctxmgr/manager.go
@@ -175,7 +175,14 @@ func (m *Manager) CreateContext(ctx context.Context, name, description string, p
 	// são corpora docs-flatten e entram pelo parser nativo (um FileInfo por
 	// chunk, preservando source/título/proveniência); demais caminhos seguem
 	// pelo scanner normal, então diretórios de docs também viram knowledge.
-	knowledgeMeta := map[string]string{segmenterMetaKey: segmenterV2}
+	// Every context created from here on is segmented boundary-aware and
+	// indexed with a situating header. Both are tagged rather than global
+	// so corpora indexed before them keep the ids and vectors they already
+	// paid for; a /context refresh re-indexes into the new shape.
+	knowledgeMeta := map[string]string{
+		segmenterMetaKey: segmenterV2,
+		situatedMetaKey:  situatedV1,
+	}
 	var files []utils.FileInfo
 	var scanPaths []string
 	if mode == ModeKnowledge {

--- a/cli/ctxmgr/retrieval.go
+++ b/cli/ctxmgr/retrieval.go
@@ -154,7 +154,7 @@ func (e *RetrievalEngine) Retrieve(ctx context.Context, fc *FileContext, query s
 	// embedded. Only a run that embedded nothing at all is an error.
 	byContent := make(map[string]string, len(segs))
 	for _, s := range segs {
-		byContent[s.ID] = s.Content
+		byContent[s.ID] = s.IndexText()
 	}
 	if embedded, err := e.embedMissing(ctx, entry, allIDs, byContent); err != nil && embedded == 0 && len(idx.MissingFor(allIDs)) == len(allIDs) {
 		return nil, fmt.Errorf("embed segments: %w", err)
@@ -367,7 +367,7 @@ func (e *RetrievalEngine) vectorRanks(ctx context.Context, entry *lexCacheEntry,
 	if missing := entry.vec.MissingFor(ids); len(missing) > 0 {
 		sub := make(map[string]string, len(missing))
 		for _, id := range missing {
-			sub[id] = entry.segs[idxByID[id]].Content
+			sub[id] = entry.segs[idxByID[id]].IndexText()
 		}
 		if err := entry.vec.Upsert(ctx, sub); err != nil {
 			e.logger.Warn("knowledge: embedding unavailable; falling back to lexical retrieval", zap.Error(err))
@@ -544,7 +544,7 @@ func (e *RetrievalEngine) Warm(ctx context.Context, fc *FileContext) (int, error
 	byID := make(map[string]string, len(entry.segs))
 	for _, s := range entry.segs {
 		ids = append(ids, s.ID)
-		byID[s.ID] = s.Content
+		byID[s.ID] = s.IndexText()
 	}
 	return e.embedMissing(ctx, entry, ids, byID)
 }

--- a/cli/ctxmgr/segment.go
+++ b/cli/ctxmgr/segment.go
@@ -32,6 +32,12 @@ type Segment struct {
 	StartLine int // 1-based, inclusive
 	EndLine   int // 1-based, inclusive
 	Content   string
+	// Context situates the passage in its document — the file and the
+	// nearest structure enclosing it. It is prefixed to the text the
+	// passage is indexed by (see IndexText) and never to what the model
+	// reads, so citations and rendered passages are unchanged. Empty on
+	// corpora indexed before situating shipped.
+	Context string
 }
 
 // SegmentOptions tunes how files are split into passages.
@@ -44,6 +50,10 @@ type SegmentOptions struct {
 	// file type reads by. Only contexts created with the v2 segmenter
 	// (see segmentOptionsFor) opt in, so existing corpora keep their ids.
 	Boundaries bool
+	// Situate prefixes each passage's indexed text with the file and the
+	// structure enclosing it (see situate.go). Only contexts tagged for it
+	// opt in, so existing corpora keep the vectors they already paid for.
+	Situate bool
 }
 
 // segmenterV2 tags contexts created after boundary-aware segmentation
@@ -56,6 +66,7 @@ const (
 // segmentOptionsFor derives the segmenter options for one context from the
 // engine defaults and the context's own tag.
 func segmentOptionsFor(fc *FileContext, base SegmentOptions) SegmentOptions {
+	base.Situate = Situated(fc)
 	if fc != nil && fc.Metadata != nil && fc.Metadata[segmenterMetaKey] == segmenterV2 {
 		base.Boundaries = true
 		if base.OverlapLines < 3 {
@@ -171,6 +182,11 @@ func segmentOne(f utils.FileInfo, opts SegmentOptions) []Segment {
 			next = end
 		}
 		start = next
+	}
+	if opts.Situate {
+		// Derived after the cut so each passage knows its own first line:
+		// the header names the file and the structure enclosing it.
+		situate(out, lines)
 	}
 	return out
 }

--- a/cli/ctxmgr/situate.go
+++ b/cli/ctxmgr/situate.go
@@ -1,0 +1,123 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package ctxmgr
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// Situating a passage in its document.
+//
+// A passage cut from the middle of a file reaches the index saying nothing
+// about where it came from: which file, which section, which declaration.
+// Retrieval then has to match on the passage's own words alone, so a query
+// naming the file or the function it is about ranks that passage no higher
+// than any other — the failure the whole hybrid stack was built to avoid.
+//
+// The fix is a short header prefixed to the text that is indexed: the file
+// it belongs to and the nearest enclosing structure above it. It is
+// derived from the file itself rather than generated, which keeps indexing
+// keyless, offline and free — a corpus of ten thousand passages costs
+// nothing to situate, and there is no provider to be down.
+//
+// What the model reads is unchanged: the header rides on the indexed text
+// only, so retrieved passages and their line-range citations stay exactly
+// what they were.
+
+// situatedMetaKey tags contexts whose passages carry a situating header,
+// so existing corpora keep the vectors they already paid for and only
+// contexts created or refreshed after this shipped are indexed with it.
+const (
+	situatedMetaKey = "situated"
+	situatedV1      = "v1"
+)
+
+// Situated reports whether this context's passages should be indexed with
+// a situating header.
+func Situated(fc *FileContext) bool {
+	return fc != nil && fc.Metadata != nil && fc.Metadata[situatedMetaKey] == situatedV1
+}
+
+// situate fills in the Context header of every passage of a file.
+//
+// The header names the file and, when the passage does not open with one
+// itself, the nearest structural line above it — a markdown heading, a
+// declaration. Passages that already begin at a boundary say so by their
+// own first line and take the file alone.
+func situate(segs []Segment, lines []string) {
+	for i := range segs {
+		segs[i].Context = situatingHeader(segs[i], lines)
+	}
+}
+
+// situatingHeader builds one passage's header.
+func situatingHeader(s Segment, lines []string) string {
+	parts := []string{filepath.Base(s.FilePath)}
+	if dir := filepath.Dir(s.FilePath); dir != "." && dir != string(filepath.Separator) && dir != "" {
+		parts[0] = s.FilePath
+	}
+	if enclosing := enclosingStructure(lines, s.StartLine, s.FileType); enclosing != "" {
+		parts = append(parts, enclosing)
+	}
+	return strings.Join(parts, " — ")
+}
+
+// enclosingStructure walks up from a passage's first line to the nearest
+// line that opens a structure, and returns it trimmed to one readable
+// phrase. Empty when the passage already starts on one, or when nothing
+// above it qualifies.
+func enclosingStructure(lines []string, startLine int, fileType string) string {
+	idx := startLine - 1 // StartLine is 1-based
+	if idx < 0 || idx >= len(lines) {
+		return ""
+	}
+	if boundaryScore(lines[idx], fileType) >= 3 {
+		return "" // the passage opens with its own structure
+	}
+	for i := idx - 1; i >= 0 && idx-i <= situateLookback; i-- {
+		if boundaryScore(lines[i], fileType) >= 3 {
+			return trimStructureLine(lines[i])
+		}
+	}
+	return ""
+}
+
+// situateLookback bounds how far above a passage the search goes. Far
+// enough to find the function or heading it sits in, short enough that a
+// passage in a long flat file is not labeled with something unrelated.
+const situateLookback = 400
+
+// trimStructureLine reduces a declaration or heading to the part worth
+// indexing: no leading markers, no trailing brace, one line, bounded.
+func trimStructureLine(line string) string {
+	t := strings.TrimSpace(line)
+	t = strings.TrimLeft(t, "#")
+	t = strings.TrimSpace(t)
+	t = strings.TrimSuffix(t, "{")
+	t = strings.TrimSpace(t)
+	if len(t) > situateHeaderMax {
+		cut := t[:situateHeaderMax]
+		if i := strings.LastIndex(cut, " "); i > situateHeaderMax/2 {
+			cut = cut[:i]
+		}
+		t = cut
+	}
+	return t
+}
+
+const situateHeaderMax = 120
+
+// IndexText is the text a passage is indexed and embedded by: the
+// situating header, when it has one, and then the passage itself. Callers
+// that render a passage for the model use Content instead — the header
+// exists to be matched against, not to be read back.
+func (s Segment) IndexText() string {
+	if s.Context == "" {
+		return s.Content
+	}
+	return s.Context + "\n" + s.Content
+}

--- a/cli/ctxmgr/situate_test.go
+++ b/cli/ctxmgr/situate_test.go
@@ -1,0 +1,126 @@
+package ctxmgr
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/utils"
+)
+
+func goFile(path, body string) utils.FileInfo {
+	return utils.FileInfo{Path: path, Type: ".go", Content: body}
+}
+
+// A passage cut from the middle of a file used to reach the index saying
+// nothing about where it came from. Retrieval then had to match on the
+// passage's own words alone.
+func TestPassageCarriesItsFileAndEnclosingStructure(t *testing.T) {
+	body := "package auth\n\n" +
+		"func ValidateToken(raw string) error {\n" +
+		strings.Repeat("\t// reasoning about the token\n", 60) +
+		"\treturn nil\n}\n"
+	segs := SegmentFiles([]utils.FileInfo{goFile("auth/token.go", body)},
+		SegmentOptions{MaxChars: 400, Situate: true, Boundaries: true})
+
+	if len(segs) < 2 {
+		t.Fatalf("want the file split into several passages, got %d", len(segs))
+	}
+	// A later passage — the one that used to arrive anonymous.
+	tail := segs[len(segs)-1]
+	if !strings.Contains(tail.Context, "auth/token.go") {
+		t.Errorf("passage must name its file, got %q", tail.Context)
+	}
+	if !strings.Contains(tail.Context, "ValidateToken") {
+		t.Errorf("passage must name the declaration enclosing it, got %q", tail.Context)
+	}
+	// The header is indexed, never rendered.
+	if strings.Contains(tail.Content, "auth/token.go") {
+		t.Error("the header must not be written into the passage content")
+	}
+	if !strings.HasPrefix(tail.IndexText(), tail.Context) {
+		t.Error("IndexText must lead with the header")
+	}
+	if !strings.HasSuffix(tail.IndexText(), tail.Content) {
+		t.Error("IndexText must end with the passage itself")
+	}
+}
+
+// Opting in is per corpus, so existing indexes keep the vectors they paid
+// for.
+func TestSituatingIsOptIn(t *testing.T) {
+	body := "package x\n\nfunc F() {\n" + strings.Repeat("\t// line\n", 40) + "}\n"
+	off := SegmentFiles([]utils.FileInfo{goFile("x/f.go", body)}, SegmentOptions{MaxChars: 400})
+	for _, s := range off {
+		if s.Context != "" {
+			t.Fatalf("a corpus that did not opt in must carry no header: %q", s.Context)
+		}
+		if s.IndexText() != s.Content {
+			t.Fatal("IndexText must equal Content when there is no header")
+		}
+	}
+}
+
+// Passage ids are content hashes and must not move: an opted-in corpus
+// re-embeds because its indexed text changed, but the ids it prunes and
+// upserts by stay the same.
+func TestSituatingDoesNotChangePassageIDs(t *testing.T) {
+	body := "package x\n\nfunc F() {\n" + strings.Repeat("\t// line\n", 40) + "}\n"
+	files := []utils.FileInfo{goFile("x/f.go", body)}
+	off := SegmentFiles(files, SegmentOptions{MaxChars: 400})
+	on := SegmentFiles(files, SegmentOptions{MaxChars: 400, Situate: true})
+	if len(off) != len(on) {
+		t.Fatalf("segment count changed: %d vs %d", len(off), len(on))
+	}
+	for i := range off {
+		if off[i].ID != on[i].ID {
+			t.Errorf("passage %d id changed with situating: %s vs %s", i, off[i].ID, on[i].ID)
+		}
+		if off[i].Content != on[i].Content {
+			t.Errorf("passage %d content changed with situating", i)
+		}
+	}
+}
+
+func TestMarkdownPassageCarriesItsHeading(t *testing.T) {
+	body := "# Guide\n\n## Installing the operator\n\n" + strings.Repeat("Some prose about it.\n", 40)
+	segs := SegmentFiles([]utils.FileInfo{{Path: "docs/guide.md", Type: ".md", Content: body}},
+		SegmentOptions{MaxChars: 300, Situate: true, Boundaries: true})
+	var found bool
+	for _, s := range segs {
+		if strings.Contains(s.Context, "Installing the operator") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("a passage under a heading must carry it; headers were %v", contextsOf(segs))
+	}
+}
+
+// A passage that opens with its own structure says so by its first line.
+func TestPassageOpeningOnAStructureTakesTheFileAlone(t *testing.T) {
+	lines := []string{"package x", "", "func F() {", "\treturn", "}"}
+	if got := enclosingStructure(lines, 3, ".go"); got != "" {
+		t.Errorf("a passage starting on a declaration needs no enclosing one, got %q", got)
+	}
+}
+
+func TestStructureLineIsTrimmedToOnePhrase(t *testing.T) {
+	if got := trimStructureLine("## Installing the operator"); got != "Installing the operator" {
+		t.Errorf("heading markers must go, got %q", got)
+	}
+	if got := trimStructureLine("func VeryLongName(a, b, c string) error {"); strings.HasSuffix(got, "{") {
+		t.Errorf("a trailing brace must go, got %q", got)
+	}
+	long := "func " + strings.Repeat("x", 300) + "()"
+	if got := trimStructureLine(long); len(got) > situateHeaderMax+4 {
+		t.Errorf("a long declaration must be bounded, got %d chars", len(got))
+	}
+}
+
+func contextsOf(segs []Segment) []string {
+	out := make([]string, 0, len(segs))
+	for _, s := range segs {
+		out = append(out, s.Context)
+	}
+	return out
+}


### PR DESCRIPTION
Audit IV, PR 9 — closes RAG-1 (P1).

## The defect

A passage cut from the middle of a file reached the index saying nothing about where it came from: not the file, not the section, not the declaration around it. Retrieval then matched on the passage's own words alone, so a query naming the file or the function it is about ranked that passage no higher than any other. That is the failure the hybrid stack exists to avoid, and it is where `@knowledge` recall lost to a manual grep.

## What changes

Each passage carries a short header — the file it belongs to, and the nearest structure enclosing it:

```
cli/ctxmgr/retrieval.go — func (e *RetrievalEngine) buildEntry(fc *FileContext, fp string) *lexCacheEntry
docs/guide.md — Installing the operator
```

The enclosing structure is found by walking up to the first line the segmenter *already* recognises as a boundary, so headings and declarations are detected by the same rule the boundary-aware cut uses. A passage that opens on one of those says so by its own first line and takes the file alone.

## Derived, not generated

The published technique asks a model to write a situating sentence per passage. That costs one call per passage, needs a provider to be up, and cannot run offline — against a stack whose retrieval is otherwise keyless by design.

The file and the enclosing structure are the part of that sentence retrieval actually matches on, and reading them costs nothing: a corpus of ten thousand passages is situated for free, offline, with no provider to be down. If a generated sentence is ever wanted on top, this header is where it would attach.

## Three invariants held

- **The header is indexed, never rendered.** It joins the text the passage is embedded and BM25-indexed by (`IndexText()`); the passage content, its line range and its citations are byte-identical to before.
- **Passage ids do not move.** They stay content hashes of the body alone, so an opted-in corpus re-embeds without its ids changing — pruning and upserting still line up.
- **Opting in is per corpus**, tagged the way the boundary-aware segmenter was, so existing indexes keep the vectors they already paid for. A `/context refresh` moves a corpus into the new shape.

## Provider and platform coverage

Indexing-side only: it changes what every provider's embedder and the local BM25 index receive, so all of them benefit with no per-provider work, and it needs no provider at all to compute. `filepath` throughout — identical on Windows, Linux and macOS.

## No new environment variable

The opt-in is the corpus tag, like the segmenter before it. Nothing to configure.

## Verification

- Full suite green, `golangci-lint --new-from-rev=main` clean, Floor 4 clean, Floor 13 clean.
- New tests: a mid-file passage names its file and its enclosing declaration; a markdown passage names its heading; the header never enters the content and `IndexText` brackets it correctly; a corpus that did not opt in carries no header and indexes exactly its content; ids and content are identical with and without situating; a passage opening on a declaration needs no enclosing one; structure lines are trimmed of markers, trailing braces and length.
