### PR TITLE
fix(cli): per-run state that is per run, and a seal that counts once stored

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -958,6 +958,16 @@ func (a *AgentMode) clientAndCtxForTurn(ctx context.Context) (llmclient.LLMClien
 	return turnClient, ctx
 }
 
+// resetPerRunState clears the state that belongs to one Run. AgentMode is
+// a single instance for the session, so anything a run leaves behind is
+// read by the next one as if it were its own.
+func (a *AgentMode) resetPerRunState() {
+	if a == nil {
+		return
+	}
+	a.taskBudgetTotal = 0
+}
+
 // effectiveRoute reports the provider and model that actually serve the
 // current turn: the AI's @model route override first, then the skill
 // frontmatter hint, then the session's own pair (with the same env/config
@@ -1002,6 +1012,14 @@ func (a *AgentMode) Run(ctx context.Context, query string, additionalContext str
 		return fmt.Errorf("agent: another Run is already in flight on this AgentMode instance")
 	}
 	defer a.runInflight.Store(false)
+
+	// Per-run state, reset here because AgentMode is one instance for the
+	// whole session: the second run of a session inherits whatever the
+	// first left behind. The task budget's ceiling is fixed on the first
+	// turn that has one, so without this the "run" ceiling was the
+	// session's — every later run announced a total it had already spent
+	// most of, and the model wound down a task that had barely started.
+	a.resetPerRunState()
 
 	// Register the orchestrator itself in the process-wide run registry.
 	// Workers, subagents and MoA members spawned from this loop inherit the

--- a/cli/ctxmgr/refresh.go
+++ b/cli/ctxmgr/refresh.go
@@ -174,6 +174,20 @@ func expandSourcePaths(paths []string) []string {
 // when something changed. Contexts created before source paths were
 // recorded cannot refresh: re-run /context update <name> <paths> once.
 func (m *Manager) RefreshContext(ctx context.Context, name string) (*FileContext, RefreshReport, error) {
+	return m.rescanContext(ctx, name, true)
+}
+
+// rescanContext re-scans a context's sources, with the reseal made an
+// explicit choice of the caller rather than a side effect.
+//
+// Adopting a seal re-cuts the corpus and makes it re-earn its vectors.
+// That is the right price for a command the user typed, and the wrong one
+// for a file save: the watcher refreshes on its own schedule, and a
+// corpus that silently re-embedded because someone touched a file would
+// spend on a migration nobody asked for, at a moment nobody chose. The
+// watcher refreshes content only; /context refresh is what moves a
+// corpus onto the current seals.
+func (m *Manager) rescanContext(ctx context.Context, name string, reseal bool) (*FileContext, RefreshReport, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -222,8 +236,12 @@ func (m *Manager) RefreshContext(ctx context.Context, name string) (*FileContext
 	// and until now it never wrote them — a context created before either
 	// seal stayed on the old cut and the bare indexed text no matter how
 	// often it was refreshed.
-	resealed := applyIndexSeals(fc)
-	rep.Resealed = resealed
+	// Checked, not written: the seal only becomes true once the context it
+	// belongs to is on disk. Writing it here and failing to save below
+	// would leave memory claiming a shape the stored corpus does not have
+	// — the retrieval cache would invalidate and re-embed, and the next
+	// process would read the old seal off disk and re-embed again.
+	rep.Resealed = reseal && indexSealsDiffer(fc)
 	if !rep.Dirty() && len(fc.FileStamps) > 0 {
 		// Nothing moved: keep UpdatedAt so retrieval caches and the
 		// vector index stay valid as they are.
@@ -261,7 +279,18 @@ func (m *Manager) RefreshContext(ctx context.Context, name string) (*FileContext
 		fc.ChunkStrategy = string(ChunkSmart)
 	}
 	fc.UpdatedAt = time.Now()
+	sealedNow := false
+	if rep.Resealed {
+		sealedNow = applyIndexSeals(fc)
+	}
 	if err := m.Storage.SaveContext(fc); err != nil {
+		if sealedNow {
+			// The corpus on disk never gained the seal, so neither does
+			// the one in memory: both stay on the shape whose vectors are
+			// already paid for, and the next refresh tries again.
+			clearIndexSeals(fc)
+			rep.Resealed = false
+		}
 		return fc, rep, fmt.Errorf("erro ao salvar contexto: %w", err)
 	}
 	m.logger.Info("context refreshed", zap.String("context", name), zap.String("report", rep.String()))

--- a/cli/ctxmgr/refresh_test.go
+++ b/cli/ctxmgr/refresh_test.go
@@ -247,3 +247,104 @@ func TestContextFingerprint_TracksSeal(t *testing.T) {
 		t.Fatal("a context that gained the seals must not reuse the unsealed cache entry")
 	}
 }
+
+// TestRefreshContext_WatcherRefreshesContentOnly covers the cost nobody
+// asked for. Adopting a seal re-cuts the corpus and makes it re-earn its
+// vectors — the right price for a command the user typed, the wrong one
+// for a file save. The watcher refreshes on its own schedule.
+func TestRefreshContext_WatcherRefreshesContentOnly(t *testing.T) {
+	m, src := newRefreshManager(t)
+	ctx := context.Background()
+	fc, err := m.CreateContext(ctx, "docs", "", []string{src}, ModeFull, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for k := range currentIndexSeals() {
+		delete(fc.Metadata, k)
+	}
+
+	// The watcher's path: content only.
+	fresh, rep, err := m.rescanContext(ctx, "docs", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.Resealed {
+		t.Fatal("a file save must not migrate a corpus onto a new seal")
+	}
+	if Situated(fresh) {
+		t.Fatal("the watcher must leave the corpus on the shape whose vectors are already paid for")
+	}
+
+	// The command the user typed does migrate it.
+	fresh, rep, err = m.RefreshContext(ctx, "docs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rep.Resealed || !Situated(fresh) {
+		t.Fatalf("/context refresh is what moves a corpus onto the current seals: %s", rep)
+	}
+}
+
+// TestRefreshContext_SealOnlyCountsOnceStored covers the half-written
+// migration. The seal decides how a corpus is cut and what its passages
+// are indexed by, so a context whose memory claims one shape while the
+// stored copy has another invalidates the retrieval cache, re-embeds, and
+// then re-embeds again in the next process that reads the old seal.
+//
+// The write is made to fail by putting a directory where the context file
+// belongs — a rename onto it fails on Windows, Linux and macOS alike,
+// unlike a permission bit.
+func TestRefreshContext_SealOnlyCountsOnceStored(t *testing.T) {
+	base := t.TempDir()
+	m, err := NewManagerWithBasePath(base, zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "a.md"), []byte("# alpha\nbody\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	fc, err := m.CreateContext(ctx, "docs", "", []string{src}, ModeFull, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for k := range currentIndexSeals() {
+		delete(fc.Metadata, k)
+	}
+	before := indexSeal(fc)
+
+	stored := filepath.Join(base, fc.ID+".json")
+	if err := os.Remove(stored); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(stored, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err = m.RefreshContext(ctx, "docs"); err == nil {
+		t.Fatal("the refresh must report the failed write")
+	}
+	if Situated(fc) {
+		t.Fatal("a seal that never reached disk must not be left in memory")
+	}
+	// The seal is the claim that must not survive the failed write. The
+	// rest of the refresh legitimately did happen in memory — the files
+	// were re-scanned — so the fingerprint moving is correct; the corpus
+	// staying on the cut and the indexed text its stored vectors were
+	// paid for is what matters.
+	if after := indexSeal(fc); after != before {
+		t.Fatalf("the seal must stay where the stored corpus is: %q then %q", before, after)
+	}
+
+	// The write recovers and the migration lands for real.
+	if err := os.Remove(stored); err != nil {
+		t.Fatal(err)
+	}
+	fresh, rep, err := m.RefreshContext(ctx, "docs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rep.Resealed || !Situated(fresh) {
+		t.Fatalf("the retry must land the seal: %s", rep)
+	}
+}

--- a/cli/ctxmgr/segment.go
+++ b/cli/ctxmgr/segment.go
@@ -96,6 +96,32 @@ func applyIndexSeals(fc *FileContext) bool {
 	return changed
 }
 
+// indexSealsDiffer reports whether a context is on a seal other than the
+// current one, without touching it — the question a refresh asks before
+// deciding it has work to do.
+func indexSealsDiffer(fc *FileContext) bool {
+	if fc == nil {
+		return true
+	}
+	for k, v := range currentIndexSeals() {
+		if fc.Metadata[k] != v {
+			return true
+		}
+	}
+	return false
+}
+
+// clearIndexSeals undoes applyIndexSeals, so a reseal that could not be
+// persisted leaves nothing behind claiming it was.
+func clearIndexSeals(fc *FileContext) {
+	if fc == nil || fc.Metadata == nil {
+		return
+	}
+	for k := range currentIndexSeals() {
+		delete(fc.Metadata, k)
+	}
+}
+
 // indexSeal renders a context's seals as a stable string for the
 // retrieval fingerprint. Sorted, so map order never invalidates a cache.
 func indexSeal(fc *FileContext) string {

--- a/cli/ctxmgr/watch.go
+++ b/cli/ctxmgr/watch.go
@@ -242,7 +242,9 @@ func (w *ContextWatcher) refresh(name string) {
 	if closed {
 		return
 	}
-	_, rep, err := w.m.RefreshContext(w.ctx, name)
+	// Content only. Adopting a seal re-embeds the corpus, and a file save
+	// is not the user asking for that — /context refresh is.
+	_, rep, err := w.m.rescanContext(w.ctx, name, false)
 	if w.notify != nil && (err != nil || rep.Dirty()) {
 		w.notify(name, rep, err)
 	}

--- a/cli/task_budget_shape_test.go
+++ b/cli/task_budget_shape_test.go
@@ -83,3 +83,16 @@ func TestRemainingTaskBudgetTokensFor_PricesTheServingPair(t *testing.T) {
 		t.Fatalf("an unsampled pair must fall back to the session average, got %d ok=%v", fresh, ok)
 	}
 }
+
+// TestAgentMode_TaskBudgetCeilingIsPerRun covers the state that outlived
+// the run it belonged to. AgentMode is one instance for the whole
+// session, so the ceiling fixed on the first run was still there on the
+// second: a fresh task announced a total it had already spent most of,
+// and the model wound down something that had barely started.
+func TestAgentMode_TaskBudgetCeilingIsPerRun(t *testing.T) {
+	a := &AgentMode{taskBudgetTotal: 400000}
+	a.resetPerRunState()
+	if a.taskBudgetTotal != 0 {
+		t.Fatalf("a new run must announce its own ceiling, inherited %d", a.taskBudgetTotal)
+	}
+}


### PR DESCRIPTION
Closes **COST-1**, **RAG-1** (P2) and **RAG-2** (P3) of Context Audit VI. All three are in code #1517 and #1518 introduced.

## COST-1 — a ceiling that outlived its run

`AgentMode` is a single instance for the whole session. The task budget's ceiling is fixed on the first turn of a run that has one, and nothing cleared it — so the second run of a session inherited the first run's total. A fresh task announced a ceiling it had already spent most of, and the model wound down something that had barely started.

Reset where a run begins, next to the guard that already prevents a second `Run` on the same instance. Extracted as `resetPerRunState` so the next piece of per-run state has an obvious home rather than becoming the same bug again.

## RAG-1 — a migration nobody asked for

Adopting an index seal re-cuts the corpus and makes it re-earn its vectors. That is the right price for `/context refresh`, which a user types. It is the wrong price for a file save — and the watcher drives the same `RefreshContext` on its own schedule, so a corpus silently re-embedded because someone touched a file, at a moment nobody chose.

The reseal is now explicit in the internal entry point. `RefreshContext` keeps its signature and still reseals; the watcher calls the content-only path.

## RAG-2 — a seal that outran the disk

The seal was written to the in-memory context **before** the context existed on disk with it. A failed write left memory claiming a shape the stored copy did not have: the retrieval cache invalidated and re-embedded, and the next process read the old seal off disk and re-embedded again — paying twice for a migration that never landed.

The seal is applied immediately before the save and undone when the save fails, so it only ever means what the stored corpus is.

The rest of the refresh is deliberately left alone: the files really were re-scanned in memory, so the fingerprint moving is correct. Reverting that too would serve new content under the old fingerprint, which is worse than the problem. The test asserts the seal specifically, not the whole fingerprint — an earlier draft over-asserted and was corrected.

## Tests

- `TestAgentMode_TaskBudgetCeilingIsPerRun` — a new run announces its own ceiling.
- `TestRefreshContext_WatcherRefreshesContentOnly` — a file save leaves the corpus on the shape whose vectors are paid for; the typed command migrates it.
- `TestRefreshContext_SealOnlyCountsOnceStored` — a failed write leaves no seal in memory, and the retry lands it for real.

The failing write is produced by putting a directory where the context file belongs, so it fails identically on Windows, Linux and macOS — a permission bit would not.

`go test ./...` clean; Floors 4, 5, 8, 12, 13, 15 verified locally.