### PR TITLE
fix(llm): cache decisions hold for the conversation, thresholds follow the window

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -1031,6 +1031,11 @@ func (a *AgentMode) Run(ctx context.Context, query string, additionalContext str
 	// CHATCLI_PROMPT_CACHE_TTL=auto: the agent/coder loop prefers the hour
 	// (long sessions that pause between tool rounds); chat and one-shot
 	// keep the 5-minute default, restored when this run ends.
+	//
+	// This states a preference; it no longer changes a conversation that
+	// already resolved one. The ttl is part of the cache_control marker,
+	// so flipping it mid-conversation rewrote the prefix and threw away
+	// the cache on every crossing between chat and the loop.
 	llmclient.SetPromptCacheTTLHint("1h")
 	defer llmclient.SetPromptCacheTTLHint("5m")
 	defer func() {

--- a/cli/cli_session.go
+++ b/cli/cli_session.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/diillson/chatcli/client/remote"
 	"github.com/diillson/chatcli/i18n"
+	llmclient "github.com/diillson/chatcli/llm/client"
 	"github.com/diillson/chatcli/models"
 	"github.com/diillson/chatcli/ui/kit"
 )
@@ -223,6 +224,9 @@ func (cli *ChatCLI) clearAllHistories() {
 	cli.history = make([]models.Message, 0)
 	cli.checkpoints = nil
 	cli.preCompaction = nil
+	// The prefix is gone either way, so the ttl "auto" settled on for the
+	// old conversation is released here rather than held into the new one.
+	llmclient.ResetPromptCacheTTL()
 }
 
 // clearConversation is /clear: the conversation restarts empty while the
@@ -242,6 +246,7 @@ func (cli *ChatCLI) clearConversation(ctx context.Context) {
 	cli.saveCheckpoint()
 	cli.history = make([]models.Message, 0)
 	cli.syncTranscript()
+	llmclient.ResetPromptCacheTTL()
 	if cli.costTracker != nil {
 		cli.costTracker.NoteExpectedCacheRebuild()
 	}

--- a/llm/bedrock/bedrock_client.go
+++ b/llm/bedrock/bedrock_client.go
@@ -521,7 +521,7 @@ func (c *BedrockClient) sendPromptAnthropicModel(ctx context.Context, wireModel,
 	// same context_management block as the first-party endpoint, and this
 	// path builds the native Anthropic body, so it travels unchanged.
 	// Audit III's PR 13 wired the response side and left this surface out.
-	if cm := client.AnthropicContextManagement(); cm != nil {
+	if cm := client.AnthropicContextManagementFor(catalog.GetContextWindow(catalog.ProviderBedrock, wireModel)); cm != nil {
 		reqBody["context_management"] = cm
 	}
 

--- a/llm/claudeai/tool_use.go
+++ b/llm/claudeai/tool_use.go
@@ -94,7 +94,7 @@ func (c *ClaudeClient) SendPromptWithTools(ctx context.Context, prompt string, h
 	}
 	// Provider context engine: let Anthropic clear stale tool results
 	// server-side (context editing beta) on top of the local compaction.
-	if cm := client.AnthropicContextManagement(); cm != nil && len(toolDefs) > 0 {
+	if cm := client.AnthropicContextManagementFor(catalog.GetContextWindow(catalog.ProviderClaudeAI, c.model)); cm != nil && len(toolDefs) > 0 {
 		reqBody["context_management"] = cm
 	}
 

--- a/llm/client/cache_prefix.go
+++ b/llm/client/cache_prefix.go
@@ -134,19 +134,68 @@ type ContextManagement struct {
 	Edits []ContextEdit `json:"edits"`
 }
 
-// AnthropicContextManagement returns the context_management request block
-// for the provider context engine: clear the oldest tool results once the
-// prompt passes 100K input tokens, keeping the five most recent tool uses
-// and freeing at least 20K tokens per edit. Nil when the engine is off.
+// contextEditWindowFraction is where the clearing edits start firing, as a
+// share of the model's own context window, and contextEditReleaseFraction
+// is how much one edit frees.
+//
+// Fractions rather than constants because the catalog spans 128K to 1M: a
+// fixed 100K trigger fires at four fifths of a small window and at a tenth
+// of a large one, so the same number meant opposite things. Half the
+// window leaves room to work before anything is cleared and still leaves
+// the cheap lossless edits their chance ahead of any summarizing.
+const (
+	contextEditWindowFraction  = 0.5
+	contextEditReleaseFraction = 0.1
+	// Floors for a model whose window the catalog does not know: the
+	// values this shipped with, so an unknown model behaves as before.
+	defaultContextEditTrigger = 100000
+	defaultContextEditRelease = 20000
+)
+
+// contextEditThresholds derives the trigger and release for one model.
+func contextEditThresholds(window int) (trigger, release int) {
+	if window <= 0 {
+		return defaultContextEditTrigger, defaultContextEditRelease
+	}
+	trigger = int(float64(window) * contextEditWindowFraction)
+	release = int(float64(window) * contextEditReleaseFraction)
+	if trigger < defaultContextEditTrigger/2 {
+		// A small window still needs room to work: never clear before the
+		// prompt is worth clearing.
+		trigger = defaultContextEditTrigger / 2
+	}
+	if release < 1 {
+		release = 1
+	}
+	return trigger, release
+}
+
+// AnthropicContextManagement returns the block with the fixed thresholds
+// this shipped with. Callers that know the model should use
+// AnthropicContextManagementFor: the same trigger means opposite things
+// on a 128K window and a 1M one.
 func AnthropicContextManagement() *ContextManagement {
+	return AnthropicContextManagementFor(0)
+}
+
+// AnthropicContextManagementFor returns the context_management request
+// block for the provider context engine: clear the oldest tool results
+// once the prompt passes half the model's context window, keeping the
+// five most recent tool uses and freeing a tenth of the window per edit.
+// Nil when the engine is off.
+//
+// window is the model's context window, from the catalog; zero falls back
+// to the fixed thresholds this shipped with.
+func AnthropicContextManagementFor(window int) *ContextManagement {
 	if !ProviderContextEngine() {
 		return nil
 	}
+	trigger, release := contextEditThresholds(window)
 	edits := []ContextEdit{{
 		Type:         "clear_tool_uses_20250919",
-		Trigger:      &ContextThreshold{Type: "input_tokens", Value: 100000},
+		Trigger:      &ContextThreshold{Type: "input_tokens", Value: trigger},
 		Keep:         &ContextThreshold{Type: "tool_uses", Value: 5},
-		ClearAtLeast: &ContextThreshold{Type: "input_tokens", Value: 20000},
+		ClearAtLeast: &ContextThreshold{Type: "input_tokens", Value: release},
 	}}
 	// Once reasoning blocks are replayed they occupy the window like any
 	// other content, so the engine needs a way to retire the old ones. The
@@ -155,7 +204,7 @@ func AnthropicContextManagement() *ContextManagement {
 	// reasoning the model is still building on.
 	edits = append(edits, ContextEdit{
 		Type:    "clear_thinking_20251015",
-		Trigger: &ContextThreshold{Type: "input_tokens", Value: 100000},
+		Trigger: &ContextThreshold{Type: "input_tokens", Value: trigger},
 		Keep:    &ContextThreshold{Type: "thinking_turns", Value: 3},
 	})
 	// Server-side compaction summarizes what the two clearing edits could
@@ -164,8 +213,11 @@ func AnthropicContextManagement() *ContextManagement {
 	// get their chance first.
 	if ProviderCompactionEngine() {
 		edits = append(edits, ContextEdit{
-			Type:    "compact_20260112",
-			Trigger: &ContextThreshold{Type: "input_tokens", Value: 150000},
+			Type: "compact_20260112",
+			// Behind the lossless edits by the same margin the fixed
+			// values used: summarizing is the last resort, so it waits
+			// until clearing has had its chance.
+			Trigger: &ContextThreshold{Type: "input_tokens", Value: trigger + trigger/2},
 		})
 	}
 	return &ContextManagement{Edits: edits}
@@ -190,6 +242,18 @@ var promptCacheTTLHint atomic.Value // string
 // SetPromptCacheTTLHint records the surface preference honored by
 // CHATCLI_PROMPT_CACHE_TTL=auto ("5m" or "1h"; anything else resets to
 // the 5-minute default).
+// promptCacheTTLHeld is the value "auto" settled on for this conversation.
+// Empty until the first request resolves it.
+var promptCacheTTLHeld atomic.Value
+
+// ResetPromptCacheTTL releases the held decision so the next request
+// resolves "auto" again. Called where a conversation restarts and the
+// prefix is being rebuilt anyway, so nothing is thrown away that was not
+// already gone.
+func ResetPromptCacheTTL() {
+	promptCacheTTLHeld.Store("")
+}
+
 func SetPromptCacheTTLHint(ttl string) {
 	if ttl != "1h" {
 		ttl = "5m"
@@ -198,18 +262,32 @@ func SetPromptCacheTTLHint(ttl string) {
 }
 
 // AnthropicCacheTTL returns the configured cache lifetime, normalized to
-// "5m" or "1h". "auto" defers to the surface hint (SetPromptCacheTTLHint);
-// anything else resolves to the 5-minute default so a typo can never
-// disable caching or send an invalid ttl.
+// "5m" or "1h". "auto" resolves once per conversation from the surface
+// hint (SetPromptCacheTTLHint) and then holds; anything else resolves to
+// the 5-minute default so a typo can never disable caching or send an
+// invalid ttl.
+//
+// Holding is the point. The ttl is part of the cache_control marker, so
+// its value IS prefix bytes: a session that alternates chat and the agent
+// loop used to mark the same messages first with the hour and then
+// without it, and every crossing threw away the prefix it had just paid
+// for. Whichever surface asks first decides for the conversation, and
+// ResetPromptCacheTTL releases it when the conversation genuinely
+// restarts.
 func AnthropicCacheTTL() string {
 	switch strings.ToLower(strings.TrimSpace(os.Getenv(PromptCacheTTLEnv))) {
 	case "1h", "60m", "hour":
 		return "1h"
 	case "auto":
-		if v, _ := promptCacheTTLHint.Load().(string); v == "1h" {
-			return "1h"
+		if held, _ := promptCacheTTLHeld.Load().(string); held != "" {
+			return held
 		}
-		return "5m"
+		resolved := "5m"
+		if v, _ := promptCacheTTLHint.Load().(string); v == "1h" {
+			resolved = "1h"
+		}
+		promptCacheTTLHeld.Store(resolved)
+		return resolved
 	default:
 		return "5m"
 	}

--- a/llm/client/cache_resources_test.go
+++ b/llm/client/cache_resources_test.go
@@ -11,22 +11,53 @@ import (
 	"time"
 )
 
-func TestPromptCacheTTL_AutoFollowsSurfaceHint(t *testing.T) {
+// TestPromptCacheTTL_AutoSettlesOncePerConversation pins what "auto"
+// means now. It used to follow the surface hint on every call, which read
+// as flexibility and behaved as a leak: the ttl is part of the
+// cache_control marker, so its value is prefix bytes, and a session that
+// crossed between chat and the agent loop re-marked the same messages and
+// threw away the prefix it had just paid for. Whichever surface asks
+// first decides for the conversation.
+func TestPromptCacheTTL_AutoSettlesOncePerConversation(t *testing.T) {
 	t.Setenv(PromptCacheTTLEnv, "auto")
+	t.Cleanup(func() { SetPromptCacheTTLHint("5m"); ResetPromptCacheTTL() })
+
+	// A conversation that starts in chat holds the 5-minute default, and
+	// entering the agent loop later does not rewrite its prefix.
+	ResetPromptCacheTTL()
 	SetPromptCacheTTLHint("5m")
 	if got := AnthropicCacheTTL(); got != "5m" {
-		t.Fatalf("auto without an agent hint must be 5m, got %s", got)
+		t.Fatalf("a chat-first conversation settles on 5m, got %s", got)
 	}
 	SetPromptCacheTTLHint("1h")
-	t.Cleanup(func() { SetPromptCacheTTLHint("5m") })
+	if got := AnthropicCacheTTL(); got != "5m" {
+		t.Fatalf("entering the agent loop must not re-mark a settled conversation, got %s", got)
+	}
+
+	// A conversation that starts in the agent loop holds the hour, and
+	// dropping back to chat does not take it away either.
+	ResetPromptCacheTTL()
+	SetPromptCacheTTLHint("1h")
 	if got := AnthropicCacheTTL(); got != "1h" {
-		t.Fatalf("auto with the agent hint must be 1h, got %s", got)
+		t.Fatalf("an agent-first conversation settles on 1h, got %s", got)
 	}
 	if PromptCacheTTLDuration() != time.Hour {
-		t.Fatal("duration must follow the resolved TTL")
+		t.Fatal("duration must follow the settled TTL")
 	}
-	// An explicit value ignores the hint.
+	SetPromptCacheTTLHint("5m")
+	if got := AnthropicCacheTTL(); got != "1h" {
+		t.Fatalf("leaving the agent loop must not re-mark a settled conversation, got %s", got)
+	}
+
+	// A new conversation resolves again: the prefix is gone anyway.
+	ResetPromptCacheTTL()
+	if got := AnthropicCacheTTL(); got != "5m" {
+		t.Fatalf("a restarted conversation resolves fresh, got %s", got)
+	}
+
+	// An explicit value ignores the hint and never settles anything.
 	t.Setenv(PromptCacheTTLEnv, "5m")
+	SetPromptCacheTTLHint("1h")
 	if got := AnthropicCacheTTL(); got != "5m" {
 		t.Fatalf("explicit 5m must win over the hint, got %s", got)
 	}

--- a/llm/client/context_engine_test.go
+++ b/llm/client/context_engine_test.go
@@ -13,11 +13,13 @@ import (
 
 func TestAnthropicContextManagement_OnlyForProviderEngine(t *testing.T) {
 	t.Setenv(ContextEngineEnv, "mcp:engine")
-	if AnthropicContextManagement() != nil || ProviderContextEngine() {
+	if AnthropicContextManagementFor(200000) != nil || ProviderContextEngine() {
 		t.Fatal("only the provider value enables server-side editing")
 	}
 	t.Setenv(ContextEngineEnv, " Provider ")
-	cm := AnthropicContextManagement()
+	// A model whose window the catalog does not know keeps the fixed
+	// thresholds this shipped with.
+	cm := AnthropicContextManagementFor(0)
 	if cm == nil || !ProviderContextEngine() {
 		t.Fatal("provider engine must be on")
 	}
@@ -26,5 +28,53 @@ func TestAnthropicContextManagement_OnlyForProviderEngine(t *testing.T) {
 		if !strings.Contains(string(raw), want) {
 			t.Fatalf("wire shape missing %s: %s", want, raw)
 		}
+	}
+}
+
+// TestContextEditThresholds_FollowTheWindow covers a number that meant
+// opposite things on different models. The catalog spans 128K to 1M, and
+// the trigger was the constant 100000 for all of them: four fifths of a
+// small window, a tenth of a large one. Half the window and a tenth of it
+// mean the same thing everywhere.
+func TestContextEditThresholds_FollowTheWindow(t *testing.T) {
+	for _, tc := range []struct{ window, trigger, release int }{
+		{1000000, 500000, 100000},
+		{200000, 100000, 20000},
+		{128000, 64000, 12800},
+	} {
+		trigger, release := contextEditThresholds(tc.window)
+		if trigger != tc.trigger || release != tc.release {
+			t.Errorf("window %d → trigger %d release %d, want %d and %d", tc.window, trigger, release, tc.trigger, tc.release)
+		}
+		if trigger >= tc.window {
+			t.Errorf("window %d: clearing must start before the window is full", tc.window)
+		}
+	}
+
+	// An unknown window keeps the values this shipped with, so a model the
+	// catalog does not carry behaves exactly as before.
+	if trigger, release := contextEditThresholds(0); trigger != defaultContextEditTrigger || release != defaultContextEditRelease {
+		t.Errorf("unknown window → %d / %d, want the shipped defaults", trigger, release)
+	}
+
+	// A very small window still gets room to work before anything clears.
+	if trigger, _ := contextEditThresholds(8000); trigger < 8000 {
+		t.Errorf("a small window must not clear immediately, trigger %d", trigger)
+	}
+
+	// Summarizing waits for the lossless edits: its trigger sits above.
+	t.Setenv(ContextEngineEnv, "provider-compact")
+	cm := AnthropicContextManagementFor(200000)
+	var clearAt, compactAt int
+	for _, e := range cm.Edits {
+		switch e.Type {
+		case "clear_tool_uses_20250919":
+			clearAt = e.Trigger.Value
+		case "compact_20260112":
+			compactAt = e.Trigger.Value
+		}
+	}
+	if compactAt <= clearAt {
+		t.Fatalf("summarizing must trigger after clearing: compact %d vs clear %d", compactAt, clearAt)
 	}
 }

--- a/llm/client/thinking_test.go
+++ b/llm/client/thinking_test.go
@@ -72,7 +72,7 @@ func TestThinkingStateStoreAndClear(t *testing.T) {
 // content, so the provider engine must be able to retire the old ones.
 func TestAnthropicContextManagementClearsThinking(t *testing.T) {
 	t.Setenv(ContextEngineEnv, "provider")
-	cm := AnthropicContextManagement()
+	cm := AnthropicContextManagementFor(200000)
 	if cm == nil {
 		t.Fatal("provider engine selected but no context_management block")
 	}
@@ -95,7 +95,7 @@ func TestAnthropicContextManagementClearsThinking(t *testing.T) {
 
 func TestAnthropicContextManagementOffByDefault(t *testing.T) {
 	t.Setenv(ContextEngineEnv, "")
-	if cm := AnthropicContextManagement(); cm != nil {
+	if cm := AnthropicContextManagementFor(200000); cm != nil {
 		t.Errorf("builtin engine must send no context_management, got %+v", cm)
 	}
 }
@@ -112,7 +112,7 @@ func TestProviderCompactionEngineAddsCompactLast(t *testing.T) {
 	if !ProviderCompactionEngine() {
 		t.Fatal("provider-compact must select server-side compaction")
 	}
-	cm := AnthropicContextManagement()
+	cm := AnthropicContextManagementFor(200000)
 	if cm == nil || len(cm.Edits) != 3 {
 		t.Fatalf("want three edits, got %+v", cm)
 	}
@@ -126,7 +126,7 @@ func TestProviderEngineWithoutCompaction(t *testing.T) {
 	if ProviderCompactionEngine() {
 		t.Error("plain provider must not ask the server to summarize")
 	}
-	cm := AnthropicContextManagement()
+	cm := AnthropicContextManagementFor(200000)
 	if cm == nil {
 		t.Fatal("plain provider still edits context")
 	}


### PR DESCRIPTION
Closes **CAG-2** and **CMP-1** (P2) of Context Audit VII. Both are the same theme: a global value changing underneath a conversation in progress.

## CAG-2 — a TTL that flipped mid-conversation

Under `CHATCLI_PROMPT_CACHE_TTL=auto` the lifetime followed whichever surface asked last. The agent loop asks for the hour on entry and restores five minutes on exit — and the TTL is part of the `cache_control` marker, so **its value is prefix bytes**. A session alternating chat and `/coder` re-marked the same messages on every crossing and threw away the prefix it had just paid for.

Claude Code treats this as a known problem and locks the decision at boot, with the cost written in the comment:

> prevents mid-session overage flips from changing the cache_control TTL, which would bust the server-side prompt cache (~20K tokens per flip)

`auto` now resolves once and holds. Whichever surface asks first decides for the conversation; the hold is released where the conversation restarts (`/clear`, `clearAllHistories`) and the prefix is being rebuilt anyway. The loop still states a preference — it no longer rewrites a conversation that already settled one.

## CMP-1 — one number that meant opposite things

The context-editing thresholds were fixed constants against a catalog spanning 128K to 1M. A trigger of 100K input tokens is four fifths of a small window and a tenth of a large one.

Trigger and release now derive from the model's own window — half and a tenth — which the catalog already knows. The shipped constants stay as the floor for a model whose window is unknown, so nothing changes for one the catalog does not carry. Summarizing stays behind the lossless edits by the same margin the fixed values used.

## A test that asserted the bug

`TestPromptCacheTTL_AutoFollowsSurfaceHint` read the TTL, moved the hint, and expected the value to follow — encoding the flip as if it were the design. That is the fourth test this session found asserting a bug's premise rather than a contract.

Replaced by `TestPromptCacheTTL_AutoSettlesOncePerConversation`, which pins the opposite in both directions and across a restart.

## Tests

- `TestPromptCacheTTL_AutoSettlesOncePerConversation` — a chat-first conversation holds 5m through entering the loop; an agent-first one holds 1h through leaving it; a restarted conversation resolves fresh; an explicit value settles nothing.
- `TestContextEditThresholds_FollowTheWindow` — 1M, 200K and 128K each get proportional values; an unknown window keeps the shipped defaults; a small window still gets room to work; summarizing triggers after clearing.

`go test ./...` clean; Floors 4, 5, 8, 12, 13, 15 verified locally.