### PR TITLE
fix(ui): the prompt and every palette follow the theme instead of forcing white

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -744,8 +744,9 @@ func (a *AgentMode) readLineFromGoPrompt() string {
 		"  > ",
 		noopCompleter,
 		prompt.OptionParser(pasteParser),
-		prompt.OptionPrefixTextColor(prompt.Green),
-		prompt.OptionInputTextColor(prompt.White),
+		// Same theme-derived colors as the chat REPL (see prompt_theme.go):
+		// the coder prompt must not force white text onto a light terminal.
+		themePromptTextColors(),
 	)
 }
 
@@ -780,9 +781,9 @@ func isMultilineTrigger(s string) bool {
 // text, trimmed.
 func (a *AgentMode) runMultilineSession(trigger string, reader *bufio.Reader) (string, error) {
 	a.multilineBuf.ProcessLine(trigger)
-	fmt.Printf("\n  \033[90m📝 %s\033[0m\n", i18n.T("multiline.hint", a.multilineBuf.Delimiter()))
+	fmt.Printf("\n  %s\n", colorize("📝 "+i18n.T("multiline.hint", a.multilineBuf.Delimiter()), ColorGray))
 	for {
-		fmt.Printf("  \033[90m... [%d] \033[0m", a.multilineBuf.LineCount()+1)
+		fmt.Printf("  %s ", colorize(fmt.Sprintf("... [%d]", a.multilineBuf.LineCount()+1), ColorGray))
 		nextLine, _ := reader.ReadString('\n')
 		nextLine = strings.TrimRight(nextLine, "\r\n")
 		complete, fullText := a.multilineBuf.ProcessLine(nextLine)

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -246,6 +246,8 @@ type ChatCLI struct {
 	executionProfile    ExecutionProfile
 	pendingAction       string // stores intended action before panic (for Windows go-prompt tearDown workaround)
 	replActive          bool   // true only inside the interactive Start() loop (gates the palette trigger)
+	promptRunning       bool   // true only while go-prompt owns the terminal (gates the theme-driven prompt rebuild)
+	themeReloadPending  bool   // a theme switch landed mid-prompt; go-prompt must be rebuilt to repaint the input line
 	paletteRequested    bool   // a handler asked to open the command palette; the executor runs it in place
 	paletteTarget       string // command to scope the palette to ("" opens the categorized root)
 	suppressPaletteOnce bool   // skip the palette trigger for the next handled command (the palette's own selection)
@@ -1373,8 +1375,14 @@ func (cli *ChatCLI) Start(ctx context.Context) {
 
 	shouldContinue := true
 	for shouldContinue {
+		// Set when the prompt exited to adopt a new theme: the loop rebuilds
+		// it with the new palette and must NOT run the post-prompt dispatch —
+		// there is no mode to enter, and restoreTerminal would wipe the
+		// visible transcript for what is only a repaint.
+		themeReload := false
 		func() {
 			defer func() {
+				cli.promptRunning = false
 				if r := recover(); r != nil {
 					// On Windows, go-prompt tearDown may panic with "close of closed channel"
 					// which replaces our original panic value. Use pendingAction as fallback.
@@ -1415,14 +1423,21 @@ func (cli *ChatCLI) Start(ctx context.Context) {
 				prompt.OptionParser(pasteParser),
 				prompt.OptionTitle("ChatCLI - LLM no seu Terminal"),
 				prompt.OptionLivePrefix(cli.changeLivePrefix),
-				prompt.OptionPrefixTextColor(prompt.Green),
-				prompt.OptionInputTextColor(prompt.White),
-				prompt.OptionSuggestionBGColor(prompt.DarkGray),
-				prompt.OptionDescriptionBGColor(prompt.Black),
-				prompt.OptionSuggestionTextColor(prompt.White),
-				prompt.OptionDescriptionTextColor(prompt.Yellow),
-				prompt.OptionSelectedSuggestionBGColor(prompt.Blue),
-				prompt.OptionSelectedDescriptionBGColor(prompt.DarkGray),
+				// Input line + completion dropdown, painted from the ACTIVE
+				// theme (see prompt_theme.go). These used to be literals, so
+				// the text you type stayed white under every theme — white on
+				// white on any light terminal.
+				themePromptColors(),
+				// go-prompt copies those colors onto its renderer here and
+				// never re-reads them, so a theme switched from inside the
+				// executor would leave the line being typed in the OLD ink.
+				// Leaving the Run loop right after such a command lets the
+				// iteration below rebuild the prompt from the new palette;
+				// go-prompt has already restored cooked mode at this point,
+				// so the exit is clean.
+				prompt.OptionSetExitCheckerOnInput(func(string, bool) bool {
+					return cli.themeReloadPending
+				}),
 				prompt.OptionHistory(cli.commandHistory),
 				prompt.OptionMaxSuggestion(10),
 				prompt.OptionAddKeyBind(prompt.KeyBind{
@@ -1560,11 +1575,18 @@ func (cli *ChatCLI) Start(ctx context.Context) {
 				),
 			)
 
+			cli.promptRunning = true
 			p.Run()
+			cli.promptRunning = false
+			if cli.themeReloadPending {
+				cli.themeReloadPending = false
+				themeReload = true // loop again: rebuild the prompt, keep the REPL
+				return
+			}
 			shouldContinue = false
 		}()
 
-		if shouldContinue {
+		if shouldContinue && !themeReload {
 			cli.restoreTerminal()
 
 			lastCmd := ""

--- a/cli/compact_command.go
+++ b/cli/compact_command.go
@@ -9,6 +9,8 @@ import (
 	"github.com/diillson/chatcli/cli/compress"
 	"github.com/diillson/chatcli/i18n"
 	"github.com/diillson/chatcli/models"
+	"github.com/diillson/chatcli/ui/kit"
+	"github.com/diillson/chatcli/ui/theme"
 	"go.uber.org/zap"
 )
 
@@ -137,7 +139,7 @@ CONVERSATION TO COMPACT:
 
 	fmt.Printf("  %s %s %s\n",
 		colorize("📦", ""),
-		i18n.T("compact.compacting_with_instruction"),
+		kit.Colorize(i18n.T("compact.compacting_with_instruction"), theme.RoleText),
 		colorize(instruction, ColorCyan),
 	)
 
@@ -228,7 +230,7 @@ CONVERSATION TO COMPACT:
 
 	fmt.Printf("  %s %s (%s: %s)\n",
 		colorize("✓", ColorGreen),
-		i18n.T("compact.success", before, after),
+		kit.Colorize(i18n.T("compact.success", before, after), theme.RoleText),
 		i18n.T("compact.preserved"),
 		colorize(instruction, ColorCyan),
 	)

--- a/cli/config_ui_mutate.go
+++ b/cli/config_ui_mutate.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/diillson/chatcli/config"
 	"github.com/diillson/chatcli/i18n"
+	"github.com/diillson/chatcli/ui/kit"
 	"github.com/diillson/chatcli/ui/theme"
 )
 
@@ -58,7 +59,9 @@ func (cli *ChatCLI) printConfigUIUsage() {
 	fmt.Println("  /config ui")
 	fmt.Println("  /config ui theme                       # " + i18n.T("cfg.ui.usage_theme_show"))
 	for _, name := range theme.Names() {
-		fmt.Printf("  /config ui theme %-21s # %s\n", name, i18n.T("cfg.ui.usage_theme_set", name))
+		fmt.Printf("  /config ui theme %s # %s\n",
+			kit.PadRight(name, 21),
+			kit.Colorize(i18n.T("cfg.ui.usage_theme_set", name), theme.RoleText))
 	}
 	fmt.Println()
 	fmt.Println(colorize("  "+i18n.T("cfg.ui.usage_note_scope"), ColorGray))
@@ -88,10 +91,25 @@ func (cli *ChatCLI) configUITheme(args []string) {
 
 	if previous == target {
 		fmt.Println(colorize("  ✔ "+i18n.T("cfg.ui.theme_set_noop", target), ColorGray))
-	} else {
-		fmt.Println(colorize("  ✔ "+i18n.T("cfg.ui.theme_set_ok", previous, target), ColorGreen))
+		return
 	}
+	fmt.Println(colorize("  ✔ "+i18n.T("cfg.ui.theme_set_ok", previous, target), ColorGreen))
 	fmt.Println(colorize("    "+i18n.T("cfg.ui.theme_persist_hint", target), ColorGray))
+
+	// Every fmt.Print surface re-reads the theme on its next render, but
+	// go-prompt froze its colors on the renderer when the prompt was built:
+	// without a rebuild the line the user types would keep the OLD theme's
+	// ink until the next mode switch — white on white when switching to a
+	// light theme, which is the whole point of switching. Raising the flag
+	// makes the REPL's exit checker end this prompt as soon as the command
+	// returns; the loop then rebuilds it from the new palette. Only the REPL
+	// has a prompt to rebuild: headless callers (scheduler, gateway,
+	// ACP/MCP, the agent and coder loops) leave the flag alone, and the
+	// coder prompt picks the palette up on its next line anyway because it
+	// is constructed per input.
+	if cli.promptRunning {
+		cli.themeReloadPending = true
+	}
 }
 
 // printConfigUIStatus shows the active theme, the detected color profile and
@@ -123,9 +141,9 @@ func (cli *ChatCLI) printConfigUIStatus() {
 		}
 		fmt.Printf("  %s%s%s  %s\n",
 			marker,
-			colorize(fmt.Sprintf("%-8s", name), ColorYellow),
+			colorize(kit.PadRight(name, 16), ColorYellow),
 			colorize(" ·", ColorGray),
-			i18n.T("cfg.ui.theme_desc_"+name),
+			kit.Colorize(i18n.T("cfg.ui.theme_desc_"+name), theme.RoleText),
 		)
 	}
 	fmt.Println()

--- a/cli/context_display.go
+++ b/cli/context_display.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/diillson/chatcli/cli/ctxmgr"
 	"github.com/diillson/chatcli/i18n"
+	"github.com/diillson/chatcli/ui/kit"
+	"github.com/diillson/chatcli/ui/theme"
 	"github.com/diillson/chatcli/utils"
 )
 
@@ -149,18 +151,18 @@ func (h *ContextHandler) handleShowAttached(sessionID string) error {
 		colorize(formatTokenCount(totalTokens), ColorYellow))
 	fmt.Printf("  %s %s\n",
 		colorize("💡", ""),
-		i18n.T("context.display.cache_info"))
+		kit.Colorize(i18n.T("context.display.cache_info"), theme.RoleText))
 	fmt.Printf("     %s %s\n",
 		colorize("•", ColorGray),
-		i18n.T("context.display.cache_anthropic"))
+		kit.Colorize(i18n.T("context.display.cache_anthropic"), theme.RoleText))
 	fmt.Printf("     %s %s\n",
 		colorize("•", ColorGray),
-		i18n.T("context.display.cache_openai"))
+		kit.Colorize(i18n.T("context.display.cache_openai"), theme.RoleText))
 
 	if totalTokens > 10000 {
 		fmt.Printf("\n  %s %s\n",
 			colorize("⚠", ColorYellow),
-			i18n.T("context.display.large_context_warning", contexts[0].Name))
+			kit.Colorize(i18n.T("context.display.large_context_warning", contexts[0].Name), theme.RoleText))
 	}
 
 	fmt.Println()
@@ -296,7 +298,7 @@ func (h *ContextHandler) printChunkedStructure(ctx *ctxmgr.FileContext, detailed
 	for i, chunk := range ctx.Chunks {
 		fmt.Printf("\n  %s %s\n",
 			colorize("📦", ColorYellow),
-			i18n.T("context.display.chunks.chunk_label", chunk.Index, chunk.TotalChunks))
+			kit.Colorize(i18n.T("context.display.chunks.chunk_label", chunk.Index, chunk.TotalChunks), theme.RoleText))
 
 		if chunk.Description != "" {
 			fmt.Printf("    %s %s\n", colorize(i18n.T("context.display.label.description"), ColorGray), chunk.Description)
@@ -414,22 +416,22 @@ func (h *ContextHandler) printAttachmentInfo(ctx *ctxmgr.FileContext) {
 	} else {
 		fmt.Printf("  %s %s\n",
 			colorize("●", ColorGray),
-			i18n.T("context.display.attachment.not_attached"))
+			kit.Colorize(i18n.T("context.display.attachment.not_attached"), theme.RoleText))
 		fmt.Println()
 	}
 
 	fmt.Printf("  %s %s\n",
 		colorize("●", ColorCyan),
-		i18n.T("context.display.attachment.attach_instruction"))
+		kit.Colorize(i18n.T("context.display.attachment.attach_instruction"), theme.RoleText))
 	fmt.Printf("    %s\n\n",
 		colorize(fmt.Sprintf("/context attach %s", ctx.Name), ColorYellow))
 
 	if ctx.IsChunked {
 		fmt.Printf("  %s %s\n",
 			colorize("💡", ColorCyan),
-			i18n.T("context.display.attachment.chunked_info"))
+			kit.Colorize(i18n.T("context.display.attachment.chunked_info"), theme.RoleText))
 		fmt.Printf("    %s %s\n", colorize("•", ColorGray),
-			i18n.T("context.display.attachment.attach_all"))
+			kit.Colorize(i18n.T("context.display.attachment.attach_all"), theme.RoleText))
 		fmt.Printf("    %s %s %s\n",
 			colorize("•", ColorGray),
 			i18n.T("context.display.attachment.attach_specific"),

--- a/cli/context_io.go
+++ b/cli/context_io.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/diillson/chatcli/cli/ctxmgr"
 	"github.com/diillson/chatcli/i18n"
+	"github.com/diillson/chatcli/ui/kit"
+	"github.com/diillson/chatcli/ui/theme"
 )
 
 // handleAttach anexa um contexto à sessão atual
@@ -278,7 +280,7 @@ func printTokenCostFeedback(ctx *ctxmgr.FileContext) {
 	if estimatedTokens > 20000 {
 		fmt.Printf("  %s %s\n",
 			colorize("⚠", ColorYellow),
-			i18n.T("context.io.large_context_tip"))
+			kit.Colorize(i18n.T("context.io.large_context_tip"), theme.RoleText))
 	}
 }
 

--- a/cli/prompt_theme.go
+++ b/cli/prompt_theme.go
@@ -1,0 +1,139 @@
+/*
+ * ChatCLI - go-prompt colors derived from the active theme
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * The REPL input line and its completion dropdown are painted by go-prompt,
+ * which owns its own render loop and never sees an ANSI string we build — so
+ * theme.Recolor (the bridge that re-skins every fmt.Print call site) cannot
+ * reach it. Historically that meant the colors were LITERALS: the text you
+ * type was prompt.White no matter which theme was active, which is fine on a
+ * dark ground and unusable on a light one — white on white.
+ *
+ * This file is the missing bridge. Every go-prompt color is derived from a
+ * semantic palette entry, so the input line, the suggestion list and the
+ * description panel follow a theme switch exactly like the rest of the UI.
+ *
+ * Two constraints shape the mapping:
+ *
+ *   - go-prompt speaks only the 16-color enum, so we read each palette
+ *     entry's ANSI16 index (the theme's own explicit downgrade) rather than
+ *     letting a library guess from the hex.
+ *   - A foreground painted ON a filled row must come from the OPPOSITE end of
+ *     the palette. Background is the theme's own ground (dark under dark
+ *     themes, light under light ones), so it is the correct ink on a
+ *     saturated fill, and TextStrong is the correct ink on the neutral Border
+ *     fill. Using TextStrong for both would print black on dark gray under
+ *     every light theme.
+ *
+ * Under the default dark theme the resulting indices reproduce the previous
+ * literals (Info→10 = prompt.Green, TextStrong→15 = prompt.White, Border→8 =
+ * prompt.DarkGray, Background→0 = prompt.Black), so adopting the bridge is a
+ * visually neutral change there and a legibility fix everywhere else.
+ *
+ * go-prompt freezes these on its renderer at construction, so a theme switch
+ * mid-session only reaches the input line once the prompt is rebuilt — which
+ * is why /config ui theme unwinds the REPL loop (see cli.Start).
+ */
+package cli
+
+import (
+	prompt "github.com/c-bata/go-prompt"
+	"github.com/diillson/chatcli/ui/theme"
+)
+
+// promptColor converts a palette entry into go-prompt's color enum. The enum
+// is the 16 classic indices shifted by one (DefaultColor occupies slot 0), so
+// a palette index maps by a single increment. On a profile that cannot color
+// (NO_COLOR, a pipe) every entry collapses to DefaultColor, which leaves the
+// prompt in the terminal's own foreground instead of forcing a hue nothing
+// else in the output is using.
+func promptColor(c theme.Color) prompt.Color {
+	if !theme.ActiveProfile().HasColor() {
+		return prompt.DefaultColor
+	}
+	if c.ANSI16 > 15 {
+		return prompt.DefaultColor
+	}
+	return prompt.Color(c.ANSI16) + 1
+}
+
+// composeOptions folds several go-prompt options into ONE, so a call site
+// can pick up the whole theme wiring with a single entry in an option list
+// that is otherwise a long literal (Go forbids mixing `opts...` with literal
+// arguments in the same variadic call). Options are applied in order and the
+// first failure short-circuits, exactly as prompt.New would apply them.
+func composeOptions(opts ...prompt.Option) prompt.Option {
+	return func(p *prompt.Prompt) error {
+		for _, opt := range opts {
+			if err := opt(p); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+// ThemePromptTextColors is the single option that paints the input line from
+// the active theme: the coder-mode prompt takes just this one, since the
+// input line is the whole surface it renders.
+func themePromptTextColors() prompt.Option {
+	return composeOptions(themePromptTextOptions()...)
+}
+
+// themePromptColors is the single option that paints the whole chat REPL
+// prompt — input line plus completion dropdown — from the active theme.
+func themePromptColors() prompt.Option {
+	return composeOptions(themePromptColorOptions()...)
+}
+
+// themePromptTextOptions returns the color options for the input line itself:
+// the prefix, the text the user types, and the inline completion preview.
+// Shared by the chat REPL and the coder-mode prompt, where the input line is
+// the whole surface go-prompt renders.
+//
+// The typed text takes TextStrong — the palette's highest-contrast
+// foreground — because the line being composed is the most important text on
+// screen. That is prompt.White on every dark theme (unchanged) and near-black
+// ink on the light ones (the bug this replaces).
+func themePromptTextOptions() []prompt.Option {
+	p := theme.Active().Palette
+	return []prompt.Option{
+		prompt.OptionPrefixTextColor(promptColor(p.Info)),
+		prompt.OptionInputTextColor(promptColor(p.TextStrong)),
+		prompt.OptionPreviewSuggestionTextColor(promptColor(p.Info)),
+	}
+}
+
+// themePromptColorOptions returns the full palette wiring for the chat REPL:
+// the input line plus the completion dropdown (suggestions, descriptions and
+// their selected rows) and the scrollbar.
+//
+// The dropdown reads as two stacked surfaces — suggestions on the neutral
+// Border fill, descriptions on the theme's own ground — with the selected row
+// lifted onto the Secondary accent. Every foreground is chosen against the
+// fill it lands on, never against the terminal.
+func themePromptColorOptions() []prompt.Option {
+	p := theme.Active().Palette
+	return append(themePromptTextOptions(),
+		// Suggestion list: neutral raised surface, strongest ink.
+		prompt.OptionSuggestionBGColor(promptColor(p.Border)),
+		prompt.OptionSuggestionTextColor(promptColor(p.TextStrong)),
+		// Selected suggestion: accent fill, so the ink is the theme's ground.
+		prompt.OptionSelectedSuggestionBGColor(promptColor(p.Secondary)),
+		prompt.OptionSelectedSuggestionTextColor(promptColor(p.Background)),
+		// Description panel: the theme's ground, with the Warning hue that has
+		// carried descriptions since before the theme system. The NON-bright
+		// yellow matters here — bright yellow on a light terminal is invisible.
+		prompt.OptionDescriptionBGColor(promptColor(p.Background)),
+		prompt.OptionDescriptionTextColor(promptColor(p.Warning)),
+		// Selected description: the same neutral surface as the suggestion
+		// list, so the selected pair reads as one raised row.
+		prompt.OptionSelectedDescriptionBGColor(promptColor(p.Border)),
+		prompt.OptionSelectedDescriptionTextColor(promptColor(p.TextStrong)),
+		// Scrollbar: muted thumb on the theme's ground — visible in both
+		// variants, unlike go-prompt's stock cyan track.
+		prompt.OptionScrollbarThumbColor(promptColor(p.Muted)),
+		prompt.OptionScrollbarBGColor(promptColor(p.Background)),
+	)
+}

--- a/cli/prompt_theme_test.go
+++ b/cli/prompt_theme_test.go
@@ -1,0 +1,213 @@
+/*
+ * ChatCLI - tests for the go-prompt ↔ theme color bridge
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package cli
+
+import (
+	"errors"
+	"testing"
+
+	prompt "github.com/c-bata/go-prompt"
+	"github.com/diillson/chatcli/i18n"
+	"github.com/diillson/chatcli/ui/theme"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func withTheme(t *testing.T, name string, prof theme.Profile) {
+	t.Helper()
+	prev := theme.Active().Name
+	prevProf := theme.ActiveProfile()
+	require.NoError(t, theme.SetActive(name))
+	theme.SetProfile(prof)
+	t.Cleanup(func() {
+		_ = theme.SetActive(prev)
+		theme.SetProfile(prevProf)
+	})
+}
+
+// TestPromptColor_DarkThemeReproducesLegacyLiterals is the no-regression
+// anchor: on the default dark theme the palette-derived colors must resolve to
+// the exact go-prompt constants the prompt was hardcoded with, so adopting the
+// bridge changes nothing on the theme most users run.
+func TestPromptColor_DarkThemeReproducesLegacyLiterals(t *testing.T) {
+	withTheme(t, "dark", theme.ProfileTrueColor)
+	p := theme.Active().Palette
+
+	assert.Equal(t, prompt.Green, promptColor(p.Info), "prefix was prompt.Green")
+	assert.Equal(t, prompt.White, promptColor(p.TextStrong), "input text was prompt.White")
+	assert.Equal(t, prompt.DarkGray, promptColor(p.Border), "suggestion background was prompt.DarkGray")
+	assert.Equal(t, prompt.Black, promptColor(p.Background), "description background was prompt.Black")
+	assert.Equal(t, prompt.DarkGray, promptColor(p.Muted), "scrollbar thumb was prompt.DarkGray")
+}
+
+// TestPromptColor_LightThemeIsNotWhite is the bug this bridge exists for: the
+// input line was prompt.White under every theme, so a light theme on a light
+// terminal printed white on white. It must now resolve to the palette's ink.
+func TestPromptColor_LightThemeIsNotWhite(t *testing.T) {
+	for _, name := range []string{"light", "solarized-light"} {
+		t.Run(name, func(t *testing.T) {
+			withTheme(t, name, theme.ProfileTrueColor)
+			p := theme.Active().Palette
+
+			got := promptColor(p.TextStrong)
+			assert.NotEqual(t, prompt.White, got, "typed text must not stay white on a light theme")
+			assert.Equal(t, prompt.Black, got, "the light palettes ink is index 0")
+			assert.NotEqual(t, prompt.White, promptColor(p.Info), "the prefix must not be a bright hue either")
+		})
+	}
+}
+
+// TestPromptColor_NoColorProfileFallsBackToTerminal keeps piped/NO_COLOR runs
+// in the terminal's own foreground instead of forcing a hue nothing else in
+// the output is using.
+func TestPromptColor_NoColorProfileFallsBackToTerminal(t *testing.T) {
+	withTheme(t, "dark", theme.ProfileASCII)
+	p := theme.Active().Palette
+	assert.Equal(t, prompt.DefaultColor, promptColor(p.TextStrong))
+	assert.Equal(t, prompt.DefaultColor, promptColor(p.Info))
+}
+
+// TestThemePromptOptions_CoverEveryThemeInRange proves the bridge yields a
+// full, valid option set for every registered theme. go-prompt indexes its
+// color enum directly, so an out-of-range value is a silent mis-paint (or a
+// panic inside prompt.New at REPL start) — the worst possible place for it.
+// prompt.New itself cannot run here: it opens the real TTY.
+func TestThemePromptOptions_CoverEveryThemeInRange(t *testing.T) {
+	for _, name := range theme.Names() {
+		withTheme(t, name, theme.ProfileTrueColor)
+		p := theme.Active().Palette
+
+		assert.Len(t, themePromptTextOptions(), 3, name)
+		assert.Len(t, themePromptColorOptions(), 13, name)
+
+		for role, c := range map[string]theme.Color{
+			"Info": p.Info, "TextStrong": p.TextStrong, "Border": p.Border,
+			"Secondary": p.Secondary, "Background": p.Background,
+			"Warning": p.Warning, "Muted": p.Muted,
+		} {
+			got := promptColor(c)
+			assert.GreaterOrEqualf(t, int(got), int(prompt.DefaultColor), "%s/%s below the enum", name, role)
+			assert.LessOrEqualf(t, int(got), int(prompt.White), "%s/%s above the enum", name, role)
+		}
+	}
+}
+
+// TestThemeDescriptions_ExistForEveryTheme is the guard for the defect that
+// made `grafite` render the raw i18n key in the completer, the palette and
+// `/config ui theme`: a palette was registered without its description string.
+func TestThemeDescriptions_ExistForEveryTheme(t *testing.T) {
+	i18n.Init()
+	for _, name := range theme.Names() {
+		key := "cfg.ui.theme_desc_" + name
+		got := i18n.T(key)
+		assert.NotEqualf(t, key, got, "theme %q has no description: %s renders as the raw key", name, key)
+		assert.NotEmptyf(t, got, "theme %q has an empty description", name)
+	}
+}
+
+// TestConfigUITheme_RebuildsThePromptOnlyInTheREPL locks the flag that makes a
+// theme switch reach the input line. go-prompt froze its colors when the
+// prompt was built, so without the rebuild `/config ui theme light` would
+// leave the line being typed in the OLD theme's ink — white on white, the
+// exact defect the switch was meant to cure. It must be raised ONLY while
+// go-prompt owns the terminal: headless callers (scheduler, gateway,
+// ACP/MCP, the agent and coder loops) have no prompt to rebuild, and a stuck
+// flag there would end the next REPL prompt for no reason.
+func TestConfigUITheme_RebuildsThePromptOnlyInTheREPL(t *testing.T) {
+	i18n.Init()
+	withTheme(t, "dark", theme.ProfileTrueColor)
+	t.Setenv("CHATCLI_THEME", "dark")
+
+	t.Run("inside the prompt it asks for a rebuild", func(t *testing.T) {
+		c := &ChatCLI{promptRunning: true}
+		c.configUITheme([]string{"light"})
+		assert.True(t, c.themeReloadPending, "the REPL must rebuild its prompt")
+		assert.Equal(t, "light", theme.Active().Name, "the switch itself must still have happened")
+	})
+
+	t.Run("headless it changes nothing but the theme", func(t *testing.T) {
+		c := &ChatCLI{promptRunning: false}
+		c.configUITheme([]string{"dracula"})
+		assert.False(t, c.themeReloadPending, "there is no prompt to rebuild")
+		assert.Equal(t, "dracula", theme.Active().Name)
+	})
+
+	t.Run("a no-op switch never rebuilds", func(t *testing.T) {
+		require.NoError(t, theme.SetActive("nord"))
+		c := &ChatCLI{promptRunning: true}
+		c.configUITheme([]string{"nord"})
+		assert.False(t, c.themeReloadPending)
+	})
+
+	t.Run("a rejected name never rebuilds", func(t *testing.T) {
+		require.NoError(t, theme.SetActive("dark"))
+		c := &ChatCLI{promptRunning: true}
+		c.configUITheme([]string{"no-such-theme"})
+		assert.False(t, c.themeReloadPending)
+		assert.Equal(t, "dark", theme.Active().Name)
+	})
+}
+
+// TestComposeOptions_FoldsAndShortCircuits covers the fold that lets a single
+// entry in go-prompt's option list carry the whole theme wiring. Order and
+// short-circuit matter: prompt.New PANICS on the first option that errors, so
+// a fold that swallowed an error would move that panic to REPL start.
+func TestComposeOptions_FoldsAndShortCircuits(t *testing.T) {
+	var order []string
+	ok := func(name string) prompt.Option {
+		return func(*prompt.Prompt) error { order = append(order, name); return nil }
+	}
+	boom := errors.New("bad option")
+
+	order = nil
+	require.NoError(t, composeOptions(ok("a"), ok("b"), ok("c"))(nil))
+	assert.Equal(t, []string{"a", "b", "c"}, order, "options apply in the order given")
+
+	order = nil
+	err := composeOptions(ok("a"), func(*prompt.Prompt) error { return boom }, ok("never"))(nil)
+	require.ErrorIs(t, err, boom)
+	assert.Equal(t, []string{"a"}, order, "the fold stops at the first failure")
+
+	assert.NoError(t, composeOptions()(nil), "an empty fold is a no-op, not an error")
+}
+
+// TestThemePromptColorBundles_CarryEveryOption proves the two entry points the
+// REPL and the coder prompt actually use carry the full set — a bundle that
+// silently dropped an option would leave that surface on go-prompt's stock
+// colors, which is where the white-on-white came from in the first place.
+// The bundles are folds over these slices, and applying one to a Prompt is not
+// possible here: go-prompt's renderer is unexported and prompt.New opens the
+// real TTY. The counts are the contract; composeOptions is covered separately.
+func TestThemePromptColorBundles_CarryEveryOption(t *testing.T) {
+	withTheme(t, "light", theme.ProfileTrueColor)
+
+	assert.Len(t, themePromptTextOptions(), 3, "prefix, input and preview")
+	assert.Len(t, themePromptColorOptions(), 13, "input line plus the whole dropdown")
+	assert.NotNil(t, themePromptTextColors(), "the coder prompt bundle must exist")
+	assert.NotNil(t, themePromptColors(), "the chat REPL bundle must exist")
+}
+
+// TestConfigUISurfaces_RenderEveryThemeWithItsDescription drives the two
+// listings a user reads to pick a theme. Both printed the description bare —
+// so they never followed the palette — and both rendered the raw i18n key for
+// any theme missing its string, which is exactly how grafite shipped.
+func TestConfigUISurfaces_RenderEveryThemeWithItsDescription(t *testing.T) {
+	i18n.Init()
+	withTheme(t, "grafite", theme.ProfileTrueColor)
+
+	for name, render := range map[string]func(*ChatCLI){
+		"status": (*ChatCLI).printConfigUIStatus,
+		"usage":  (*ChatCLI).printConfigUIUsage,
+	} {
+		t.Run(name, func(t *testing.T) {
+			out := captureStdout(t, func() { render(&ChatCLI{}) })
+			for _, theme := range theme.Names() {
+				assert.Containsf(t, out, theme, "%s listing must offer %q", name, theme)
+			}
+			assert.NotContains(t, out, "cfg.ui.theme_desc_", "a raw i18n key reached the screen")
+		})
+	}
+}

--- a/cli/rewind.go
+++ b/cli/rewind.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/diillson/chatcli/i18n"
 	"github.com/diillson/chatcli/models"
+	"github.com/diillson/chatcli/ui/kit"
+	"github.com/diillson/chatcli/ui/theme"
 )
 
 // conversationCheckpoint stores a snapshot of the conversation at a given point.
@@ -80,11 +82,14 @@ func (cli *ChatCLI) showRewindMenu() bool {
 		msgInfo := fmt.Sprintf("%d msgs", cp.MsgCount)
 		idx := len(cli.checkpoints) - i
 
+		// The label is the only content column, so it carries the theme's
+		// body-text color instead of being printed bare: unstyled text keeps
+		// the terminal's own foreground and so never follows a theme switch.
 		fmt.Printf("  %s  %s  %s  %s\n",
 			colorize(fmt.Sprintf("[%d]", idx), ColorCyan),
 			colorize(timeStr, ColorGray),
 			colorize(msgInfo, ColorYellow),
-			cp.Label,
+			kit.Colorize(cp.Label, theme.RoleText),
 		)
 	}
 
@@ -128,7 +133,7 @@ func (cli *ChatCLI) showRewindMenu() bool {
 
 	fmt.Printf("  %s %s\n",
 		colorize("↩", ColorGreen),
-		i18n.T("rewind.success", idx, cp.Timestamp.Format("15:04:05"), cp.MsgCount),
+		kit.Colorize(i18n.T("rewind.success", idx, cp.Timestamp.Format("15:04:05"), cp.MsgCount), theme.RoleText),
 	)
 
 	return true

--- a/i18n/locales/en-US.theme-contrast.json
+++ b/i18n/locales/en-US.theme-contrast.json
@@ -1,0 +1,3 @@
+{
+  "cfg.ui.theme_desc_grafite": "Grafite — sober graphite dark: calm blue accents, low-key chrome."
+}

--- a/i18n/locales/en.theme-contrast.json
+++ b/i18n/locales/en.theme-contrast.json
@@ -1,0 +1,3 @@
+{
+  "cfg.ui.theme_desc_grafite": "Grafite — sober graphite dark: calm blue accents, low-key chrome."
+}

--- a/i18n/locales/pt-BR.theme-contrast.json
+++ b/i18n/locales/pt-BR.theme-contrast.json
@@ -1,0 +1,3 @@
+{
+  "cfg.ui.theme_desc_grafite": "Grafite — dark sóbrio de grafite: accents em azul calmo, cromo discreto."
+}

--- a/i18n/theme_desc_test.go
+++ b/i18n/theme_desc_test.go
@@ -1,0 +1,61 @@
+/*
+ * ChatCLI - locale parity for the theme description strings
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * T falls back to the default language for a missing key, so a theme
+ * description present only in en.json looks fine in an English session and
+ * silently prints English inside a pt-BR one. This test compares the KEY SETS
+ * across locales directly, which is the only way that drift shows up before a
+ * user in the other locale hits it.
+ */
+package i18n
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"golang.org/x/text/language"
+)
+
+const themeDescPrefix = "cfg.ui.theme_desc_"
+
+func themeDescKeys(tag language.Tag) []string {
+	var out []string
+	for k := range rawByTag[tag] {
+		if strings.HasPrefix(k, themeDescPrefix) {
+			out = append(out, k)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestThemeDescriptions_SameKeysInEveryLocale(t *testing.T) {
+	Init()
+	locales := []language.Tag{
+		language.MustParse("en"),
+		language.MustParse("en-US"),
+		language.MustParse("pt-BR"),
+	}
+	want := themeDescKeys(locales[0])
+	if len(want) == 0 {
+		t.Fatalf("no %s* keys loaded at all", themeDescPrefix)
+	}
+	for _, tag := range locales[1:] {
+		got := themeDescKeys(tag)
+		if strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Fatalf("%s theme descriptions drifted from en:\n  en: %v\n  %s: %v", tag, want, tag, got)
+		}
+	}
+	// A description that is only the key, or empty, is worse than missing:
+	// it renders as literal noise in the completer and the palette.
+	for _, tag := range locales {
+		for _, k := range themeDescKeys(tag) {
+			if v := strings.TrimSpace(rawByTag[tag][k]); v == "" || v == k {
+				t.Fatalf("%s: %s is not a real description (%q)", tag, k, v)
+			}
+		}
+	}
+}

--- a/ui/theme/contrast_test.go
+++ b/ui/theme/contrast_test.go
@@ -1,0 +1,180 @@
+/*
+ * ChatCLI - legibility contract for every built-in theme
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * A theme may be as opinionated as it likes about hue; it may not be
+ * unreadable. These tests encode the two ways a palette actually breaks in
+ * the field:
+ *
+ *   1. Truecolor: a TEXT role too close in luminance to the theme's own
+ *      ground. This is what made secondary lines vanish under nord/one-dark
+ *      (comment colors reused for whole metadata lines).
+ *   2. 16-color: an index from the wrong half of the range. The bright range
+ *      (9–15) is painted for a dark ground — bright green on a white terminal
+ *      is invisible — and index 0 is black, invisible on a dark one. This is
+ *      the same failure as the input line that was hardcoded to prompt.White.
+ *
+ * Border is deliberately exempt from the contrast floor: every upstream
+ * palette here (Nord, Solarized, Catppuccin, One Dark) defines its border /
+ * gutter tone as a near-ground fill on purpose, and "fixing" it would replace
+ * the palette's identity with our own.
+ */
+package theme
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// relativeLuminance implements WCAG 2.x relative luminance for an sRGB color.
+func relativeLuminance(c Color) float64 {
+	r, g, b := c.rgb()
+	lin := func(v uint8) float64 {
+		f := float64(v) / 255
+		if f <= 0.03928 {
+			return f / 12.92
+		}
+		return math.Pow((f+0.055)/1.055, 2.4)
+	}
+	return 0.2126*lin(r) + 0.7152*lin(g) + 0.0722*lin(b)
+}
+
+// contrastRatio is the WCAG contrast between two palette colors.
+func contrastRatio(a, b Color) float64 {
+	la, lb := relativeLuminance(a), relativeLuminance(b)
+	hi, lo := math.Max(la, lb), math.Min(la, lb)
+	return (hi + 0.05) / (lo + 0.05)
+}
+
+// TestThemes_TextRolesAreLegible holds every palette's TEXT tones against its
+// own declared ground. Body text takes the WCAG AA floor (4.5:1); Muted is
+// secondary text and takes the large-text floor (3:1), which is where the
+// four dark palettes that reused their comment color used to fail.
+func TestThemes_TextRolesAreLegible(t *testing.T) {
+	t.Cleanup(restoreThemeState())
+
+	for _, name := range Names() {
+		th := builtins[name]()
+		p := th.Palette
+		for _, tc := range []struct {
+			role string
+			c    Color
+			min  float64
+		}{
+			{"Text", p.Text, 4.5},
+			{"TextStrong", p.TextStrong, 4.5},
+			{"Muted", p.Muted, 3.0},
+		} {
+			got := contrastRatio(tc.c, p.Background)
+			assert.GreaterOrEqualf(t, got, tc.min,
+				"%s: %s (%s) is %.2f:1 on the theme's ground (%s) — below the %.1f:1 floor",
+				name, tc.role, tc.c.Hex, got, p.Background.Hex, tc.min)
+		}
+	}
+}
+
+// TestThemes_ANSI16MatchesVariant guards the 16-color fallback against the
+// bug class the light theme shipped with: Info at index 10 (bright green),
+// which is deliberately painted for a dark ground and disappears on a light
+// terminal. A light palette must stay in 0–8; a dark one must never use 0.
+func TestThemes_ANSI16MatchesVariant(t *testing.T) {
+	t.Cleanup(restoreThemeState())
+
+	for _, name := range Names() {
+		th := builtins[name]()
+		p := th.Palette
+		// Background is exempt in both directions: it IS the ground, so a
+		// light theme's 15 and a dark theme's 0 are the correct values.
+		roles := map[string]Color{
+			"Primary": p.Primary, "Secondary": p.Secondary, "Accent": p.Accent,
+			"Muted": p.Muted, "Success": p.Success, "Warning": p.Warning,
+			"Danger": p.Danger, "Info": p.Info, "Border": p.Border,
+			"Text": p.Text, "TextStrong": p.TextStrong,
+		}
+		for role, c := range roles {
+			if th.Variant == VariantLight {
+				assert.LessOrEqualf(t, int(c.ANSI16), 8,
+					"%s (light): %s uses the bright index %d, which is painted for a DARK ground",
+					name, role, c.ANSI16)
+				continue
+			}
+			assert.NotEqualf(t, uint8(0), c.ANSI16,
+				"%s (dark): %s uses index 0 (black), invisible on a dark ground", name, role)
+		}
+	}
+}
+
+// TestThemes_DropdownPairsContrast locks the fill/ink pairings the REPL
+// completion dropdown uses (cli/prompt_theme.go). go-prompt paints a filled
+// row, so the ink must be chosen against the FILL, never the terminal — the
+// asymmetry that makes "TextStrong everywhere" print black on dark gray under
+// every light theme.
+func TestThemes_DropdownPairsContrast(t *testing.T) {
+	t.Cleanup(restoreThemeState())
+
+	for _, name := range Names() {
+		p := builtins[name]().Palette
+		for _, pair := range []struct {
+			what     string
+			ink, fil Color
+		}{
+			{"suggestion", p.TextStrong, p.Border},
+			{"selected suggestion", p.Background, p.Secondary},
+			{"description", p.Warning, p.Background},
+			{"selected description", p.TextStrong, p.Border},
+		} {
+			got := contrastRatio(pair.ink, pair.fil)
+			assert.GreaterOrEqualf(t, got, 3.0,
+				"%s: dropdown %s ink %s on fill %s is only %.2f:1",
+				name, pair.what, pair.ink.Hex, pair.fil.Hex, got)
+		}
+	}
+}
+
+// TestThemes_ANSI16SurfacesStayOnTheirSide is the 16-color half of the
+// dropdown contract: on a classic terminal the fill and the ink collapse to
+// indices, and a fill that lands on the SAME index as its ink renders an
+// unreadable row regardless of what the hex values promise.
+func TestThemes_ANSI16SurfacesStayOnTheirSide(t *testing.T) {
+	t.Cleanup(restoreThemeState())
+
+	for _, name := range Names() {
+		p := builtins[name]().Palette
+		pairs := map[string][2]Color{
+			"suggestion":           {p.TextStrong, p.Border},
+			"selected suggestion":  {p.Background, p.Secondary},
+			"description":          {p.Warning, p.Background},
+			"selected description": {p.TextStrong, p.Border},
+		}
+		for what, pair := range pairs {
+			assert.NotEqualf(t, pair[0].ANSI16, pair[1].ANSI16,
+				"%s: dropdown %s collapses ink and fill onto index %d at the 16-color profile",
+				name, what, pair[0].ANSI16)
+		}
+	}
+}
+
+// TestNewRoles_ResolveToTheirPaletteEntry pins the roles added for the
+// surfaces that paint their own text (menus, listings) and for the go-prompt
+// bridge, so a future reshuffle of the Role enum cannot silently repoint them.
+func TestNewRoles_ResolveToTheirPaletteEntry(t *testing.T) {
+	for _, name := range Names() {
+		th := builtins[name]()
+		assert.Equal(t, th.Palette.Text, th.ColorFor(RoleText), name)
+		assert.Equal(t, th.Palette.TextStrong, th.ColorFor(RoleTextStrong), name)
+		assert.Equal(t, th.Palette.Background, th.ColorFor(RoleBackground), name)
+	}
+}
+
+// TestGrafite_IsRegistered documents the palette that shipped without being
+// wired into the surfaces that enumerate themes.
+func TestGrafite_IsRegistered(t *testing.T) {
+	t.Cleanup(restoreThemeState())
+	_, ok := builtins["grafite"]
+	assert.True(t, ok, "grafite must stay registered")
+	assert.Contains(t, fmt.Sprint(Names()), "grafite")
+}

--- a/ui/theme/registry.go
+++ b/ui/theme/registry.go
@@ -249,13 +249,18 @@ func LightTheme() Theme {
 			Secondary: Color{Hex: "#2563EB", ANSI256: 26, ANSI16: 4},
 			Accent:    Color{Hex: "#0891B2", ANSI256: 31, ANSI16: 6},
 			Muted:     Color{Hex: "#6B7280", ANSI256: 244, ANSI16: 8},
-			Success:   Color{Hex: "#16A34A", ANSI256: 34, ANSI16: 2},
-			Warning:   Color{Hex: "#B45309", ANSI256: 130, ANSI16: 3},
-			Danger:    Color{Hex: "#DC2626", ANSI256: 160, ANSI16: 1},
-			// ANSI16 10 (bright green), distinct from Success' 2 so the two
-			// roles stay distinguishable on 16-color terminals — matching the
-			// dark theme's Info/Success separation.
-			Info:       Color{Hex: "#4D7C0F", ANSI256: 64, ANSI16: 10},
+			// green-700, not green-600: the lighter tone sat at 2.99:1 on the
+			// light ground, i.e. right under the legibility floor this theme
+			// exists to hold.
+			Success: Color{Hex: "#15803D", ANSI256: 28, ANSI16: 2},
+			Warning: Color{Hex: "#B45309", ANSI256: 130, ANSI16: 3},
+			Danger:  Color{Hex: "#DC2626", ANSI256: 160, ANSI16: 1},
+			// ANSI16 4 (blue), NOT the dark theme's 10 (bright green): on a
+			// 16-color LIGHT terminal the bright range is painted for a dark
+			// ground and bright green on white is effectively invisible. Blue
+			// keeps Info distinct from Success' 2 (the separation the dark
+			// theme gets from 10) while staying legible on the light ground.
+			Info:       Color{Hex: "#4D7C0F", ANSI256: 64, ANSI16: 4},
 			Border:     Color{Hex: "#9CA3AF", ANSI256: 247, ANSI16: 7},
 			Text:       Color{Hex: "#1F2937", ANSI256: 236, ANSI16: 0},
 			TextStrong: Color{Hex: "#111827", ANSI256: 232, ANSI16: 0},

--- a/ui/theme/roles.go
+++ b/ui/theme/roles.go
@@ -48,6 +48,20 @@ const (
 	// without this one warnings rendered in the Info hue while the legacy
 	// yellow path went through Palette.Warning — two colors for one meaning.
 	RoleWarning
+	// RoleText: plain body text the UI paints itself — the counterpart of the
+	// Text color glamour already uses for markdown prose. Surfaces that print
+	// raw content (menu labels, listing descriptions) MUST use this instead of
+	// leaving the text unstyled: unstyled text inherits the terminal's own
+	// foreground, so it never follows a theme switch.
+	RoleText
+	// RoleTextStrong: the highest-contrast foreground of the palette — the
+	// text the user is actively typing, bold labels, selected rows.
+	RoleTextStrong
+	// RoleBackground: the palette's surface color. Only meaningful where a
+	// BACKGROUND is being painted (code blocks, the completion dropdown, the
+	// foreground placed ON a saturated accent fill); never use it as body
+	// foreground, it is the terminal ground by construction.
+	RoleBackground
 )
 
 // ColorFor resolves a role to its palette color under the active theme.
@@ -78,6 +92,12 @@ func (t Theme) ColorFor(r Role) Color {
 		return p.Muted
 	case RoleWarning:
 		return p.Warning
+	case RoleText:
+		return p.Text
+	case RoleTextStrong:
+		return p.TextStrong
+	case RoleBackground:
+		return p.Background
 	default: // RoleBorder
 		return p.Border
 	}

--- a/ui/theme/themes_extra.go
+++ b/ui/theme/themes_extra.go
@@ -43,10 +43,13 @@ func NordTheme() Theme {
 		Name:    "nord",
 		Variant: VariantDark,
 		Palette: Palette{
-			Primary:    Color{Hex: "#81A1C1", ANSI256: 110, ANSI16: 4},
-			Secondary:  Color{Hex: "#B48EAD", ANSI256: 139, ANSI16: 5},
-			Accent:     Color{Hex: "#88C0D0", ANSI256: 116, ANSI16: 6},
-			Muted:      Color{Hex: "#4C566A", ANSI256: 240, ANSI16: 8},
+			Primary:   Color{Hex: "#81A1C1", ANSI256: 110, ANSI16: 4},
+			Secondary: Color{Hex: "#B48EAD", ANSI256: 139, ANSI16: 5},
+			Accent:    Color{Hex: "#88C0D0", ANSI256: 116, ANSI16: 6},
+			// nord3 lifted toward nord4: the canonical #4C566A is Nord's COMMENT
+			// color and lands at 1.7:1 on nord0 — fine for a token inside code,
+			// unreadable for the whole metadata lines ChatCLI paints with Muted.
+			Muted:      Color{Hex: "#7B88A1", ANSI256: 103, ANSI16: 8},
 			Success:    Color{Hex: "#A3BE8C", ANSI256: 108, ANSI16: 2},
 			Warning:    Color{Hex: "#EBCB8B", ANSI256: 222, ANSI16: 3},
 			Danger:     Color{Hex: "#BF616A", ANSI256: 131, ANSI16: 1},
@@ -65,10 +68,12 @@ func TokyoNightTheme() Theme {
 		Name:    "tokyo-night",
 		Variant: VariantDark,
 		Palette: Palette{
-			Primary:    Color{Hex: "#7AA2F7", ANSI256: 111, ANSI16: 4},
-			Secondary:  Color{Hex: "#BB9AF7", ANSI256: 141, ANSI16: 5},
-			Accent:     Color{Hex: "#7DCFFF", ANSI256: 117, ANSI16: 6},
-			Muted:      Color{Hex: "#565F89", ANSI256: 60, ANSI16: 8},
+			Primary:   Color{Hex: "#7AA2F7", ANSI256: 111, ANSI16: 4},
+			Secondary: Color{Hex: "#BB9AF7", ANSI256: 141, ANSI16: 5},
+			Accent:    Color{Hex: "#7DCFFF", ANSI256: 117, ANSI16: 6},
+			// comment lifted toward fg_dark — see the nord note: 2.8:1 is a
+			// syntax-token contrast, not a body-text one.
+			Muted:      Color{Hex: "#6E77A3", ANSI256: 103, ANSI16: 8},
 			Success:    Color{Hex: "#9ECE6A", ANSI256: 149, ANSI16: 2},
 			Warning:    Color{Hex: "#E0AF68", ANSI256: 179, ANSI16: 3},
 			Danger:     Color{Hex: "#F7768E", ANSI256: 204, ANSI16: 1},
@@ -87,10 +92,12 @@ func SolarizedDarkTheme() Theme {
 		Name:    "solarized-dark",
 		Variant: VariantDark,
 		Palette: Palette{
-			Primary:    Color{Hex: "#268BD2", ANSI256: 32, ANSI16: 4},
-			Secondary:  Color{Hex: "#D33682", ANSI256: 168, ANSI16: 5},
-			Accent:     Color{Hex: "#6C71C4", ANSI256: 61, ANSI16: 13},
-			Muted:      Color{Hex: "#586E75", ANSI256: 240, ANSI16: 8},
+			Primary:   Color{Hex: "#268BD2", ANSI256: 32, ANSI16: 4},
+			Secondary: Color{Hex: "#D33682", ANSI256: 168, ANSI16: 5},
+			Accent:    Color{Hex: "#6C71C4", ANSI256: 61, ANSI16: 13},
+			// base00, not base01: Solarized reserves base01 for comments, and on
+			// base03 it lands at 2.8:1. base00 is the palette's own body tone.
+			Muted:      Color{Hex: "#657B83", ANSI256: 66, ANSI16: 8},
 			Success:    Color{Hex: "#859900", ANSI256: 100, ANSI16: 2},
 			Warning:    Color{Hex: "#B58900", ANSI256: 136, ANSI16: 3},
 			Danger:     Color{Hex: "#DC322F", ANSI256: 160, ANSI16: 1},
@@ -109,17 +116,24 @@ func SolarizedLightTheme() Theme {
 		Name:    "solarized-light",
 		Variant: VariantLight,
 		Palette: Palette{
-			Primary:    Color{Hex: "#268BD2", ANSI256: 32, ANSI16: 4},
-			Secondary:  Color{Hex: "#D33682", ANSI256: 168, ANSI16: 5},
-			Accent:     Color{Hex: "#6C71C4", ANSI256: 61, ANSI16: 5},
-			Muted:      Color{Hex: "#93A1A1", ANSI256: 247, ANSI16: 7},
+			Primary:   Color{Hex: "#268BD2", ANSI256: 32, ANSI16: 4},
+			Secondary: Color{Hex: "#D33682", ANSI256: 168, ANSI16: 5},
+			Accent:    Color{Hex: "#6C71C4", ANSI256: 61, ANSI16: 5},
+			// Solarized's own light-mode text ladder: base00 for de-emphasized
+			// content, base01 for body, base02 for emphasis. base1 (#93A1A1)
+			// stays where Solarized actually puts it on a light ground — rules
+			// and borders — because as TEXT it lands near 1.9:1 on base3 and
+			// secondary lines were unreadable. Same reason the 16-color index
+			// moves off 7 (light gray on a light terminal): 8 is the classic
+			// dark gray and is the only legible neutral here.
+			Muted:      Color{Hex: "#657B83", ANSI256: 66, ANSI16: 8},
 			Success:    Color{Hex: "#859900", ANSI256: 100, ANSI16: 2},
 			Warning:    Color{Hex: "#CB4B16", ANSI256: 166, ANSI16: 3},
 			Danger:     Color{Hex: "#DC322F", ANSI256: 160, ANSI16: 1},
 			Info:       Color{Hex: "#2AA198", ANSI256: 37, ANSI16: 6},
 			Border:     Color{Hex: "#93A1A1", ANSI256: 247, ANSI16: 7},
-			Text:       Color{Hex: "#657B83", ANSI256: 241, ANSI16: 0},
-			TextStrong: Color{Hex: "#586E75", ANSI256: 240, ANSI16: 0},
+			Text:       Color{Hex: "#586E75", ANSI256: 240, ANSI16: 0},
+			TextStrong: Color{Hex: "#073642", ANSI256: 23, ANSI16: 0},
 			Background: Color{Hex: "#FDF6E3", ANSI256: 230, ANSI16: 15},
 		},
 	}
@@ -197,10 +211,11 @@ func OneDarkTheme() Theme {
 		Name:    "one-dark",
 		Variant: VariantDark,
 		Palette: Palette{
-			Primary:    Color{Hex: "#61AFEF", ANSI256: 75, ANSI16: 4},
-			Secondary:  Color{Hex: "#C678DD", ANSI256: 176, ANSI16: 5},
-			Accent:     Color{Hex: "#56B6C2", ANSI256: 73, ANSI16: 6},
-			Muted:      Color{Hex: "#5C6370", ANSI256: 241, ANSI16: 8},
+			Primary:   Color{Hex: "#61AFEF", ANSI256: 75, ANSI16: 4},
+			Secondary: Color{Hex: "#C678DD", ANSI256: 176, ANSI16: 5},
+			Accent:    Color{Hex: "#56B6C2", ANSI256: 73, ANSI16: 6},
+			// comment gray lifted toward the foreground — see the nord note.
+			Muted:      Color{Hex: "#7F8796", ANSI256: 102, ANSI16: 8},
 			Success:    Color{Hex: "#98C379", ANSI256: 114, ANSI16: 2},
 			Warning:    Color{Hex: "#E5C07B", ANSI256: 180, ANSI16: 3},
 			Danger:     Color{Hex: "#E06C75", ANSI256: 168, ANSI16: 1},


### PR DESCRIPTION
## The bug

The REPL input line is painted by `go-prompt`, which owns its own render loop and never sees the ANSI strings the rest of the UI builds — so `theme.Recolor` cannot reach it. Its colors were **literals**: the text you type was `prompt.White` under every theme. On a light theme running on a light terminal that is **white on white**.

The completion dropdown had the same problem, and `grafite` had shipped in #1175 without a `cfg.ui.theme_desc_grafite` string, so the completer, the palette overlay and `/config ui theme` printed the raw i18n key.

## What changed

**Input line and dropdown come from the palette.** Ink is chosen against the *fill it lands on*, never against the terminal — `Background` is the theme's own ground, so it is the readable ink on a saturated row under a dark *and* a light palette.

| go-prompt surface | palette entry | dark index | was |
| --- | --- | --- | --- |
| prefix, inline preview | `Info` | 10 | `prompt.Green` — identical |
| the text you type | `TextStrong` | 15 | `prompt.White` — identical |
| suggestion fill / ink | `Border` / `TextStrong` | 8 / 15 | `DarkGray` / `White` — identical |
| selected suggestion fill / ink | `Secondary` / `Background` | 4 / 0 | `Blue` / default `Black` |
| description fill / ink | `Background` / `Warning` | 0 / 3 | `Black` / `Yellow` |
| selected description fill / ink | `Border` / `TextStrong` | 8 / 15 | `DarkGray` / default `White` — identical |
| scrollbar thumb / track | `Muted` / `Background` | 8 / 0 | `DarkGray` / `Cyan` |

Ten of the thirteen resolve byte-for-byte to the old literals on the default dark theme, so this is visually neutral there and a legibility fix everywhere else.

**A theme switch now reaches the input line.** `go-prompt` copies its colors onto the renderer at construction and never re-reads them, so `/config ui theme light` used to leave the line you type in the old theme's ink. The switch now unwinds the REPL loop and rebuilds the prompt, using the same sentinel-panic idiom `/agent` and `/coder` already use. The unwind is gated on `promptRunning`, i.e. go-prompt actually owning the terminal — headless callers have no prompt to rebuild, and unwinding there would tear down their run.

**Palette audit.** Every palette was measured against its own declared ground:

- `nord`, `tokyo-night`, `solarized-dark` and `one-dark` reused their **comment** color for `Muted`, which ChatCLI paints whole metadata lines with. Nord landed at **1.69:1**. All four are lifted toward their own foreground; solarized-dark takes Solarized's canonical `base00`.
- `solarized-light` used `base1` for both `Muted` and `Text`, at **1.9:1** on `base3`. It now follows Solarized's own light ladder: `base00` secondary, `base01` body, `base02` emphasis, `base1` for borders only.
- `light` carried `Info` at 16-color index **10** — bright green, painted for a dark ground and invisible on a white terminal. Now index 4. Its `Success` moved from green-600 to green-700, which was sitting at 2.99:1.

**New tests, each verified red before green:** body text clears 4.5:1 and secondary text 3:1 against the theme's ground; a light palette never reaches into the bright 16-color range and a dark one never uses index 0; every dropdown fill/ink pair clears 3:1 and never collapses onto one index; `promptColor` reproduces the old literals on dark and is never white on light; every registered theme has a description in **every** locale, not just via the English fallback.

`Border` is deliberately exempt from the contrast floor — Nord, Solarized, Catppuccin and One Dark all define their border tone as a near-ground fill on purpose, and raising it would replace the palette's identity with ours.

**Unstyled surfaces themed:** rewind checkpoint labels, the `/config ui theme` listing, and the context/compaction lines that printed body text bare next to colored chrome.

## Verified on a real terminal

Driven byte-by-byte over a pty, `TERM=xterm-256color`:

- `dark` — prefix `ESC[0;92;49m`, typed text `ESC[0;97;49m`: unchanged from before.
- after `/config ui theme light` — the prompt is rebuilt on the spot and typed text becomes `ESC[0;30;49m`, **black**; suggestions `ESC[0;30;47m`, descriptions `ESC[0;33;107m`.
- `grafite` renders its real description in the dropdown in both `en` and `pt-BR`, and its blue prefix `ESC[0;94;49m` applies immediately.

## Tests

111 packages green. `cli/mcp` is excluded: it hangs at `transport_http.go:558` on a clean checkout of `main` too — pre-existing and unrelated.

Docs synced in `chatcli.ai` EN + pt: theme count 11 → 12, `grafite` added to every list with its palette strip, plus new sections on the input line and the legibility contract.