### PR TITLE
docs(readme): the provider count is 14 now that GitHub Models is gone

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <h1 align="center">ChatCLI</h1>
 <p align="center">
   <strong>Unified AI platform for terminal, gRPC server, and Kubernetes.</strong><br>
-  <sub>15 providers · 14 autonomous agents · 7-pattern quality pipeline · one binary.</sub>
+  <sub>14 providers · 14 autonomous agents · 7-pattern quality pipeline · one binary.</sub>
 </p>
 
 <div align="center">
@@ -305,7 +305,7 @@ helm install chatcli oci://ghcr.io/diillson/charts/chatcli \
 
 ## Supported Providers
 
-> 15 providers with a unified interface. Automatic failover with intelligent error classification, cross-provider extended thinking, and prompt caching where available.
+> 14 providers with a unified interface. Automatic failover with intelligent error classification, cross-provider extended thinking, and prompt caching where available.
 
 | Provider | Default Model | Tool Calling | Vision | Reasoning / Thinking |
 |---|---|---|---|---|


### PR DESCRIPTION
The English README still opened with **15 providers** in the header line and repeated it in the multi-provider callout, while its own feature table already listed the correct 14 and `README_PT.md` had been fully updated. `GITHUB_MODELS` was removed in 1.199.0 (#1547).

Counted against the runtime rather than against the previous number:

```
$ grep -o 'm.clients\["[A-Z_]*"' llm/manager/llm_manager.go | sort -u | wc -l
14
```

which matches the `Instance` CRD enum: `OPENAI, OPENAI_ASSISTANT, CLAUDEAI, BEDROCK, GOOGLEAI, XAI, ZAI, MINIMAX, MOONSHOT, STACKSPOT, OLLAMA, COPILOT, OPENROUTER, DEVIN`.

The same count was corrected on `chatcli.ai` (both introductions, model routing and the cost-tracking coverage note, EN + pt), where the routing page also used `deepseek` on GitHub Models as its example of one model id living in two providers — now OpenRouter, which serves it and still exists.