### PR TITLE
feat(agent): a run under a spending ceiling tells the model how much room is left

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -931,6 +931,15 @@ func (a *AgentMode) clientAndCtxForTurn(ctx context.Context) (llmclient.LLMClien
 	} else if a.skillEffortHint != llmclient.EffortUnset {
 		ctx = llmclient.WithEffortHint(ctx, a.skillEffortHint)
 	}
+	// A run under a spending ceiling tells the model how much room is
+	// left, so a long task winds down instead of being cut off mid-step
+	// when the hard stop fires. Nothing is attached when there is no
+	// ceiling, or too little left to state.
+	if a.cli != nil && a.cli.costTracker != nil {
+		if tokens, ok := a.cli.costTracker.RemainingTaskBudgetTokens(); ok {
+			ctx = llmclient.WithTaskBudget(ctx, llmclient.AnthropicTaskBudget(tokens))
+		}
+	}
 	return turnClient, ctx
 }
 

--- a/cli/cost_task_budget.go
+++ b/cli/cost_task_budget.go
@@ -1,0 +1,100 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+// Turning a spending ceiling into something the model can pace against.
+//
+// ChatCLI's budgets are money: a session limit, a daily limit, and a hard
+// stop that refuses the next turn once either is exhausted. That works,
+// and it is invisible to the model — a long run is cut off mid-task with
+// no chance to wind down, and the partial work is lost.
+//
+// The provider's task budget is the other half: a token ceiling the model
+// reads while generating, so it paces itself and finishes cleanly. The two
+// are in different units, and inventing a conversion factor would hand the
+// model a number that is confidently wrong.
+//
+// So the conversion is measured, not guessed. The session already records
+// what it spent and how many completion tokens it produced; their ratio is
+// this session's own cost per output token, on its own models, with its
+// own cache behavior. Remaining dollars divided by that ratio is how many
+// more tokens this session can afford to generate — derived from what
+// actually happened rather than from a price table and an assumption
+// about the shape of the next turn.
+//
+// Advisory by construction: the budget only ever tells the model roughly
+// how much room is left. The hard stop remains the thing that enforces.
+
+// taskBudgetMinTokens is the provider's floor for a task budget. Below it
+// there is nothing meaningful to say, so nothing is sent — a run that
+// close to its ceiling is about to be stopped anyway.
+const taskBudgetMinTokens = 20000
+
+// remainingBudgetUSD is what is left before the nearer of the two limits
+// stops the run. Reports false when no limit is configured, or when the
+// hard stop is not armed: without it the budget is a notice rather than a
+// ceiling, and there is nothing for the model to pace against.
+func (ct *CostTracker) remainingBudgetUSD() (float64, bool) {
+	ct.mu.RLock()
+	defer ct.mu.RUnlock()
+	if !ct.budgetHardStop {
+		return 0, false
+	}
+	remaining, ok := 0.0, false
+	if ct.budgetLimitUSD > 0 {
+		remaining, ok = ct.budgetLimitUSD-ct.totalCostUSD, true
+	}
+	if ct.dailyLimitUSD > 0 {
+		daily := ct.dailyLimitUSD - ct.dailySpentUSD
+		if !ok || daily < remaining {
+			remaining, ok = daily, true
+		}
+	}
+	if !ok || remaining <= 0 {
+		return 0, false
+	}
+	return remaining, true
+}
+
+// costPerCompletionToken is what this session has actually paid, per token
+// it generated. Reports false until the session has produced enough of
+// both to make the ratio meaningful.
+func (ct *CostTracker) costPerCompletionToken() (float64, bool) {
+	ct.mu.RLock()
+	defer ct.mu.RUnlock()
+	if ct.totalCompletionTokens < taskBudgetMinSampleTokens || ct.totalCostUSD <= 0 {
+		return 0, false
+	}
+	return ct.totalCostUSD / float64(ct.totalCompletionTokens), true
+}
+
+// taskBudgetMinSampleTokens is how much the session must have generated
+// before its own cost ratio is worth extrapolating from. A handful of
+// tokens on a cache-cold first turn is not a rate.
+const taskBudgetMinSampleTokens = 2000
+
+// RemainingTaskBudgetTokens converts the remaining spend into the token
+// ceiling a task budget carries. Reports false when there is no ceiling to
+// express, no measured rate to convert with, or so little room left that
+// the provider's floor would reject it.
+func (ct *CostTracker) RemainingTaskBudgetTokens() (int, bool) {
+	if ct == nil {
+		return 0, false
+	}
+	remainingUSD, ok := ct.remainingBudgetUSD()
+	if !ok {
+		return 0, false
+	}
+	perToken, ok := ct.costPerCompletionToken()
+	if !ok {
+		return 0, false
+	}
+	tokens := int(remainingUSD / perToken)
+	if tokens < taskBudgetMinTokens {
+		return 0, false
+	}
+	return tokens, true
+}

--- a/cli/cost_task_budget_test.go
+++ b/cli/cost_task_budget_test.go
@@ -1,0 +1,101 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+)
+
+func trackerSpending(t *testing.T, limitUSD float64, hardStop bool, completionTokens int, costUSD float64) *CostTracker {
+	t.Helper()
+	ct := NewCostTrackerAt(t.TempDir())
+	ct.mu.Lock()
+	ct.budgetLimitUSD = limitUSD
+	ct.budgetHardStop = hardStop
+	ct.totalCompletionTokens = int64(completionTokens)
+	ct.totalCostUSD = costUSD
+	ct.mu.Unlock()
+	return ct
+}
+
+// The conversion is measured: remaining dollars over this session's own
+// cost per generated token. A price table and an assumption about the next
+// turn would hand the model a number that is confidently wrong.
+func TestTaskBudgetComesFromMeasuredSpend(t *testing.T) {
+	// $10 limit, $2 spent producing 100k tokens → $0.00002/token,
+	// $8 left → 400k tokens of room.
+	ct := trackerSpending(t, 10, true, 100_000, 2)
+	tokens, ok := ct.RemainingTaskBudgetTokens()
+	if !ok {
+		t.Fatal("a session with a ceiling and a measured rate must produce a budget")
+	}
+	if tokens < 390_000 || tokens > 410_000 {
+		t.Errorf("budget = %d, want about 400000", tokens)
+	}
+}
+
+// Without the hard stop the budget is a notice, not a ceiling, and there
+// is nothing for the model to pace against.
+func TestNoBudgetWithoutAHardStop(t *testing.T) {
+	ct := trackerSpending(t, 10, false, 100_000, 2)
+	if _, ok := ct.RemainingTaskBudgetTokens(); ok {
+		t.Error("a soft budget must not be sent as a task budget")
+	}
+}
+
+func TestNoBudgetWithoutALimit(t *testing.T) {
+	ct := trackerSpending(t, 0, true, 100_000, 2)
+	if _, ok := ct.RemainingTaskBudgetTokens(); ok {
+		t.Error("no configured limit means no ceiling to express")
+	}
+}
+
+// A handful of tokens on a cache-cold first turn is not a rate.
+func TestNoBudgetBeforeThereIsARate(t *testing.T) {
+	ct := trackerSpending(t, 10, true, 100, 0.01)
+	if _, ok := ct.RemainingTaskBudgetTokens(); ok {
+		t.Error("too few samples must not be extrapolated from")
+	}
+}
+
+// Below the provider's floor there is nothing meaningful to say, and the
+// run is about to be stopped anyway.
+func TestNoBudgetBelowTheProviderFloor(t *testing.T) {
+	// $0.10 left at $0.00002/token → 5000 tokens, under the 20000 floor.
+	ct := trackerSpending(t, 2.10, true, 100_000, 2)
+	if _, ok := ct.RemainingTaskBudgetTokens(); ok {
+		t.Error("a budget under the provider floor must not be sent")
+	}
+}
+
+func TestExhaustedBudgetSendsNothing(t *testing.T) {
+	ct := trackerSpending(t, 2, true, 100_000, 2)
+	if _, ok := ct.RemainingTaskBudgetTokens(); ok {
+		t.Error("an exhausted budget has no room to report")
+	}
+}
+
+// The daily limit counts too, and the nearer of the two wins.
+func TestTheNearerLimitWins(t *testing.T) {
+	ct := trackerSpending(t, 100, true, 100_000, 2)
+	ct.mu.Lock()
+	ct.dailyLimitUSD = 3
+	ct.dailySpentUSD = 2
+	ct.mu.Unlock()
+	tokens, ok := ct.RemainingTaskBudgetTokens()
+	if !ok {
+		t.Fatal("a daily ceiling must produce a budget")
+	}
+	// $1 left daily, not $98 session.
+	if tokens > 60_000 {
+		t.Errorf("budget = %d, want the daily remainder (about 50000)", tokens)
+	}
+}
+
+func TestNilTrackerIsSafe(t *testing.T) {
+	var ct *CostTracker
+	if _, ok := ct.RemainingTaskBudgetTokens(); ok {
+		t.Error("a session without cost tracking has no budget to report")
+	}
+	_ = models.UsageInfo{}
+}

--- a/llm/catalog/catalog.go
+++ b/llm/catalog/catalog.go
@@ -389,7 +389,7 @@ var registry = []ModelMeta{
 		Capabilities: []string{
 			"vision",
 			"json_mode", "tools",
-			"adaptive_thinking", "output_effort", "mid_conversation_system",
+			"adaptive_thinking", "output_effort", "task_budget", "mid_conversation_system",
 		},
 	},
 	{
@@ -417,7 +417,7 @@ var registry = []ModelMeta{
 		Capabilities: []string{
 			"vision",
 			"json_mode", "tools",
-			"adaptive_thinking", "output_effort", "mid_conversation_system",
+			"adaptive_thinking", "output_effort", "task_budget", "mid_conversation_system",
 		},
 	},
 	{
@@ -440,7 +440,7 @@ var registry = []ModelMeta{
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
 		APIVersion:      config.ClaudeAIAPIVersionDefault,
-		Capabilities:    []string{"vision", "json_mode", "tools", "adaptive_thinking", "output_effort"},
+		Capabilities:    []string{"vision", "json_mode", "tools", "adaptive_thinking", "output_effort", "task_budget"},
 	},
 	{
 		// Sonnet 5 (claude-sonnet-5, Jun 2026): the Sonnet-tier successor —
@@ -462,14 +462,14 @@ var registry = []ModelMeta{
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
 		APIVersion:      config.ClaudeAIAPIVersionDefault,
-		Capabilities:    []string{"vision", "json_mode", "tools", "adaptive_thinking", "output_effort"},
+		Capabilities:    []string{"vision", "json_mode", "tools", "adaptive_thinking", "output_effort", "task_budget"},
 	},
 	{
 		// Opus 4.8 (claude-opus-4-8, May 28 2026): 1M context by default on
 		// the Claude API, 128K max output. Same API constraints as 4.7
 		// (no temperature/top_p/top_k; adaptive thinking only — extended
 		// thinking budgets return 400). New capabilities at launch:
-		//   - "adaptive_thinking", "output_effort": only supported thinking mode
+		//   - "adaptive_thinking", "output_effort", "task_budget": only supported thinking mode
 		//   - "fast_mode": research-preview "speed":"fast" for ~2.5x output
 		//     tokens per second at premium pricing
 		//   - "mid_conversation_system": role:"system" messages accepted
@@ -490,7 +490,7 @@ var registry = []ModelMeta{
 		Capabilities: []string{
 			"vision",
 			"json_mode", "tools",
-			"adaptive_thinking", "output_effort", "fast_mode",
+			"adaptive_thinking", "output_effort", "task_budget", "fast_mode",
 			"mid_conversation_system", "low_cache_minimum",
 		},
 	},
@@ -508,7 +508,7 @@ var registry = []ModelMeta{
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
 		APIVersion:      config.ClaudeAIAPIVersionDefault,
-		Capabilities:    []string{"vision", "json_mode", "tools", "adaptive_thinking", "output_effort"},
+		Capabilities:    []string{"vision", "json_mode", "tools", "adaptive_thinking", "output_effort", "task_budget"},
 	},
 	// There is no Sonnet 4.7: Anthropic went from Sonnet 4.6 straight to
 	// Sonnet 5. The forward-projected placeholder that used to sit here
@@ -1330,7 +1330,7 @@ var registry = []ModelMeta{
 		ContextWindow:   1000000,
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking", "output_effort", "bedrock_mantle_only"},
+		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking", "output_effort", "task_budget", "bedrock_mantle_only"},
 	},
 	// Fable 5 (Jun 9 2026). Dateless ID per Anthropic's Bedrock docs —
 	// Fable 5, Opus 4.8 and Opus 4.7 have NO ARN-versioned model IDs on
@@ -1350,7 +1350,7 @@ var registry = []ModelMeta{
 		ContextWindow:   1000000,
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking", "output_effort", "bedrock_mantle_only"},
+		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking", "output_effort", "task_budget", "bedrock_mantle_only"},
 	},
 	// Opus 5 (Jul 2026). Like Sonnet 5 and Fable 5, served through the
 	// Claude-in-Amazon-Bedrock Messages endpoint (the models overview lists
@@ -1365,7 +1365,7 @@ var registry = []ModelMeta{
 		ContextWindow:   1000000,
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking", "output_effort", "bedrock_mantle_only"},
+		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking", "output_effort", "task_budget", "bedrock_mantle_only"},
 	},
 	// Sonnet 5 (Jun 2026). Served EXCLUSIVELY by the Claude-in-Amazon-
 	// Bedrock Messages endpoint (bedrock-mantle.{region}.api.aws) — it has
@@ -1380,7 +1380,7 @@ var registry = []ModelMeta{
 		ContextWindow:   1000000,
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking", "output_effort", "bedrock_mantle_only"},
+		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking", "output_effort", "task_budget", "bedrock_mantle_only"},
 	},
 	// Claude 4.8 (May 28 2026). Opus 4.8 = 1M / 128K per Anthropic.
 	// Canonical id is the global. inference profile: the bare dateless id
@@ -1403,7 +1403,7 @@ var registry = []ModelMeta{
 		PreferredAPI:    APIAnthropicMessages,
 		Capabilities: []string{
 			"tools", "vision", "json_mode",
-			"adaptive_thinking", "output_effort", "low_cache_minimum",
+			"adaptive_thinking", "output_effort", "task_budget", "low_cache_minimum",
 		},
 	},
 
@@ -1423,7 +1423,7 @@ var registry = []ModelMeta{
 		ContextWindow:   1000000,
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking", "output_effort"},
+		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking", "output_effort", "task_budget"},
 	},
 
 	// Claude 4.6 (abr 2026). Bedrock specs follow the AWS model cards:

--- a/llm/claudeai/claude_client.go
+++ b/llm/claudeai/claude_client.go
@@ -249,6 +249,7 @@ func applyThinkingForEffort(reqBody map[string]interface{}, model string, ctx co
 		catalog.HasCapability(catalog.ProviderClaudeAI, model, "output_effort") {
 		reqBody["output_config"] = cfg
 	}
+	applyTaskBudget(reqBody, model, ctx)
 	if usesAdaptiveThinkingOnly(model) {
 		reqBody["thinking"] = map[string]interface{}{"type": "adaptive"}
 		return true
@@ -726,6 +727,7 @@ func (c *ClaudeClient) sendOAuthTitleRequest(ctx context.Context, userText strin
 // Anthropic Messages API for the active credential mode. The token argument
 // is the raw access token (no "oauth:"/"token:"/"apikey:" prefix).
 func (c *ClaudeClient) applyAuthHeaders(req *http.Request, token string) {
+	defer applyTaskBudgetBeta(req)
 	switch c.provider.Mode() {
 	case auth.AuthModeOAuth:
 		applyOAuthHeaders(req, token)
@@ -752,6 +754,16 @@ func applyExtendedCacheTTLBeta(req *http.Request) {
 	}
 	if client.ProviderCompactionEngine() {
 		addAnthropicBeta(req, client.CompactionBeta)
+	}
+}
+
+// applyTaskBudgetBeta adds the task-budget beta when this turn carries a
+// budget. Read from the request's own context rather than from the body,
+// so it holds on every auth mode without threading the payload through
+// the header helpers.
+func applyTaskBudgetBeta(req *http.Request) {
+	if client.TaskBudgetFromContext(req.Context()) != nil {
+		addAnthropicBeta(req, client.TaskBudgetBeta)
 	}
 }
 
@@ -980,4 +992,26 @@ func streamErrorToAPIError(errType, message string) error {
 		message = errType
 	}
 	return &utils.APIError{StatusCode: status, Message: utils.SanitizeSensitiveText(errType + ": " + message)}
+}
+
+// applyTaskBudget attaches the task budget to output_config when the run
+// has a spending ceiling to pace against and the model reads one.
+//
+// output_config may already carry the effort level, so the block is merged
+// rather than assigned: the two are independent settings that share a
+// field. The budget travels as a typed value, which is why the map is
+// built as interface-valued here.
+func applyTaskBudget(reqBody map[string]interface{}, model string, ctx context.Context) bool {
+	budget := client.TaskBudgetFromContext(ctx)
+	if budget == nil || !catalog.HasCapability(catalog.ProviderClaudeAI, model, "task_budget") {
+		return false
+	}
+	cfg, _ := reqBody["output_config"].(map[string]string)
+	merged := make(map[string]interface{}, len(cfg)+1)
+	for k, v := range cfg {
+		merged[k] = v
+	}
+	merged["task_budget"] = budget
+	reqBody["output_config"] = merged
+	return true
 }

--- a/llm/claudeai/task_budget_test.go
+++ b/llm/claudeai/task_budget_test.go
@@ -1,0 +1,62 @@
+package claudeai
+
+import (
+	"context"
+	"testing"
+
+	"github.com/diillson/chatcli/llm/client"
+)
+
+// output_config already carries the effort level, so the budget merges
+// into it rather than replacing it — two independent settings sharing one
+// field.
+func TestTaskBudgetMergesWithEffort(t *testing.T) {
+	ctx := client.WithEffortHint(context.Background(), client.EffortXHigh)
+	ctx = client.WithTaskBudget(ctx, client.AnthropicTaskBudget(64000))
+
+	body := map[string]interface{}{"max_tokens": 4096}
+	applyThinkingForEffort(body, "claude-opus-5", ctx)
+
+	cfg, ok := body["output_config"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("output_config missing or wrong shape: %+v", body["output_config"])
+	}
+	if cfg["effort"] != "xhigh" {
+		t.Errorf("the effort level must survive the merge: %+v", cfg)
+	}
+	budget, ok := cfg["task_budget"].(*client.TaskBudget)
+	if !ok {
+		t.Fatalf("task_budget missing: %+v", cfg)
+	}
+	if budget.Type != "tokens" || budget.Total != 64000 || budget.Remaining != 64000 {
+		t.Errorf("task_budget = %+v", budget)
+	}
+}
+
+// A model that does not read the field must not be sent it.
+func TestTaskBudgetOnlyForModelsThatReadIt(t *testing.T) {
+	ctx := client.WithTaskBudget(context.Background(), client.AnthropicTaskBudget(64000))
+	body := map[string]interface{}{"max_tokens": 4096}
+	if applyTaskBudget(body, "claude-sonnet-4-5", ctx) {
+		t.Error("a model without the capability must not carry a task budget")
+	}
+	if _, present := body["output_config"]; present {
+		t.Errorf("nothing should have been written: %+v", body)
+	}
+}
+
+func TestNoTaskBudgetWithoutOne(t *testing.T) {
+	body := map[string]interface{}{"max_tokens": 4096}
+	if applyTaskBudget(body, "claude-opus-5", context.Background()) {
+		t.Error("a turn with no budget must send none")
+	}
+}
+
+func TestAnthropicTaskBudgetRejectsNothingToSay(t *testing.T) {
+	if b := client.AnthropicTaskBudget(0); b != nil {
+		t.Errorf("an empty budget must be nil, got %+v", b)
+	}
+	if b := client.AnthropicTaskBudget(-1); b != nil {
+		t.Errorf("a negative budget must be nil, got %+v", b)
+	}
+}

--- a/llm/client/cache_prefix.go
+++ b/llm/client/cache_prefix.go
@@ -34,6 +34,32 @@ const ContextEngineEnv = "CHATCLI_CONTEXT_ENGINE"
 // ContextManagementBeta is the Anthropic beta that enables context editing.
 const ContextManagementBeta = "context-management-2025-06-27"
 
+// TaskBudgetBeta is the Anthropic beta that enables the task budget: a
+// token ceiling the model reads while generating, so it paces itself
+// instead of being cut off mid-task.
+const TaskBudgetBeta = "task-budgets-2026-03-13"
+
+// TaskBudget is the output_config.task_budget block.
+type TaskBudget struct {
+	Type string `json:"type"`
+	// Total is the ceiling for the whole task.
+	Total int `json:"total"`
+	// Remaining is how much of it is left. Sent because ChatCLI rewrites
+	// history when it compacts, and a server that cannot see the earlier
+	// turns cannot derive the spend itself.
+	Remaining int `json:"remaining"`
+}
+
+// AnthropicTaskBudget builds the task-budget block for a run with the
+// given number of tokens left to spend. Nil when there is nothing to say,
+// so callers can assign it without a check.
+func AnthropicTaskBudget(remainingTokens int) *TaskBudget {
+	if remainingTokens <= 0 {
+		return nil
+	}
+	return &TaskBudget{Type: "tokens", Total: remainingTokens, Remaining: remainingTokens}
+}
+
 // CompactionBeta is the Anthropic beta that enables server-side
 // compaction, where the API summarizes the older conversation itself
 // instead of the client spending a turn on a summarizer.

--- a/llm/client/skill_hints.go
+++ b/llm/client/skill_hints.go
@@ -134,3 +134,28 @@ func AnthropicOutputConfig(e SkillEffort) map[string]string {
 	}
 	return map[string]string{"effort": level}
 }
+
+// The task budget travels the same way the effort hint does: attached to
+// the turn's context by the caller that knows the run's ceiling, read by
+// whichever provider adapter serves the turn. Providers that do not
+// understand it ignore the value, so nothing has to know who is on the
+// other end.
+
+type taskBudgetCtxKey struct{}
+
+// WithTaskBudget attaches a task budget to ctx for one turn.
+func WithTaskBudget(ctx context.Context, budget *TaskBudget) context.Context {
+	if budget == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, taskBudgetCtxKey{}, budget)
+}
+
+// TaskBudgetFromContext returns the turn's task budget, or nil.
+func TaskBudgetFromContext(ctx context.Context) *TaskBudget {
+	if ctx == nil {
+		return nil
+	}
+	b, _ := ctx.Value(taskBudgetCtxKey{}).(*TaskBudget)
+	return b
+}


### PR DESCRIPTION
Audit IV, PR 10 — closes CMP-6 (P2).

## The defect

ChatCLI's budgets are money: a session limit, a daily limit, and a hard stop that refuses the next turn once either is exhausted. It works, and it is invisible to the model — a long coder run gets cut off mid-step with no chance to wind down, and the partial work is lost.

The provider's task budget is the other half of that: a token ceiling the model reads while generating, so it paces itself and closes out cleanly.

## The part worth reading

The two are in different units. Inventing a conversion — a price table, an assumed input/output ratio for the next turn — hands the model a number that is confidently wrong, which is worse than saying nothing.

So it is **measured**. The session already records what it spent and how many tokens it generated. Their ratio is this session's own cost per output token, on its own models, with its own cache behavior. Remaining dollars over that ratio is how many more tokens it can afford to generate, derived from what actually happened rather than from an assumption about what comes next.

Nothing is sent when there is nothing to say:

- no configured limit — there is no ceiling to express;
- no hard stop — a soft budget is a notice, not a ceiling, and there is nothing to pace against;
- fewer than 2,000 generated tokens — a handful on a cache-cold first turn is not a rate;
- less room than the provider's own 20,000-token floor — the run is about to be stopped anyway.

## Wiring

The budget rides on the turn's context the way the effort hint already does, so no adapter has to know who is on the other end. On the Anthropic path it **merges into `output_config`** beside the effort level rather than replacing it — two independent settings sharing one field — and carries `remaining` explicitly, because compaction rewrites the history a server would otherwise derive the spend from. The beta flag is added from the request's own context, so it holds on every auth mode without threading the payload through the header helpers.

Gated by a `task_budget` catalog capability rather than reusing `output_effort`: they cover the same models today and the API documents them as separate model sets, so they will diverge.

Advisory by construction — the hard stop remains the thing that enforces.

## Portability

Request shaping and arithmetic. Identical on Windows, Linux and macOS.

## No new environment variable

It reads the budget the session already has (`CHATCLI_BUDGET_HARD_STOP` and the limits).

## Verification

- Full suite green, `golangci-lint --new-from-rev=main` clean, Floor 4 clean, Floor 13 clean.
- New tests: a session with a ceiling and a measured rate produces a budget of the expected size; a soft budget, no limit, too few samples, an exhausted budget and one under the provider floor each send nothing; the nearer of the session and daily limits wins; a nil tracker is safe; the budget merges with the effort level instead of replacing it; a model without the capability is not sent one; an empty or negative budget is nil.
