### PR TITLE
feat(llm): the OAuth path carries per-turn context like the others

### DIFF
--- a/llm/claudeai/claude_client.go
+++ b/llm/claudeai/claude_client.go
@@ -635,8 +635,12 @@ func (c *ClaudeClient) buildOAuthMessagesAndSystem(prompt string, history []mode
 	var messages []map[string]interface{}
 	var systemParts []string
 	var structuredParts []map[string]interface{}
+	turnScoped := client.NewTurnContextEmitter(catalog.ProviderClaudeAI, c.model)
 
 	for _, msg := range history {
+		if turnScoped.Claim(msg) {
+			continue
+		}
 		switch strings.ToLower(strings.TrimSpace(msg.Role)) {
 		case "assistant":
 			messages = append(messages, map[string]interface{}{
@@ -665,6 +669,8 @@ func (c *ClaudeClient) buildOAuthMessagesAndSystem(prompt string, history []mode
 				"content": visionwire.AnthropicOAuthContent(msg.Content, msg.Images),
 			})
 		}
+		// One position later than the history holds it: see the emitter.
+		messages = appendTurnScoped(messages, turnScoped)
 	}
 
 	if len(history) == 0 || history[len(history)-1].Role != "user" || history[len(history)-1].Content != prompt {
@@ -675,6 +681,10 @@ func (c *ClaudeClient) buildOAuthMessagesAndSystem(prompt string, history []mode
 			})
 		}
 	}
+	// A block claimed on the last history entry: the prompt above is the
+	// user message it belongs to.
+	messages = appendTurnScoped(messages, turnScoped)
+	c.turnScoped = turnScoped
 
 	systemObjs := []interface{}{
 		oauthTextBlock(oauthBaseSystemPrompt),

--- a/llm/claudeai/turn_scoped_wire_test.go
+++ b/llm/claudeai/turn_scoped_wire_test.go
@@ -6,6 +6,9 @@
 package claudeai
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/diillson/chatcli/llm/catalog"
@@ -211,5 +214,70 @@ func TestTurnScoped_SecondTurnStillCarriesContext(t *testing.T) {
 	messages, _ = c.buildMessagesAndSystem("second question", turn2)
 	if got := renderedTurnContextBlocks(messages); got != 1 {
 		t.Fatalf("turn 2 rendered %d blocks, want exactly 1 — 0 means the model lost its context, 2 means the earlier one never cleared", got)
+	}
+}
+
+// TestOAuthBuildMessages_CarriesTheBlockToo closes the surface Audit VI
+// found missing. The Anthropic client has three message builders, not
+// two: the API-key path, the tool loop, and this one for OAuth sessions.
+// Only the first two were wired, so an OAuth session kept sending the
+// block as a user message while the other two sent a system message —
+// the same conversation serialized two ways depending on how the user
+// had authenticated.
+func TestOAuthBuildMessages_CarriesTheBlockToo(t *testing.T) {
+	c := &ClaudeClient{model: "claude-opus-5", logger: zap.NewNop()}
+	messages, _ := c.buildOAuthMessagesAndSystem("second question", turnScopedHistory())
+
+	var roles []string
+	for _, m := range messages {
+		roles = append(roles, roleAt(m))
+	}
+	want := []string{"user", "assistant", "user", "system"}
+	if len(roles) != len(want) {
+		t.Fatalf("roles = %v, want %v", roles, want)
+	}
+	for i := range want {
+		if roles[i] != want[i] {
+			t.Fatalf("roles = %v, want %v — the OAuth builder must place the block like the other two", roles, want)
+		}
+	}
+	if clearAtOf(messages[len(messages)-1]) != client.ClearAtNextUserMessage {
+		t.Fatal("the OAuth path must scope the block to the turn too")
+	}
+
+	// The OAuth header helper sets anthropic-beta wholesale, so the
+	// clear_at opt-in has to be appended after it rather than replaced by
+	// it. Without the flag the field is rejected as an unknown field.
+	req := httptest.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", nil)
+	applyOAuthHeaders(req, "tok")
+	c.applyTurnScopedSystemBeta(req)
+	betas := req.Header.Get("anthropic-beta")
+	if !strings.Contains(betas, client.TurnScopedSystemBeta) {
+		t.Fatalf("anthropic-beta = %q, want the clear_at beta appended", betas)
+	}
+	if !strings.Contains(betas, oauthAnthropicBeta) {
+		t.Fatalf("anthropic-beta = %q, the OAuth betas must survive", betas)
+	}
+}
+
+// TestOAuthBuildMessages_UnsupportedModelIsUnchanged keeps the OAuth path
+// under the same no-regression rule as the others.
+func TestOAuthBuildMessages_UnsupportedModelIsUnchanged(t *testing.T) {
+	c := &ClaudeClient{model: "claude-sonnet-5", logger: zap.NewNop()}
+	messages, _ := c.buildOAuthMessagesAndSystem("second question", turnScopedHistory())
+	for _, m := range messages {
+		if clearAtOf(m) != "" {
+			t.Fatal("a model without the capability must never receive clear_at")
+		}
+	}
+	if c.turnScoped.Used() {
+		t.Fatal("nothing was emitted, so no beta may be declared")
+	}
+	req := httptest.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", nil)
+	applyOAuthHeaders(req, "tok")
+	before := req.Header.Get("anthropic-beta")
+	c.applyTurnScopedSystemBeta(req)
+	if req.Header.Get("anthropic-beta") != before {
+		t.Fatal("a request carrying no turn-scoped message must carry no extra beta")
 	}
 }


### PR DESCRIPTION
Closes **CAG-2** (P1) of Context Audit VI.

## The gap

When #1519 shipped I wrote "the four surfaces that build an Anthropic message array" and checked claudeai ×2 and bedrock ×2. I never went looking for whether there were others. There was one: `buildOAuthMessagesAndSystem`.

So an OAuth session went on sending the per-turn block as a **user message** while the other two Anthropic builders sent it as a **system message**. The same conversation serialized two ways depending on how the user had authenticated, and an OAuth session never got what the capability exists for.

## The fix

The OAuth builder defers the block by one position like the others, so a block renders on the turn it belongs to and clears afterwards.

Its header helper (`applyOAuthHeaders`) sets `anthropic-beta` **wholesale**, so the `clear_at` opt-in has to be appended after it rather than replaced by it. That is what the deferred call in `applyAuthHeaders` already does, and a test now pins it — including that the OAuth betas survive.

## Ordering

This lands **after** #1520, not before. Wiring a third builder onto the old redundancy rule would only have widened the reach of a per-turn block that had stopped being read — which is why the audit's roadmap put it second.

## Tests

- `TestOAuthBuildMessages_CarriesTheBlockToo` — the block lands after the user turn it belongs to, scoped to the turn; the beta is appended to the OAuth header list rather than replacing it.
- `TestOAuthBuildMessages_UnsupportedModelIsUnchanged` — Sonnet 5 on OAuth keeps the user-role block, receives no `clear_at`, and adds no beta.

`go test ./...` clean; Floors 4, 5, 8, 12, 13, 15 verified locally.