### PR TITLE
feat(llm): xAI and MiniMax count their own tokens

### DIFF
--- a/llm/minimax/count_tokens.go
+++ b/llm/minimax/count_tokens.go
@@ -1,0 +1,117 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * MiniMax token counting (POST /v1/responses/input_tokens): the endpoint
+ * takes the same request the model would answer and returns how many input
+ * tokens it counts, without running it.
+ *
+ * Only on the native surface. With MINIMAX_API_COMPAT set the client
+ * speaks another vendor's schema against another base URL, and this
+ * endpoint is not part of that contract — the capability reports absent
+ * there rather than guessing.
+ */
+package minimax
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/diillson/chatcli/auth"
+	"github.com/diillson/chatcli/llm/client"
+	"github.com/diillson/chatcli/models"
+	"github.com/diillson/chatcli/utils"
+)
+
+const countTokensTimeout = 10 * time.Second
+
+var _ client.TokenCounter = (*MiniMaxClient)(nil)
+
+// countTokensURL derives the counting endpoint from the resolved chat
+// URL, so a custom base URL is honored.
+func (c *MiniMaxClient) countTokensURL() string {
+	base := strings.TrimSuffix(strings.TrimSuffix(c.apiURL, "/"), "/text/chatcompletion_v2")
+	base = strings.TrimSuffix(strings.TrimSuffix(base, "/"), "/chat/completions")
+	return base + "/responses/input_tokens"
+}
+
+// countInput shapes the conversation the way the endpoint takes it: the
+// same role/content items the Responses schema carries.
+func countInput(prompt string, history []models.Message) []map[string]string {
+	items := make([]map[string]string, 0, len(history)+1)
+	for _, msg := range history {
+		role := strings.ToLower(strings.TrimSpace(msg.Role))
+		if role != "system" && role != "user" && role != "assistant" {
+			role = "user"
+		}
+		items = append(items, map[string]string{"role": role, "content": msg.Content})
+	}
+	if p := strings.TrimSpace(prompt); p != "" &&
+		(len(history) == 0 || history[len(history)-1].Role != "user" || history[len(history)-1].Content != prompt) {
+		items = append(items, map[string]string{"role": "user", "content": prompt})
+	}
+	return items
+}
+
+// CountTokens implements client.TokenCounter.
+func (c *MiniMaxClient) CountTokens(ctx context.Context, prompt string, history []models.Message) (int, error) {
+	if c.anthropicCompat {
+		return 0, fmt.Errorf("input_tokens: not served on the compatibility surface")
+	}
+	items := countInput(prompt, history)
+	if len(items) == 0 {
+		return 0, nil
+	}
+	payload, err := json.Marshal(map[string]interface{}{"model": c.model, "input": items})
+	if err != nil {
+		return 0, err
+	}
+	opCtx, cancel := context.WithTimeout(ctx, countTokensTimeout)
+	defer cancel()
+
+	resp, err := auth.DoWithRefresh(opCtx, c.provider, func(token string) (*http.Response, error) {
+		req, reqErr := http.NewRequestWithContext(opCtx, http.MethodPost, c.countTokensURL(), utils.NewJSONReader(payload))
+		if reqErr != nil {
+			return nil, reqErr
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		return c.client.Do(req)
+	})
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	if err != nil {
+		return 0, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return 0, &utils.APIError{StatusCode: resp.StatusCode, Message: utils.SanitizeSensitiveText(string(body))}
+	}
+	var out struct {
+		InputTokens int `json:"input_tokens"`
+		BaseResp    *struct {
+			StatusCode int    `json:"status_code"`
+			StatusMsg  string `json:"status_msg"`
+		} `json:"base_resp"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		return 0, fmt.Errorf("input_tokens: unreadable response: %w", err)
+	}
+	// MiniMax reports application errors in base_resp with HTTP 200.
+	if out.BaseResp != nil && out.BaseResp.StatusCode != 0 {
+		return 0, fmt.Errorf("input_tokens: %s", utils.SanitizeSensitiveText(out.BaseResp.StatusMsg))
+	}
+	if out.InputTokens <= 0 {
+		return 0, fmt.Errorf("input_tokens: response carried no count")
+	}
+	return out.InputTokens, nil
+}

--- a/llm/minimax/count_tokens_test.go
+++ b/llm/minimax/count_tokens_test.go
@@ -1,0 +1,75 @@
+package minimax
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+func TestCountTokensReadsInputTokens(t *testing.T) {
+	var body map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/responses/input_tokens") {
+			t.Errorf("path = %q, want the counting endpoint", r.URL.Path)
+		}
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		_, _ = w.Write([]byte(`{"object":"response.input_tokens","input_tokens":1234}`))
+	}))
+	defer srv.Close()
+
+	c := NewMiniMaxClient(testProvider("k"), "MiniMax-M2.7", zap.NewNop(), 1, 0)
+	c.apiURL = srv.URL + "/v1/text/chatcompletion_v2"
+
+	n, err := c.CountTokens(context.Background(), "and now?",
+		[]models.Message{{Role: "system", Content: "be careful"}})
+	if err != nil {
+		t.Fatalf("CountTokens: %v", err)
+	}
+	if n != 1234 {
+		t.Errorf("count = %d, want the reported input_tokens", n)
+	}
+	items, _ := body["input"].([]interface{})
+	if len(items) != 2 {
+		t.Fatalf("want the history plus the prompt, got %+v", body["input"])
+	}
+}
+
+// MiniMax reports application errors inside base_resp with HTTP 200, so a
+// failure would otherwise read as a valid count.
+func TestCountTokensSurfacesBaseRespErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"base_resp":{"status_code":1004,"status_msg":"invalid api key"}}`))
+	}))
+	defer srv.Close()
+	c := NewMiniMaxClient(testProvider("k"), "MiniMax-M2.7", zap.NewNop(), 1, 0)
+	c.apiURL = srv.URL + "/v1/text/chatcompletion_v2"
+	if _, err := c.CountTokens(context.Background(), "hi", nil); err == nil {
+		t.Error("an application error must be reported, not counted")
+	}
+}
+
+// The compatibility surface speaks another vendor's schema against another
+// base URL; this endpoint is not part of that contract.
+func TestCountTokensAbsentOnTheCompatibilitySurface(t *testing.T) {
+	c := NewMiniMaxClient(testProvider("k"), "MiniMax-M2.7", zap.NewNop(), 1, 0)
+	c.anthropicCompat = true
+	if _, err := c.CountTokens(context.Background(), "hi", nil); err == nil {
+		t.Error("the capability must report absent rather than guess")
+	}
+}
+
+func TestCountTokensSkipsAnEmptyConversation(t *testing.T) {
+	c := NewMiniMaxClient(testProvider("k"), "MiniMax-M2.7", zap.NewNop(), 1, 0)
+	c.apiURL = "http://127.0.0.1:0/v1/text/chatcompletion_v2"
+	if n, err := c.CountTokens(context.Background(), "   ", nil); err != nil || n != 0 {
+		t.Errorf("an empty conversation costs nothing and calls nothing: %d, %v", n, err)
+	}
+}

--- a/llm/xai/count_tokens.go
+++ b/llm/xai/count_tokens.go
@@ -1,0 +1,122 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * xAI token counting (POST /v1/tokenize-text): the endpoint tokenizes a
+ * string and returns the tokens, so the count is the length of that array.
+ *
+ * It takes text rather than messages, so what is sent is the same
+ * conversation the chat call would carry, flattened the way the chat body
+ * flattens it. That makes the count an accurate measure of the prompt's
+ * text and a slight under-count of the request, which adds a few
+ * per-message framing tokens the endpoint never sees. The capability's
+ * contract allows for that: it calibrates and reports, and no budget
+ * decision depends on it.
+ */
+package xai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/diillson/chatcli/auth"
+	"github.com/diillson/chatcli/llm/client"
+	"github.com/diillson/chatcli/models"
+	"github.com/diillson/chatcli/utils"
+)
+
+const countTokensTimeout = 10 * time.Second
+
+var _ client.TokenCounter = (*XAIClient)(nil)
+
+// countTokensURL derives the tokenizer endpoint from the resolved chat
+// completions URL, so a custom base URL is honored.
+func (c *XAIClient) countTokensURL() string {
+	return strings.TrimSuffix(strings.TrimSuffix(c.apiURL, "/"), "/chat/completions") + "/tokenize-text"
+}
+
+// countText flattens the conversation the way the tokenizer takes it: one
+// string, roles included, because the role labels are billed too.
+func countText(prompt string, history []models.Message) string {
+	var b strings.Builder
+	for _, msg := range history {
+		role := strings.ToLower(strings.TrimSpace(msg.Role))
+		if role == "" {
+			role = "user"
+		}
+		b.WriteString(role)
+		b.WriteString(": ")
+		b.WriteString(msg.Content)
+		b.WriteString("\n")
+	}
+	if p := strings.TrimSpace(prompt); p != "" &&
+		(len(history) == 0 || history[len(history)-1].Role != "user" || history[len(history)-1].Content != prompt) {
+		b.WriteString("user: ")
+		b.WriteString(prompt)
+	}
+	return b.String()
+}
+
+// CountTokens implements client.TokenCounter.
+func (c *XAIClient) CountTokens(ctx context.Context, prompt string, history []models.Message) (int, error) {
+	text := countText(prompt, history)
+	if strings.TrimSpace(text) == "" {
+		return 0, nil
+	}
+	payload, err := json.Marshal(map[string]interface{}{"model": c.model, "text": text})
+	if err != nil {
+		return 0, err
+	}
+	opCtx, cancel := context.WithTimeout(ctx, countTokensTimeout)
+	defer cancel()
+
+	resp, err := auth.DoWithRefresh(opCtx, c.provider, func(token string) (*http.Response, error) {
+		req, reqErr := http.NewRequestWithContext(opCtx, http.MethodPost, c.countTokensURL(), utils.NewJSONReader(payload))
+		if reqErr != nil {
+			return nil, reqErr
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		return c.client.Do(req)
+	})
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return 0, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return 0, &utils.APIError{StatusCode: resp.StatusCode, Message: utils.SanitizeSensitiveText(string(body))}
+	}
+	var out struct {
+		TokenIDs []json.RawMessage `json:"token_ids"`
+		Tokens   []json.RawMessage `json:"tokens"`
+		Error    *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		return 0, fmt.Errorf("tokenize-text: unreadable response: %w", err)
+	}
+	if out.Error != nil && out.Error.Message != "" {
+		return 0, fmt.Errorf("tokenize-text: %s", utils.SanitizeSensitiveText(out.Error.Message))
+	}
+	// Both spellings are accepted: the count is the length either way, and
+	// a rename of the array would otherwise read as a zero-token prompt.
+	if n := len(out.TokenIDs); n > 0 {
+		return n, nil
+	}
+	if n := len(out.Tokens); n > 0 {
+		return n, nil
+	}
+	return 0, fmt.Errorf("tokenize-text: response carried no tokens")
+}

--- a/llm/xai/count_tokens_test.go
+++ b/llm/xai/count_tokens_test.go
@@ -1,0 +1,94 @@
+package xai
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+func TestCountTokensReturnsTheTokenCount(t *testing.T) {
+	var body map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/tokenize-text") {
+			t.Errorf("path = %q, want the tokenizer endpoint", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-xai-key" {
+			t.Errorf("Authorization = %q", got)
+		}
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		_, _ = w.Write([]byte(`{"token_ids":[1,2,3,4,5]}`))
+	}))
+	defer srv.Close()
+
+	c := NewXAIClient(testProvider("test-xai-key"), "grok-4", zap.NewNop(), 1, 0)
+	c.apiURL = srv.URL + "/v1/chat/completions"
+
+	n, err := c.CountTokens(context.Background(), "and now?",
+		[]models.Message{{Role: "system", Content: "be careful"}, {Role: "user", Content: "hi"}})
+	if err != nil {
+		t.Fatalf("CountTokens: %v", err)
+	}
+	if n != 5 {
+		t.Errorf("count = %d, want the length of the token array", n)
+	}
+	// The whole conversation travels, roles included — they are billed too.
+	text, _ := body["text"].(string)
+	for _, want := range []string{"be careful", "hi", "and now?", "system:", "user:"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("text is missing %q: %q", want, text)
+		}
+	}
+}
+
+// Both array spellings count: a rename would otherwise read as a
+// zero-token prompt, which is worse than an error.
+func TestCountTokensAcceptsEitherArray(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"tokens":["a","b","c"]}`))
+	}))
+	defer srv.Close()
+	c := NewXAIClient(testProvider("k"), "grok-4", zap.NewNop(), 1, 0)
+	c.apiURL = srv.URL + "/v1/chat/completions"
+	n, err := c.CountTokens(context.Background(), "hi", nil)
+	if err != nil || n != 3 {
+		t.Fatalf("count = %d, err = %v", n, err)
+	}
+}
+
+func TestCountTokensSurfacesFailures(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"message":"bad key"}}`))
+	}))
+	defer srv.Close()
+	c := NewXAIClient(testProvider("k"), "grok-4", zap.NewNop(), 1, 0)
+	c.apiURL = srv.URL + "/v1/chat/completions"
+	if _, err := c.CountTokens(context.Background(), "hi", nil); err == nil {
+		t.Error("an HTTP failure must be reported, not counted as zero")
+	}
+
+	empty := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer empty.Close()
+	c.apiURL = empty.URL + "/v1/chat/completions"
+	if _, err := c.CountTokens(context.Background(), "hi", nil); err == nil {
+		t.Error("a response with no tokens must be an error, not zero")
+	}
+}
+
+func TestCountTokensSkipsAnEmptyConversation(t *testing.T) {
+	c := NewXAIClient(testProvider("k"), "grok-4", zap.NewNop(), 1, 0)
+	c.apiURL = "http://127.0.0.1:0/v1/chat/completions" // never dialed
+	if n, err := c.CountTokens(context.Background(), "  ", nil); err != nil || n != 0 {
+		t.Errorf("an empty conversation costs nothing and calls nothing: %d, %v", n, err)
+	}
+}


### PR DESCRIPTION
Audit IV, PR 11 — closes COST-5 (P3), and corrects the premise it rested on.

## The premise was stale

Audit I recorded xAI, MiniMax and Ollama as having no counting API and left them on usage calibration. Checking it: **xAI serves a tokenizer endpoint** (`POST /v1/tokenize-text`) and **MiniMax counts the input tokens of a request without running it** (`POST /v1/responses/input_tokens`). Eleven providers had exact counting and these two estimated — on the same code paths that decide when to compact.

Ollama still has none, and stays where it is.

## xAI

The endpoint takes **text**, not messages, so the conversation is flattened the way the chat body flattens it, with the role labels included because they are billed too. The result is exact for the prompt's text and slightly under the request, which adds per-message framing the endpoint never sees.

That is within the capability's own contract — it exists to calibrate the chars-per-token ratio and report prompt sizes, and its doc comment already states that no budget decision may depend on it. A count that is a few framing tokens light is far closer than the 4.0 chars-per-token default it replaces.

Both spellings of the returned array (`token_ids`, `tokens`) are counted: a rename would otherwise read as a zero-token prompt, which is worse than an error.

## MiniMax

Answers only on the native surface. With `MINIMAX_API_COMPAT` set the client speaks another vendor's schema against another base URL, and this endpoint is not part of that contract — the capability reports absent rather than guessing.

MiniMax reports application errors inside `base_resp` with HTTP 200, so those are surfaced rather than counted as a valid number.

## Both

- Derive the endpoint from the resolved chat URL, so a custom base URL is honored.
- Fail loudly rather than returning zero. A wrong count is worse than a missing one: the caller falls back to estimation on error, and silently reports a zero-token prompt on a wrong success.
- An empty conversation costs nothing and makes no call.

## A note on verification

The wire shapes come from each provider's published documentation, and the tests exercise them against fixtures rather than the live APIs — I have no credentials for either here. That is why both paths degrade to the existing estimate on any error, which is also what the `TokenCounter` contract requires of every caller.

## Portability

HTTP and string handling. Identical on Windows, Linux and macOS.

## Verification

- Full suite green, `golangci-lint --new-from-rev=main` clean, Floor 4 clean, Floor 13 clean.
- New tests: the count is the length of the token array and the whole conversation travels with its roles; either array spelling counts; an HTTP failure and a token-less response are errors; MiniMax reads `input_tokens` and sends history plus prompt; a `base_resp` error is surfaced; the compatibility surface reports absent; an empty conversation returns zero without dialling.
