### PR TITLE
fix(llm): a turn-scoped system message goes where the provider accepts it

### DIFF
--- a/llm/bedrock/bedrock_client.go
+++ b/llm/bedrock/bedrock_client.go
@@ -618,7 +618,9 @@ func (c *BedrockClient) buildMessagesAndSystem(prompt string, history []models.M
 		if turnScoped.Claim(msg) {
 			continue
 		}
-		switch strings.ToLower(strings.TrimSpace(msg.Role)) {
+		role := strings.ToLower(strings.TrimSpace(msg.Role))
+		messages = appendTurnScopedBefore(messages, turnScoped, role)
+		switch role {
 		case "assistant":
 			messages = append(messages, map[string]interface{}{
 				"role":    "assistant",
@@ -646,8 +648,6 @@ func (c *BedrockClient) buildMessagesAndSystem(prompt string, history []models.M
 		default:
 			messages = append(messages, map[string]interface{}{"role": "user", "content": visionwire.AnthropicContent(msg.Content, msg.Images)})
 		}
-		// One position later than the history holds it: see the emitter.
-		messages = appendTurnScoped(messages, turnScoped)
 	}
 
 	if len(history) == 0 || history[len(history)-1].Role != "user" || history[len(history)-1].Content != prompt {
@@ -655,8 +655,8 @@ func (c *BedrockClient) buildMessagesAndSystem(prompt string, history []models.M
 			messages = append(messages, map[string]interface{}{"role": "user", "content": prompt})
 		}
 	}
-	// A block claimed on the last history entry: the prompt above is the
-	// user message it belongs to.
+	// The end of the array: the other position the provider accepts, and
+	// where the block renders for the turn being sent.
 	messages = appendTurnScoped(messages, turnScoped)
 	c.turnScoped = turnScoped
 
@@ -1151,6 +1151,17 @@ func (c *BedrockClient) storeThinkingFromBody(body []byte) {
 
 // appendTurnScoped writes whatever the emitter buffered into the message
 // array, in the one shape both Bedrock transports send.
+func appendTurnScopedBefore(messages []map[string]interface{}, e *client.TurnContextEmitter, role string) []map[string]interface{} {
+	for _, m := range e.FlushBefore(role) {
+		messages = append(messages, map[string]interface{}{
+			"role":     m.Role,
+			"clear_at": m.ClearAt,
+			"content":  m.Content,
+		})
+	}
+	return messages
+}
+
 func appendTurnScoped(messages []map[string]interface{}, e *client.TurnContextEmitter) []map[string]interface{} {
 	for _, m := range e.Flush() {
 		messages = append(messages, map[string]interface{}{

--- a/llm/claudeai/claude_client.go
+++ b/llm/claudeai/claude_client.go
@@ -576,7 +576,9 @@ func (c *ClaudeClient) buildMessagesAndSystem(prompt string, history []models.Me
 		if turnScoped.Claim(msg) {
 			continue
 		}
-		switch strings.ToLower(strings.TrimSpace(msg.Role)) {
+		role := strings.ToLower(strings.TrimSpace(msg.Role))
+		messages = appendTurnScopedBefore(messages, turnScoped, role)
+		switch role {
 		case "assistant":
 			messages = append(messages, map[string]interface{}{"role": "assistant", "content": visionwire.AnthropicContent(msg.Content, msg.Images)})
 		case "system":
@@ -598,8 +600,6 @@ func (c *ClaudeClient) buildMessagesAndSystem(prompt string, history []models.Me
 		default:
 			messages = append(messages, map[string]interface{}{"role": "user", "content": visionwire.AnthropicContent(msg.Content, msg.Images)})
 		}
-		// One position later than the history holds it: see the emitter.
-		messages = appendTurnScoped(messages, turnScoped)
 	}
 
 	if len(history) == 0 || history[len(history)-1].Role != "user" || history[len(history)-1].Content != prompt {
@@ -607,8 +607,8 @@ func (c *ClaudeClient) buildMessagesAndSystem(prompt string, history []models.Me
 			messages = append(messages, map[string]interface{}{"role": "user", "content": prompt})
 		}
 	}
-	// A block claimed on the last history entry has nothing after it yet;
-	// the prompt above is the user message it belongs to.
+	// The end of the array: the other position the provider accepts, and
+	// where the block renders for the turn being sent.
 	messages = appendTurnScoped(messages, turnScoped)
 	c.turnScoped = turnScoped
 
@@ -641,7 +641,9 @@ func (c *ClaudeClient) buildOAuthMessagesAndSystem(prompt string, history []mode
 		if turnScoped.Claim(msg) {
 			continue
 		}
-		switch strings.ToLower(strings.TrimSpace(msg.Role)) {
+		role := strings.ToLower(strings.TrimSpace(msg.Role))
+		messages = appendTurnScopedBefore(messages, turnScoped, role)
+		switch role {
 		case "assistant":
 			messages = append(messages, map[string]interface{}{
 				"role":    "assistant",
@@ -669,8 +671,6 @@ func (c *ClaudeClient) buildOAuthMessagesAndSystem(prompt string, history []mode
 				"content": visionwire.AnthropicOAuthContent(msg.Content, msg.Images),
 			})
 		}
-		// One position later than the history holds it: see the emitter.
-		messages = appendTurnScoped(messages, turnScoped)
 	}
 
 	if len(history) == 0 || history[len(history)-1].Role != "user" || history[len(history)-1].Content != prompt {
@@ -681,8 +681,8 @@ func (c *ClaudeClient) buildOAuthMessagesAndSystem(prompt string, history []mode
 			})
 		}
 	}
-	// A block claimed on the last history entry: the prompt above is the
-	// user message it belongs to.
+	// The end of the array: the other position the provider accepts, and
+	// where the block renders for the turn being sent.
 	messages = appendTurnScoped(messages, turnScoped)
 	c.turnScoped = turnScoped
 
@@ -1058,6 +1058,15 @@ func applyTaskBudget(reqBody map[string]interface{}, model string, ctx context.C
 // turn-scoped system message is written in exactly one place.
 func appendTurnScoped(messages []map[string]interface{}, e *client.TurnContextEmitter) []map[string]interface{} {
 	for _, m := range e.Flush() {
+		messages = append(messages, turnScopedBlock(m))
+	}
+	return messages
+}
+
+// appendTurnScopedBefore writes whatever must precede a message with this
+// role. Only an assistant turn may be preceded by a system message.
+func appendTurnScopedBefore(messages []map[string]interface{}, e *client.TurnContextEmitter, role string) []map[string]interface{} {
+	for _, m := range e.FlushBefore(role) {
 		messages = append(messages, turnScopedBlock(m))
 	}
 	return messages

--- a/llm/claudeai/tool_use.go
+++ b/llm/claudeai/tool_use.go
@@ -240,6 +240,12 @@ func buildClaudeToolMessages(prompt string, history []models.Message, turnScoped
 			continue
 		}
 		role := strings.ToLower(strings.TrimSpace(msg.Role))
+		// Only an assistant turn may be preceded by a system message, and a
+		// tool loop is mostly user-role messages: that is how tool results
+		// travel. A block written before one is rejected outright.
+		for _, ts := range turnScoped.FlushBefore(role) {
+			messages = append(messages, turnScopedBlock(ts))
+		}
 
 		switch role {
 		case "system":
@@ -320,10 +326,6 @@ func buildClaudeToolMessages(prompt string, history []models.Message, turnScoped
 				"content": visionwire.AnthropicContent(msg.Content, msg.Images),
 			})
 		}
-		// One position later than the history holds it: see the emitter.
-		for _, ts := range turnScoped.Flush() {
-			messages = append(messages, turnScopedBlock(ts))
-		}
 	}
 
 	// Add prompt as user message if needed
@@ -336,8 +338,8 @@ func buildClaudeToolMessages(prompt string, history []models.Message, turnScoped
 		}
 	}
 
-	// A block claimed on the last history entry: the prompt above is the
-	// user message it belongs to.
+	// The end of the array: the other position the provider accepts, and
+	// where the block renders for the turn being sent.
 	for _, ts := range turnScoped.Flush() {
 		messages = append(messages, turnScopedBlock(ts))
 	}

--- a/llm/claudeai/turn_scoped_wire_test.go
+++ b/llm/claudeai/turn_scoped_wire_test.go
@@ -281,3 +281,102 @@ func TestOAuthBuildMessages_UnsupportedModelIsUnchanged(t *testing.T) {
 		t.Fatal("a request carrying no turn-scoped message must carry no extra beta")
 	}
 }
+
+// assertSystemPlacementLegal encodes the rule the provider stated in the
+// 400 that this test exists because of:
+//
+//	messages.N: role 'system' must precede an 'assistant' message or end
+//	the array
+//
+// The original placement — directly after the user turn the block belongs
+// to — satisfied it only when an assistant turn happened to come next. A
+// tool loop is mostly user-role messages, because that is how tool results
+// travel, and two user turns in a row is what a failed request leaves
+// behind. Both produced [user, system, user] and were rejected outright.
+func assertSystemPlacementLegal(t *testing.T, label string, messages []interface{}) {
+	t.Helper()
+	for i, m := range messages {
+		if roleAt(m) != "system" {
+			continue
+		}
+		if i == len(messages)-1 {
+			continue // ends the array
+		}
+		if next := roleAt(messages[i+1]); next != "assistant" {
+			t.Errorf("%s: messages.%d is role 'system' followed by %q — must precede an assistant message or end the array", label, i, next)
+		}
+	}
+}
+
+func asAny(messages []map[string]interface{}) []interface{} {
+	out := make([]interface{}, 0, len(messages))
+	for _, m := range messages {
+		out = append(out, m)
+	}
+	return out
+}
+
+// TestTurnScoped_PlacementIsLegalOnEveryHistoryShape runs every Anthropic
+// builder over the shapes that broke in production and over the tool loop
+// that would have broken next.
+func TestTurnScoped_PlacementIsLegalOnEveryHistoryShape(t *testing.T) {
+	tc := func(n string) models.Message { return models.TurnContextMessage("[TURN CONTEXT] " + n) }
+
+	shapes := map[string][]models.Message{
+		"chat, one turn": {
+			{Role: "system", Content: "sys"},
+			tc("t1"), {Role: "user", Content: "q1"},
+		},
+		"chat, several turns": {
+			{Role: "system", Content: "sys"},
+			tc("t1"), {Role: "user", Content: "q1"}, {Role: "assistant", Content: "a1"},
+			tc("t2"), {Role: "user", Content: "q2"}, {Role: "assistant", Content: "a2"},
+			tc("t3"), {Role: "user", Content: "q3"},
+		},
+		// What the production session actually held: a turn whose request
+		// failed leaves a user message with no assistant answer, and the
+		// next turn appends another block and another user message.
+		"two user turns in a row after a failed request": {
+			{Role: "system", Content: "sys"},
+			tc("t1"), {Role: "user", Content: "q1"}, {Role: "assistant", Content: "a1"},
+			tc("t2"), {Role: "user", Content: "q2"},
+			tc("t3"), {Role: "user", Content: "q3"},
+		},
+		// Tool results travel as user-role messages, so a block held for
+		// the next assistant turn has to survive several of them.
+		"tool loop": {
+			{Role: "system", Content: "sys"},
+			tc("t1"), {Role: "user", Content: "build it"},
+			{Role: "assistant", Content: "running", ToolCalls: []models.ToolCall{{ID: "c1", Name: "run"}}},
+			{Role: "tool", Content: "exit 1", ToolCallID: "c1"},
+			tc("t2"),
+			{Role: "tool", Content: "exit 0", ToolCallID: "c1"},
+			{Role: "assistant", Content: "done"},
+			tc("t3"), {Role: "user", Content: "thanks"},
+		},
+		"block is the last entry": {
+			{Role: "system", Content: "sys"},
+			{Role: "user", Content: "q1"}, {Role: "assistant", Content: "a1"}, tc("t1"),
+		},
+	}
+
+	for name, history := range shapes {
+		t.Run(name, func(t *testing.T) {
+			last := ""
+			if n := len(history); n > 0 {
+				last = history[n-1].Content
+			}
+			c := &ClaudeClient{model: "claude-opus-5", logger: zap.NewNop()}
+
+			msgs, _ := c.buildMessagesAndSystem(last, history)
+			assertSystemPlacementLegal(t, "api-key builder", asAny(msgs))
+
+			oauth, _ := c.buildOAuthMessagesAndSystem(last, history)
+			assertSystemPlacementLegal(t, "oauth builder", asAny(oauth))
+
+			tool := buildClaudeToolMessages(last, history,
+				client.NewTurnContextEmitter(catalog.ProviderClaudeAI, "claude-opus-5"))
+			assertSystemPlacementLegal(t, "tool loop", tool)
+		})
+	}
+}

--- a/llm/client/turn_context_wire.go
+++ b/llm/client/turn_context_wire.go
@@ -27,15 +27,31 @@
  * Every provider whose catalog entry does not claim it keeps the
  * user-role block byte for byte, so this can only add.
  *
- * Placement is the whole trick. A turn-scoped message renders only while
- * no user message follows it, so emitting the block where the history
- * holds it — ahead of the user's turn — would clear it on the very
- * request that introduced it. It is emitted one position later, directly
- * after the message it accompanies. That position is stable for the life
- * of the conversation: the same history always serializes to the same
- * bytes, which is what re-sending a cleared message verbatim requires. A
- * block that lands at a different index on a later request is an edit to
- * an earlier message, and misses the cache from there on.
+ * Placement answers to two rules at once, and the provider enforces one
+ * of them:
+ *
+ *   messages.N: role 'system' must precede an 'assistant' message or end
+ *   the array
+ *
+ * So a block may sit immediately before an assistant turn, or last. It may
+ * never sit before a user turn — and a tool loop is full of user-role
+ * messages, because that is how tool results travel.
+ *
+ * The second rule is what makes the block useful: it renders only while no
+ * user message follows it. Emitting it where the history holds it, ahead
+ * of the user's turn, would clear it on the very request that introduced
+ * it.
+ *
+ * Both are satisfied by holding the block until the next assistant turn is
+ * about to be written, and by flushing whatever is left at the end of the
+ * array. A block before an assistant turn is legal and, since a later user
+ * message always follows, correctly cleared. A block at the end is legal
+ * and renders, which is the copy the current turn reads.
+ *
+ * Position stays a function of the history alone, which is what re-sending
+ * a cleared message verbatim requires: a block that lands at a different
+ * index on a later request is an edit to an earlier message, and misses
+ * the cache from there on.
  */
 package client
 
@@ -115,17 +131,58 @@ func (e *TurnContextEmitter) Claim(msg models.Message) bool {
 	return true
 }
 
-// Flush returns what was claimed and clears it. Callers call it right
-// after appending an ordinary message, which is what places the block one
-// position later than the history holds it.
+// FlushBefore returns what must be written immediately ahead of a message
+// with this role, and clears it. Only an assistant turn may be preceded by
+// a system message; before anything else the block waits, which is what
+// keeps a tool loop legal — tool results travel as user-role messages, and
+// a block written before one is rejected outright.
+func (e *TurnContextEmitter) FlushBefore(role string) []TurnScopedSystem {
+	if e == nil || len(e.pending) == 0 {
+		return nil
+	}
+	if !strings.EqualFold(strings.TrimSpace(role), "assistant") {
+		return nil
+	}
+	return e.take()
+}
+
+// Flush returns whatever is still pending, for the end of the array — the
+// one other position the provider accepts, and the one where the block
+// renders for the turn being sent.
 func (e *TurnContextEmitter) Flush() []TurnScopedSystem {
 	if e == nil || len(e.pending) == 0 {
 		return nil
 	}
-	out := e.pending
+	return e.take()
+}
+
+// take returns the pending blocks as a single message.
+//
+// Coalesced because the provider's rule leaves at most one legal slot in
+// the shapes that pile blocks up: a system message must precede an
+// assistant turn or end the array, and the first of two adjacent system
+// messages does neither. Blocks pile up when several turns pass with no
+// assistant between them — which is what a failed request leaves behind,
+// and what a run of tool results looks like.
+//
+// Joining is deterministic given the history, so the position and the
+// bytes are still a function of the conversation alone.
+func (e *TurnContextEmitter) take() []TurnScopedSystem {
+	pending := e.pending
 	e.pending = nil
 	e.emitted = true
-	return out
+	if len(pending) == 1 {
+		return pending
+	}
+	parts := make([]string, 0, len(pending))
+	for _, p := range pending {
+		parts = append(parts, p.Content)
+	}
+	return []TurnScopedSystem{{
+		Role:    "system",
+		ClearAt: ClearAtNextUserMessage,
+		Content: strings.Join(parts, "\n\n"),
+	}}
 }
 
 // Used reports whether any turn-scoped message was actually emitted, so


### PR DESCRIPTION
**Production hotfix.** OAuth sessions on Opus 5 and Fable 5.1 are currently returning 400 on every turn.

```
❌ API error: status 400
messages.7: role 'system' must precede an 'assistant' message or end the array
```

## What I got wrong

I placed the block **directly after the user turn it belongs to**. That satisfies the provider's rule only when an assistant turn happens to come next. Two ordinary shapes break it:

- **A tool loop** is mostly user-role messages — that is how tool results travel.
- **A turn whose request failed** leaves a user message with no answer, so the next turn appends another block and another user message.

Both produce `[user, system, user]`, and the API refuses the whole request. Once one turn fails, every following turn inherits the shape — which is why the session above never recovered until the user switched to Sonnet 5, the one model without the capability.

## The rule, implemented

A block is held until an assistant turn is about to be written, and whatever is left goes at the end of the array. Those are the two positions the provider accepts, and both do the right thing:

- before an assistant turn → legal, and correctly cleared, since a later user message always follows;
- at the end → legal, and renders, which is the copy the current turn reads.

Blocks that pile up are **coalesced into one message**: the first of two adjacent system messages neither precedes an assistant turn nor ends the array. They pile up in exactly the shapes above. Joining is deterministic given the history, so position and bytes stay a function of the conversation alone and a cleared message is still re-sent verbatim.

## How this got to production

The reach was widened twice in the same session before it surfaced — once by making the block travel every turn (#1520), once by wiring the OAuth builder (#1522). Before #1522 an OAuth session never emitted the block at all, which is why it broke the moment that merged.

What was missing throughout is the thing this PR adds: **a test that encodes the provider's own rule**, instead of my reading of the placement docs.

`assertSystemPlacementLegal` is the 400's text as an assertion, and `TestTurnScoped_PlacementIsLegalOnEveryHistoryShape` runs all three Anthropic builders over five history shapes — including the two that broke and the tool loop that would have broken next. With the rule reverted, `chat, one turn` alone fails on both builders.

## Tests

- `TestTurnScoped_PlacementIsLegalOnEveryHistoryShape` — the provider's rule, over the api-key builder, the OAuth builder and the tool loop, across: one chat turn, several chat turns, two user turns in a row after a failed request, a tool loop with several tool results, and a block as the last entry.
- Existing placement, no-regression and stability tests all still pass.

`go test ./...` clean; Floors 4, 5, 8, 12, 13, 15 verified locally.