### PR TITLE
fix(helm): stop advertising security updates on releases that carry none

### DIFF
--- a/deploy/helm/chatcli-operator/Chart.yaml
+++ b/deploy/helm/chatcli-operator/Chart.yaml
@@ -25,14 +25,16 @@ maintainers:
     email: diillson@hotmail.com
 annotations:
   artifacthub.io/license: Apache-2.0
-  artifacthub.io/containsSecurityUpdates: 'true'
+  # Both this flag and artifacthub.io/changes below are rewritten from
+  # CHANGELOG.md at publish time by scripts/generate-artifacthub-changelog.sh,
+  # which sets the flag only when the release actually carries a security
+  # entry. It used to be hardcoded 'true', so every release after the 1.198.0
+  # auth work advertised security fixes it did not contain. The values
+  # committed here describe the chart as it stands in the repository.
+  artifacthub.io/containsSecurityUpdates: 'false'
   artifacthub.io/changes: |
-    - kind: changed
-      description: An Instance whose server would listen on a reachable address with no credential is no longer provisioned; the operator raises the AuthenticationConfigured condition on it instead
-    - kind: security
-      description: The server refuses to start unauthenticated on a reachable address, so spec.server.token or spec.server.security.jwtSecretRef is required unless bindAddress is loopback
-    - kind: fixed
-      description: The bindAddress field documented a 127.0.0.1 default it never had; unset means every interface inside a cluster
+    - kind: removed
+      description: The GITHUB_MODELS provider value, retired upstream, is gone from the Instance CRD enum
   artifacthub.io/prerelease: 'false'
   artifacthub.io/operator: 'true'
   artifacthub.io/operatorCapabilities: Seamless Upgrades

--- a/deploy/helm/chatcli/Chart.yaml
+++ b/deploy/helm/chatcli/Chart.yaml
@@ -24,16 +24,16 @@ maintainers:
     email: diillson@hotmail.com
 annotations:
   artifacthub.io/license: Apache-2.0
-  artifacthub.io/containsSecurityUpdates: 'true'
+  # Both this flag and artifacthub.io/changes below are rewritten from
+  # CHANGELOG.md at publish time by scripts/generate-artifacthub-changelog.sh,
+  # which sets the flag only when the release actually carries a security
+  # entry. It used to be hardcoded 'true', so every release after the 1.198.0
+  # auth work advertised security fixes it did not contain. The values
+  # committed here describe the chart as it stands in the repository.
+  artifacthub.io/containsSecurityUpdates: 'false'
   artifacthub.io/changes: |
-    - kind: security
-      description: The server refuses to start unauthenticated on a reachable address; set server.token or security.jwtSecretRef, or bind loopback
-    - kind: security
-      description: JWTs without an exp claim are rejected, and the auth-failure rate limit counts per client instead of per connection
-    - kind: changed
-      description: An Instance without a credential is no longer provisioned; the operator raises the AuthenticationConfigured condition instead
     - kind: removed
-      description: The safety values block, whose only effect was a variable no code reads
+      description: The GITHUB_MODELS provider value, retired upstream, is gone from the Instance CRD enum and the chart values schema
   artifacthub.io/prerelease: 'false'
   artifacthub.io/operator: 'false'
   artifacthub.io/crds: |

--- a/scripts/generate-artifacthub-changelog.sh
+++ b/scripts/generate-artifacthub-changelog.sh
@@ -2,7 +2,16 @@
 # generate-artifacthub-changelog.sh
 #
 # Parses the latest version section from CHANGELOG.md and injects it as
-# the `artifacthub.io/changes` annotation into one or more Chart.yaml files.
+# the `artifacthub.io/changes` annotation into one or more Chart.yaml files,
+# and keeps `artifacthub.io/containsSecurityUpdates` in step with it.
+#
+# That second part is why the flag exists here at all: it used to be a literal
+# 'true' in Chart.yaml, set during a release that really did carry security
+# fixes and never turned off again. Every release after it advertised security
+# updates it did not contain, which is worse than saying nothing — an operator
+# who prioritises security upgrades cannot tell the real one from the noise.
+# The flag is now derived from the same changelog block as the changes list:
+# true when that block has a security entry, false when it does not.
 #
 # Usage:
 #   ./scripts/generate-artifacthub-changelog.sh deploy/helm/chatcli/Chart.yaml [deploy/helm/chatcli-operator/Chart.yaml ...]
@@ -93,8 +102,15 @@ if [[ -z "$annotation" ]]; then
   exit 0
 fi
 
-# Build the full annotation value (pipe literal block scalar)
-annotation_value="|\n${annotation}"
+# The security flag follows the entries we just built: a release is a security
+# release when its changelog block carries a security entry, and is not one
+# otherwise. Deriving it here is what stops the flag latching 'true' forever.
+if grep -qE '^[[:space:]]*- kind: security[[:space:]]*$' <<< "$annotation"; then
+  security_updates="true"
+else
+  security_updates="false"
+fi
+security_line="  artifacthub.io/containsSecurityUpdates: '${security_updates}'"
 
 # Inject into each Chart.yaml
 for chart_file in "$@"; do
@@ -152,5 +168,23 @@ for chart_file in "$@"; do
   } > "$chart_file"
 
   rm -f "$tmpfile"
-  echo "OK: Updated $chart_file with artifacthub.io/changes annotation"
+
+  # Rewrite the security flag in place, or add it right under `annotations:`
+  # when the chart has never carried one. awk rather than `sed -i` because
+  # the in-place flag is not portable between GNU and BSD sed.
+  tmpfile=$(mktemp)
+  if grep -q 'artifacthub\.io/containsSecurityUpdates:' "$chart_file"; then
+    awk -v line="$security_line" '
+      /^[[:space:]]*artifacthub\.io\/containsSecurityUpdates:/ { print line; next }
+      { print }
+    ' "$chart_file" > "$tmpfile"
+  else
+    awk -v line="$security_line" '
+      { print }
+      /^annotations:[[:space:]]*$/ { print line }
+    ' "$chart_file" > "$tmpfile"
+  fi
+  mv "$tmpfile" "$chart_file"
+
+  echo "OK: Updated $chart_file (changes annotation; containsSecurityUpdates=${security_updates})"
 done


### PR DESCRIPTION
## The bug

Both charts carry `artifacthub.io/containsSecurityUpdates: 'true'`. It was set by hand in #1512, the release that really did harden the server's auth — and it never turned off again.

`artifacthub.io/changes` is regenerated from `CHANGELOG.md` at publish time by `scripts/generate-artifacthub-changelog.sh`. The security flag is not, so it has been shipping as `true` on every release since. `1.199.1` contains exactly one change — a terminal theme fix — and went to Artifact Hub flagged as a security release.

That is worse than saying nothing: an operator who prioritises security upgrades can no longer tell the real one from the noise.

## The fix

The flag now follows the same changelog block the changes list is built from, in the script that already rewrites that annotation at publish time — `true` when the block carries a `kind: security` entry, `false` when it does not. Deriving it is what stops it latching: a genuine security release turns it on, and the next release turns it back off without anyone remembering to.

The committed values were stale in the same way — both charts still carried the 1.198.0 auth changelog while shipping 1.199.1. They now describe what the chart actually changed since: `GITHUB_MODELS` leaving the Instance CRD enum and the values schema.

## Verified

Ran the script against three inputs:

| Input | `containsSecurityUpdates` |
| --- | --- |
| the current `CHANGELOG.md` (one `fixed` entry) | `false` |
| a changelog with a `### Security` section | `true` |
| the chart left at `true`, then a release with no security entry | back to `false` |

That third row is the bug itself, and it is the one that now behaves.

`helm lint` and `helm template` pass on both charts. `shellcheck` is clean on the script — including a pre-existing `SC2034` for a variable it built and never used, which this drops.

## Note

The flag can only be `true` when the release's changelog block has a `Security` section, which `release-please` emits from a `security:` commit type. A genuine security release that lands under `fix:` will now publish as `false` rather than `true` — accurate about "no declared security entry", but worth knowing when cutting one.