### PR TITLE
fix(devin): the model listing no longer strips the workspace-trust waiver from turns

### DIFF
--- a/llm/devincli/devincli_client_test.go
+++ b/llm/devincli/devincli_client_test.go
@@ -550,3 +550,47 @@ func argvLines(t *testing.T, record string) []string {
 	require.NoError(t, err)
 	return strings.Split(strings.TrimSpace(string(argv)), "\n")
 }
+
+// TestProviderSwitchThenTurn_KeepsTheWorkspaceTrustWaiver walks the exact
+// sequence from the field: start elsewhere, switch to DEVIN — which lists the
+// account's models first — then send a message. The listing used to poison a
+// process-wide latch and strip the waiver from the turn that followed, so the
+// first thing the user typed after switching died with "Refusing to run in an
+// untrusted workspace" on a CLI that was perfectly capable of the flag.
+func TestProviderSwitchThenTurn_KeepsTheWorkspaceTrustWaiver(t *testing.T) {
+	t.Cleanup(func() { workspaceTrustUnsupported.Store(false) })
+	workspaceTrustUnsupported.Store(false)
+	record := filepath.Join(t.TempDir(), "argv")
+
+	// The real 3000.6 CLI: `models list` rejects the flag outright, while
+	// --print refuses to run without it.
+	bin := fakeDevin(t, `
+echo "$@" >> `+record+`
+case "$1" in
+  models)
+    case " $* " in
+      *" --respect-workspace-trust "*)
+        echo "error: unexpected argument '--respect-workspace-trust' found" >&2; exit 2;;
+    esac
+    echo '{"models":[]}'; exit 0;;
+esac
+case " $* " in
+  *" --respect-workspace-trust false "*) ;;
+  *) echo "Error: Refusing to run in an untrusted workspace: /tmp/x" >&2; exit 1;;
+esac
+printf '<<<CHATCLI_REPLY_BEGIN>>>\nOK\n<<<CHATCLI_REPLY_END>>>\n'
+`)
+	c := NewClient(bin, "kimi-k3", zap.NewNop(), 1, 0)
+
+	// The provider switch lists models…
+	_, _ = c.ListModels(context.Background())
+	// …and the very next message must still reach the model.
+	got, err := c.SendPrompt(context.Background(), "oi", nil, 0)
+	require.NoError(t, err, "the turn right after a provider switch must still carry the waiver")
+	assert.Equal(t, "OK", got)
+
+	lines := argvLines(t, record)
+	require.GreaterOrEqual(t, len(lines), 2)
+	assert.NotContains(t, lines[0], "--respect-workspace-trust", "the listing must not send it")
+	assert.Contains(t, lines[len(lines)-1], "--respect-workspace-trust false", "the turn must send it")
+}

--- a/llm/devincli/devincli_models.go
+++ b/llm/devincli/devincli_models.go
@@ -124,13 +124,8 @@ func (c *Client) ListModels(ctx context.Context) ([]client.ModelInfo, error) {
 	}
 	defer func() { _ = os.RemoveAll(workDir) }()
 
+	// No flag latching here, deliberately — see execModelsList.
 	out, detail, runErr := c.execModelsList(ctx, workDir)
-	// Same latch-and-retry as a turn: a build predating
-	// --respect-workspace-trust refuses to parse it, and the model list must
-	// keep working on an older binary. See workspaceTrustArgs.
-	if runErr != nil && latchUnsupportedFlag(detail, c.logger, c.binPath) {
-		out, detail, runErr = c.execModelsList(ctx, workDir)
-	}
 	if ctx.Err() == context.DeadlineExceeded {
 		return nil, fmt.Errorf("%s: %w", i18n.T("llm.devincli.list_timeout", devinListModelsTimeout.String()), ctx.Err())
 	}
@@ -199,13 +194,25 @@ func synthesizeFamilies(variants []devinVariant) []devinFamily {
 }
 
 // execModelsList runs one `devin models list` invocation in workDir and
-// returns its stdout plus a sanitized failure detail. Args are rebuilt on
-// every call so a retry picks up whatever the flag latch just learned.
+// returns its stdout plus a sanitized failure detail.
+//
+// The listing carries NO workspace-trust flag, and that is load-bearing
+// rather than an oversight. `--respect-workspace-trust` is documented as a
+// global flag, but the `models` subcommand's parser rejects it outright:
+//
+//	error: unexpected argument '--respect-workspace-trust' found
+//
+// which is indistinguishable from an old binary that never knew the flag. A
+// listing that passed it would therefore latch it as unsupported for the
+// whole process and strip it from every later TURN — turning a provider
+// switch, which lists models first, into "Refusing to run in an untrusted
+// workspace" on the very next message. The listing does not need the waiver
+// anyway: it performs no trust check, which is why it worked before the
+// waiver existed and still does.
 func (c *Client) execModelsList(ctx context.Context, workDir string) ([]byte, string, error) {
-	args := append([]string{"models", "list", "--format", "json"}, workspaceTrustArgs()...)
+	args := []string{"models", "list", "--format", "json"}
 	// #nosec G204 G702 -- binPath resolves from operator configuration
-	// (PATH lookup or DEVIN_CLI_PATH) and argv is a fixed subcommand plus
-	// the boolean workspace-trust flag, never model or network input.
+	// (PATH lookup or DEVIN_CLI_PATH) and argv is a fixed subcommand.
 	cmd := exec.CommandContext(ctx, c.binPath, args...)
 	cmd.WaitDelay = 2 * time.Second
 	cmd.Dir = workDir

--- a/llm/devincli/devincli_models_test.go
+++ b/llm/devincli/devincli_models_test.go
@@ -134,9 +134,10 @@ func TestListModels_ProjectsFamiliesThenVariants(t *testing.T) {
 		assert.NotContainsf(t, " "+args+" ", " "+turnOnly+" ",
 			"listing must not carry the turn flag %s", turnOnly)
 	}
-	// The listing runs in the same throwaway temp directory a turn does, so
-	// it needs the same waiver or a current CLI refuses to run there.
-	assert.Contains(t, args, "--respect-workspace-trust false")
+	// The listing must NOT carry the workspace-trust flag: the models
+	// subcommand's parser rejects it, and that rejection is indistinguishable
+	// from an old binary, which would latch the flag off for every later turn.
+	assert.NotContains(t, args, "--respect-workspace-trust")
 }
 
 func TestListModels_RegistersDiscoveredSpecsInCatalog(t *testing.T) {
@@ -373,4 +374,37 @@ func TestRestoreSnapshot_CorruptFileIsAnError(t *testing.T) {
 	path := isolateSnapshot(t)
 	require.NoError(t, os.WriteFile(path, []byte("{not json"), 0o600))
 	require.Error(t, restoreSnapshot())
+}
+
+// TestListModels_NeverDisablesTheWorkspaceTrustFlagForTurns reproduces the
+// field report: boot on another provider, `/provider` to DEVIN — which lists
+// models first — then send a message, and the turn dies with "Refusing to run
+// in an untrusted workspace".
+//
+// The cause was the listing carrying the waiver. `devin models list` rejects
+// it with "unexpected argument", the same wording an old binary uses for a
+// flag it never had, so the process latched the flag as unsupported and
+// stripped it from every turn that followed. Whatever the listing does, it
+// must never decide what a TURN is allowed to send.
+func TestListModels_NeverDisablesTheWorkspaceTrustFlagForTurns(t *testing.T) {
+	isolateSnapshot(t)
+	t.Cleanup(func() { workspaceTrustUnsupported.Store(false) })
+	workspaceTrustUnsupported.Store(false)
+
+	// Impersonates the real CLI: the models subcommand refuses the flag the
+	// print mode requires.
+	bin := fakeDevin(t, `
+case " $* " in
+  *" --respect-workspace-trust "*)
+    echo "error: unexpected argument '--respect-workspace-trust' found" >&2; exit 2;;
+esac
+echo '{"models":[]}'
+`)
+	c := NewClient(bin, "", zap.NewNop(), 1, 0)
+	_, _ = c.ListModels(context.Background())
+
+	assert.False(t, workspaceTrustUnsupported.Load(),
+		"listing models must not latch the flag off for the whole process")
+	assert.Equal(t, []string{"--respect-workspace-trust", "false"}, workspaceTrustArgs(),
+		"the next turn must still send the waiver")
 }


### PR DESCRIPTION
## The bug

Regression from #1552, reported from the field: boot on another provider, `/provider` to DEVIN, send a message — and the turn dies with

```
Error: Refusing to run in an untrusted workspace: /var/folders/.../chatcli-devin-1798424032
```

on a CLI that handles the flag fine. Starting a session directly on DEVIN worked, which is what made it look like a stale binary.

The difference is the **model listing**. Switching providers calls `ListModels` first, and #1552 gave that invocation the same waiver the turns get. But `devin models list` does not accept it:

```
$ devin models list --format json --respect-workspace-trust false
error: unexpected argument '--respect-workspace-trust' found
```

`--respect-workspace-trust` is documented as a global flag; the `models` subcommand's parser disagrees. And that wording is exactly what an old binary emits for a flag it never had — which is what the latch added in #1552 looks for. So the listing latched the flag as unsupported **for the whole process**, and every turn after it went out bare.

## The fix

The listing sends the plain subcommand again and takes no part in deciding what a turn may send. It never needed the waiver: `models list` performs no trust check, which is why it worked before the waiver existed and still does.

`execModelsList` now carries the reasoning, so the next person who reads "global flag" in the Devin docs does not put it back.

## Verified

Both new tests were checked **red before green** by restoring the flag in the listing:

- `TestListModels_NeverDisablesTheWorkspaceTrustFlagForTurns` — the listing must not latch the flag off for the process.
- `TestProviderSwitchThenTurn_KeepsTheWorkspaceTrustWaiver` — walks the reported sequence against a fake CLI that mimics the real one (models rejects the flag, `--print` requires it). With the flag back in the listing it fails with the exact field error, `Refusing to run in an untrusted workspace`.

Against the real `devin 3000.6.14`: `models list --format json` parses (reaches the auth step), while adding the flag is a parse error.

The user's `DEVIN_CLI_EXTRA_ARGS="--respect-workspace-trust false"` workaround was unaffected by this bug, and the dedupe means it keeps working after the fix without doubling the flag.