### PR TITLE
fix(llm): the task budget travels, on both providers that read it

### DIFF
--- a/llm/bedrock/bedrock_client.go
+++ b/llm/bedrock/bedrock_client.go
@@ -212,6 +212,10 @@ type BedrockClient struct {
 	// request, and this is the handoff between the builder and the
 	// transport that has to declare the beta.
 	turnScoped *client.TurnContextEmitter
+	// taskBudgetSent records whether the request being built carries a
+	// task budget, so the Messages transport declares that beta and only
+	// that beta. The InvokeModel path reads it from the body instead.
+	taskBudgetSent bool
 
 	model       string
 	region      string
@@ -512,6 +516,7 @@ func (c *BedrockClient) sendPromptAnthropicModel(ctx context.Context, wireModel,
 	c.applyTurnScopedSystemBeta(reqBody)
 
 	applyAnthropicThinkingForEffort(reqBody, wireModel, ctx)
+	applyBedrockTaskBudgetBeta(reqBody, applyBedrockTaskBudget(reqBody, wireModel, ctx))
 	// Provider context engine: the Anthropic models served here take the
 	// same context_management block as the first-party endpoint, and this
 	// path builds the native Anthropic body, so it travels unchanged.
@@ -711,6 +716,50 @@ func supportsExtendedThinking(model string) bool {
 		strings.Contains(m, "sonnet-4") ||
 		strings.Contains(m, "3-7-sonnet") ||
 		strings.Contains(m, "claude-3-7")
+}
+
+// applyBedrockTaskBudget attaches the task budget to output_config on the
+// native Anthropic body both Bedrock transports send.
+//
+// The catalog advertises task_budget on the Bedrock mirrors of every model
+// that reads it, and this package never sent the field — the capability
+// was announced and unimplemented, so a run under a spending ceiling got
+// paced on the first-party API and not here.
+//
+// Called after the effort routing and outside it: a spending ceiling is
+// not a reasoning setting, and the effort path returns early when no
+// effort was chosen. Calling it before would have the effort assignment
+// overwrite the merged map.
+func applyBedrockTaskBudget(reqBody map[string]interface{}, model string, ctx context.Context) bool {
+	budget := client.TaskBudgetFromContext(ctx)
+	if budget == nil || !catalog.HasCapability(catalog.ProviderBedrock, model, "task_budget") {
+		return false
+	}
+	cfg, _ := reqBody["output_config"].(map[string]string)
+	merged := make(map[string]interface{}, len(cfg)+1)
+	for k, v := range cfg {
+		merged[k] = v
+	}
+	merged["task_budget"] = budget
+	reqBody["output_config"] = merged
+	return true
+}
+
+// applyBedrockTaskBudgetBeta opts an InvokeModel request into the
+// task-budget beta, and only when the request carries one. Bedrock takes
+// beta flags in the body on this path; the Messages transport sends the
+// header.
+func applyBedrockTaskBudgetBeta(reqBody map[string]interface{}, sent bool) {
+	if !sent {
+		return
+	}
+	existing, _ := reqBody["anthropic_beta"].([]string)
+	for _, b := range existing {
+		if b == client.TaskBudgetBeta {
+			return
+		}
+	}
+	reqBody["anthropic_beta"] = append(existing, client.TaskBudgetBeta)
 }
 
 // applyAnthropicThinkingForEffort routes the per-turn skill effort hint

--- a/llm/bedrock/mantle.go
+++ b/llm/bedrock/mantle.go
@@ -202,6 +202,7 @@ func (c *BedrockClient) sendPromptAnthropicMantle(ctx context.Context, prompt st
 	}
 
 	applyAnthropicThinkingForEffort(reqBody, c.model, ctx)
+	c.taskBudgetSent = applyBedrockTaskBudget(reqBody, c.model, ctx)
 	// Rolling conversation breakpoint; the configured TTL applies on Claude
 	// 4.5+ (Bedrock accepts "ttl":"1h" in cache_control).
 	client.MarkAnthropicHistoryBreakpoint(client.AnthropicMessages{Maps: messages}, client.AnthropicCacheMarkerWithTTL(extendedCacheTTLModel(c.model)))
@@ -255,8 +256,15 @@ func (c *BedrockClient) doMantleRequest(ctx context.Context, endpoint string, pa
 	req.Header.Set("anthropic-version", mantleAnthropicVersion)
 	// The Messages transport is HTTP, so the beta opt-in takes the header
 	// form here rather than the body field InvokeModel uses.
+	var betas []string
 	if c.turnScoped.Used() {
-		req.Header.Set("anthropic-beta", client.TurnScopedSystemBeta)
+		betas = append(betas, client.TurnScopedSystemBeta)
+	}
+	if c.taskBudgetSent {
+		betas = append(betas, client.TaskBudgetBeta)
+	}
+	if len(betas) > 0 {
+		req.Header.Set("anthropic-beta", strings.Join(betas, ","))
 	}
 
 	if bearer := strings.TrimSpace(os.Getenv("AWS_BEARER_TOKEN_BEDROCK")); bearer != "" {

--- a/llm/bedrock/task_budget_test.go
+++ b/llm/bedrock/task_budget_test.go
@@ -1,0 +1,80 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package bedrock
+
+import (
+	"context"
+	"testing"
+
+	"github.com/diillson/chatcli/llm/client"
+)
+
+// TestBedrockTaskBudget_TravelsOnTheMirrors covers a capability the
+// catalog advertised and the package never implemented: task_budget is on
+// the Bedrock mirror of every model that reads it, and this package did
+// not mention the field anywhere. A run under a spending ceiling was
+// paced on the first-party API and not here.
+func TestBedrockTaskBudget_TravelsOnTheMirrors(t *testing.T) {
+	ctx := client.WithTaskBudget(context.Background(), client.AnthropicTaskBudgetFor(400000, 120000))
+	body := map[string]interface{}{"max_tokens": 4096}
+
+	if !applyBedrockTaskBudget(body, "anthropic.claude-opus-5", ctx) {
+		t.Fatal("the Bedrock mirror advertises task_budget and must send it")
+	}
+	cfg, ok := body["output_config"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("output_config missing: %+v", body["output_config"])
+	}
+	budget, ok := cfg["task_budget"].(*client.TaskBudget)
+	if !ok || budget.Total != 400000 || budget.Remaining != 120000 {
+		t.Fatalf("task_budget = %+v", cfg["task_budget"])
+	}
+
+	// InvokeModel takes beta flags in the body, and only on a request that
+	// carries one.
+	applyBedrockTaskBudgetBeta(body, true)
+	betas, _ := body["anthropic_beta"].([]string)
+	if len(betas) != 1 || betas[0] != client.TaskBudgetBeta {
+		t.Fatalf("anthropic_beta = %v", body["anthropic_beta"])
+	}
+	applyBedrockTaskBudgetBeta(body, true)
+	if betas, _ = body["anthropic_beta"].([]string); len(betas) != 1 {
+		t.Fatalf("beta duplicated: %v", betas)
+	}
+
+	empty := map[string]interface{}{}
+	applyBedrockTaskBudgetBeta(empty, false)
+	if _, ok := empty["anthropic_beta"]; ok {
+		t.Fatal("a request carrying no budget must carry no beta")
+	}
+}
+
+// TestBedrockTaskBudget_TravelsWithoutAnEffort mirrors the first-party
+// regression: the ceiling is not a reasoning setting, and the effort
+// routing it used to live inside returns early when no effort was chosen.
+func TestBedrockTaskBudget_TravelsWithoutAnEffort(t *testing.T) {
+	ctx := client.WithTaskBudget(context.Background(), client.AnthropicTaskBudget(64000))
+	body := map[string]interface{}{"max_tokens": 4096}
+	if applyAnthropicThinkingForEffort(body, "anthropic.claude-opus-5", ctx) {
+		t.Fatal("precondition: no effort means no thinking block")
+	}
+	if !applyBedrockTaskBudget(body, "anthropic.claude-opus-5", ctx) {
+		t.Fatal("a spending ceiling must travel whether or not an effort was chosen")
+	}
+}
+
+// TestBedrockTaskBudget_OnlyForModelsThatReadIt keeps the field off a
+// model whose entry does not claim it.
+func TestBedrockTaskBudget_OnlyForModelsThatReadIt(t *testing.T) {
+	ctx := client.WithTaskBudget(context.Background(), client.AnthropicTaskBudget(64000))
+	body := map[string]interface{}{"max_tokens": 4096}
+	if applyBedrockTaskBudget(body, "anthropic.claude-3-5-sonnet-20241022-v2:0", ctx) {
+		t.Fatal("a model that does not read the field must not be sent it")
+	}
+	if _, ok := body["output_config"]; ok {
+		t.Fatal("no output_config may be created for it")
+	}
+}

--- a/llm/claudeai/claude_client.go
+++ b/llm/claudeai/claude_client.go
@@ -255,7 +255,6 @@ func applyThinkingForEffort(reqBody map[string]interface{}, model string, ctx co
 		catalog.HasCapability(catalog.ProviderClaudeAI, model, "output_effort") {
 		reqBody["output_config"] = cfg
 	}
-	applyTaskBudget(reqBody, model, ctx)
 	if usesAdaptiveThinkingOnly(model) {
 		reqBody["thinking"] = map[string]interface{}{"type": "adaptive"}
 		return true
@@ -327,7 +326,12 @@ func (c *ClaudeClient) SendPrompt(ctx context.Context, prompt string, history []
 	// Skill effort hint → thinking. Opus 4.7+ only accepts adaptive
 	// thinking; older 4.x and Sonnet 3.7 accept budgeted extended
 	// thinking. applyThinkingForEffort routes by catalog capability.
-	if applyThinkingForEffort(reqBody, c.model, ctx) {
+	thinkingAttached := applyThinkingForEffort(reqBody, c.model, ctx)
+	// After the effort routing, and outside it: a spending ceiling is not
+	// a reasoning setting, and lived inside one long enough to never be
+	// sent (see applyTaskBudget).
+	applyTaskBudget(reqBody, c.model, ctx)
+	if thinkingAttached {
 		c.logger.Debug("claudeai: thinking enabled from skill effort hint",
 			zap.Any("thinking", reqBody["thinking"]),
 			zap.String("model", c.model))
@@ -1038,6 +1042,13 @@ func streamErrorToAPIError(errType, message string) error {
 // rather than assigned: the two are independent settings that share a
 // field. The budget travels as a typed value, which is why the map is
 // built as interface-valued here.
+//
+// Call it AFTER the effort routing, never inside it. Sharing a field is
+// the only thing these two have in common: effort routing returns early
+// when no effort was chosen, and the routing that would choose one is off
+// by default — so a budget called from in there never traveled at all.
+// Calling it before instead would have the effort assignment overwrite
+// the merged map.
 func applyTaskBudget(reqBody map[string]interface{}, model string, ctx context.Context) bool {
 	budget := client.TaskBudgetFromContext(ctx)
 	if budget == nil || !catalog.HasCapability(catalog.ProviderClaudeAI, model, "task_budget") {

--- a/llm/claudeai/task_budget_test.go
+++ b/llm/claudeai/task_budget_test.go
@@ -16,6 +16,7 @@ func TestTaskBudgetMergesWithEffort(t *testing.T) {
 
 	body := map[string]interface{}{"max_tokens": 4096}
 	applyThinkingForEffort(body, "claude-opus-5", ctx)
+	applyTaskBudget(body, "claude-opus-5", ctx)
 
 	cfg, ok := body["output_config"].(map[string]interface{})
 	if !ok {
@@ -58,5 +59,38 @@ func TestAnthropicTaskBudgetRejectsNothingToSay(t *testing.T) {
 	}
 	if b := client.AnthropicTaskBudget(-1); b != nil {
 		t.Errorf("a negative budget must be nil, got %+v", b)
+	}
+}
+
+// TestTaskBudgetTravelsWithoutAnEffort is the regression this ordering
+// exists for. The budget used to be attached from inside the effort
+// routing, which returns early when no effort was chosen — and the
+// routing that chooses one ships off by default. So the ceiling never
+// traveled under the default configuration, and every turn of work spent
+// on getting its numbers right applied to a field nobody sent.
+func TestTaskBudgetTravelsWithoutAnEffort(t *testing.T) {
+	ctx := client.WithTaskBudget(context.Background(), client.AnthropicTaskBudget(64000))
+	if client.EffortFromContext(ctx) != client.EffortUnset {
+		t.Fatal("precondition: no effort hint on this turn")
+	}
+
+	body := map[string]interface{}{"max_tokens": 4096}
+	if attached := applyThinkingForEffort(body, "claude-opus-5", ctx); attached {
+		t.Fatal("precondition: no effort means no thinking block")
+	}
+	if !applyTaskBudget(body, "claude-opus-5", ctx) {
+		t.Fatal("a spending ceiling must travel whether or not an effort was chosen")
+	}
+
+	cfg, ok := body["output_config"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("output_config missing: %+v", body["output_config"])
+	}
+	if _, ok := cfg["effort"]; ok {
+		t.Errorf("no effort was chosen, so none may be sent: %+v", cfg)
+	}
+	budget, ok := cfg["task_budget"].(*client.TaskBudget)
+	if !ok || budget.Total != 64000 {
+		t.Fatalf("task_budget = %+v", cfg["task_budget"])
 	}
 }

--- a/llm/claudeai/tool_use.go
+++ b/llm/claudeai/tool_use.go
@@ -101,6 +101,9 @@ func (c *ClaudeClient) SendPromptWithTools(ctx context.Context, prompt string, h
 	// Skill effort hint → thinking (tool-use path). Opus 4.7+ uses adaptive,
 	// older models use budgeted extended thinking — see applyThinkingForEffort.
 	applyThinkingForEffort(reqBody, c.model, ctx)
+	// A spending ceiling is not a reasoning setting: it travels whether or
+	// not an effort was chosen. See applyTaskBudget.
+	applyTaskBudget(reqBody, c.model, ctx)
 
 	// Opus 4.8 fast mode opt-in via ANTHROPIC_SPEED=fast.
 	applyFastModeIfRequested(reqBody, c.model)


### PR DESCRIPTION
Closes **COST-1** and **COST-2** (P1) of Context Audit VII.

## COST-1 — a ceiling nobody was sending

`applyTaskBudget` had exactly one caller, and it sat inside `applyThinkingForEffort`, **after** its early return:

```go
func applyThinkingForEffort(reqBody map[string]interface{}, model string, ctx context.Context) bool {
	effort := client.EffortFromContext(ctx)
	if effort == client.EffortUnset {
		return false          // ← every default-configured turn leaves here
	}
	...
	applyTaskBudget(reqBody, model, ctx)   // ← never reached
```

Effort routing ships `off` by default (`CHATCLI_OUTPUT_EFFORT_ROUTING`), so on a default configuration no effort hint is ever set and the budget never travelled. Two audit rounds of work on the ceiling — fixing the total, clamping the remainder, pricing it in the serving pair — all applied to a field that was not being sent.

A spending ceiling is not a reasoning setting. They share `output_config` and nothing else. The budget is now attached after the effort routing and outside it, on both request builders — **after**, because the effort path assigns that field rather than merging into it.

## COST-2 — a capability announced and unimplemented

The catalog advertises `task_budget` on the Bedrock mirror of every model that reads it. `llm/bedrock` did not mention the field anywhere. A run under a spending ceiling was paced on the first-party API and nowhere else.

Both transports now send it, with the beta declared the way each accepts it — body field for InvokeModel, header for the Messages transport — and only on a request that actually carries a budget.

## A test that asserted the bug

`TestTaskBudgetMergesWithEffort` called `applyThinkingForEffort` and expected the budget to appear, which encoded the coupling as if it were the design. It now calls both, and `TestTaskBudgetTravelsWithoutAnEffort` pins what actually broke.

## Tests

- `TestTaskBudgetTravelsWithoutAnEffort` — a turn with no effort hint carries the ceiling, and carries no effort.
- `TestBedrockTaskBudget_TravelsOnTheMirrors` — the field lands on the mirror, the beta is declared once, and a request with no budget declares none.
- `TestBedrockTaskBudget_TravelsWithoutAnEffort` / `_OnlyForModelsThatReadIt` — the same two rules on Bedrock.

`go test ./...` clean; Floors 4, 5, 8, 12, 13, 15 verified locally.