### PR TITLE
docs(readme): document the GitHub Models removal and pin the next version

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,16 @@ OPENAI_API_KEY=sk-xxx
 | Ollama | — | `OLLAMA_MODEL` | `OLLAMA_ENABLED=true`, `OLLAMA_BASE_URL` |
 | OpenAI (Responses API) | `OPENAI_API_KEY` | `OPENAI_MODEL` | `OPENAI_RESPONSES_API_URL` |
 
+> **Removed provider — GitHub Models.** GitHub retired GitHub Models on
+> July 30 2026 (playground, model catalog, inference API and BYOK, for
+> every customer), so the `GITHUB_MODELS` provider was dropped. The env
+> vars `GITHUB_MODELS_MODEL`, `GITHUB_MODELS_TOKEN`,
+> `GITHUB_MODELS_MAX_TOKENS` and `GITHUB_MODELS_API_URL` no longer have
+> any effect, and `GITHUB_MODELS` is no longer accepted as a provider
+> value (including in the operator's `Instance` CRD). **GitHub Copilot is
+> a different product and is unaffected** — if you were on GitHub Models
+> for OpenAI models, `COPILOT` or `OPENAI` are the direct replacements.
+
 #### Environment file (.env) discovery
 
 ChatCLI looks for its environment file in this order, and the **first file that exists wins**:

--- a/README_PT.md
+++ b/README_PT.md
@@ -137,6 +137,17 @@ OPENAI_API_KEY=sk-xxx
 | Ollama | — | `OLLAMA_MODEL` | `OLLAMA_ENABLED=true`, `OLLAMA_BASE_URL` |
 | OpenAI (Responses API) | `OPENAI_API_KEY` | `OPENAI_MODEL` | `OPENAI_RESPONSES_API_URL` |
 
+> **Provider removido — GitHub Models.** O GitHub aposentou o GitHub
+> Models em 30/Jul/2026 (playground, catálogo de modelos, API de
+> inferência e BYOK, para todos os clientes), então o provider
+> `GITHUB_MODELS` foi removido. As variáveis `GITHUB_MODELS_MODEL`,
+> `GITHUB_MODELS_TOKEN`, `GITHUB_MODELS_MAX_TOKENS` e
+> `GITHUB_MODELS_API_URL` deixaram de ter efeito, e `GITHUB_MODELS` não é
+> mais aceito como valor de provider (inclusive no CRD `Instance` do
+> operator). **O GitHub Copilot é produto diferente e não foi afetado** —
+> se você usava o GitHub Models para modelos OpenAI, `COPILOT` ou
+> `OPENAI` são os substitutos diretos.
+
 #### Descoberta do arquivo de ambiente (.env)
 
 O ChatCLI procura o arquivo de ambiente nesta ordem, e o **primeiro que existir vence**:


### PR DESCRIPTION
## Por quê

O merge do #1547 fez o release-please calcular **2.0.0**, por causa do `!` no subject e do rodapé `BREAKING CHANGE:`. O corte de uma major não é desejado agora.

Nada foi publicado — o 2.0.0 existe apenas como o PR de release **#1548**, sem tag e sem release; a última versão publicada continua sendo a **v1.198.0**. Este PR corrige a numeração antes de qualquer corte.

## Como

Rodapé `Release-As: 1.199.0` no commit. Ao entrar na main, o release-please regenera o #1548 como **1.199.0**.

Vale registrar que **o label `breaking-change` do CI e a versão do release são independentes**: o label é exigência do Floor 4/13 para identificador exportado removido e não entra na conta do release-please. O #1547 continua corretamente rotulado, e ainda assim a versão sai como minor.

## O 1.199.0 é defensável aqui

O GitHub Models foi desligado em **30/Jul/2026** e o endpoint responde `github_models_retirement_brownout` desde então. Nenhuma instalação funcional depende do provider removido — quem apontava para ele já estava quebrado há mais de um mês. Não há quebra de comportamento real para quem está em 1.198.0.

A ressalva honesta: `GITHUB_MODELS` deixa de ser aceito no enum do CRD `Instance`, então um `ChatCLIInstance` que ainda carregue o valor passa a ser rejeitado na admissão. É por isso que a nota de migração abaixo entra junto, em vez de a remoção seguir sem documentação.

## O que muda no diff

Nota de migração nos **dois READMEs** (EN e PT, em paridade): por que o provider saiu, quais env vars deixaram de ter efeito, que o valor não é mais aceito como provider — inclusive no CRD — e que **o GitHub Copilot é produto diferente e não foi afetado**, com `COPILOT` e `OPENAI` como substitutos diretos.

Sem mudança de código.