### PR TITLE
fix(ctxmgr): refresh adopts the current segmenter and situating seals

### DIFF
--- a/cli/context_refresh.go
+++ b/cli/context_refresh.go
@@ -90,6 +90,11 @@ func (h *ContextHandler) handleRefresh(ctx context.Context, args []string) error
 		return nil
 	}
 	fmt.Println(colorize("  "+i18n.T("context.refresh.done", name, rep.Changed, rep.Added, rep.Removed), ColorGreen))
+	if rep.Resealed {
+		// A refresh that moved zero files still did work, and the work
+		// costs embeddings: say so instead of printing three zeros.
+		fmt.Println(colorize("  "+i18n.T("context.refresh.resealed", name), ColorCyan))
+	}
 	return nil
 }
 

--- a/cli/ctxmgr/manager.go
+++ b/cli/ctxmgr/manager.go
@@ -179,10 +179,7 @@ func (m *Manager) CreateContext(ctx context.Context, name, description string, p
 	// indexed with a situating header. Both are tagged rather than global
 	// so corpora indexed before them keep the ids and vectors they already
 	// paid for; a /context refresh re-indexes into the new shape.
-	knowledgeMeta := map[string]string{
-		segmenterMetaKey: segmenterV2,
-		situatedMetaKey:  situatedV1,
-	}
+	knowledgeMeta := currentIndexSeals()
 	var files []utils.FileInfo
 	var scanPaths []string
 	if mode == ModeKnowledge {

--- a/cli/ctxmgr/refresh.go
+++ b/cli/ctxmgr/refresh.go
@@ -44,14 +44,23 @@ type RefreshReport struct {
 	Added     int
 	Removed   int
 	Unchanged int
+	// Resealed marks a refresh that moved the context onto the current
+	// segmenter and situating versions. It makes the refresh dirty on its
+	// own: not one file has to have moved for the passages to be cut
+	// differently and indexed by different text.
+	Resealed bool
 }
 
 // Dirty reports whether anything changed.
-func (r RefreshReport) Dirty() bool { return r.Changed+r.Added+r.Removed > 0 }
+func (r RefreshReport) Dirty() bool { return r.Changed+r.Added+r.Removed > 0 || r.Resealed }
 
 // String renders the report compactly (for notices and logs).
 func (r RefreshReport) String() string {
-	return fmt.Sprintf("changed=%d added=%d removed=%d unchanged=%d", r.Changed, r.Added, r.Removed, r.Unchanged)
+	base := fmt.Sprintf("changed=%d added=%d removed=%d unchanged=%d", r.Changed, r.Added, r.Removed, r.Unchanged)
+	if r.Resealed {
+		base += " resealed=true"
+	}
+	return base
 }
 
 // contentHash is the stamp hash of a file body.
@@ -206,6 +215,15 @@ func (m *Manager) RefreshContext(ctx context.Context, name string) (*FileContext
 	}
 	freshStamps := stampFiles(files)
 	rep := diffStamps(fc.FileStamps, files, freshStamps)
+	// A refresh is also how a context adopts the seals it was created
+	// before. Creation tags every new context with the current segmenter
+	// and situating versions and leaves older corpora on the shape they
+	// already paid vectors for; the way off that shape is this command,
+	// and until now it never wrote them — a context created before either
+	// seal stayed on the old cut and the bare indexed text no matter how
+	// often it was refreshed.
+	resealed := applyIndexSeals(fc)
+	rep.Resealed = resealed
 	if !rep.Dirty() && len(fc.FileStamps) > 0 {
 		// Nothing moved: keep UpdatedAt so retrieval caches and the
 		// vector index stay valid as they are.

--- a/cli/ctxmgr/refresh_test.go
+++ b/cli/ctxmgr/refresh_test.go
@@ -181,3 +181,69 @@ func TestWatchDirsFor_SkipsNoiseDirs(t *testing.T) {
 		t.Fatalf("dirs = %v", dirs)
 	}
 }
+
+// TestRefreshContext_AdoptsCurrentSeals covers the promise creation makes
+// on a context's behalf: the seals are tagged rather than global so old
+// corpora keep the vectors they paid for, and a refresh is the documented
+// way off that shape. Refresh never wrote them, so a context created
+// before either seal stayed on the old cut and the bare indexed text no
+// matter how often it was refreshed.
+func TestRefreshContext_AdoptsCurrentSeals(t *testing.T) {
+	m, src := newRefreshManager(t)
+	ctx := context.Background()
+	fc, err := m.CreateContext(ctx, "docs", "", []string{src}, ModeFull, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Age it back to a context built before the seals existed.
+	for k := range currentIndexSeals() {
+		delete(fc.Metadata, k)
+	}
+	if Situated(fc) {
+		t.Fatal("precondition: the context must start unsealed")
+	}
+	before := contextFingerprint(fc)
+
+	// Not one file has moved.
+	fresh, rep, err := m.RefreshContext(ctx, "docs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.Changed+rep.Added+rep.Removed != 0 {
+		t.Fatalf("no file moved, yet the diff reports %s", rep)
+	}
+	if !rep.Resealed || !rep.Dirty() {
+		t.Fatalf("adopting a seal is work: report = %s", rep)
+	}
+	if !Situated(fresh) {
+		t.Fatal("refresh must move the context onto the current situating version")
+	}
+	if fresh.Metadata[segmenterMetaKey] != segmenterV2 {
+		t.Fatalf("refresh must move the context onto the current segmenter, got %q", fresh.Metadata[segmenterMetaKey])
+	}
+	if after := contextFingerprint(fresh); after == before {
+		t.Fatal("the retrieval cache must be invalidated by a reseal: the corpus is cut differently and indexed by different text")
+	}
+
+	// Idempotent: a context already on the current seals is not re-cut on
+	// every refresh, or the watcher would re-embed the corpus forever.
+	_, rep2, err := m.RefreshContext(ctx, "docs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep2.Resealed || rep2.Dirty() {
+		t.Fatalf("a sealed context must refresh clean, got %s", rep2)
+	}
+}
+
+// TestContextFingerprint_TracksSeal pins the invalidation directly: the
+// seal is what decides the cut and the indexed text, so two otherwise
+// identical contexts that differ only in it must not share a cache entry.
+func TestContextFingerprint_TracksSeal(t *testing.T) {
+	fc := &FileContext{Name: "docs", FileCount: 2, TotalSize: 100, UpdatedAt: time.Unix(0, 0)}
+	bare := contextFingerprint(fc)
+	applyIndexSeals(fc)
+	if sealed := contextFingerprint(fc); sealed == bare {
+		t.Fatal("a context that gained the seals must not reuse the unsealed cache entry")
+	}
+}

--- a/cli/ctxmgr/retrieval.go
+++ b/cli/ctxmgr/retrieval.go
@@ -592,7 +592,10 @@ func (e *RetrievalEngine) embedMissing(ctx context.Context, entry *lexCacheEntry
 // contextFingerprint identifies one revision of a context's content; caches
 // keyed by it invalidate exactly when the context is updated.
 func contextFingerprint(fc *FileContext) string {
-	return fmt.Sprintf("%s|%d|%d|%s", fc.UpdatedAt.UTC().Format("20060102T150405.000"), fc.FileCount, fc.TotalSize, KnowledgeNormalizeMode())
+	// The seals belong here: they decide how the corpus is cut and what
+	// text each passage is indexed by, so a context that gains one has to
+	// be re-derived even though not one of its files moved.
+	return fmt.Sprintf("%s|%d|%d|%s|%s", fc.UpdatedAt.UTC().Format("20060102T150405.000"), fc.FileCount, fc.TotalSize, KnowledgeNormalizeMode(), indexSeal(fc))
 }
 
 // normalizeHits min-max-normalizes BM25 scores to [0,1] by segment index.

--- a/cli/ctxmgr/segment.go
+++ b/cli/ctxmgr/segment.go
@@ -18,6 +18,7 @@ package ctxmgr
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"sort"
 	"strings"
 	"unicode/utf8"
 
@@ -62,6 +63,61 @@ const (
 	segmenterMetaKey = "segmenter"
 	segmenterV2      = "v2"
 )
+
+// currentIndexSeals are the seals every context created — or refreshed —
+// from here on carries. They are tags rather than global switches so a
+// corpus is only ever re-cut and re-embedded when the context is built or
+// refreshed, never on the next query — a live corpus keeps serving the
+// vectors it already paid for until a refresh moves it.
+func currentIndexSeals() map[string]string {
+	return map[string]string{
+		segmenterMetaKey: segmenterV2,
+		situatedMetaKey:  situatedV1,
+	}
+}
+
+// applyIndexSeals writes the current seals onto a context and reports
+// whether any of them changed — the signal that its passages have to be
+// re-cut and its vectors re-earned even when no file moved.
+func applyIndexSeals(fc *FileContext) bool {
+	if fc == nil {
+		return false
+	}
+	changed := false
+	for k, v := range currentIndexSeals() {
+		if fc.Metadata == nil {
+			fc.Metadata = map[string]string{}
+		}
+		if fc.Metadata[k] != v {
+			fc.Metadata[k] = v
+			changed = true
+		}
+	}
+	return changed
+}
+
+// indexSeal renders a context's seals as a stable string for the
+// retrieval fingerprint. Sorted, so map order never invalidates a cache.
+func indexSeal(fc *FileContext) string {
+	if fc == nil || fc.Metadata == nil {
+		return ""
+	}
+	keys := make([]string, 0, 2)
+	for k := range currentIndexSeals() {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for i, k := range keys {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(fc.Metadata[k])
+	}
+	return b.String()
+}
 
 // segmentOptionsFor derives the segmenter options for one context from the
 // engine defaults and the context's own tag.
@@ -187,6 +243,16 @@ func segmentOne(f utils.FileInfo, opts SegmentOptions) []Segment {
 		// Derived after the cut so each passage knows its own first line:
 		// the header names the file and the structure enclosing it.
 		situate(out, lines)
+		// The id keys the vector cache, so it has to name what was
+		// embedded, not only what was cut. Boundary-aware segmentation
+		// moves the cut and changes the id on its own; situating leaves
+		// the cut alone and changes only the indexed text, so without
+		// this a corpus that gained a header kept every id it had, the
+		// index reported nothing missing, and the header never reached
+		// a single vector.
+		for i := range out {
+			out[i].ID = situatedSegmentID(out[i].ID, out[i].Context)
+		}
 	}
 	return out
 }
@@ -243,6 +309,21 @@ func segmentID(path string, startLine int, body string) string {
 	_, _ = h.Write([]byte(itoa(startLine)))
 	_, _ = h.Write([]byte{0})
 	_, _ = h.Write([]byte(body))
+	sum := h.Sum(nil)
+	return hex.EncodeToString(sum[:12])
+}
+
+// situatedSegmentID derives the id of a passage indexed with a situating
+// header from the id of its raw cut. Passages without a header keep the
+// bare id, so turning situating on is the only thing that moves them.
+func situatedSegmentID(base, context string) string {
+	if context == "" {
+		return base
+	}
+	h := sha256.New()
+	_, _ = h.Write([]byte(base))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(context))
 	sum := h.Sum(nil)
 	return hex.EncodeToString(sum[:12])
 }

--- a/cli/ctxmgr/situate_test.go
+++ b/cli/ctxmgr/situate_test.go
@@ -60,10 +60,14 @@ func TestSituatingIsOptIn(t *testing.T) {
 	}
 }
 
-// Passage ids are content hashes and must not move: an opted-in corpus
-// re-embeds because its indexed text changed, but the ids it prunes and
-// upserts by stay the same.
-func TestSituatingDoesNotChangePassageIDs(t *testing.T) {
+// Passage ids key the vector cache, so they name what was embedded — not
+// only what was cut. This test used to assert the opposite, on the belief
+// that an opted-in corpus "re-embeds because its indexed text changed";
+// it does not. Re-embedding is driven by the ids the index reports
+// missing, so an unchanged id means an unchanged vector, and the situating
+// header never reached a single one. The cut is still identical either
+// way: only the id and the indexed text move.
+func TestSituatingMovesPassageIDsSoVectorsAreReEarned(t *testing.T) {
 	body := "package x\n\nfunc F() {\n" + strings.Repeat("\t// line\n", 40) + "}\n"
 	files := []utils.FileInfo{goFile("x/f.go", body)}
 	off := SegmentFiles(files, SegmentOptions{MaxChars: 400})
@@ -72,11 +76,24 @@ func TestSituatingDoesNotChangePassageIDs(t *testing.T) {
 		t.Fatalf("segment count changed: %d vs %d", len(off), len(on))
 	}
 	for i := range off {
-		if off[i].ID != on[i].ID {
-			t.Errorf("passage %d id changed with situating: %s vs %s", i, off[i].ID, on[i].ID)
-		}
 		if off[i].Content != on[i].Content {
-			t.Errorf("passage %d content changed with situating", i)
+			t.Errorf("passage %d content changed with situating: the cut must be identical", i)
+		}
+		if on[i].Context == "" {
+			t.Errorf("passage %d opted in but carries no header", i)
+			continue
+		}
+		if off[i].ID == on[i].ID {
+			t.Errorf("passage %d kept its id though its indexed text changed: the vector would never be re-earned", i)
+		}
+	}
+
+	// Situating twice is not a second migration: the id is a function of
+	// the cut and the header, so a corpus already situated stays put.
+	again := SegmentFiles(files, SegmentOptions{MaxChars: 400, Situate: true})
+	for i := range on {
+		if on[i].ID != again[i].ID {
+			t.Errorf("passage %d id is not stable across re-segmentation", i)
 		}
 	}
 }

--- a/i18n/locales/en-US.context-reseal.json
+++ b/i18n/locales/en-US.context-reseal.json
@@ -1,0 +1,3 @@
+{
+  "context.refresh.resealed": "context %q now indexes with the current segmenter and situating headers; its passages were re-cut and will be re-embedded on the next query"
+}

--- a/i18n/locales/en.context-reseal.json
+++ b/i18n/locales/en.context-reseal.json
@@ -1,0 +1,3 @@
+{
+  "context.refresh.resealed": "context %q now indexes with the current segmenter and situating headers; its passages were re-cut and will be re-embedded on the next query"
+}

--- a/i18n/locales/pt-BR.context-reseal.json
+++ b/i18n/locales/pt-BR.context-reseal.json
@@ -1,0 +1,3 @@
+{
+  "context.refresh.resealed": "o contexto %q passa a indexar com o segmentador e os cabeçalhos de situação atuais; suas passagens foram recortadas de novo e serão re-embedadas na próxima consulta"
+}


### PR DESCRIPTION
Closes the P1 finding **RAG-1** of Context Audit V.

## The promise

`CreateContext` carries this comment, and it is the contract users were given:

> Every context created from here on is segmented boundary-aware and indexed with a situating header. Both are tagged rather than global so corpora indexed before them keep the ids and vectors they already paid for; **a `/context refresh` re-indexes into the new shape.**

`RefreshContext` never wrote the seals. A context built before either one stayed on the fixed-window cut and the bare indexed text no matter how often it was refreshed — and the seals are tagged precisely so that refresh is the only way off. There was no way off.

## Three links

**1. Refresh writes the seals.** And adopting one makes the refresh dirty on its own: not one file has to move for the passages to be cut differently and indexed by different text. Without this the refresh returns early on `!rep.Dirty()` and never even reaches the rebuild.

**2. The seal enters the retrieval fingerprint.** Otherwise the in-memory segment and lexical caches keep serving passages cut under the old rules for the life of the process.

**3. Passage ids name what was embedded, not only what was cut.** This is the link that quietly did nothing. Boundary-aware segmentation moves the cut, so it moves the id and the vector index re-embeds on its own. Situating leaves the cut identical and changes only the indexed text — so every id stayed put, `MissingFor` reported nothing missing, and the situating header never reached a single vector. A situated corpus was searched by vectors of its unsituated text.

## A test that pinned the bug's premise

`TestSituatingDoesNotChangePassageIDs` asserted ids must not move, on the stated belief that "an opted-in corpus re-embeds because its indexed text changed, but the ids it prunes and upserts by stay the same". It does not re-embed: re-embedding is driven by the ids the index reports missing, so an unchanged id means an unchanged vector.

Replaced by `TestSituatingMovesPassageIDsSoVectorsAreReEarned`, which pins the real contract — the cut is byte-identical, the id moves, and situating twice is not a second migration.

## Cost, stated plainly

A corpus that adopts a seal re-embeds once. That is the point: the seal changes what is indexed, so the vectors have to be re-earned. It happens when a context is created or refreshed, never on a query, and a context already on the current seals refreshes clean — pinned by a test, so the watcher cannot re-embed in a loop.

`/context refresh` now says when it resealed, instead of reporting three zeros for work that costs embeddings. String added as an i18n fragment, EN and pt-BR.

## Tests

- `TestRefreshContext_AdoptsCurrentSeals` — zero files moved, seals adopted, report dirty, fingerprint invalidated, second refresh clean.
- `TestContextFingerprint_TracksSeal` — the seal invalidates the cache entry.
- `TestSituatingMovesPassageIDsSoVectorsAreReEarned` — as above.

Each fails with its own link reverted and passes with all three. `go test ./...` clean.