### PR TITLE
fix(cli): declare the rewrites we choose, and fix the ceiling we announce

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -64,7 +64,14 @@ type AgentMode struct {
 	activatedTools map[string]bool
 	// deferrableTools is the set the index advertises, kept so a
 	// find_tools call can be answered without rebuilding it.
-	deferrableTools     []models.ToolDefinition
+	deferrableTools []models.ToolDefinition
+	// deferrableCount is the manager tool count the set was captured at,
+	// so a server that finishes connecting mid-run is noticed.
+	deferrableCount int
+	// taskBudgetTotal is the ceiling this run announced on the first turn
+	// it had one. It stays put for the rest of the run: only the remainder
+	// moves (see AnthropicTaskBudgetFor).
+	taskBudgetTotal     int
 	cli                 *ChatCLI
 	logger              *zap.Logger
 	executor            *agent.CommandExecutor
@@ -936,8 +943,16 @@ func (a *AgentMode) clientAndCtxForTurn(ctx context.Context) (llmclient.LLMClien
 	// when the hard stop fires. Nothing is attached when there is no
 	// ceiling, or too little left to state.
 	if a.cli != nil && a.cli.costTracker != nil {
-		if tokens, ok := a.cli.costTracker.RemainingTaskBudgetTokens(); ok {
-			ctx = llmclient.WithTaskBudget(ctx, llmclient.AnthropicTaskBudget(tokens))
+		provider, model := a.effectiveRoute()
+		if tokens, ok := a.cli.costTracker.RemainingTaskBudgetTokensFor(provider, model); ok {
+			// The ceiling is fixed the first turn the run has one; only
+			// what is left of it moves. Recomputing both every turn showed
+			// the model a ceiling that shrank with its own spend — and one
+			// that grew when a daily limit rolled over mid-run.
+			if a.taskBudgetTotal <= 0 {
+				a.taskBudgetTotal = tokens
+			}
+			ctx = llmclient.WithTaskBudget(ctx, llmclient.AnthropicTaskBudgetFor(a.taskBudgetTotal, tokens))
 		}
 	}
 	return turnClient, ctx
@@ -2470,9 +2485,14 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 			// stop traveling and are advertised through the index built
 			// once for this run; the model pulls what it needs and keeps
 			// it for the rest of the run.
+			a.adoptToolsConnectedMidRun()
 			plan := workers.PlanToolDefs(core, a.deferrableTools, a.activatedTools, a.toolDeferThreshold())
 			nativeToolDefs = plan.Defs
 		}
+		// The effort, the tool set and the task budget all live outside the
+		// history and all decide whether the prefix can be reused. Declare a
+		// change so the coming cache write reads as the rebuild it is.
+		a.cli.noteWireShape(llmclient.EffortFromContext(turnCtx), nativeToolDefs, llmclient.TaskBudgetFromContext(turnCtx) != nil)
 
 		// Chamada à LLM (native tools or text)
 		var aiResponse string

--- a/cli/agent_tool_defer.go
+++ b/cli/agent_tool_defer.go
@@ -86,6 +86,7 @@ func (a *AgentMode) handleFindTools(call models.ToolCall) (string, bool) {
 func (a *AgentMode) prepareDeferredTools() string {
 	a.activatedTools = map[string]bool{}
 	a.deferrableTools = nil
+	a.deferrableCount = 0
 	if a.cli == nil || a.cli.mcpManager == nil || a.cli.mcpManager.ToolCount() == 0 {
 		return ""
 	}
@@ -101,8 +102,100 @@ func (a *AgentMode) prepareDeferredTools() string {
 		return ""
 	}
 	a.deferrableTools = deferrable
+	a.deferrableCount = a.cli.mcpManager.ToolCount()
 	a.logger.Info("deferring tool definitions behind a searchable index",
 		zap.Int("deferred", plan.Deferred),
 		zap.Int("loaded", len(plan.Defs)))
 	return plan.Index
+}
+
+// adoptToolsConnectedMidRun folds tools that appeared after the run
+// started into the deferred set.
+//
+// MCP servers connect on their own schedule and a session starts them
+// deliberately mid-run. The deferrable set was captured once, while the
+// cached prompt was assembled, so a server that finished connecting after
+// that was invisible twice over: its schemas did not travel, and it was
+// not in the set find_tools searches — the model could neither call it nor
+// discover that it existed.
+//
+// The new definitions are activated so they travel this turn, which is the
+// only way the model learns of them: the index that would have advertised
+// them is baked into the prefix and is not worth rewriting for this. That
+// is bounded — past the run's defer threshold the newcomers stay in the
+// searchable set only, still reachable through find_tools, which is what
+// deferral is for. Either way the tools array changed, and the caller
+// declares that to the cache telemetry.
+func (a *AgentMode) adoptToolsConnectedMidRun() {
+	if a.cli == nil || a.cli.mcpManager == nil || a.deferrableCount == 0 {
+		return
+	}
+	count := a.cli.mcpManager.ToolCount()
+	if count == a.deferrableCount {
+		return
+	}
+	a.deferrableCount = count
+	if a.activatedTools == nil {
+		a.activatedTools = map[string]bool{}
+	}
+	current := a.cli.mcpManager.GetTools()
+	arrived, activated := foldArrivedTools(current, a.deferrableTools, a.activatedTools, a.toolDeferThreshold())
+	a.deferrableTools = current
+	a.logger.Info("deferred tool set changed mid-run",
+		zap.Int("arrived", arrived),
+		zap.Int("activated", activated),
+		zap.Int("tools", count))
+}
+
+// foldArrivedTools decides what to do with definitions that appeared since
+// the deferred set was captured, mutating activated in place. It returns
+// how many arrived and how many were activated.
+//
+// Newcomers are activated so their schemas travel, which is the only way
+// the model learns they exist: the index that would advertise them is
+// baked into the cached prefix and is not worth rewriting for this. The
+// activation stops at the run's defer threshold, so a large server
+// connecting mid-run cannot undo the deferral that made room in the first
+// place — past it the newcomers stay searchable through find_tools, which
+// is what deferral is for. A set that only shrank activates nothing and is
+// still refreshed, so find_tools stops offering schemas nothing can serve.
+func foldArrivedTools(current, known []models.ToolDefinition, activated map[string]bool, threshold int) (arrived, activatedNow int) {
+	seen := make(map[string]bool, len(known))
+	for _, d := range known {
+		seen[d.Function.Name] = true
+	}
+	weight := activatedToolsChars(known, activated)
+	for _, d := range current {
+		if seen[d.Function.Name] {
+			continue
+		}
+		arrived++
+		if w := toolDefChars(d); weight+w <= threshold {
+			activated[d.Function.Name] = true
+			weight += w
+			activatedNow++
+		}
+	}
+	return arrived, activatedNow
+}
+
+// toolDefChars is one definition's serialized weight.
+func toolDefChars(d models.ToolDefinition) int {
+	b, err := json.Marshal(d)
+	if err != nil {
+		return 0
+	}
+	return len(b)
+}
+
+// activatedToolsChars is what the already-activated definitions weigh, so
+// adopting newcomers stays inside the same budget the run deferred under.
+func activatedToolsChars(defs []models.ToolDefinition, activated map[string]bool) int {
+	total := 0
+	for _, d := range defs {
+		if activated[d.Function.Name] {
+			total += toolDefChars(d)
+		}
+	}
+	return total
 }

--- a/cli/cache_prefix_notice.go
+++ b/cli/cache_prefix_notice.go
@@ -1,0 +1,81 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Declaring the rewrites we make on purpose.
+ *
+ * The cache telemetry separates a rebuild ChatCLI asked for from a miss
+ * caused by an unstable prefix, and alerts after three unexplained misses
+ * in a row. It only knows what it is told, and three request fields that
+ * arrived later change the prefix without telling it: the effort router
+ * moves output_config between present and absent turn to turn, activating
+ * a deferred tool changes the tools array that is serialized ahead of the
+ * system block, and a task budget appearing mid-run adds a field that was
+ * not there before. All three are our decisions, and all three used to
+ * read as instability — so the alert fired at the user for something the
+ * user did not do.
+ *
+ * A change is only reported when the shape actually differs from the last
+ * request: announcing a rebuild every turn would tell the telemetry
+ * nothing at all.
+ */
+package cli
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/diillson/chatcli/llm/client"
+	"github.com/diillson/chatcli/models"
+)
+
+// wireShape is the part of a request outside the history that decides
+// whether the provider can reuse the cached prefix.
+type wireShape struct {
+	effort      string
+	toolNames   string
+	taskBudgets bool
+}
+
+// String renders the shape for the debug log that explains a rebuild.
+func (w wireShape) String() string {
+	return "effort=" + w.effort + " budget=" + strconv.FormatBool(w.taskBudgets) + " tools=" + strconv.Itoa(strings.Count(w.toolNames, ",")+1)
+}
+
+// toolShape summarizes a tool array by the names it carries, in a stable
+// order: a set that gained or lost a definition is a different prefix,
+// while the same set serialized in a different order is not.
+func toolShape(defs []models.ToolDefinition) string {
+	if len(defs) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(defs))
+	for _, d := range defs {
+		names = append(names, d.Function.Name)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ",")
+}
+
+// noteWireShape compares this turn's request shape against the last one
+// and, when they differ, tells the telemetry the coming cache write is a
+// rebuild we asked for. The first turn of a session establishes the shape
+// without reporting anything: there is no cache to rebuild yet.
+func (cli *ChatCLI) noteWireShape(effort client.SkillEffort, defs []models.ToolDefinition, hasTaskBudget bool) {
+	if cli == nil {
+		return
+	}
+	shape := wireShape{
+		effort:      string(effort),
+		toolNames:   toolShape(defs),
+		taskBudgets: hasTaskBudget,
+	}
+	prev, established := cli.lastWireShape, cli.wireShapeSet
+	cli.lastWireShape, cli.wireShapeSet = shape, true
+	if !established || prev == shape {
+		return
+	}
+	cli.notePrefixChanged("wire shape: " + prev.String() + " → " + shape.String())
+}

--- a/cli/cache_prefix_notice_test.go
+++ b/cli/cache_prefix_notice_test.go
@@ -1,0 +1,145 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/llm/client"
+	"github.com/diillson/chatcli/models"
+)
+
+func toolDef(name string) models.ToolDefinition {
+	d := models.ToolDefinition{Type: "function"}
+	d.Function.Name = name
+	return d
+}
+
+// rebuildPendingNow reads the flag the telemetry consults on the next
+// request, without waiting for one.
+func rebuildPendingNow(ct *CostTracker) bool {
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+	return ct.cache.rebuildPending
+}
+
+func clearRebuild(ct *CostTracker) {
+	ct.mu.Lock()
+	ct.cache.rebuildPending = false
+	ct.mu.Unlock()
+}
+
+// TestNoteWireShape_DeclaresOurOwnRewrites covers the three request fields
+// that live outside the history and decide prefix reuse. Each used to be
+// counted against prefix stability: the alert after three unexplained
+// misses fired at the user for decisions ChatCLI made.
+func TestNoteWireShape_DeclaresOurOwnRewrites(t *testing.T) {
+	cli := &ChatCLI{costTracker: NewCostTracker()}
+
+	// The first turn establishes the shape: there is no cache to rebuild.
+	cli.noteWireShape(client.EffortHigh, []models.ToolDefinition{toolDef("read_file")}, false)
+	if rebuildPendingNow(cli.costTracker) {
+		t.Fatal("the first turn of a session has no cache to declare a rebuild of")
+	}
+	// An unchanged shape is not a rebuild either, or the flag would be set
+	// every turn and mean nothing.
+	cli.noteWireShape(client.EffortHigh, []models.ToolDefinition{toolDef("read_file")}, false)
+	if rebuildPendingNow(cli.costTracker) {
+		t.Fatal("an unchanged request shape must not be reported as a rebuild")
+	}
+
+	for _, tc := range []struct {
+		name   string
+		effort client.SkillEffort
+		defs   []models.ToolDefinition
+		budget bool
+	}{
+		{"effort routed down", client.EffortLow, []models.ToolDefinition{toolDef("read_file")}, false},
+		{"deferred tool activated", client.EffortLow, []models.ToolDefinition{toolDef("read_file"), toolDef("mcp_query")}, false},
+		{"task budget appears", client.EffortLow, []models.ToolDefinition{toolDef("read_file"), toolDef("mcp_query")}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clearRebuild(cli.costTracker)
+			cli.noteWireShape(tc.effort, tc.defs, tc.budget)
+			if !rebuildPendingNow(cli.costTracker) {
+				t.Fatalf("%s changes the prefix and must be declared as a rebuild", tc.name)
+			}
+		})
+	}
+
+	// Tool order is not identity: the same set serialized differently is
+	// the same prefix and must not read as a rebuild.
+	clearRebuild(cli.costTracker)
+	cli.noteWireShape(client.EffortLow, []models.ToolDefinition{toolDef("mcp_query"), toolDef("read_file")}, true)
+	if rebuildPendingNow(cli.costTracker) {
+		t.Fatal("reordering the same tool set is not a prefix change")
+	}
+}
+
+// mcpToolDef mimics what the manager hands the agent for one MCP tool.
+func mcpToolDef(name, description string) models.ToolDefinition {
+	d := toolDef("mcp_" + name)
+	d.Function.Description = description
+	return d
+}
+
+// TestFoldArrivedTools_ServerConnectingMidRun covers CMP-2: the deferred
+// set is captured once, while the cached prompt is assembled, and MCP
+// servers connect on their own schedule. A server that finished connecting
+// after that was invisible twice over — its schemas did not travel, and it
+// was not in the set find_tools searches.
+func TestFoldArrivedTools_ServerConnectingMidRun(t *testing.T) {
+	known := []models.ToolDefinition{mcpToolDef("query", "run a query")}
+	activated := map[string]bool{}
+
+	// A second server finishes connecting.
+	current := append(append([]models.ToolDefinition{}, known...),
+		mcpToolDef("deploy", "ship a release"),
+		mcpToolDef("rollback", "undo a release"))
+
+	arrived, activatedNow := foldArrivedTools(current, known, activated, 1<<20)
+	if arrived != 2 {
+		t.Fatalf("arrived = %d, want the two tools the new server brought", arrived)
+	}
+	if activatedNow != 2 || !activated["mcp_deploy"] || !activated["mcp_rollback"] {
+		t.Fatalf("newcomers must travel so the model can learn they exist: %v", activated)
+	}
+
+	// Nothing new: no churn, and nothing is activated a second time.
+	if arrived, activatedNow = foldArrivedTools(current, current, activated, 1<<20); arrived != 0 || activatedNow != 0 {
+		t.Fatalf("an unchanged set must fold nothing, got arrived=%d activated=%d", arrived, activatedNow)
+	}
+
+	// A server disconnecting is a change too, and activates nothing.
+	if arrived, _ = foldArrivedTools(known, current, map[string]bool{}, 1<<20); arrived != 0 {
+		t.Fatalf("a shrinking set has no arrivals, got %d", arrived)
+	}
+}
+
+// TestFoldArrivedTools_StaysInsideTheDeferBudget pins the bound: a large
+// server connecting mid-run must not undo the deferral that made room in
+// the first place. Past the threshold the newcomers stay searchable
+// through find_tools rather than traveling.
+func TestFoldArrivedTools_StaysInsideTheDeferBudget(t *testing.T) {
+	big := strings.Repeat("a very long tool description. ", 40)
+	known := []models.ToolDefinition{mcpToolDef("query", "run a query")}
+	current := append(append([]models.ToolDefinition{}, known...),
+		mcpToolDef("one", big), mcpToolDef("two", big), mcpToolDef("three", big))
+
+	activated := map[string]bool{}
+	threshold := toolDefChars(mcpToolDef("one", big)) * 2
+	arrived, activatedNow := foldArrivedTools(current, known, activated, threshold)
+	if arrived != 3 {
+		t.Fatalf("arrived = %d, want 3", arrived)
+	}
+	if activatedNow != 2 {
+		t.Fatalf("activation must stop at the defer threshold, activated %d of 3", activatedNow)
+	}
+	if activatedToolsChars(current, activated) > threshold {
+		t.Fatal("the activated set outgrew the budget the run deferred under")
+	}
+}

--- a/cli/chat_pipeline.go
+++ b/cli/chat_pipeline.go
@@ -746,13 +746,22 @@ func (cli *ChatCLI) noticeSkillResolution(resolution SkillClientResolution) {
 // the user has issued a `/thinking` override the override wins; an explicit
 // EffortUnset override means "thinking off" and detaches the hint entirely.
 func (cli *ChatCLI) applyChatEffortHint(ctx context.Context, skillEffort client.SkillEffort) context.Context {
-	if eff, overridden := cli.applyThinkingOverride(skillEffort); overridden {
-		if eff != client.EffortUnset {
-			return client.WithEffortHint(ctx, eff)
-		}
+	effective, overridden := cli.applyThinkingOverride(skillEffort)
+	if !overridden {
+		effective = skillEffort
+	}
+	// Chat carries no tools by design and no task budget, so effort is the
+	// whole of this surface's request shape — and the router moves it turn
+	// to turn on its own. Declare the change so the rebuild it causes is
+	// not counted against prefix stability.
+	cli.noteWireShape(effective, nil, false)
+	// An active override resolving to Unset means thinking is explicitly
+	// off: send no hint at all. Unset without an override is just "nothing
+	// chosen" and travels as before.
+	if overridden && effective == client.EffortUnset {
 		return ctx
 	}
-	return client.WithEffortHint(ctx, skillEffort)
+	return client.WithEffortHint(ctx, effective)
 }
 
 // executeLLMTurn delegates to the streaming path when the active client

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -171,6 +171,12 @@ var CommandFlags = map[string]map[string][]prompt.Suggest{
 
 // ChatCLI representa a interface de linha de comando do chat
 type ChatCLI struct {
+	// lastWireShape is the request shape of the previous turn — the effort,
+	// the tool set and whether a task budget rode along. Compared each turn
+	// so a rewrite we chose is declared to the cache telemetry instead of
+	// reading as an unstable prefix (see cache_prefix_notice.go).
+	lastWireShape        wireShape
+	wireShapeSet         bool
 	Client               client.LLMClient
 	manager              manager.LLMManager
 	logger               *zap.Logger

--- a/cli/cost_task_budget.go
+++ b/cli/cost_task_budget.go
@@ -71,6 +71,28 @@ func (ct *CostTracker) costPerCompletionToken() (float64, bool) {
 	return ct.totalCostUSD / float64(ct.totalCompletionTokens), true
 }
 
+// costPerCompletionTokenOf is the same rate for one provider:model pair.
+//
+// The session-wide average is only a rate while the session stays on one
+// model. A session that switched — an @model route, a fallback chain, a
+// dedicated summarizer — blends prices that differ by more than an order
+// of magnitude, and the ceiling the model reads is then denominated in a
+// model that does not exist. Reports false until this pair has generated
+// enough on its own, so the caller can fall back to the session average
+// rather than extrapolate from a handful of tokens.
+func (ct *CostTracker) costPerCompletionTokenOf(provider, model string) (float64, bool) {
+	if provider == "" || model == "" {
+		return 0, false
+	}
+	ct.mu.RLock()
+	defer ct.mu.RUnlock()
+	rec, ok := ct.modelUsage[modelKey(provider, model)]
+	if !ok || rec.CompletionTokens < taskBudgetMinSampleTokens || rec.TotalCostUSD <= 0 {
+		return 0, false
+	}
+	return rec.TotalCostUSD / float64(rec.CompletionTokens), true
+}
+
 // taskBudgetMinSampleTokens is how much the session must have generated
 // before its own cost ratio is worth extrapolating from. A handful of
 // tokens on a cache-cold first turn is not a rate.
@@ -81,6 +103,15 @@ const taskBudgetMinSampleTokens = 2000
 // express, no measured rate to convert with, or so little room left that
 // the provider's floor would reject it.
 func (ct *CostTracker) RemainingTaskBudgetTokens() (int, bool) {
+	return ct.RemainingTaskBudgetTokensFor("", "")
+}
+
+// RemainingTaskBudgetTokensFor is RemainingTaskBudgetTokens denominated in
+// the tokens of the pair that actually serves the turn, falling back to the
+// session average while that pair has no rate of its own. Callers that know
+// their route should use this: the ceiling only means something in the
+// currency the next turn will be billed in.
+func (ct *CostTracker) RemainingTaskBudgetTokensFor(provider, model string) (int, bool) {
 	if ct == nil {
 		return 0, false
 	}
@@ -88,9 +119,11 @@ func (ct *CostTracker) RemainingTaskBudgetTokens() (int, bool) {
 	if !ok {
 		return 0, false
 	}
-	perToken, ok := ct.costPerCompletionToken()
+	perToken, ok := ct.costPerCompletionTokenOf(provider, model)
 	if !ok {
-		return 0, false
+		if perToken, ok = ct.costPerCompletionToken(); !ok {
+			return 0, false
+		}
 	}
 	tokens := int(remainingUSD / perToken)
 	if tokens < taskBudgetMinTokens {

--- a/cli/task_budget_shape_test.go
+++ b/cli/task_budget_shape_test.go
@@ -1,0 +1,85 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"testing"
+
+	"github.com/diillson/chatcli/llm/client"
+)
+
+// TestAnthropicTaskBudgetFor_CeilingIsFixed pins what the field means: a
+// total the run announced once, and a remainder that only shrinks. Sending
+// the same number for both — which is what a per-turn recomputation
+// produces — shows the model a ceiling that moves with its own spend.
+func TestAnthropicTaskBudgetFor_CeilingIsFixed(t *testing.T) {
+	const total = 400000
+	b := client.AnthropicTaskBudgetFor(total, 120000)
+	if b == nil || b.Total != total || b.Remaining != 120000 {
+		t.Fatalf("mid-run budget = %+v, want a fixed ceiling with a smaller remainder", b)
+	}
+
+	// A daily limit rolling over at midnight makes the remaining spend
+	// jump. The ceiling a run announced is the ceiling it keeps.
+	if grown := client.AnthropicTaskBudgetFor(total, total*3); grown.Remaining != total {
+		t.Fatalf("remaining must never exceed the announced ceiling, got %d", grown.Remaining)
+	}
+
+	// Nothing to say stays nothing to say, so callers assign without a check.
+	if client.AnthropicTaskBudgetFor(0, 0) != nil || client.AnthropicTaskBudgetFor(total, 0) != nil {
+		t.Fatal("an empty budget must be nil")
+	}
+
+	// The first turn of a run is the one case where both are equal.
+	if first := client.AnthropicTaskBudget(total); first.Total != total || first.Remaining != total {
+		t.Fatalf("first turn = %+v", first)
+	}
+}
+
+// TestRemainingTaskBudgetTokensFor_PricesTheServingPair covers a session
+// that switched models. The session-wide average blends prices that differ
+// by an order of magnitude, so the ceiling it produces is denominated in a
+// model that does not exist.
+func TestRemainingTaskBudgetTokensFor_PricesTheServingPair(t *testing.T) {
+	ct := NewCostTracker()
+	ct.budgetLimitUSD = 100
+	ct.budgetHardStop = true
+
+	// An expensive model did most of the session's work, and a cheap one
+	// is about to serve the next turn.
+	seed := func(provider, model string, tokens int64, cost float64) {
+		rec := ct.getOrCreateRecord(modelKey(provider, model), provider, model)
+		rec.CompletionTokens = tokens
+		rec.TotalCostUSD = cost
+		ct.totalCompletionTokens += tokens
+		ct.totalCostUSD += cost
+	}
+	seed("ANTHROPIC", "claude-opus-5", 100000, 7.5) // $75 / Mtok
+	seed("OPENAI", "gpt-5.6-luna", 100000, 0.5)     // $5  / Mtok
+
+	blended, ok := ct.RemainingTaskBudgetTokens()
+	if !ok {
+		t.Fatal("the session average must still work as a fallback")
+	}
+	cheap, ok := ct.RemainingTaskBudgetTokensFor("OPENAI", "gpt-5.6-luna")
+	if !ok {
+		t.Fatal("a pair with its own samples must be priced by them")
+	}
+	if cheap <= blended {
+		t.Fatalf("the cheap model must buy more tokens than the blended average: %d vs %d", cheap, blended)
+	}
+	expensive, _ := ct.RemainingTaskBudgetTokensFor("ANTHROPIC", "claude-opus-5")
+	if expensive >= blended {
+		t.Fatalf("the expensive model must buy fewer: %d vs %d", expensive, blended)
+	}
+
+	// A pair with no samples of its own falls back rather than
+	// extrapolating from nothing.
+	fresh, ok := ct.RemainingTaskBudgetTokensFor("XAI", "grok-5")
+	if !ok || fresh != blended {
+		t.Fatalf("an unsampled pair must fall back to the session average, got %d ok=%v", fresh, ok)
+	}
+}

--- a/llm/client/cache_prefix.go
+++ b/llm/client/cache_prefix.go
@@ -50,14 +50,33 @@ type TaskBudget struct {
 	Remaining int `json:"remaining"`
 }
 
-// AnthropicTaskBudget builds the task-budget block for a run with the
-// given number of tokens left to spend. Nil when there is nothing to say,
-// so callers can assign it without a check.
+// AnthropicTaskBudget builds the task-budget block for the first turn of a
+// run, where the ceiling and what is left of it are the same number. Nil
+// when there is nothing to say, so callers can assign it without a check.
+//
+// Later turns must use AnthropicTaskBudgetFor: a run that recomputes both
+// numbers every turn shows the model a ceiling that shrinks with the
+// spend, which is not what the field means.
 func AnthropicTaskBudget(remainingTokens int) *TaskBudget {
-	if remainingTokens <= 0 {
+	return AnthropicTaskBudgetFor(remainingTokens, remainingTokens)
+}
+
+// AnthropicTaskBudgetFor builds the block from a ceiling fixed when the run
+// started and what is left of it now.
+//
+// Remaining is clamped to total. The remaining spend is derived from a
+// budget that can grow underneath a run — a daily limit rolls over at
+// midnight — and a run whose ceiling grew mid-task would tell the model it
+// has more room than it started with, which is the opposite of what a
+// budget is for. The ceiling a run announced is the ceiling it keeps.
+func AnthropicTaskBudgetFor(total, remaining int) *TaskBudget {
+	if total <= 0 || remaining <= 0 {
 		return nil
 	}
-	return &TaskBudget{Type: "tokens", Total: remainingTokens, Remaining: remainingTokens}
+	if remaining > total {
+		remaining = total
+	}
+	return &TaskBudget{Type: "tokens", Total: total, Remaining: remaining}
 }
 
 // CompactionBeta is the Anthropic beta that enables server-side


### PR DESCRIPTION
Closes **CAG-1** (P1), **CMP-2**, **CMP-3** and **COST-1** (P2) of Context Audit V. Four findings, one PR: they are the same three request fields seen from different sides.

## CAG-1 — three rewrites that never declared themselves

Audits I–III built telemetry that tells a rebuild *we asked for* apart from a miss caused by an unstable prefix, and alerts after three unexplained misses. `notePrefixChanged` covered provider, model, skill pin, attach/detach and session load. Three fields that arrived later were not covered:

- the effort router moves `output_config` between present and absent turn to turn;
- activating a deferred tool changes the `tools` array, which is serialized ahead of the system block;
- a task budget appearing mid-run adds a field that was not there before.

All three are our decisions. All three read as instability — the alert fired at the user for something the user did not do.

Both surfaces now compare the request shape against the previous turn. **Only a genuine change is declared**: announcing a rebuild every turn would tell the telemetry nothing at all. The first turn establishes the shape without reporting anything — there is no cache to rebuild yet — and tool order is not part of identity, since the same set serialized differently is the same prefix.

## CMP-3 — a ceiling that moved

`AnthropicTaskBudget` sent the same number as `Total` and as `Remaining`, recomputed every turn from the remaining spend. The model saw a ceiling that shrank with its own spend, and one that **grew** when a daily limit rolled over at midnight mid-run.

The ceiling is fixed the first turn a run has one; only the remainder moves; the remainder is clamped to the ceiling so a rollover cannot hand a run more room than it announced. `AnthropicTaskBudget` stays as the first-turn shape and delegates, so nothing exported changed signature.

## COST-1 — priced in a model that does not exist

The dollars-to-tokens conversion used the session-wide average cost per generated token. A session that switched models — `@model use`, a fallback chain, a dedicated summarizer — blends prices that differ by an order of magnitude, and the ceiling is then denominated in an average model that never served a turn.

The rate now comes from the `provider:model` pair that serves the turn, falling back to the session average only while that pair has no samples of its own. `RemainingTaskBudgetTokens` delegates to the new `…For` variant.

## CMP-2 — a server nobody could see

The deferrable set is captured once, while the cached prompt is assembled. MCP servers connect on their own schedule, and Audit III recorded that sessions start them mid-run deliberately. A server that finished connecting after the capture was invisible twice over: its schemas did not travel **and** it was not in the set `find_tools` searches — the model could neither call it nor discover that it existed.

The set is refreshed when the manager's tool count moves, and newcomers are activated so their schemas travel, which is the only way the model learns of them: the index that would advertise them is baked into the prefix and is not worth rewriting for this.

That is bounded. Activation stops at the run's own defer threshold, so a large server connecting mid-run cannot undo the deferral that made room in the first place — past it the newcomers stay reachable through `find_tools`, which is what deferral is for. A set that only shrank activates nothing and is still refreshed, so `find_tools` stops offering schemas nothing can serve.

The decision is extracted as `foldArrivedTools`, separate from the manager plumbing, so it is tested directly rather than behind a live MCP server.

## Tests

- `TestNoteWireShape_DeclaresOurOwnRewrites` — each of the three fields declares a rebuild; the first turn and an unchanged shape declare nothing; reordering tools is not a change.
- `TestAnthropicTaskBudgetFor_CeilingIsFixed` — fixed ceiling, shrinking remainder, midnight rollover clamped.
- `TestRemainingTaskBudgetTokensFor_PricesTheServingPair` — the cheap model buys more tokens than the blend, the expensive one fewer, an unsampled pair falls back.
- `TestFoldArrivedTools_ServerConnectingMidRun` / `…_StaysInsideTheDeferBudget` — newcomers travel; a shrinking set has no arrivals; activation stops at the threshold.

`go test ./...` clean. Floors 4, 5, 8, 12, 15 verified locally.