### PR TITLE
feat(llm): per-turn context as a turn-scoped system message

### DIFF
--- a/llm/bedrock/bedrock_client.go
+++ b/llm/bedrock/bedrock_client.go
@@ -170,17 +170,21 @@ func normalizeBedrockModelID(model string) string {
 
 // filterBedrockCapabilities strips capability flags that exist on the
 // first-party Claude API but are not served by Bedrock, per Anthropic's
-// platform-availability matrix: fast_mode (research preview, first-party
-// only) and mid_conversation_system (unsupported on Bedrock). Advertising
-// either on a Bedrock entry would make the request builders emit
-// parameters AWS rejects.
+// platform-availability matrix: fast_mode is a research preview and stays
+// first-party only. Advertising it on a Bedrock entry would make the
+// request builders emit a parameter AWS rejects.
+//
+// mid_conversation_system used to be stripped here as unsupported. It is
+// served on Bedrock — the platform matrix lists the Claude API, Amazon
+// Bedrock and Google Cloud for it, and for the clear_at beta on the same
+// models — so stripping it denied Bedrock a capability it has.
 func filterBedrockCapabilities(caps []string) []string {
 	if caps == nil {
 		return nil
 	}
 	out := make([]string, 0, len(caps))
 	for _, c := range caps {
-		if c == "fast_mode" || c == "mid_conversation_system" {
+		if c == "fast_mode" {
 			continue
 		}
 		out = append(out, c)
@@ -202,6 +206,13 @@ func filterBedrockCapabilities(caps []string) []string {
 //   - Shared credentials file (~/.aws/credentials) — selected by AWS_PROFILE
 //   - EC2/ECS/EKS IAM roles
 type BedrockClient struct {
+	// turnScoped records the emitter of the request currently being built,
+	// so the clear_at opt-in rides only on a request that carries a
+	// turn-scoped system message. Held as a pointer: the emitter is per
+	// request, and this is the handoff between the builder and the
+	// transport that has to declare the beta.
+	turnScoped *client.TurnContextEmitter
+
 	model       string
 	region      string
 	profile     string
@@ -498,6 +509,7 @@ func (c *BedrockClient) sendPromptAnthropicModel(ctx context.Context, wireModel,
 	if systemObj != nil {
 		reqBody["system"] = systemObj
 	}
+	c.applyTurnScopedSystemBeta(reqBody)
 
 	applyAnthropicThinkingForEffort(reqBody, wireModel, ctx)
 	// Provider context engine: the Anthropic models served here take the
@@ -601,7 +613,11 @@ func (c *BedrockClient) buildMessagesAndSystem(prompt string, history []models.M
 	var systemBlocks []map[string]interface{}
 	var plainSystemParts []string
 
+	turnScoped := client.NewTurnContextEmitter(catalog.ProviderBedrock, c.model)
 	for _, msg := range history {
+		if turnScoped.Claim(msg) {
+			continue
+		}
 		switch strings.ToLower(strings.TrimSpace(msg.Role)) {
 		case "assistant":
 			messages = append(messages, map[string]interface{}{
@@ -630,6 +646,8 @@ func (c *BedrockClient) buildMessagesAndSystem(prompt string, history []models.M
 		default:
 			messages = append(messages, map[string]interface{}{"role": "user", "content": visionwire.AnthropicContent(msg.Content, msg.Images)})
 		}
+		// One position later than the history holds it: see the emitter.
+		messages = appendTurnScoped(messages, turnScoped)
 	}
 
 	if len(history) == 0 || history[len(history)-1].Role != "user" || history[len(history)-1].Content != prompt {
@@ -637,6 +655,10 @@ func (c *BedrockClient) buildMessagesAndSystem(prompt string, history []models.M
 			messages = append(messages, map[string]interface{}{"role": "user", "content": prompt})
 		}
 	}
+	// A block claimed on the last history entry: the prompt above is the
+	// user message it belongs to.
+	messages = appendTurnScoped(messages, turnScoped)
+	c.turnScoped = turnScoped
 
 	if len(systemBlocks) > 0 {
 		for _, part := range plainSystemParts {
@@ -1125,4 +1147,38 @@ func (c *BedrockClient) storeThinkingFromBody(body []byte) {
 		return
 	}
 	c.thinking.StoreThinking(c.model, client.ParseAnthropicThinkingBody(body))
+}
+
+// appendTurnScoped writes whatever the emitter buffered into the message
+// array, in the one shape both Bedrock transports send.
+func appendTurnScoped(messages []map[string]interface{}, e *client.TurnContextEmitter) []map[string]interface{} {
+	for _, m := range e.Flush() {
+		messages = append(messages, map[string]interface{}{
+			"role":     m.Role,
+			"clear_at": m.ClearAt,
+			"content":  m.Content,
+		})
+	}
+	return messages
+}
+
+// applyTurnScopedSystemBeta opts one request into the clear_at beta, but
+// only when a turn-scoped system message actually travels on it.
+//
+// Bedrock takes beta flags in the request body rather than in a header on
+// the InvokeModel path, so this is the InvokeModel form; the Messages
+// transport sends the header instead. Without the flag the field is
+// rejected as unknown, so a request that carries no such message must not
+// carry the flag either.
+func (c *BedrockClient) applyTurnScopedSystemBeta(reqBody map[string]interface{}) {
+	if c == nil || !c.turnScoped.Used() {
+		return
+	}
+	existing, _ := reqBody["anthropic_beta"].([]string)
+	for _, b := range existing {
+		if b == client.TurnScopedSystemBeta {
+			return
+		}
+	}
+	reqBody["anthropic_beta"] = append(existing, client.TurnScopedSystemBeta)
 }

--- a/llm/bedrock/mantle.go
+++ b/llm/bedrock/mantle.go
@@ -253,6 +253,11 @@ func (c *BedrockClient) doMantleRequest(ctx context.Context, endpoint string, pa
 	}
 	req.Header.Set("content-type", "application/json")
 	req.Header.Set("anthropic-version", mantleAnthropicVersion)
+	// The Messages transport is HTTP, so the beta opt-in takes the header
+	// form here rather than the body field InvokeModel uses.
+	if c.turnScoped.Used() {
+		req.Header.Set("anthropic-beta", client.TurnScopedSystemBeta)
+	}
 
 	if bearer := strings.TrimSpace(os.Getenv("AWS_BEARER_TOKEN_BEDROCK")); bearer != "" {
 		// Short-term bearer tokens (aws-bedrock-token-generator) travel in

--- a/llm/bedrock/newmodels_test.go
+++ b/llm/bedrock/newmodels_test.go
@@ -90,10 +90,14 @@ func TestNormalizeBedrockModelID(t *testing.T) {
 	}
 }
 
-// filterBedrockCapabilities strips first-party-only capability flags when a
-// Claude model is mirrored onto Bedrock: fast_mode (research preview,
-// first-party API only) and mid_conversation_system (not served by Bedrock
-// per Anthropic's platform-availability matrix).
+// filterBedrockCapabilities strips the one first-party-only capability
+// flag when a Claude model is mirrored onto Bedrock: fast_mode, a research
+// preview served on the Claude API alone.
+//
+// mid_conversation_system must survive the filter. It was stripped here as
+// unsupported, and the platform-availability matrix lists Amazon Bedrock
+// alongside the Claude API and Google Cloud both for it and for the
+// clear_at beta — so the filter was denying Bedrock a capability it has.
 func TestFilterBedrockCapabilities(t *testing.T) {
 	in := []string{
 		"vision", "json_mode", "tools",
@@ -102,7 +106,7 @@ func TestFilterBedrockCapabilities(t *testing.T) {
 	}
 	got := filterBedrockCapabilities(in)
 	assert.ElementsMatch(t,
-		[]string{"vision", "json_mode", "tools", "adaptive_thinking", "low_cache_minimum"},
+		[]string{"vision", "json_mode", "tools", "adaptive_thinking", "low_cache_minimum", "mid_conversation_system"},
 		got)
 	assert.Nil(t, filterBedrockCapabilities(nil))
 }
@@ -146,7 +150,10 @@ func TestRegisterBedrockModelEnrichment(t *testing.T) {
 	assert.Equal(t, 77000, meta.MaxOutputTokens)
 	assert.Contains(t, meta.Capabilities, "adaptive_thinking")
 	assert.NotContains(t, meta.Capabilities, "fast_mode", "first-party-only capability must be filtered")
-	assert.NotContains(t, meta.Capabilities, "mid_conversation_system")
+	// mid_conversation_system is served on Bedrock and must survive the
+	// mirror: the platform-availability matrix lists Amazon Bedrock for it
+	// and for the clear_at beta, on the same models as the Claude API.
+	assert.Contains(t, meta.Capabilities, "mid_conversation_system")
 
 	// Known ids short-circuit: re-registering must not clobber the static
 	// entry's specs.

--- a/llm/bedrock/turn_scoped_wire_test.go
+++ b/llm/bedrock/turn_scoped_wire_test.go
@@ -1,0 +1,98 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package bedrock
+
+import (
+	"testing"
+
+	"github.com/diillson/chatcli/llm/client"
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+func bedrockTurnScopedHistory() []models.Message {
+	return []models.Message{
+		{Role: "system", Content: "you are a CLI"},
+		{Role: "user", Content: "first question"},
+		{Role: "assistant", Content: "first answer"},
+		models.TurnContextMessage("today is Friday; cwd is /repo"),
+		{Role: "user", Content: "second question"},
+	}
+}
+
+func bedrockRoles(messages []map[string]interface{}) []string {
+	out := make([]string, 0, len(messages))
+	for _, m := range messages {
+		s, _ := m["role"].(string)
+		out = append(out, s)
+	}
+	return out
+}
+
+// TestBedrockBuildMessages_TurnContextFollowsItsUserTurn pins that the
+// Bedrock mirror takes the same path as the first-party API. The two
+// clients build the Anthropic array independently, and a conversation
+// that serialized differently on one surface would miss the cache on
+// every switch between them.
+func TestBedrockBuildMessages_TurnContextFollowsItsUserTurn(t *testing.T) {
+	c := &BedrockClient{model: "anthropic.claude-opus-5", logger: zap.NewNop()}
+	messages, _ := c.buildMessagesAndSystem("second question", bedrockTurnScopedHistory())
+
+	want := []string{"user", "assistant", "user", "system"}
+	got := bedrockRoles(messages)
+	if len(got) != len(want) {
+		t.Fatalf("roles = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("roles = %v, want %v", got, want)
+		}
+	}
+	last := messages[len(messages)-1]
+	if last["clear_at"] != client.ClearAtNextUserMessage {
+		t.Fatalf("the block must be turn-scoped, got %v", last["clear_at"])
+	}
+
+	// Bedrock takes beta flags in the InvokeModel body rather than in a
+	// header, and only on a request that actually carries one.
+	body := map[string]interface{}{}
+	c.applyTurnScopedSystemBeta(body)
+	betas, _ := body["anthropic_beta"].([]string)
+	if len(betas) != 1 || betas[0] != client.TurnScopedSystemBeta {
+		t.Fatalf("anthropic_beta = %v, want the clear_at beta", body["anthropic_beta"])
+	}
+	// Applying twice must not duplicate the flag.
+	c.applyTurnScopedSystemBeta(body)
+	if betas, _ = body["anthropic_beta"].([]string); len(betas) != 1 {
+		t.Fatalf("beta duplicated: %v", betas)
+	}
+}
+
+// TestBedrockBuildMessages_UnsupportedModelIsUnchanged is the
+// no-regression guard: Sonnet 5 on Bedrock keeps the user-role block and
+// must never be opted into the beta.
+func TestBedrockBuildMessages_UnsupportedModelIsUnchanged(t *testing.T) {
+	c := &BedrockClient{model: "anthropic.claude-sonnet-5", logger: zap.NewNop()}
+	messages, _ := c.buildMessagesAndSystem("second question", bedrockTurnScopedHistory())
+
+	want := []string{"user", "assistant", "user", "user"}
+	got := bedrockRoles(messages)
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("roles = %v, want %v", got, want)
+		}
+	}
+	for _, m := range messages {
+		if _, ok := m["clear_at"]; ok {
+			t.Fatal("a model without the capability must never receive clear_at")
+		}
+	}
+	body := map[string]interface{}{}
+	c.applyTurnScopedSystemBeta(body)
+	if _, ok := body["anthropic_beta"]; ok {
+		t.Fatal("a request carrying no turn-scoped message must carry no beta")
+	}
+}

--- a/llm/catalog/catalog.go
+++ b/llm/catalog/catalog.go
@@ -440,7 +440,7 @@ var registry = []ModelMeta{
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
 		APIVersion:      config.ClaudeAIAPIVersionDefault,
-		Capabilities:    []string{"vision", "json_mode", "tools", "adaptive_thinking", "output_effort", "task_budget"},
+		Capabilities:    []string{"vision", "json_mode", "tools", "adaptive_thinking", "output_effort", "task_budget", "mid_conversation_system"},
 	},
 	{
 		// Sonnet 5 (claude-sonnet-5, Jun 2026): the Sonnet-tier successor —
@@ -1306,12 +1306,15 @@ var registry = []ModelMeta{
 	// este catálogo com o que a conta AWS realmente tem acesso.
 
 	// NOTE (capabilities on Bedrock mirrors): fast_mode is a first-party
-	// research preview and mid_conversation_system is not served by Bedrock
-	// (Anthropic platform-availability matrix) — neither flag may appear on
-	// ProviderBedrock entries or the client would emit parameters AWS
-	// rejects. Per-block prompt caching (cache_control) IS supported for
-	// Claude on Bedrock; only the top-level automatic cache parameter is
-	// first-party-only, and this client never emits it.
+	// research preview and may not appear on ProviderBedrock entries, or
+	// the client would emit a parameter AWS rejects.
+	// mid_conversation_system is a different case: it was excluded here as
+	// unsupported, and the platform-availability matrix lists the Claude
+	// API, Amazon Bedrock and Google Cloud for it — and the same three for
+	// the clear_at beta on the same models. It belongs on the mirrors of
+	// the models that have it. Per-block prompt caching (cache_control) IS
+	// supported for Claude on Bedrock; only the top-level automatic cache
+	// parameter is first-party-only, and this client never emits it.
 
 	// Fable 5.1 (Sep 1 2026, AWS what's-new 2026/09 + Bedrock model card
 	// anthropic-claude-fable-5-1). Same shape as Fable 5: dateless id,
@@ -1330,7 +1333,7 @@ var registry = []ModelMeta{
 		ContextWindow:   1000000,
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking", "output_effort", "task_budget", "bedrock_mantle_only"},
+		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking", "output_effort", "task_budget", "bedrock_mantle_only", "mid_conversation_system"},
 	},
 	// Fable 5 (Jun 9 2026). Dateless ID per Anthropic's Bedrock docs —
 	// Fable 5, Opus 4.8 and Opus 4.7 have NO ARN-versioned model IDs on
@@ -1350,7 +1353,7 @@ var registry = []ModelMeta{
 		ContextWindow:   1000000,
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking", "output_effort", "task_budget", "bedrock_mantle_only"},
+		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking", "output_effort", "task_budget", "bedrock_mantle_only", "mid_conversation_system"},
 	},
 	// Opus 5 (Jul 2026). Like Sonnet 5 and Fable 5, served through the
 	// Claude-in-Amazon-Bedrock Messages endpoint (the models overview lists
@@ -1365,7 +1368,7 @@ var registry = []ModelMeta{
 		ContextWindow:   1000000,
 		MaxOutputTokens: 128000,
 		PreferredAPI:    APIAnthropicMessages,
-		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking", "output_effort", "task_budget", "bedrock_mantle_only"},
+		Capabilities:    []string{"tools", "vision", "json_mode", "adaptive_thinking", "output_effort", "task_budget", "bedrock_mantle_only", "mid_conversation_system"},
 	},
 	// Sonnet 5 (Jun 2026). Served EXCLUSIVELY by the Claude-in-Amazon-
 	// Bedrock Messages endpoint (bedrock-mantle.{region}.api.aws) — it has
@@ -1404,6 +1407,7 @@ var registry = []ModelMeta{
 		Capabilities: []string{
 			"tools", "vision", "json_mode",
 			"adaptive_thinking", "output_effort", "task_budget", "low_cache_minimum",
+			"mid_conversation_system",
 		},
 	},
 

--- a/llm/catalog/catalog_test.go
+++ b/llm/catalog/catalog_test.go
@@ -343,12 +343,13 @@ func TestClaudeOpus48Specs(t *testing.T) {
 	legacy, ok := Resolve(ProviderBedrock, "global.anthropic.claude-opus-4-8-20260528-v1:0")
 	assert.True(t, ok, "legacy dated Bedrock id must still resolve as alias")
 	assert.Equal(t, "global.anthropic.claude-opus-4-8", legacy.ID)
-	// fast_mode is a first-party research preview and
-	// mid_conversation_system is not served by Bedrock — neither may be
-	// advertised on the Bedrock mirror or the client would emit
-	// parameters AWS rejects.
+	// fast_mode is a first-party research preview and may not be
+	// advertised on the Bedrock mirror, or the client would emit a
+	// parameter AWS rejects. mid_conversation_system is the opposite case:
+	// the platform-availability matrix lists Amazon Bedrock alongside the
+	// Claude API and Google Cloud, so the mirror must advertise it.
 	assert.False(t, HasCapability(ProviderBedrock, "claude-opus-4-8", "fast_mode"))
-	assert.False(t, HasCapability(ProviderBedrock, "claude-opus-4-8", "mid_conversation_system"))
+	assert.True(t, HasCapability(ProviderBedrock, "claude-opus-4-8", "mid_conversation_system"))
 }
 
 // TestClaudeOpus5Specs pins the published Opus 5 specs (models overview,
@@ -372,9 +373,9 @@ func TestClaudeOpus5Specs(t *testing.T) {
 	assert.False(t,
 		HasCapability(ProviderClaudeAI, "claude-opus-5", "fast_mode"),
 		"claude-opus-5 must not advertise fast_mode (not documented for Opus 5)")
-	assert.False(t,
+	assert.True(t,
 		HasCapability(ProviderClaudeAI, "claude-opus-5", "mid_conversation_system"),
-		"mid_conversation_system is documented for Opus 4.8 only")
+		"Opus 5 is on the supported list for mid-conversation system messages")
 	// Regression guards: the opus-4.x lookups must keep resolving to their
 	// own entries after the opus-5 entry lands, and vice-versa.
 	m48, ok := Resolve(ProviderClaudeAI, "claude-opus-4-8")
@@ -440,8 +441,9 @@ func TestBedrockFable5Entry(t *testing.T) {
 		"Bedrock Fable 5 must advertise adaptive_thinking")
 	assert.False(t,
 		HasCapability(ProviderBedrock, "anthropic.claude-fable-5", "fast_mode"))
-	assert.False(t,
-		HasCapability(ProviderBedrock, "anthropic.claude-fable-5", "mid_conversation_system"))
+	assert.True(t,
+		HasCapability(ProviderBedrock, "anthropic.claude-fable-5", "mid_conversation_system"),
+		"served on Bedrock per the platform-availability matrix")
 }
 
 // TestBedrockOpus5Entry pins Opus 5 on Bedrock. Like Sonnet 5 and Fable 5
@@ -469,8 +471,9 @@ func TestBedrockOpus5Entry(t *testing.T) {
 		"Opus 5 must be flagged mantle-only so the client picks the Messages endpoint")
 	assert.False(t,
 		HasCapability(ProviderBedrock, "anthropic.claude-opus-5", "fast_mode"))
-	assert.False(t,
-		HasCapability(ProviderBedrock, "anthropic.claude-opus-5", "mid_conversation_system"))
+	assert.True(t,
+		HasCapability(ProviderBedrock, "anthropic.claude-opus-5", "mid_conversation_system"),
+		"served on Bedrock per the platform-availability matrix")
 	// Regression guard: the Bedrock opus-4.x entries keep resolving to
 	// their own IDs.
 	m48, ok := Resolve(ProviderBedrock, "anthropic.claude-opus-4-8")

--- a/llm/claudeai/claude_client.go
+++ b/llm/claudeai/claude_client.go
@@ -44,6 +44,12 @@ type ClaudeClient struct {
 	backoff     time.Duration
 	apiURL      string
 
+	// turnScoped records the emitter of the request currently being built,
+	// so the clear_at beta header is added only when a turn-scoped system
+	// message actually travels. Held as a pointer: the emitter is per
+	// request, and this is the handoff between the builder and the header.
+	turnScoped *client.TurnContextEmitter
+
 	// usage holds THIS instance's most recent API usage. Read-side only:
 	// populated from response bodies/SSE events after the original
 	// processing, so the OAuth-sensitive request path stays untouched.
@@ -564,8 +570,12 @@ func (c *ClaudeClient) buildMessagesAndSystem(prompt string, history []models.Me
 	var messages []map[string]interface{}
 	var systemBlocks []map[string]interface{}
 	var plainSystemParts []string
+	turnScoped := client.NewTurnContextEmitter(catalog.ProviderClaudeAI, c.model)
 
 	for _, msg := range history {
+		if turnScoped.Claim(msg) {
+			continue
+		}
 		switch strings.ToLower(strings.TrimSpace(msg.Role)) {
 		case "assistant":
 			messages = append(messages, map[string]interface{}{"role": "assistant", "content": visionwire.AnthropicContent(msg.Content, msg.Images)})
@@ -588,6 +598,8 @@ func (c *ClaudeClient) buildMessagesAndSystem(prompt string, history []models.Me
 		default:
 			messages = append(messages, map[string]interface{}{"role": "user", "content": visionwire.AnthropicContent(msg.Content, msg.Images)})
 		}
+		// One position later than the history holds it: see the emitter.
+		messages = appendTurnScoped(messages, turnScoped)
 	}
 
 	if len(history) == 0 || history[len(history)-1].Role != "user" || history[len(history)-1].Content != prompt {
@@ -595,6 +607,10 @@ func (c *ClaudeClient) buildMessagesAndSystem(prompt string, history []models.Me
 			messages = append(messages, map[string]interface{}{"role": "user", "content": prompt})
 		}
 	}
+	// A block claimed on the last history entry has nothing after it yet;
+	// the prompt above is the user message it belongs to.
+	messages = appendTurnScoped(messages, turnScoped)
+	c.turnScoped = turnScoped
 
 	// Prefer structured blocks (with cache_control) over plain string
 	if len(systemBlocks) > 0 {
@@ -728,6 +744,7 @@ func (c *ClaudeClient) sendOAuthTitleRequest(ctx context.Context, userText strin
 // is the raw access token (no "oauth:"/"token:"/"apikey:" prefix).
 func (c *ClaudeClient) applyAuthHeaders(req *http.Request, token string) {
 	defer applyTaskBudgetBeta(req)
+	defer c.applyTurnScopedSystemBeta(req)
 	switch c.provider.Mode() {
 	case auth.AuthModeOAuth:
 		applyOAuthHeaders(req, token)
@@ -764,6 +781,16 @@ func applyExtendedCacheTTLBeta(req *http.Request) {
 func applyTaskBudgetBeta(req *http.Request) {
 	if client.TaskBudgetFromContext(req.Context()) != nil {
 		addAnthropicBeta(req, client.TaskBudgetBeta)
+	}
+}
+
+// applyTurnScopedSystemBeta adds the clear_at beta when the request being
+// built actually carries a turn-scoped system message. Without the flag
+// the field is rejected as unknown; with it on every request, turns that
+// carry nothing would be opted into a beta for no reason.
+func (c *ClaudeClient) applyTurnScopedSystemBeta(req *http.Request) {
+	if c != nil && c.turnScoped.Used() {
+		addAnthropicBeta(req, client.TurnScopedSystemBeta)
 	}
 }
 
@@ -1014,4 +1041,14 @@ func applyTaskBudget(reqBody map[string]interface{}, model string, ctx context.C
 	merged["task_budget"] = budget
 	reqBody["output_config"] = merged
 	return true
+}
+
+// appendTurnScoped writes whatever the emitter buffered into the message
+// array. Kept next to the builders that call it so the wire shape of a
+// turn-scoped system message is written in exactly one place.
+func appendTurnScoped(messages []map[string]interface{}, e *client.TurnContextEmitter) []map[string]interface{} {
+	for _, m := range e.Flush() {
+		messages = append(messages, turnScopedBlock(m))
+	}
+	return messages
 }

--- a/llm/claudeai/thinking_replay_test.go
+++ b/llm/claudeai/thinking_replay_test.go
@@ -45,7 +45,7 @@ func TestBuildClaudeToolMessagesReplaysThinkingFirst(t *testing.T) {
 		},
 		{Role: "tool", ToolCallID: "tu_1", Content: "package main"},
 	}
-	raw, err := json.Marshal(buildClaudeToolMessages("", history))
+	raw, err := json.Marshal(buildClaudeToolMessages("", history, nil))
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}

--- a/llm/claudeai/tool_result_error_test.go
+++ b/llm/claudeai/tool_result_error_test.go
@@ -36,7 +36,7 @@ func TestBuildClaudeToolMessages_EmitsNativeIsError(t *testing.T) {
 			ErrorCode:  "ENOENT",
 		},
 	}
-	msgs := buildClaudeToolMessages("", history)
+	msgs := buildClaudeToolMessages("", history, nil)
 	require.NotEmpty(t, msgs)
 
 	// Find the user message containing the tool_result block.
@@ -88,7 +88,7 @@ func TestBuildClaudeToolMessages_NoErrorPassesThrough(t *testing.T) {
 			Content:    "found 3 matches",
 		},
 	}
-	msgs := buildClaudeToolMessages("", history)
+	msgs := buildClaudeToolMessages("", history, nil)
 	require.NotEmpty(t, msgs)
 
 	var toolResultBlock map[string]interface{}
@@ -126,7 +126,7 @@ func TestBuildClaudeToolMessages_ErrorWithoutCodeStillSetsFlag(t *testing.T) {
 			IsError:    true,
 		},
 	}
-	msgs := buildClaudeToolMessages("", history)
+	msgs := buildClaudeToolMessages("", history, nil)
 	require.NotEmpty(t, msgs)
 
 	envelope := msgs[0].(map[string]interface{})

--- a/llm/claudeai/tool_use.go
+++ b/llm/claudeai/tool_use.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/diillson/chatcli/auth"
 	"github.com/diillson/chatcli/i18n"
+	"github.com/diillson/chatcli/llm/catalog"
 	"github.com/diillson/chatcli/llm/client"
 	"github.com/diillson/chatcli/llm/internal/visionwire"
 	"github.com/diillson/chatcli/models"
@@ -56,7 +57,9 @@ func (c *ClaudeClient) SendPromptWithTools(ctx context.Context, prompt string, h
 	systemBlocks := coalesceCacheControl(buildSystemBlocks(history), anthropicMaxCacheBreakpoints-1)
 
 	// Build messages (excluding system messages)
-	messages := buildClaudeToolMessages(prompt, history)
+	turnScoped := client.NewTurnContextEmitter(catalog.ProviderClaudeAI, c.model)
+	messages := buildClaudeToolMessages(prompt, history, turnScoped)
+	c.turnScoped = turnScoped
 
 	// Build tool definitions for Anthropic format.
 	// Mark the LAST tool with cache_control: ephemeral so the whole tool
@@ -221,10 +224,21 @@ func buildSystemBlocks(history []models.Message) []map[string]interface{} {
 }
 
 // buildClaudeToolMessages constructs messages for Claude's tool use format.
-func buildClaudeToolMessages(prompt string, history []models.Message) []interface{} {
-	var messages []interface{}
+//
+// turnScoped defers ChatCLI's per-turn context blocks by one position so
+// they render on the turn they belong to and clear afterwards; it claims
+// nothing on a model without the capability, and the loop is then exactly
+// what it was.
+func buildClaudeToolMessages(prompt string, history []models.Message, turnScoped *client.TurnContextEmitter) []interface{} {
+	// One wire message per history entry, plus the prompt: system entries
+	// leave a hole and turn-scoped blocks fill one, so this is the shape,
+	// not a guarantee.
+	messages := make([]interface{}, 0, len(history)+1)
 
 	for _, msg := range history {
+		if turnScoped.Claim(msg) {
+			continue
+		}
 		role := strings.ToLower(strings.TrimSpace(msg.Role))
 
 		switch role {
@@ -306,6 +320,10 @@ func buildClaudeToolMessages(prompt string, history []models.Message) []interfac
 				"content": visionwire.AnthropicContent(msg.Content, msg.Images),
 			})
 		}
+		// One position later than the history holds it: see the emitter.
+		for _, ts := range turnScoped.Flush() {
+			messages = append(messages, turnScopedBlock(ts))
+		}
 	}
 
 	// Add prompt as user message if needed
@@ -316,6 +334,12 @@ func buildClaudeToolMessages(prompt string, history []models.Message) []interfac
 				"content": prompt,
 			})
 		}
+	}
+
+	// A block claimed on the last history entry: the prompt above is the
+	// user message it belongs to.
+	for _, ts := range turnScoped.Flush() {
+		messages = append(messages, turnScopedBlock(ts))
 	}
 
 	return messages
@@ -444,4 +468,13 @@ func parseClaudeToolResponse(body string, logger *zap.Logger) (*models.LLMRespon
 	}
 
 	return response, nil
+}
+
+// turnScopedBlock is the wire shape of one turn-scoped system message.
+func turnScopedBlock(ts client.TurnScopedSystem) map[string]interface{} {
+	return map[string]interface{}{
+		"role":     ts.Role,
+		"clear_at": ts.ClearAt,
+		"content":  ts.Content,
+	}
 }

--- a/llm/claudeai/turn_scoped_wire_test.go
+++ b/llm/claudeai/turn_scoped_wire_test.go
@@ -1,0 +1,155 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package claudeai
+
+import (
+	"testing"
+
+	"github.com/diillson/chatcli/llm/catalog"
+	"github.com/diillson/chatcli/llm/client"
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+// roleAt names the role of one wire message, whatever concrete map shape
+// the builder produced.
+func roleAt(m interface{}) string {
+	switch v := m.(type) {
+	case map[string]interface{}:
+		s, _ := v["role"].(string)
+		return s
+	}
+	return ""
+}
+
+func clearAtOf(m interface{}) string {
+	if v, ok := m.(map[string]interface{}); ok {
+		s, _ := v["clear_at"].(string)
+		return s
+	}
+	return ""
+}
+
+func turnScopedHistory() []models.Message {
+	return []models.Message{
+		{Role: "system", Content: "you are a CLI"},
+		{Role: "user", Content: "first question"},
+		{Role: "assistant", Content: "first answer"},
+		models.TurnContextMessage("today is Friday; cwd is /repo"),
+		{Role: "user", Content: "second question"},
+	}
+}
+
+// TestBuildMessages_TurnContextRendersAfterItsUserTurn is the placement
+// contract. A turn-scoped system message renders only while no user
+// message follows it, so emitting the block where the history holds it —
+// ahead of the user's turn — would clear it on the very request that
+// introduced it.
+func TestBuildMessages_TurnContextRendersAfterItsUserTurn(t *testing.T) {
+	c := &ClaudeClient{model: "claude-opus-5", logger: zap.NewNop()}
+	messages, _ := c.buildMessagesAndSystem("second question", turnScopedHistory())
+
+	var roles []string
+	for _, m := range messages {
+		roles = append(roles, roleAt(m))
+	}
+	want := []string{"user", "assistant", "user", "system"}
+	if len(roles) != len(want) {
+		t.Fatalf("roles = %v, want %v", roles, want)
+	}
+	for i := range want {
+		if roles[i] != want[i] {
+			t.Fatalf("roles = %v, want %v — the block must follow the user turn it belongs to", roles, want)
+		}
+	}
+	last := messages[len(messages)-1]
+	if clearAtOf(last) != client.ClearAtNextUserMessage {
+		t.Fatalf("the block must be turn-scoped, got clear_at=%q", clearAtOf(last))
+	}
+	if !c.turnScoped.Used() {
+		t.Fatal("a request carrying the block must declare the beta")
+	}
+}
+
+// TestBuildMessages_UnsupportedModelIsUnchanged is the no-regression
+// guard on this surface: a model without the capability must serialize
+// exactly what it always did, block included, as a user message in place.
+func TestBuildMessages_UnsupportedModelIsUnchanged(t *testing.T) {
+	c := &ClaudeClient{model: "claude-sonnet-5", logger: zap.NewNop()}
+	messages, _ := c.buildMessagesAndSystem("second question", turnScopedHistory())
+
+	var roles []string
+	for _, m := range messages {
+		roles = append(roles, roleAt(m))
+		if clearAtOf(m) != "" {
+			t.Fatal("a model without the capability must never receive clear_at")
+		}
+	}
+	want := []string{"user", "assistant", "user", "user"}
+	for i := range want {
+		if roles[i] != want[i] {
+			t.Fatalf("roles = %v, want %v — the block stays a user message in place", roles, want)
+		}
+	}
+	if c.turnScoped.Used() {
+		t.Fatal("nothing was emitted, so no beta may be declared")
+	}
+}
+
+// TestBuildClaudeToolMessages_PlacesTheBlockIdentically pins the tool loop
+// against the same rule: the two builders must not disagree, or the same
+// conversation would serialize differently depending on whether the turn
+// used tools, and the prompt cache would miss on every switch.
+func TestBuildClaudeToolMessages_PlacesTheBlockIdentically(t *testing.T) {
+	e := client.NewTurnContextEmitter(catalog.ProviderClaudeAI, "claude-opus-5")
+	messages := buildClaudeToolMessages("second question", turnScopedHistory(), e)
+
+	var roles []string
+	for _, m := range messages {
+		roles = append(roles, roleAt(m))
+	}
+	want := []string{"user", "assistant", "user", "system"}
+	if len(roles) != len(want) {
+		t.Fatalf("roles = %v, want %v", roles, want)
+	}
+	for i := range want {
+		if roles[i] != want[i] {
+			t.Fatalf("roles = %v, want %v", roles, want)
+		}
+	}
+	if clearAtOf(messages[len(messages)-1]) != client.ClearAtNextUserMessage {
+		t.Fatal("the tool loop must scope the block to the turn too")
+	}
+}
+
+// TestBuildClaudeToolMessages_StablePositionAcrossRequests is what makes
+// a cleared block safe to keep re-sending. A block that lands at a
+// different index on a later request is an edit to an earlier message:
+// the prompt cache misses from there on, and on models that check it
+// every later thinking block fails the conversation check.
+func TestBuildClaudeToolMessages_StablePositionAcrossRequests(t *testing.T) {
+	history := turnScopedHistory()
+	first := buildClaudeToolMessages("second question", history,
+		client.NewTurnContextEmitter(catalog.ProviderClaudeAI, "claude-opus-5"))
+
+	// The conversation moves on: the answer lands, a new turn context and
+	// a new user turn are appended.
+	grown := append(append([]models.Message{}, history...),
+		models.Message{Role: "assistant", Content: "second answer"},
+		models.TurnContextMessage("today is Saturday; cwd is /repo"),
+		models.Message{Role: "user", Content: "third question"})
+	second := buildClaudeToolMessages("third question", grown,
+		client.NewTurnContextEmitter(catalog.ProviderClaudeAI, "claude-opus-5"))
+
+	if len(second) <= len(first) {
+		t.Fatalf("the array must only grow: %d then %d", len(first), len(second))
+	}
+	for i := range first {
+		if roleAt(first[i]) != roleAt(second[i]) || clearAtOf(first[i]) != clearAtOf(second[i]) {
+			t.Fatalf("message %d moved between requests: %v then %v", i, first[i], second[i])
+		}
+	}
+}

--- a/llm/client/turn_context_wire.go
+++ b/llm/client/turn_context_wire.go
@@ -1,0 +1,134 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * How per-turn context reaches the model, decided per provider.
+ *
+ * ChatCLI carries per-turn context — the date, proactive recall,
+ * auto-activated skills, channel pushes — as a flagged user-role message
+ * appended right before the user's turn. Appending is what holds the
+ * prompt cache, since nothing before it moves, but the block then sits in
+ * the window for the rest of the session.
+ *
+ * A provider that accepts a role:"system" message inside messages can do
+ * better: the block goes in as an instruction rather than as the user's
+ * words, and clear_at scopes it to the turn it belongs to — it renders
+ * once and, from the next user message on, stays in the array without
+ * rendering, at no token cost. It has to stay: the array is what the
+ * prompt cache and, on models that check it, the thinking-block
+ * conversation are matched against.
+ *
+ * The decision lives here rather than in one provider's client because
+ * nothing about it is provider-specific except the answer. It is read from
+ * the model catalog, so every surface that serves a capable model — the
+ * first-party API and the Bedrock mirror alike — takes the same path, and
+ * a provider that ships an equivalent later is one catalog flag away.
+ * Every provider whose catalog entry does not claim it keeps the
+ * user-role block byte for byte, so this can only add.
+ *
+ * Placement is the whole trick. A turn-scoped message renders only while
+ * no user message follows it, so emitting the block where the history
+ * holds it — ahead of the user's turn — would clear it on the very
+ * request that introduced it. It is emitted one position later, directly
+ * after the message it accompanies. That position is stable for the life
+ * of the conversation: the same history always serializes to the same
+ * bytes, which is what re-sending a cleared message verbatim requires. A
+ * block that lands at a different index on a later request is an edit to
+ * an earlier message, and misses the cache from there on.
+ */
+package client
+
+import (
+	"strings"
+
+	"github.com/diillson/chatcli/llm/catalog"
+	"github.com/diillson/chatcli/models"
+)
+
+// MidConversationSystemCapability is the catalog flag for a model that
+// accepts role:"system" messages inside messages.
+const MidConversationSystemCapability = "mid_conversation_system"
+
+// TurnScopedSystemBeta enables clear_at on those messages. Without it the
+// field is rejected as an unknown field, so it travels only on a request
+// that actually carries one.
+const TurnScopedSystemBeta = "mid-conversation-system-clear-at-2026-08-21"
+
+// ClearAtNextUserMessage scopes a system message to the turn it was
+// appended on.
+const ClearAtNextUserMessage = "next_user_message"
+
+// TurnScopedSystem is the wire form of one turn-scoped system message.
+//
+// Content is plain text: a turn-scoped message takes text blocks only —
+// tool additions and removals, output_config and cache_control are all
+// rejected on one. None of that costs anything here, since the point of
+// the message is to sit after the cached prefix rather than inside it.
+type TurnScopedSystem struct {
+	Role    string
+	ClearAt string
+	Content string
+}
+
+// SupportsTurnScopedSystem reports whether this provider and model take a
+// turn-scoped system message. Everything else keeps the user-role block.
+func SupportsTurnScopedSystem(provider, model string) bool {
+	if strings.TrimSpace(model) == "" {
+		return false
+	}
+	return catalog.HasCapability(provider, model, MidConversationSystemCapability)
+}
+
+// TurnContextEmitter defers turn-context blocks by one position while a
+// provider's message array is built. A model without the capability
+// yields an emitter that claims nothing, so its caller's loop is
+// unchanged.
+type TurnContextEmitter struct {
+	enabled bool
+	emitted bool
+	pending []TurnScopedSystem
+}
+
+// NewTurnContextEmitter builds the emitter for one request.
+func NewTurnContextEmitter(provider, model string) *TurnContextEmitter {
+	return &TurnContextEmitter{enabled: SupportsTurnScopedSystem(provider, model)}
+}
+
+// Claim takes a message the emitter will send as a turn-scoped system
+// message, reporting false when the caller should render it as it always
+// has.
+func (e *TurnContextEmitter) Claim(msg models.Message) bool {
+	if e == nil || !e.enabled || !msg.IsTurnContext() || msg.Content == "" {
+		return false
+	}
+	// Images cannot ride on a system message; a block carrying them is
+	// rendered the old way rather than losing them.
+	if len(msg.Images) > 0 {
+		return false
+	}
+	e.pending = append(e.pending, TurnScopedSystem{
+		Role:    "system",
+		ClearAt: ClearAtNextUserMessage,
+		Content: msg.Content,
+	})
+	return true
+}
+
+// Flush returns what was claimed and clears it. Callers call it right
+// after appending an ordinary message, which is what places the block one
+// position later than the history holds it.
+func (e *TurnContextEmitter) Flush() []TurnScopedSystem {
+	if e == nil || len(e.pending) == 0 {
+		return nil
+	}
+	out := e.pending
+	e.pending = nil
+	e.emitted = true
+	return out
+}
+
+// Used reports whether any turn-scoped message was actually emitted, so
+// the beta header travels only on requests that carry one instead of
+// opting every turn into a beta.
+func (e *TurnContextEmitter) Used() bool { return e != nil && e.emitted }

--- a/llm/client/turn_context_wire_test.go
+++ b/llm/client/turn_context_wire_test.go
@@ -1,0 +1,117 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package client
+
+import (
+	"testing"
+
+	"github.com/diillson/chatcli/llm/catalog"
+	"github.com/diillson/chatcli/models"
+)
+
+func turnContext(text string) models.Message {
+	return models.TurnContextMessage(text)
+}
+
+// TestTurnContextEmitter_OnlyClaimsWhereTheWireTakesIt is the no-regression
+// guard. A turn-scoped system message is an Anthropic wire form; every
+// provider whose catalog entry does not claim the capability must go on
+// carrying the block as the user-role message it has always been.
+func TestTurnContextEmitter_OnlyClaimsWhereTheWireTakesIt(t *testing.T) {
+	for _, tc := range []struct {
+		provider, model string
+		want            bool
+	}{
+		{catalog.ProviderClaudeAI, "claude-opus-5", true},
+		{catalog.ProviderClaudeAI, "claude-fable-5-1", true},
+		{catalog.ProviderClaudeAI, "claude-opus-4-8", true},
+		// Sonnet 5 is explicitly excluded upstream: the top-level system
+		// field is the only channel there.
+		{catalog.ProviderClaudeAI, "claude-sonnet-5", false},
+		// Served on Bedrock, so the mirror takes it too.
+		{catalog.ProviderBedrock, "anthropic.claude-opus-5", true},
+		{catalog.ProviderBedrock, "anthropic.claude-sonnet-5", false},
+		// Every other provider keeps the user-role block.
+		{catalog.ProviderOpenAI, "gpt-5.6", false},
+		{catalog.ProviderGoogleAI, "gemini-3.1-pro", false},
+		{catalog.ProviderXAI, "grok-4", false},
+		{catalog.ProviderOpenRouter, "anthropic/claude-opus-5", false},
+		{"", "", false},
+	} {
+		e := NewTurnContextEmitter(tc.provider, tc.model)
+		if got := e.Claim(turnContext("today is Friday")); got != tc.want {
+			t.Errorf("%s/%s claim = %v, want %v", tc.provider, tc.model, got, tc.want)
+		}
+	}
+}
+
+// TestTurnContextEmitter_ClaimsOnlyTurnContext pins what the emitter is
+// allowed to touch: ChatCLI's own per-turn block, never the user's words
+// or anything the provider already has a place for.
+func TestTurnContextEmitter_ClaimsOnlyTurnContext(t *testing.T) {
+	e := NewTurnContextEmitter(catalog.ProviderClaudeAI, "claude-opus-5")
+	for _, msg := range []models.Message{
+		{Role: "user", Content: "what changed?"},
+		{Role: "assistant", Content: "nothing"},
+		{Role: "system", Content: "you are a CLI"},
+		{Role: "tool", Content: "exit 0", ToolCallID: "t1"},
+		models.TurnContextMessage(""), // nothing to say
+	} {
+		if e.Claim(msg) {
+			t.Fatalf("emitter claimed a message it must not touch: %+v", msg)
+		}
+	}
+	// A block carrying images is rendered the old way rather than losing
+	// them: a system message takes text only.
+	withImage := turnContext("look at this")
+	withImage.Images = []models.ImageContent{{}}
+	if e.Claim(withImage) {
+		t.Fatal("a turn-context block with images must keep the user-role path")
+	}
+	if e.Used() {
+		t.Fatal("nothing was emitted, so no beta may be declared")
+	}
+}
+
+// TestTurnContextEmitter_DefersByOnePosition covers the placement rule. A
+// turn-scoped message renders only while no user message follows it, so a
+// block emitted where the history holds it — ahead of the user's turn —
+// would clear on the very request that introduced it.
+func TestTurnContextEmitter_DefersByOnePosition(t *testing.T) {
+	e := NewTurnContextEmitter(catalog.ProviderClaudeAI, "claude-opus-5")
+	if !e.Claim(turnContext("today is Friday")) {
+		t.Fatal("precondition: the block must be claimed")
+	}
+	// Nothing is available until the message it accompanies is appended.
+	if got := e.Flush(); len(got) != 1 || got[0].Content != "today is Friday" {
+		t.Fatalf("flush = %+v, want the claimed block once", got)
+	}
+	if got := e.Flush(); got != nil {
+		t.Fatalf("a block must be emitted exactly once, got %+v", got)
+	}
+	if !e.Used() {
+		t.Fatal("a request that carried a block must declare the beta")
+	}
+
+	// Shape: text only, scoped to this turn. cache_control, output_config
+	// and tool changes are all rejected on a turn-scoped message, so none
+	// of them may appear.
+	_ = e.Claim(turnContext("second block"))
+	got := e.Flush()
+	if got[0].Role != "system" || got[0].ClearAt != ClearAtNextUserMessage {
+		t.Fatalf("wire shape = %+v", got[0])
+	}
+}
+
+// TestTurnContextEmitter_NilSafe covers the callers that pass no emitter
+// (the non-tool paths and existing tests): claiming nothing means their
+// loops are byte-for-byte what they were.
+func TestTurnContextEmitter_NilSafe(t *testing.T) {
+	var e *TurnContextEmitter
+	if e.Claim(turnContext("x")) || e.Flush() != nil || e.Used() {
+		t.Fatal("a nil emitter must be inert")
+	}
+}


### PR DESCRIPTION
Closes **CAG-2** (P2) of Context Audit V, and fixes two catalog errors found while verifying it.

## What this is, and what it is not

The audit prescribed emitting per-turn context as a mid-conversation system message with `clear_at`. Before building on that I verified the field exists — it does, and the constraints are specific enough that guessing them would have produced a 400 on every turn.

**This is an Anthropic wire feature.** A `role: "system"` message inside `messages` is served on the Claude API, Amazon Bedrock and Google Cloud, on Fable 5/5.1, Mythos 5/5.1, Opus 4.8 and Opus 5 — not on Sonnet 5, and not by any other provider ChatCLI serves. There is no equivalent to implement elsewhere; claiming otherwise would mean inventing a field.

**What is generic is the decision.** It lives in `llm/client`, keyed off the model catalog, not inside the Anthropic client — so every surface serving a capable model takes the same path, a provider that ships an equivalent later is one catalog flag away, and every provider whose entry does not claim it serializes byte-for-byte what it did before. That last part is guarded by tests, not by assertion.

## The problem

Per-turn context rides as a flagged user-role message appended right before the user's turn. Appending is what holds the prompt cache — nothing before it moves — but the block then sits in the window for the rest of the session.

A turn-scoped system message closes the second half: it renders on the turn it belongs to and, from the next user message on, stays in the array without rendering, at no token cost. It has to stay — the array is what the cache and, on models that check it, the thinking-block conversation are matched against.

## Placement is the whole trick

A turn-scoped message renders only while no user message follows it. Emitting the block where the history holds it — **ahead** of the user's turn — would clear it on the very request that introduced it, and it would never render at all.

It is emitted one position later, directly after the message it accompanies. That position is stable for the life of the conversation, which is what re-sending a cleared message verbatim requires: a block landing at a different index on a later request is an edit to an earlier message, and the cache misses from there on. `TestBuildClaudeToolMessages_StablePositionAcrossRequests` pins exactly that.

## Surfaces wired

All four builders that produce an Anthropic message array:

| Surface | Beta opt-in |
|---|---|
| Claude API — chat | `anthropic-beta` header |
| Claude API — tool loop | `anthropic-beta` header |
| Bedrock — InvokeModel | `anthropic_beta` body field |
| Bedrock — Messages transport | `anthropic-beta` header |

The opt-in travels **only on a request that actually carries a block** — without the flag the field is rejected as unknown, and with it on every request, turns that carry nothing would be opted into a beta for no reason.

The two Anthropic builders are independent code, so a conversation that serialized differently between them would miss the cache on every switch between a tool turn and a chat turn. A test pins that they agree.

## Two catalog corrections

Checking the capability against the published support matrix turned up two errors:

- **Opus 5 supports it and the entry never said so.**
- **The Bedrock mirror stripped the flag as unsupported.** The matrix lists Amazon Bedrock alongside the Claude API and Google Cloud both for the feature and for its beta — so the filter was denying Bedrock a capability it has.

Three tests asserted the old belief (`"mid_conversation_system is documented for Opus 4.8 only"`, `"not served by Bedrock"`). They now assert the matrix.

## Constraints honored

A turn-scoped message takes **text blocks only** — tool additions and removals, `output_config` and `cache_control` are each a 400 on one. None of that costs anything here: the point of the block is to sit *after* the cached prefix, not inside it. A block carrying images keeps the user-role path rather than losing them.

## Portability

Wire-format code end to end — no filesystem, no terminal, no platform surface. Identical on Windows, Linux and macOS.

## Tests

- `TestTurnContextEmitter_OnlyClaimsWhereTheWireTakesIt` — the no-regression table across providers: Opus 5, Fable 5.1, Opus 4.8 and the Bedrock mirrors claim; Sonnet 5, OpenAI, Gemini, xAI, OpenRouter and the empty pair do not.
- `TestTurnContextEmitter_ClaimsOnlyTurnContext` — never the user's words, a system prompt, a tool result, an empty block, or one carrying images.
- `TestBuildMessages_TurnContextRendersAfterItsUserTurn` / `TestBedrockBuildMessages_TurnContextFollowsItsUserTurn` — placement, on both clients.
- `TestBuildMessages_UnsupportedModelIsUnchanged` / `TestBedrockBuildMessages_UnsupportedModelIsUnchanged` — an unsupported model serializes what it always did and is never opted into the beta.
- `TestBuildClaudeToolMessages_PlacesTheBlockIdentically` — the two builders agree.
- `TestBuildClaudeToolMessages_StablePositionAcrossRequests` — the array only grows; nothing already sent moves.

All fail with the deferral disabled and pass with it. `go test ./...` clean; Floors 4, 5, 8, 12, 13, 15 verified locally.