### PR TITLE
fix(cli): reasoning blocks are part of a journaled message identity

### DIFF
--- a/cli/transcript_journal.go
+++ b/cli/transcript_journal.go
@@ -27,6 +27,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash"
 	"io"
 	"os"
 	"path/filepath"
@@ -127,9 +128,15 @@ func openTranscriptJournal(dir, id string) (*transcriptJournal, error) {
 }
 
 // messageHash identifies a message by role, content, tool-result id,
-// every native tool call (id, name, arguments) and the image count, so two
-// assistant messages that differ only in the call they made — the common
-// shape in a tool loop — never collapse into one journal entry.
+// every native tool call (id, name, arguments), the image count and the
+// reasoning blocks it carries, so two assistant messages that differ only
+// in the call they made — or only in the reasoning that produced it, the
+// shape a retried tool loop emits — never collapse into one journal entry.
+//
+// The reasoning bytes are appended only when the message actually carries
+// blocks. A message without them hashes exactly as it did before reasoning
+// was persisted, so journals written by earlier builds still match their
+// live history and are extended rather than re-walked as a rewrite.
 func messageHash(m models.Message) string {
 	h := sha256.New()
 	h.Write([]byte(m.Role))
@@ -149,7 +156,32 @@ func messageHash(m models.Message) string {
 	}
 	h.Write([]byte{0})
 	h.Write([]byte(strconv.Itoa(len(m.Images))))
+	writeThinkingIdentity(h, m.Thinking)
 	return hex.EncodeToString(h.Sum(nil))
+}
+
+// writeThinkingIdentity folds the reasoning blocks into an open hash, in
+// order: a block's position is part of its identity because the provider
+// contract replays the sequence verbatim. Every field is covered — the
+// signature and the encrypted payload are what a provider validates, and
+// the text is the only discriminator for providers that sign neither.
+// Writes nothing for a message that carries no blocks (see messageHash).
+func writeThinkingIdentity(h hash.Hash, blocks []models.ThinkingBlock) {
+	if len(blocks) == 0 {
+		return
+	}
+	h.Write([]byte{0})
+	h.Write([]byte(strconv.Itoa(len(blocks))))
+	for _, b := range blocks {
+		h.Write([]byte{0})
+		h.Write([]byte(b.Type))
+		h.Write([]byte{0})
+		h.Write([]byte(b.Signature))
+		h.Write([]byte{0})
+		h.Write([]byte(b.Data))
+		h.Write([]byte{0})
+		h.Write([]byte(b.Thinking))
+	}
 }
 
 // hashHistory hashes every message of a history in order.
@@ -330,8 +362,18 @@ func readWorkerTranscript(path string) ([]transcriptEvent, error) {
 
 // transcriptIndex maps message hash → message over the journaled
 // messages (first occurrence wins; the journal dedups on append anyway).
+//
+// A rewrite event stores the hashes of the history it replaced, and
+// /rewind resolves those against this index — so a hash recorded by an
+// earlier build has to keep resolving. Reasoning-free messages hash
+// unchanged (see messageHash), which covers every journal older than
+// persisted reasoning. Journals written in between hold reasoning under
+// the pre-change digest, so each such message is also indexed under the
+// hash it would have had without its blocks. Aliases go in a second pass:
+// a real reasoning-free twin always outranks one.
 func transcriptIndex(events []transcriptEvent) map[string]models.Message {
 	idx := make(map[string]models.Message, len(events))
+	var withReasoning []*models.Message
 	for _, ev := range events {
 		if ev.Kind != "msg" || ev.Message == nil || ev.Worker != "" {
 			continue
@@ -339,6 +381,16 @@ func transcriptIndex(events []transcriptEvent) map[string]models.Message {
 		h := messageHash(*ev.Message)
 		if _, ok := idx[h]; !ok {
 			idx[h] = *ev.Message
+		}
+		if len(ev.Message.Thinking) > 0 {
+			withReasoning = append(withReasoning, ev.Message)
+		}
+	}
+	for _, m := range withReasoning {
+		bare := *m
+		bare.Thinking = nil
+		if h := messageHash(bare); idx[h].Role == "" {
+			idx[h] = *m
 		}
 	}
 	return idx

--- a/cli/transcript_journal_test.go
+++ b/cli/transcript_journal_test.go
@@ -263,3 +263,177 @@ func TestMemoryFlush_QueuesUnextractedSegment(t *testing.T) {
 }
 
 func zapNop() *zap.Logger { return zap.NewNop() }
+
+// thinkingBlocks builds one signed reasoning block for the tests below.
+func thinkingBlocks(sig string) []models.ThinkingBlock {
+	return []models.ThinkingBlock{{Type: "thinking", Thinking: "let me check " + sig, Signature: sig}}
+}
+
+// TestMessageHash_ReasoningIsPartOfIdentity pins both halves of the
+// contract: reasoning discriminates, and its absence changes nothing.
+func TestMessageHash_ReasoningIsPartOfIdentity(t *testing.T) {
+	base := models.Message{Role: "assistant", Content: "reading the file"}
+	base.ToolCalls = []models.ToolCall{{ID: "call_1", Name: "read_file"}}
+
+	a, b := base, base
+	a.Thinking = thinkingBlocks("sig-A")
+	b.Thinking = thinkingBlocks("sig-B")
+	if messageHash(a) == messageHash(b) {
+		t.Fatal("turns identical in content and calls but differing in reasoning must not share a hash")
+	}
+	if messageHash(a) == messageHash(base) {
+		t.Fatal("a reasoning block must change the hash of the turn carrying it")
+	}
+
+	// Order is identity: the provider replays the sequence verbatim.
+	two := base
+	two.Thinking = []models.ThinkingBlock{a.Thinking[0], b.Thinking[0]}
+	swapped := base
+	swapped.Thinking = []models.ThinkingBlock{b.Thinking[0], a.Thinking[0]}
+	if messageHash(two) == messageHash(swapped) {
+		t.Fatal("reasoning order must be part of the hash")
+	}
+
+	// Migration guard: a message without reasoning hashes exactly as it did
+	// before reasoning was persisted, so journals from earlier builds still
+	// match their history. The constant is the pre-change digest.
+	const preReasoningDigest = "1d83ebbe8302299c84843bdf174f521a3fa221d0cb5df16e507751f469be131b"
+	if got := messageHash(models.Message{Role: "assistant", Content: "a1"}); got != preReasoningDigest {
+		t.Fatalf("hash of a reasoning-free message changed: %s (journals written by earlier builds no longer match)", got)
+	}
+}
+
+// TestTranscriptJournal_RewriteKeepsTwinTurnsWithDistinctReasoning covers
+// the path where the collision actually cost a message: after a compaction
+// the journal re-walks the history and skips what it has already seen, so
+// a turn whose twin-in-text came earlier used to be dropped from the record.
+func TestTranscriptJournal_RewriteKeepsTwinTurnsWithDistinctReasoning(t *testing.T) {
+	t.Setenv(atrest.EnvKey, "")
+	dir := t.TempDir()
+	j, err := openTranscriptJournal(dir, "tr-twins")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	// A retried tool loop: the same answer and the same call, twice, with
+	// the reasoning that led there differing.
+	twin := func(sig string) models.Message {
+		return models.Message{
+			Role:      "assistant",
+			Content:   "running it",
+			ToolCalls: []models.ToolCall{{ID: "call_1", Name: "run_command"}},
+			Thinking:  thinkingBlocks(sig),
+		}
+	}
+	history := []models.Message{
+		{Role: "system", Content: "sys"},
+		{Role: "user", Content: "build it"},
+		twin("sig-A"),
+		{Role: "tool", Content: "exit 1", ToolCallID: "call_1"},
+		twin("sig-B"),
+		{Role: "tool", Content: "exit 0", ToolCallID: "call_1"},
+	}
+	if err := j.Sync(history); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	// Compaction rewrites the window: the tail survives, the head collapses.
+	compacted := []models.Message{
+		history[0],
+		{Role: "user", Content: "[STRUCTURED SUMMARY]", Meta: &models.MessageMeta{IsSummary: true}},
+		history[4],
+		history[5],
+	}
+	if err := j.Sync(compacted); err != nil {
+		t.Fatalf("sync after rewrite: %v", err)
+	}
+
+	msgs, err := readTranscript(j.path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var sigs []string
+	for _, m := range msgs {
+		for _, b := range m.Thinking {
+			sigs = append(sigs, b.Signature)
+		}
+	}
+	if len(sigs) != 2 || sigs[0] != "sig-A" || sigs[1] != "sig-B" {
+		t.Fatalf("both turns must survive the rewrite with their own reasoning, got %v", sigs)
+	}
+}
+
+// TestTranscriptJournal_ExtendsJournalWrittenBeforeReasoning proves the
+// migration on a real file: a journal recorded by an earlier build is
+// extended, not re-walked as a rewrite, and nothing is duplicated.
+func TestTranscriptJournal_ExtendsJournalWrittenBeforeReasoning(t *testing.T) {
+	t.Setenv(atrest.EnvKey, "")
+	dir := t.TempDir()
+	// Two events exactly as an earlier build wrote them: no thinking field.
+	legacy := `{"ts":"2026-09-01T10:00:00Z","kind":"msg","message":{"role":"user","content":"u1"}}
+{"ts":"2026-09-01T10:00:01Z","kind":"msg","message":{"role":"assistant","content":"a1"}}
+`
+	path := filepath.Join(dir, "tr-legacy.jsonl")
+	if err := os.WriteFile(path, []byte(legacy), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	j, err := openTranscriptJournal(dir, "tr-legacy")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	history := []models.Message{
+		{Role: "user", Content: "u1"},
+		{Role: "assistant", Content: "a1"},
+		{Role: "user", Content: "u2"},
+	}
+	if err := j.Sync(history); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	msgs, _ := readTranscript(path)
+	if len(msgs) != 3 || msgs[2].Content != "u2" {
+		t.Fatalf("legacy journal = %d msgs, want the two legacy plus u2", len(msgs))
+	}
+}
+
+// TestTranscriptIndex_ResolvesHashesRecordedByEarlierBuilds guards the
+// consumer that actually persists hashes: a rewrite event stores the
+// history it replaced by hash, and /rewind resolves those against the
+// index. Both pre-change shapes must still resolve — a reasoning-free
+// message (every journal older than persisted reasoning) and a
+// reasoning-carrying one recorded while the hash still ignored its blocks.
+func TestTranscriptIndex_ResolvesHashesRecordedByEarlierBuilds(t *testing.T) {
+	plain := models.Message{Role: "user", Content: "u1"}
+	reasoned := models.Message{
+		Role:      "assistant",
+		Content:   "running it",
+		ToolCalls: []models.ToolCall{{ID: "call_1", Name: "run_command"}},
+		Thinking:  thinkingBlocks("sig-A"),
+	}
+	// The digests an earlier build would have written into the rewrite
+	// event: reasoning played no part in either.
+	bare := reasoned
+	bare.Thinking = nil
+	recorded := []string{messageHash(plain), messageHash(bare)}
+
+	idx := transcriptIndex([]transcriptEvent{
+		{Kind: "msg", Message: &plain},
+		{Kind: "msg", Message: &reasoned},
+	})
+	restored, ok := resolveHashes(idx, recorded)
+	if !ok {
+		t.Fatal("a restore point recorded before reasoning entered the hash must still resolve")
+	}
+	if len(restored) != 2 || len(restored[1].Thinking) != 1 || restored[1].Thinking[0].Signature != "sig-A" {
+		t.Fatalf("the resolved message must carry its reasoning, got %+v", restored)
+	}
+
+	// An alias never outranks a real reasoning-free message with the same
+	// bytes: the exact match wins.
+	twin := bare
+	idx = transcriptIndex([]transcriptEvent{
+		{Kind: "msg", Message: &reasoned},
+		{Kind: "msg", Message: &twin},
+	})
+	if got := idx[messageHash(bare)]; len(got.Thinking) != 0 {
+		t.Fatal("an exact reasoning-free match must win over the alias of a reasoning-carrying twin")
+	}
+}


### PR DESCRIPTION
Closes the P1 finding **CMP-1** of Context Audit V.

## The defect

`messageHash` identifies a journaled message by role, content, tool-result id, every native tool call and the image count. Persisted reasoning (#1501) arrived after that function was last widened, so two assistant turns identical in text and in the call they made hash the same even when the reasoning that produced them differs.

Proven by test — without the fix:

```
--- FAIL: TestMessageHash_ReasoningIsPartOfIdentity
    turns identical in content and calls but differing in reasoning must not share a hash
--- FAIL: TestTranscriptJournal_RewriteKeepsTwinTurnsWithDistinctReasoning
    both turns must survive the rewrite with their own reasoning, got [sig-A]
```

That second line is the cost. The event carries the whole message, reasoning included, so nothing is lost on the ordinary append path. The damage is on the rewrite path: after a compaction the journal re-walks the history and skips what `seen` already holds, so a retried tool loop that answers the same way twice loses its second turn from the durable record, and `/rewind` rebuilds a history without it.

## The fix

Reasoning folds into the hash — every block, in order, with type, signature, encrypted payload and text. Providers that sign neither leave the text as the only discriminator, so all four fields are covered; order is covered because the provider contract replays the sequence verbatim.

## Migration

The reasoning bytes are written **only when a message carries blocks**, so a message without them keeps the digest it has always had.

That guard is load-bearing rather than cosmetic: a `rewrite` event persists the hashes of the history it replaced, and `/rewind compact` resolves them against `transcriptIndex`. Making the change unconditional would have invalidated every restore point in every existing journal.

Journals written in the window between #1501 and this PR can hold reasoning under the older digest, so `transcriptIndex` also indexes each reasoning-carrying message under its reasoning-free hash. Aliases are inserted in a second pass, so a genuine reasoning-free twin always outranks one.

## Tests

- `TestMessageHash_ReasoningIsPartOfIdentity` — reasoning discriminates, order counts, and a pinned pre-change digest fails the build if a reasoning-free message ever hashes differently.
- `TestTranscriptJournal_RewriteKeepsTwinTurnsWithDistinctReasoning` — the retried tool loop across a compaction; both turns survive with their own reasoning.
- `TestTranscriptIndex_ResolvesHashesRecordedByEarlierBuilds` — both pre-change shapes still resolve, and the alias never outranks an exact match.
- `TestTranscriptJournal_ExtendsJournalWrittenBeforeReasoning` — a journal file in the old on-disk shape is extended, not duplicated.

All red before the change, green after. `go test ./cli/... ./models/...` clean.
