### PR TITLE
fix(cli): per-turn context follows what the model still reads

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -980,7 +980,10 @@ func (a *AgentMode) effectiveRoute() (provider, model string) {
 	if provider == "" {
 		provider = os.Getenv("LLM_PROVIDER")
 	}
-	if provider == "" {
+	if provider == "" && config.Global != nil {
+		// Nil before config boot, and on any surface that builds an
+		// AgentMode without one. Reading through it used to panic, which
+		// only stayed invisible while every caller ran after boot.
 		provider = config.Global.GetString("LLM_PROVIDER")
 	}
 	return provider, a.cli.Model
@@ -1366,8 +1369,14 @@ func (a *AgentMode) appendTurnContext(text string) {
 	full := turnContextHeader + text
 	// A block that would repeat the last one still in history is not
 	// appended: the model already read it, and a run of thirty turns used
-	// to carry thirty copies of the same date line into the window.
-	if turnContextIsRedundant(a.cli.history, full) {
+	// to carry thirty copies of the same date line into the window. On a
+	// turn-scoped provider "still in history" stops implying "still read",
+	// so the route decides — see turnContextIsRedundant.
+	var provider, model string
+	if a.cli != nil {
+		provider, model = a.effectiveRoute()
+	}
+	if turnContextIsRedundant(provider, model, a.cli.history, full) {
 		return
 	}
 	a.cli.history = append(a.cli.history, models.TurnContextMessage(full))

--- a/cli/cli_llm.go
+++ b/cli/cli_llm.go
@@ -58,7 +58,7 @@ func (cli *ChatCLI) processLLMRequest(parentCtx context.Context, in string) {
 	// and not persisted: the model already read it, and adding it again
 	// only spends window. Anything that actually changed travels.
 	turnCtx := assembly.turnContext
-	if turnContextIsRedundant(cli.history, turnContextText(turnCtx)) {
+	if turnContextIsRedundant(cli.Provider, cli.Model, cli.history, turnContextText(turnCtx)) {
 		turnCtx = nil
 	}
 	tempHistory := cli.buildChatTempHistoryWithContext(assembly.parts, turnCtx, userInput, additionalContext, images)

--- a/cli/turn_context.go
+++ b/cli/turn_context.go
@@ -29,6 +29,7 @@ package cli
 import (
 	"strings"
 
+	"github.com/diillson/chatcli/llm/client"
 	"github.com/diillson/chatcli/models"
 )
 
@@ -49,9 +50,23 @@ func lastTurnContextText(history []models.Message) string {
 // Comparison is on the whole text, so any real change — the day rolling
 // over, a new working directory, an MCP channel push, a recall block —
 // makes the block travel again. Only a byte-for-byte repeat is skipped.
-func turnContextIsRedundant(history []models.Message, text string) bool {
+//
+// The question is whether the model still READS the earlier block, not
+// whether the array still holds it. On a provider that takes turn-scoped
+// system messages the two stopped being the same thing: an earlier block
+// stays in the array — it has to, or the prompt cache and the
+// thinking-block conversation check both break — but it renders only
+// while no user message follows it, and every later turn puts one there.
+// Nothing already sent is visible, so nothing can be redundant, and
+// skipping meant the model read its context once and never again. That is
+// what the capability is for: a cleared block costs no tokens, so sending
+// one every turn is the shape the feature describes.
+func turnContextIsRedundant(provider, model string, history []models.Message, text string) bool {
 	if strings.TrimSpace(text) == "" {
 		return true
+	}
+	if client.SupportsTurnScopedSystem(provider, model) {
+		return false
 	}
 	return text == lastTurnContextText(history)
 }

--- a/cli/turn_context_dedup_test.go
+++ b/cli/turn_context_dedup_test.go
@@ -17,18 +17,18 @@ func TestTurnContextIsRedundantOnlyOnAnExactRepeat(t *testing.T) {
 		tc("Current date: 2026-09-04"),
 		{Role: "assistant", Content: "hello"},
 	}
-	if !turnContextIsRedundant(history, "Current date: 2026-09-04") {
+	if !turnContextIsRedundant("OPENAI", "gpt-5.6", history, "Current date: 2026-09-04") {
 		t.Error("an exact repeat must not be injected again")
 	}
 	// The day rolling over, a new working directory or a channel push all
 	// change the text, and the block must travel again.
-	if turnContextIsRedundant(history, "Current date: 2026-09-05") {
+	if turnContextIsRedundant("OPENAI", "gpt-5.6", history, "Current date: 2026-09-05") {
 		t.Error("a changed block must travel")
 	}
-	if !turnContextIsRedundant(history, "   ") {
+	if !turnContextIsRedundant("OPENAI", "gpt-5.6", history, "   ") {
 		t.Error("an empty block is nothing to say")
 	}
-	if turnContextIsRedundant(nil, "Current date: 2026-09-04") {
+	if turnContextIsRedundant("OPENAI", "gpt-5.6", nil, "Current date: 2026-09-04") {
 		t.Error("the first block of a session must always travel")
 	}
 }

--- a/cli/turn_context_test.go
+++ b/cli/turn_context_test.go
@@ -155,3 +155,43 @@ func TestTurnContext_AgentHelpersAndPendingStash(t *testing.T) {
 		t.Fatal("nil CLI falls back to the default ratio")
 	}
 }
+
+// TestTurnContextIsRedundant_TracksWhatTheModelStillReads is the guard on
+// the regression turn-scoped system messages introduced. Skipping a repeat
+// was safe while the earlier block still rendered as a user message. On a
+// turn-scoped provider it does not: it stays in the array — it has to —
+// but stops rendering the moment a user message follows it, which every
+// later turn provides. The model read its context once and never again.
+func TestTurnContextIsRedundant_TracksWhatTheModelStillReads(t *testing.T) {
+	const block = "[TURN CONTEXT] today is 2026-09-04; cwd /repo"
+	history := []models.Message{
+		{Role: "user", Content: "first question"},
+		models.TurnContextMessage(block),
+		{Role: "assistant", Content: "first answer"},
+	}
+
+	// A provider that renders the earlier block keeps skipping the repeat:
+	// thirty turns must not carry thirty copies of the same date line.
+	if !turnContextIsRedundant("CLAUDEAI", "claude-sonnet-5", history, block) {
+		t.Fatal("a still-rendered block makes an identical one redundant")
+	}
+	if !turnContextIsRedundant("OPENAI", "gpt-5.6", history, block) {
+		t.Fatal("every provider without the capability keeps the old rule")
+	}
+
+	// A turn-scoped provider does not. Nothing already sent is visible, so
+	// nothing can be redundant — and a cleared block costs no tokens.
+	for _, model := range []string{"claude-opus-5", "claude-fable-5-1", "claude-opus-4-8"} {
+		if turnContextIsRedundant("CLAUDEAI", model, history, block) {
+			t.Fatalf("%s clears the earlier block, so the repeat is the only copy the model can read", model)
+		}
+	}
+	if turnContextIsRedundant("BEDROCK", "anthropic.claude-opus-5", history, block) {
+		t.Fatal("the Bedrock mirror clears it too")
+	}
+
+	// Empty stays empty on every provider: there is nothing to say.
+	if !turnContextIsRedundant("CLAUDEAI", "claude-opus-5", history, "   ") {
+		t.Fatal("an empty block is redundant everywhere")
+	}
+}

--- a/llm/claudeai/turn_scoped_wire_test.go
+++ b/llm/claudeai/turn_scoped_wire_test.go
@@ -153,3 +153,63 @@ func TestBuildClaudeToolMessages_StablePositionAcrossRequests(t *testing.T) {
 		}
 	}
 }
+
+// renderedTurnContextBlocks counts the turn-context blocks the model
+// actually reads in one request: a turn-scoped system message renders
+// only while no user message follows it.
+func renderedTurnContextBlocks(messages []map[string]interface{}) int {
+	rendered := 0
+	for i, m := range messages {
+		if roleAt(m) != "system" {
+			continue
+		}
+		visible := true
+		for _, later := range messages[i+1:] {
+			if roleAt(later) == "user" {
+				visible = false
+				break
+			}
+		}
+		if visible {
+			rendered++
+		}
+	}
+	return rendered
+}
+
+// TestTurnScoped_SecondTurnStillCarriesContext is the end-to-end guard on
+// the regression turn-scoping introduced. The per-turn block is skipped
+// when it repeats the last one still in history, and on a turn-scoped
+// model "still in history" stopped implying "still read": the earlier
+// block stays in the array and renders for nobody. A day-resolution date
+// line is byte-identical all day, so the model read its context on turn 1
+// and never again.
+func TestTurnScoped_SecondTurnStillCarriesContext(t *testing.T) {
+	const block = "[TURN CONTEXT] today is 2026-09-04; cwd /repo"
+	c := &ClaudeClient{model: "claude-opus-5", logger: zap.NewNop()}
+
+	// Turn 1: the block is injected and read.
+	turn1 := []models.Message{
+		{Role: "system", Content: "you are a CLI"},
+		models.TurnContextMessage(block),
+		{Role: "user", Content: "first question"},
+	}
+	messages, _ := c.buildMessagesAndSystem("first question", turn1)
+	if got := renderedTurnContextBlocks(messages); got != 1 {
+		t.Fatalf("turn 1 rendered %d blocks, want 1", got)
+	}
+
+	// Turn 2: the text has not changed. The block must still be injected,
+	// because nothing the model can read carries it any more.
+	if !client.SupportsTurnScopedSystem(catalog.ProviderClaudeAI, c.model) {
+		t.Fatal("precondition: the model under test must be turn-scoped")
+	}
+	turn2 := append(append([]models.Message{}, turn1...),
+		models.Message{Role: "assistant", Content: "first answer"},
+		models.TurnContextMessage(block),
+		models.Message{Role: "user", Content: "second question"})
+	messages, _ = c.buildMessagesAndSystem("second question", turn2)
+	if got := renderedTurnContextBlocks(messages); got != 1 {
+		t.Fatalf("turn 2 rendered %d blocks, want exactly 1 — 0 means the model lost its context, 2 means the earlier one never cleared", got)
+	}
+}


### PR DESCRIPTION
Closes **CAG-1** (P0) of Context Audit VI. This is a regression #1519 introduced two hours ago — it is mine, and it goes in alone, before anything else in that roadmap.

## What broke

The per-turn block is skipped when it repeats the last one still in history. That was safe while the earlier copy still **rendered** as a user message: the model had already read it, and a run of thirty turns did not need thirty copies of the same date line.

Turn-scoped system messages broke the equivalence. The earlier block stays in the array — it has to, or the prompt cache and the thinking-block conversation check both break — but it renders only while no user message follows it, and every later turn puts one there.

So nothing already sent was visible, and skipping the repeat left the model with **no per-turn context at all** from the second turn on.

```
TURNO 2, claude-opus-5 (bloco byte-idêntico, injeção pulada):
  [1] role=system  clear_at=next_user_message   <== LIMPO, NÃO RENDERIZA
blocos que o modelo LÊ = 0

claude-sonnet-5 (sem a capacidade):
  [0] role=user "today is 2026-09-04; cwd /repo"  <— continua sendo lido
```

## Why the trigger is the common case

`cli/workspace/context_builder.go:256-262` resolves the dynamic context to the **day**, by explicit decision — and the comment says it is that way *because* the block travels on a per-turn message. In a session without retrieval, recall, a skill or a channel push, the text is byte-identical all day: the model reads the date on turn 1 and never again. The agent surface carries the same rule at `agent_mode.go:1370`.

Any block that stabilises for two turns has the same fate: seen once, then gone.

## The fix

Redundancy now asks whether the model **still reads** the earlier block, not whether the array still holds it. On a turn-scoped provider nothing already sent is visible, so nothing is redundant and the block travels every turn — the shape the capability describes, and free, since a cleared block is billed no tokens.

Every provider without the capability keeps the old rule byte for byte.

## One thing found on the way

Resolving the route for that decision exposed a nil dereference in `effectiveRoute`: it read the global config without checking it existed. Invisible only because every caller so far ran after boot.

## Tests

- `TestTurnContextIsRedundant_TracksWhatTheModelStillReads` — Sonnet 5, OpenAI and every other provider keep skipping repeats; Opus 5, Fable 5.1, Opus 4.8 and the Bedrock mirror do not; empty stays empty everywhere.
- `TestTurnScoped_SecondTurnStillCarriesContext` — end-to-end over the real wire array, counting what actually renders: **exactly one** block on turn 1 and on turn 2. Zero means the model lost its context; two means the earlier one never cleared.

Both fail with the rule reverted. `go test ./...` clean.