### PR TITLE
fix(llm): the cache breakpoint survives a trailing system message

### DIFF
--- a/llm/claudeai/turn_scoped_wire_test.go
+++ b/llm/claudeai/turn_scoped_wire_test.go
@@ -380,3 +380,72 @@ func TestTurnScoped_PlacementIsLegalOnEveryHistoryShape(t *testing.T) {
 		})
 	}
 }
+
+// countCacheBreakpoints counts the cache_control markers a request carries
+// on its message array.
+func countCacheBreakpoints(messages []map[string]interface{}) int {
+	n := 0
+	for _, m := range messages {
+		blocks, ok := m["content"].([]map[string]interface{})
+		if !ok {
+			continue
+		}
+		for _, b := range blocks {
+			if _, marked := b["cache_control"]; marked {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+// TestTurnScoped_HistoryStaysCacheable covers what fixing the 400 cost.
+// The rolling breakpoint marks the last message so the whole conversation
+// becomes a cacheable prefix, and it gives up when that message is not a
+// user turn — a guard written for assistant prefills, before a system
+// message could appear inside the array at all.
+//
+// Putting the block at the end of the array made that guard fire on every
+// turn: no breakpoint, no cached prefix, and nothing said so. The block
+// itself can never carry the marker — cache_control is rejected on a
+// turn-scoped message — so the breakpoint belongs on the turn behind it.
+func TestTurnScoped_HistoryStaysCacheable(t *testing.T) {
+	history := []models.Message{
+		{Role: "system", Content: "sys"},
+		{Role: "user", Content: "q1"},
+		{Role: "assistant", Content: "a1"},
+		models.TurnContextMessage("[TURN CONTEXT] today is 2026-09-05"),
+		{Role: "user", Content: "q2"},
+	}
+
+	for _, model := range []string{"claude-opus-5", "claude-fable-5-1", "claude-sonnet-5"} {
+		t.Run(model, func(t *testing.T) {
+			c := &ClaudeClient{model: model, logger: zap.NewNop()}
+			messages, _ := c.buildMessagesAndSystem("q2", history)
+			client.MarkAnthropicHistoryBreakpoint(client.AnthropicMessages{Maps: messages}, client.AnthropicCacheMarker())
+
+			if got := countCacheBreakpoints(messages); got != 1 {
+				t.Fatalf("%s: %d cache breakpoints, want 1 — the conversation must stay a cacheable prefix", model, got)
+			}
+			// The marker must never land on the block itself.
+			for _, m := range messages {
+				if roleAt(m) != "system" {
+					continue
+				}
+				if _, ok := m["cache_control"]; ok {
+					t.Fatal("cache_control is rejected on a turn-scoped system message")
+				}
+			}
+		})
+	}
+
+	// An assistant prefill still stays unmarked: the guard this walks past
+	// exists for that case and must survive.
+	c := &ClaudeClient{model: "claude-opus-5", logger: zap.NewNop()}
+	prefill := append(append([]models.Message{}, history...), models.Message{Role: "assistant", Content: "partial"})
+	messages, _ := c.buildMessagesAndSystem("", prefill)
+	client.MarkAnthropicHistoryBreakpoint(client.AnthropicMessages{Maps: messages}, client.AnthropicCacheMarker())
+	if got := countCacheBreakpoints(messages); got != 0 {
+		t.Fatalf("an assistant prefill must stay unmarked, got %d breakpoints", got)
+	}
+}

--- a/llm/client/cache_prefix.go
+++ b/llm/client/cache_prefix.go
@@ -248,15 +248,44 @@ type AnthropicMessages struct {
 	List []interface{}
 }
 
-// last returns the final message of whichever list is populated.
-func (m AnthropicMessages) last() map[string]interface{} {
-	if n := len(m.Maps); n > 0 {
-		return m.Maps[n-1]
+// at returns message i of whichever list is populated.
+func (m AnthropicMessages) at(i int) map[string]interface{} {
+	if len(m.Maps) > 0 {
+		return m.Maps[i]
 	}
-	if n := len(m.List); n > 0 {
-		if last, ok := m.List[n-1].(map[string]interface{}); ok {
-			return last
+	if msg, ok := m.List[i].(map[string]interface{}); ok {
+		return msg
+	}
+	return nil
+}
+
+// count is how many messages the request carries.
+func (m AnthropicMessages) count() int {
+	if n := len(m.Maps); n > 0 {
+		return n
+	}
+	return len(m.List)
+}
+
+// lastMarkable returns the final message that can carry the rolling cache
+// breakpoint, walking past trailing turn-scoped system messages.
+//
+// A system message inside messages is a new shape: it did not exist when
+// the breakpoint was written, and it rejects cache_control outright. It
+// also sits last whenever the current turn carries per-turn context — so
+// a marker placed on "the final message" stopped being placed at all, and
+// the whole conversation quietly stopped being a cacheable prefix on every
+// model that takes the form.
+func (m AnthropicMessages) lastMarkable() map[string]interface{} {
+	for i := m.count() - 1; i >= 0; i-- {
+		msg := m.at(i)
+		if msg == nil {
+			return nil
 		}
+		if role, _ := msg["role"].(string); strings.EqualFold(role, "system") {
+			continue
+		}
+		return msg
 	}
 	return nil
 }
@@ -268,12 +297,14 @@ func (m AnthropicMessages) last() map[string]interface{} {
 // element type, and adapter content types that marshal to one of those.
 // Empty content is left alone — the API rejects empty text blocks — and so
 // is a request whose last message is an assistant turn (a prefill), which
-// must stay unmarked.
+// must stay unmarked. Trailing turn-scoped system messages are walked past
+// rather than marked: they reject cache_control, and the breakpoint
+// belongs on the turn behind them.
 func MarkAnthropicHistoryBreakpoint(messages AnthropicMessages, marker CacheMarker) {
 	if marker == nil {
 		return
 	}
-	last := messages.last()
+	last := messages.lastMarkable()
 	if last == nil {
 		return
 	}


### PR DESCRIPTION
Closes **CAG-1** (P0) of Context Audit VII. A regression #1523 introduced yesterday while fixing the 400.

## What broke

Fixing the 400 moved the turn-scoped block to the end of the message array. The rolling cache breakpoint marks the last message so the whole conversation becomes a cacheable prefix — and gives up when that message is not a `user` turn:

```go
if role, _ := last["role"].(string); !strings.EqualFold(role, "user") {
    return
}
```

That guard was written for assistant prefills, back when a system message could not appear inside `messages` at all. After #1523 it fired on **every turn carrying per-turn context**:

```
claude-sonnet-5            ultima=user     breakpoints=1
claude-opus-5              ultima=system   breakpoints=0
anthropic.claude-opus-5    ultima=system   breakpoints=0
```

No breakpoint, no cached prefix, on every model that takes the form and every surface that sends one — and nothing said so. The whole point of carrying the block as an appended message was to keep the prefix cacheable; this silently gave up exactly that.

## The fix

The block itself can never carry the marker — `cache_control` is rejected on a turn-scoped message. The breakpoint belongs on the turn behind it, so the search walks past trailing system messages rather than stopping at the last message.

The prefill guard is untouched: an assistant turn at the end still stays unmarked, and a test pins it.

## Tests

`TestTurnScoped_HistoryStaysCacheable` — exactly one breakpoint on Opus 5, Fable 5.1 and Sonnet 5; the marker never lands on the block itself; an assistant prefill stays unmarked. Reverting the walk gives `0 cache breakpoints` on both capable models.

`go test ./...` clean; Floors 4, 5, 8, 12, 13, 15 verified locally.