### PR TITLE
fix(usage): normalize input token accounting across every provider schema

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -2562,6 +2562,11 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 		// served this turn (see clientAndCtxForTurn). turnUsage is hoisted
 		// so the per-turn telemetry line (showTurnStats) can reuse it.
 		var turnUsage *models.UsageInfo
+		// The pair that actually served the turn, hoisted alongside
+		// turnUsage: the telemetry line must price and size the window
+		// against the SAME pair the tracker recorded under, or a skill
+		// route override makes the two disagree about one turn.
+		var turnProvider, turnModel string
 		if a.cli.costTracker != nil && err == nil {
 			inputChars := 0
 			for _, m := range turnHistory {
@@ -2569,6 +2574,7 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 			}
 			turnUsage = llmclient.GetUsageOrEstimate(turnClient, inputChars, len(aiResponse))
 			effProvider, effModel := a.effectiveRoute()
+			turnProvider, turnModel = effProvider, effModel
 			a.cli.costTracker.RecordRealUsage(effProvider, effModel, turnUsage)
 			// The provider context engine cleared tool results server-side:
 			// mirror that locally and do not calibrate on this turn (the
@@ -2609,7 +2615,8 @@ func (a *AgentMode) processAIResponseAndAct(ctx context.Context, maxTurns int) e
 			// user stays aware of spend/context inside agent & coder too.
 			var telem string
 			if turnUsage != nil && a.cli.costTracker != nil {
-				telem = strings.Join(a.cli.telemetryParts(turnUsage, a.cli.costTracker.TotalCost(), true), " · ")
+				telem = strings.Join(a.cli.telemetryParts(turnProvider, turnModel,
+					turnUsage, a.cli.costTracker.TotalCost(), true), " · ")
 			}
 			fmt.Println(metrics.FormatTurnInfo(turn+1, maxTurns, turnDuration, &metrics.TurnStats{
 				TurnAgents:       turnAgents,

--- a/cli/chat_envelope_footer_test.go
+++ b/cli/chat_envelope_footer_test.go
@@ -37,15 +37,15 @@ func TestChatEnvelopeFooter_ShowsCostAndContext(t *testing.T) {
 
 func TestTelemetryParts_NilWhenNoUsage(t *testing.T) {
 	cli := &ChatCLI{Provider: "OPENAI", Model: "gpt-4o"}
-	assert.Nil(t, cli.telemetryParts(nil, 1.0, true), "no usage → no parts")
-	assert.Nil(t, cli.telemetryParts(&models.UsageInfo{}, 1.0, true), "zero usage → no parts")
+	assert.Nil(t, cli.telemetryParts("", "", nil, 1.0, true), "no usage → no parts")
+	assert.Nil(t, cli.telemetryParts("", "", &models.UsageInfo{}, 1.0, true), "zero usage → no parts")
 }
 
 func TestTelemetryParts_IncludeTokensPrependsSummary(t *testing.T) {
 	cli := &ChatCLI{Provider: "OPENAI", Model: "gpt-4o"}
 	usage := &models.UsageInfo{PromptTokens: 1000, CompletionTokens: 500}
 
-	withTokens := cli.telemetryParts(usage, 0.5, true)
+	withTokens := cli.telemetryParts("", "", usage, 0.5, true)
 	if assert.NotEmpty(t, withTokens) {
 		// The leading part is the token in/out summary ("1000↑ 500↓").
 		assert.Contains(t, withTokens[0], "↑", "first part is the token summary")
@@ -53,7 +53,7 @@ func TestTelemetryParts_IncludeTokensPrependsSummary(t *testing.T) {
 	}
 
 	// Without tokens (chat footer path), the summary is absent.
-	noTokens := cli.telemetryParts(usage, 0.5, false)
+	noTokens := cli.telemetryParts("", "", usage, 0.5, false)
 	if assert.NotEmpty(t, noTokens) {
 		assert.NotContains(t, noTokens[0], "↑", "footer path omits the token summary")
 	}
@@ -61,7 +61,7 @@ func TestTelemetryParts_IncludeTokensPrependsSummary(t *testing.T) {
 
 func TestTelemetryParts_ShowsCostAndContext(t *testing.T) {
 	cli := &ChatCLI{Provider: "OPENAI", Model: "gpt-4o"}
-	parts := cli.telemetryParts(&models.UsageInfo{PromptTokens: 1000, CompletionTokens: 500}, 0.5, true)
+	parts := cli.telemetryParts("", "", &models.UsageInfo{PromptTokens: 1000, CompletionTokens: 500}, 0.5, true)
 
 	joined := strings.Join(parts, " · ")
 	assert.Contains(t, joined, "$", "shows the cost figure passed in")
@@ -70,7 +70,7 @@ func TestTelemetryParts_ShowsCostAndContext(t *testing.T) {
 
 func TestTelemetryParts_OmitsCostWhenZero(t *testing.T) {
 	cli := &ChatCLI{Provider: "OPENAI", Model: "gpt-4o"}
-	parts := cli.telemetryParts(&models.UsageInfo{PromptTokens: 1000, CompletionTokens: 500}, 0, true)
+	parts := cli.telemetryParts("", "", &models.UsageInfo{PromptTokens: 1000, CompletionTokens: 500}, 0, true)
 	assert.NotContains(t, strings.Join(parts, " · "), "$", "zero cost → no cost part")
 }
 
@@ -93,11 +93,11 @@ func TestTelemetryParts_CompressionSavingsAreTurnDeltas(t *testing.T) {
 	if _, res := layer.CompressToolOutput("@search", b.String()); res.SavedBytes() == 0 {
 		t.Fatal("fixture produced no savings")
 	}
-	first := strings.Join(cli.telemetryParts(usage, 0, false), " · ")
+	first := strings.Join(cli.telemetryParts("", "", usage, 0, false), " · ")
 	assert.Contains(t, first, i18n.T("chat.envelope.compression_saved", ""), "first render shows fresh savings")
 
 	// Second render with no new compression: no savings part repeated.
-	second := strings.Join(cli.telemetryParts(usage, 0, false), " · ")
+	second := strings.Join(cli.telemetryParts("", "", usage, 0, false), " · ")
 	assert.NotContains(t, second, i18n.T("chat.envelope.compression_saved", ""),
 		"already-reported savings must not repeat on the next turn")
 }
@@ -123,14 +123,14 @@ func TestClampPct_Bounds(t *testing.T) {
 func TestTelemetryParts_ContextPctCountsCachedInput(t *testing.T) {
 	bedrock := &ChatCLI{Provider: "BEDROCK", Model: "global.anthropic.claude-sonnet-5"}
 	usage := &models.UsageInfo{PromptTokens: 20000, CompletionTokens: 800, CacheReadInputTokens: 570000, CacheCreationInputTokens: 10000, IsReal: true}
-	joined := strings.Join(bedrock.telemetryParts(usage, 0, false), " · ")
+	joined := strings.Join(bedrock.telemetryParts("", "", usage, 0, false), " · ")
 	assert.Contains(t, joined, "ctx 60%", "additive schema: prompt + cache read + cache write over the 1M window")
 
 	// Subset schema: OpenAI's prompt_tokens already includes cached_tokens,
 	// so adding them again would double count.
 	openai := &ChatCLI{Provider: "OPENAI", Model: "gpt-4o"}
 	sub := &models.UsageInfo{PromptTokens: 64000, CompletionTokens: 100, CacheReadInputTokens: 60000, IsReal: true}
-	joined = strings.Join(openai.telemetryParts(sub, 0, false), " · ")
+	joined = strings.Join(openai.telemetryParts("", "", sub, 0, false), " · ")
 	assert.Contains(t, joined, "ctx 50%", "subset schema: prompt tokens alone over the 128K window")
 }
 

--- a/cli/chat_pipeline.go
+++ b/cli/chat_pipeline.go
@@ -991,7 +991,7 @@ func (cli *ChatCLI) renderAssistantResponse(
 // the footer adds no new bookkeeping. It returns "" (no footer drawn) when
 // usage is unreported, keeping the box clean for providers that omit counts.
 func (cli *ChatCLI) chatEnvelopeFooter(servedProvider, servedModel string, usage *models.UsageInfo) string {
-	if usage == nil || (usage.PromptTokens == 0 && usage.CompletionTokens == 0) {
+	if usage == nil || (usage.InputTotal() == 0 && usage.CompletionTokens == 0) {
 		return ""
 	}
 
@@ -1007,7 +1007,7 @@ func (cli *ChatCLI) chatEnvelopeFooter(servedProvider, servedModel string, usage
 	}
 	turnCost := estimateTurnCostUSD(servedProvider, servedModel, usage)
 
-	parts := cli.telemetryParts(usage, turnCost, false)
+	parts := cli.telemetryParts(servedProvider, servedModel, usage, turnCost, false)
 	if len(parts) == 0 {
 		return ""
 	}
@@ -1021,21 +1021,35 @@ func (cli *ChatCLI) chatEnvelopeFooter(servedProvider, servedModel string, usage
 // When includeTokens is set, a leading "in↑ out↓" token summary is prepended
 // (the agent line has no header to carry it, unlike the chat envelope). Returns
 // nil when usage is unreported so callers can omit the telemetry cleanly.
-func (cli *ChatCLI) telemetryParts(usage *models.UsageInfo, costUSD float64, includeTokens bool) []string {
-	if usage == nil || (usage.PromptTokens == 0 && usage.CompletionTokens == 0) {
+//
+// provider/model are the pair that actually SERVED the turn (a skill hint or
+// route override may have swapped both). Window sizing, cache semantics and
+// the cost beside them must all read the same pair, or one turn is described
+// by two different models.
+func (cli *ChatCLI) telemetryParts(provider, model string, usage *models.UsageInfo, costUSD float64, includeTokens bool) []string {
+	if usage == nil || (usage.InputTotal() == 0 && usage.CompletionTokens == 0) {
 		return nil
+	}
+	if provider == "" {
+		provider = cli.Provider
+	}
+	if model == "" {
+		model = cli.Model
 	}
 	parts := make([]string, 0, 4)
 	if includeTokens {
-		parts = append(parts, i18n.T("chat.envelope.tokens", usage.PromptTokens, usage.CompletionTokens))
+		// The whole input, cache included — see UsageInfo.InputTotal. The
+		// raw PromptTokens rendered a 22K-token turn as "3↑" on every
+		// additive schema.
+		parts = append(parts, i18n.T("chat.envelope.tokens", usage.InputTotal(), usage.CompletionTokens))
 	}
 	if costUSD > 0 {
 		parts = append(parts, formatTurnCost(costUSD))
 	}
-	if window := catalog.GetContextWindow(cli.Provider, cli.Model); window > 0 {
+	if window := catalog.GetContextWindow(provider, model); window > 0 {
 		// Cached input counts: see contextTokens — PromptTokens alone is
 		// only the uncached delta on Anthropic/Bedrock schemas.
-		pct := float64(contextTokens(cli.Provider, cli.Model, usage)) / float64(window) * 100
+		pct := float64(contextTokens(provider, model, usage)) / float64(window) * 100
 		// Prefer the projection for the NEXT request (current history plus
 		// the prefix that will front it): that is what decides whether the
 		// next turn compacts, and it may legitimately exceed 100%.
@@ -1052,7 +1066,7 @@ func (cli *ChatCLI) telemetryParts(usage *models.UsageInfo, costUSD float64, inc
 	// Prompt-cache share of this turn's input, on every provider that
 	// reports cache tokens (Anthropic/Bedrock additive counts, OpenAI/
 	// Gemini/Grok/Kimi subset counts). Omitted when nothing was reported.
-	if hit, ok := TurnCacheHitPct(cli.Provider, cli.Model, usage); ok {
+	if hit, ok := TurnCacheHitPct(provider, model, usage); ok {
 		parts = append(parts, i18n.T("chat.envelope.cache_pct", clampPct(hit)))
 	}
 	// Compression savings SINCE THE LAST RENDER — per-turn, matching the cost
@@ -1169,8 +1183,11 @@ func formatLatency(d time.Duration) string {
 // formatTokenSummary renders usage as "312↑ 1.8k↓". Returns the i18n
 // placeholder when usage is unreported (provider didn't return counts).
 func formatTokenSummary(u *models.UsageInfo) string {
-	if u == nil || (u.PromptTokens == 0 && u.CompletionTokens == 0) {
+	if u == nil || (u.InputTotal() == 0 && u.CompletionTokens == 0) {
 		return i18n.T("chat.envelope.no_tokens")
 	}
-	return i18n.T("chat.envelope.tokens", u.PromptTokens, u.CompletionTokens)
+	// InputTotal, not PromptTokens: on the Anthropic/Bedrock schemas the
+	// latter is only the uncached delta, so a turn that shipped a 22K
+	// prefix (and paid to write it into the cache) rendered as "3↑".
+	return i18n.T("chat.envelope.tokens", u.InputTotal(), u.CompletionTokens)
 }

--- a/cli/context_status.go
+++ b/cli/context_status.go
@@ -21,6 +21,7 @@ import (
 	"github.com/diillson/chatcli/cli/compress"
 	"github.com/diillson/chatcli/i18n"
 	"github.com/diillson/chatcli/llm/catalog"
+	"github.com/diillson/chatcli/llm/client"
 	"github.com/diillson/chatcli/models"
 )
 
@@ -67,6 +68,14 @@ type contextStatusReport struct {
 	PrefixBudgetTokens int
 	PrefixPct          float64
 	Degraded           []string
+
+	// MeasuredInputTokens is what the PROVIDER counted for the last call,
+	// schema-normalized (cache reads and writes included). Everything above
+	// it is a local chars x ratio projection; this is the only figure that
+	// came from the model's own tokenizer, so showing both is what lets a
+	// user see the estimate drifting instead of discovering it when
+	// compaction fires early. Zero when the client reported nothing yet.
+	MeasuredInputTokens int
 }
 
 // summarizeHistory computes the role breakdown of the live history. Weight
@@ -154,6 +163,10 @@ func (cli *ChatCLI) buildContextStatusReport(ctx context.Context) contextStatusR
 	if cli.costTracker != nil {
 		r.Cache = cli.costTracker.CacheStats()
 	}
+	// What the provider actually counted for the last call on this client.
+	if uac, ok := client.AsUsageAware(cli.Client); ok {
+		r.MeasuredInputTokens = contextTokens(cli.Provider, cli.Model, uac.LastUsage())
+	}
 	return r
 }
 
@@ -225,6 +238,10 @@ func (cli *ChatCLI) showContextStatus(ctx context.Context) {
 	}
 	if edits, toolUses, tokens := cli.costTracker.ContextEditStats(); edits > 0 {
 		fmt.Printf("    %s\n", colorize(i18n.T("context.status.provider_edits", edits, toolUses, formatTokenCount(tokens)), ColorGray))
+	}
+	if r.MeasuredInputTokens > 0 {
+		fmt.Printf("    %s %s tok\n", kitPad(i18n.T("context.status.measured_input")),
+			formatTokenCount(int64(r.MeasuredInputTokens)))
 	}
 	if r.Window > 0 {
 		fmt.Printf("    %s ≈%s tok (%s)\n", kitPad(i18n.T("context.status.total_projected")),

--- a/cli/cost_cache_telemetry.go
+++ b/cli/cost_cache_telemetry.go
@@ -62,6 +62,10 @@ type cacheTelemetry struct {
 	lastActivity time.Time
 	lastProvider string
 	lastModel    string
+	// lastAdditive is how the LAST report counted its cache tokens, taken
+	// from the payload itself (usageCacheAccounting) instead of re-guessing
+	// from the provider/model names when the ratio is rendered.
+	lastAdditive bool
 
 	rebuildPending bool // set by NoteExpectedCacheRebuild until the next request
 	missStreak     int
@@ -84,12 +88,32 @@ func (c *cacheTelemetry) bucket(provider string) *providerCache {
 	return b
 }
 
+// usageCacheAccounting reports whether THIS report counted cache tokens
+// alongside the prompt count. The adapter that parsed the payload already
+// decided that (models.UsageInfo.Normalize), and its answer is readable
+// whenever the report carries cache activity: an additive schema lands a
+// normalized input strictly above PromptTokens, a subset schema lands on
+// it. With no cache activity the two are indistinguishable and nothing
+// was cached anyway, so the provider/model heuristic decides — as it also
+// does for usage restored from a session written before normalization.
+//
+// This is what keeps a provider whose surface disagrees with its model
+// name honest: MiniMax serves the same model over an OpenAI-shaped and an
+// Anthropic-shaped endpoint, and only the payload says which one answered.
+func usageCacheAccounting(provider, model string, u *models.UsageInfo) bool {
+	if u != nil && u.InputTokensTotal > 0 &&
+		u.CacheReadInputTokens+u.CacheCreationInputTokens > 0 {
+		return u.InputTokensTotal > u.PromptTokens
+	}
+	return cacheTokensAdditive(provider, model)
+}
+
 // observe folds one real usage report into the telemetry.
 func (c *cacheTelemetry) observe(provider, model string, u *models.UsageInfo, now time.Time) {
 	read := int64(u.CacheReadInputTokens)
 	write := int64(u.CacheCreationInputTokens)
 	prompt := int64(u.PromptTokens)
-	additive := cacheTokensAdditive(provider, model)
+	additive := usageCacheAccounting(provider, model, u)
 
 	b := c.bucket(provider)
 	first := b.requests == 0
@@ -108,6 +132,7 @@ func (c *cacheTelemetry) observe(provider, model string, u *models.UsageInfo, no
 	c.lastActivity = now
 	c.lastProvider = provider
 	c.lastModel = model
+	c.lastAdditive = additive
 	b.requests++
 	b.readTokens += read
 	b.inputTokens += prompt
@@ -184,7 +209,7 @@ func TurnCacheHitPct(provider, model string, u *models.UsageInfo) (float64, bool
 	if u == nil || (u.CacheReadInputTokens == 0 && u.CacheCreationInputTokens == 0) {
 		return 0, false
 	}
-	return cacheHitPct(cacheTokensAdditive(provider, model),
+	return cacheHitPct(usageCacheAccounting(provider, model, u),
 		int64(u.CacheReadInputTokens), int64(u.CacheCreationInputTokens), int64(u.PromptTokens)), true
 }
 
@@ -252,7 +277,7 @@ func (ct *CostTracker) cacheStatsLocked() CacheStats {
 	// The hit ratio is the last-used provider's own: each provider has its
 	// own cache and schema, so blending an additive and a subset provider
 	// into one ratio would describe neither.
-	additive := cacheTokensAdditive(c.lastProvider, c.lastModel)
+	additive := c.lastAdditive
 	if b := c.byProvider[strings.ToUpper(strings.TrimSpace(c.lastProvider))]; b != nil {
 		stats.HitPct = cacheHitPct(additive, b.readTokens, b.writeTokens, b.inputTokens)
 	} else {

--- a/cli/cost_tracker.go
+++ b/cli/cost_tracker.go
@@ -56,6 +56,14 @@ type ModelUsageRecord struct {
 	CompletionTokens int64 `json:"completion_tokens"`
 	TotalTokens      int64 `json:"total_tokens"`
 
+	// InputTokens is the schema-normalized input (cache included) summed
+	// over the record's requests — the figure that is comparable between
+	// providers. PromptTokens stays exactly as the provider reported it
+	// because the cost math depends on that raw split. Zero on records
+	// persisted before normalization existed; readers fall back to
+	// PromptTokens.
+	InputTokens int64 `json:"input_tokens,omitempty"`
+
 	// Prompt-cache tokens. Anthropic reports them ALONGSIDE input_tokens
 	// (additive); OpenAI/Gemini report cache reads as a SUBSET of the
 	// prompt count — recomputeCost handles both semantics.
@@ -147,6 +155,7 @@ type CostTracker struct {
 
 	// Aggregates (computed from modelUsage)
 	totalPromptTokens     int64
+	totalInputTokens      int64
 	totalCompletionTokens int64
 	totalCacheCreation    int64
 	totalCacheRead        int64
@@ -328,10 +337,19 @@ func (ct *CostTracker) RecordRealUsage(provider, model string, usage *models.Usa
 
 	rec.PromptTokens += int64(usage.PromptTokens)
 	rec.CompletionTokens += int64(usage.CompletionTokens)
-	totalTokens := usage.TotalTokens
-	if totalTokens == 0 {
-		// Providers that omit total_tokens must not zero the record's total.
-		totalTokens = usage.PromptTokens + usage.CompletionTokens
+	// InputTokens is the comparable figure across providers: PromptTokens
+	// means "uncached delta" on additive schemas and "whole input" on
+	// subset ones, so summing it alone made the /cost totals of a Bedrock
+	// session and an OpenAI session incomparable. Cost still prices
+	// PromptTokens and the cache pools separately — this is the display and
+	// reporting number, not a billing input.
+	inputTokens := contextTokens(provider, model, usage)
+	rec.InputTokens += int64(inputTokens)
+	totalTokens := inputTokens + usage.CompletionTokens
+	if reported := usage.TotalTokens; reported > totalTokens {
+		// Never shrink a provider-reported total that folds in counts of
+		// its own (Gemini adds thoughtsTokenCount).
+		totalTokens = reported
 	}
 	rec.TotalTokens += int64(totalTokens)
 	rec.CacheCreationTokens += int64(usage.CacheCreationInputTokens)
@@ -380,6 +398,7 @@ func (ct *CostTracker) RecordUsage(provider, model string, promptTokens, complet
 		PromptTokens:     promptTokens,
 		CompletionTokens: completionTokens,
 		TotalTokens:      promptTokens + completionTokens,
+		InputTokensTotal: promptTokens,
 		IsReal:           false,
 	})
 }
@@ -494,7 +513,7 @@ func (ct *CostTracker) TotalCost() float64 {
 func (ct *CostTracker) TotalTokens() int64 {
 	ct.mu.RLock()
 	defer ct.mu.RUnlock()
-	return ct.totalPromptTokens + ct.totalCompletionTokens
+	return ct.totalInputTokens + ct.totalCompletionTokens
 }
 
 // Snapshot returns a copy of the current session cost data — the same shape
@@ -519,7 +538,7 @@ func (ct *CostTracker) snapshotLocked() SessionCostData {
 		ModelUsage:    usage,
 		TotalCostUSD:  ct.totalCostUSD,
 		TotalRequests: ct.totalRequests,
-		TotalTokens:   ct.totalPromptTokens + ct.totalCompletionTokens,
+		TotalTokens:   ct.totalInputTokens + ct.totalCompletionTokens,
 
 		CacheResources:         ct.cacheResources,
 		CacheStorageTokenHours: ct.cacheStorageTokenHours,
@@ -802,6 +821,7 @@ func recomputeRecordCost(rec *ModelUsageRecord) {
 
 func (ct *CostTracker) recomputeAggregates() {
 	ct.totalPromptTokens = 0
+	ct.totalInputTokens = 0
 	ct.totalCompletionTokens = 0
 	ct.totalCacheCreation = 0
 	ct.totalCacheRead = 0
@@ -811,6 +831,7 @@ func (ct *CostTracker) recomputeAggregates() {
 
 	for _, rec := range ct.modelUsage {
 		ct.totalPromptTokens += rec.PromptTokens
+		ct.totalInputTokens += recordInputTokens(rec)
 		ct.totalCompletionTokens += rec.CompletionTokens
 		ct.totalCacheCreation += rec.CacheCreationTokens
 		ct.totalCacheRead += rec.CacheReadTokens
@@ -1372,8 +1393,10 @@ func tieredCallCostUSD(provider, model string, usage *models.UsageInfo) float64 
 	if usage == nil || usage.CostUSD > 0 {
 		return 0
 	}
-	context := usage.PromptTokens + usage.CacheReadInputTokens + usage.CacheCreationInputTokens
-	in, out := longContextMultipliers(provider, model, context)
+	// Schema-normalized: adding the cached counts unconditionally
+	// double-counted them on subset schemas (Gemini, Grok), which could tip
+	// a request over the long-context threshold it never crossed.
+	in, out := longContextMultipliers(provider, model, contextTokens(provider, model, usage))
 	if in == 1 && out == 1 {
 		return 0
 	}
@@ -1434,11 +1457,34 @@ func contextTokens(provider, model string, usage *models.UsageInfo) int {
 	if usage == nil {
 		return 0
 	}
+	// The provider adapter classified its own payload — believe it over any
+	// guess made from the provider/model strings. This is what makes a
+	// Claude model behave correctly whether it was served by Anthropic
+	// (additive), by an OpenAI-compatible gateway (subset) or by a CLI that
+	// proxies several backends.
+	if usage.InputTokensTotal > 0 {
+		return usage.InputTokensTotal
+	}
+	// Not normalized: usage restored from a session recorded by an older
+	// build, or an estimate. Fall back to the name-based heuristic.
 	n := usage.PromptTokens
 	if cacheTokensAdditive(provider, model) {
 		n += usage.CacheReadInputTokens + usage.CacheCreationInputTokens
 	}
 	return n
+}
+
+// recordInputTokens is the schema-normalized input of a record, with the
+// fallback that keeps sessions persisted before normalization readable:
+// their InputTokens is zero, and PromptTokens is what those builds recorded.
+func recordInputTokens(rec *ModelUsageRecord) int64 {
+	if rec == nil {
+		return 0
+	}
+	if rec.InputTokens > 0 {
+		return rec.InputTokens
+	}
+	return rec.PromptTokens
 }
 
 // getCachePricing returns cache write and cache read cost per 1M tokens.

--- a/cli/history_compactor.go
+++ b/cli/history_compactor.go
@@ -704,6 +704,7 @@ func sumUsage(a, b *models.UsageInfo) *models.UsageInfo {
 		return a
 	}
 	out := *a
+	out.InputTokensTotal = a.InputTotal() + b.InputTotal()
 	out.PromptTokens += b.PromptTokens
 	out.CompletionTokens += b.CompletionTokens
 	out.TotalTokens += b.TotalTokens

--- a/cli/llm_audit.go
+++ b/cli/llm_audit.go
@@ -207,7 +207,9 @@ func (w *llmAuditWriter) record(ev client.RequestAuditEvent) {
 	}
 	if ev.Phase == "recv" && ev.Status == "success" && w.usage != nil {
 		if u := w.usage(); u != nil {
-			entry.InputTokens = u.PromptTokens
+			// The whole input, cache included: an audit trail that logged
+			// only the uncached delta understated every cached turn.
+			entry.InputTokens = u.InputTotal()
 			entry.OutputTokens = u.CompletionTokens
 			entry.CacheReadTokens = u.CacheReadInputTokens
 			entry.CacheWriteTokens = u.CacheCreationInputTokens

--- a/cli/token_calibrator.go
+++ b/cli/token_calibrator.go
@@ -88,8 +88,90 @@ func (c *tokenCalibrator) Observe(provider, model string, chars, tokens int) {
 	c.scheduleSave()
 }
 
+// modelFamilyKey reduces a provider-specific model id to the model itself,
+// so ratios learned on one surface can seed another. Tokenization belongs
+// to the MODEL, not to who serves it: Claude Sonnet 4.6 splits text the
+// same way whether Anthropic, Bedrock or a CLI wrapper delivers it, and
+// gpt-6-astra does too. Without this, every provider started at the blind
+// 4.0 default even when a sibling entry had already measured the same
+// model — which is how one conversation showed "ctx 2%" on one provider
+// and "ctx 11%" on another.
+//
+// Strips the Bedrock inference-profile shape (region prefix, vendor
+// prefix, date stamp, -v1:0 revision); anything else passes through.
+func modelFamilyKey(model string) string {
+	m := strings.ToLower(strings.TrimSpace(model))
+	if m == "" {
+		return ""
+	}
+	for _, p := range []string{"global.", "us.", "eu.", "apac.", "au.", "ca.", "sa."} {
+		if strings.HasPrefix(m, p) {
+			m = m[len(p):]
+			break
+		}
+	}
+	for _, p := range []string{"anthropic.", "amazon.", "meta.", "mistral.", "ai21.",
+		"cohere.", "deepseek.", "openai.", "qwen.", "writer.", "stability.",
+		"twelvelabs.", "luma.", "moonshotai.", "xai.", "zai."} {
+		if strings.HasPrefix(m, p) {
+			m = m[len(p):]
+			break
+		}
+	}
+	// "-v1:0" / ":0" revision suffix.
+	if i := strings.LastIndex(m, ":"); i > 0 && isAllDigits(m[i+1:]) {
+		m = m[:i]
+	}
+	if i := strings.LastIndex(m, "-v"); i > 0 && isAllDigits(m[i+2:]) {
+		m = m[:i]
+	}
+	// "-20260115" date stamp.
+	if i := strings.LastIndex(m, "-"); i > 0 && len(m[i+1:]) == 8 && isAllDigits(m[i+1:]) {
+		m = m[:i]
+	}
+	return m
+}
+
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// familyRatioLocked finds a ratio learned for the same model under another
+// provider, preferring the best-sampled one. Caller holds the read lock.
+func (c *tokenCalibrator) familyRatioLocked(model string) (float64, int) {
+	family := modelFamilyKey(model)
+	if family == "" {
+		return 0, 0
+	}
+	bestRatio, bestSamples := 0.0, 0
+	for key, ratio := range c.ratios {
+		if ratio <= 0 {
+			continue
+		}
+		i := strings.Index(key, ":")
+		if i < 0 || modelFamilyKey(key[i+1:]) != family {
+			continue
+		}
+		if n := c.samples[key]; n > bestSamples {
+			bestRatio, bestSamples = ratio, n
+		}
+	}
+	return bestRatio, bestSamples
+}
+
 // CharsPerToken returns the learned ratio and how many samples produced it;
-// (defaultCharsPerToken, 0) before any sample.
+// (defaultCharsPerToken, 0) before any sample. With no sample for this exact
+// provider:model pair, a ratio measured for the SAME MODEL under another
+// provider is used (see modelFamilyKey) — a measured sibling beats the
+// blind default. The reported sample count is that sibling's.
 func (c *tokenCalibrator) CharsPerToken(provider, model string) (float64, int) {
 	if c == nil {
 		return defaultCharsPerToken, 0
@@ -99,6 +181,9 @@ func (c *tokenCalibrator) CharsPerToken(provider, model string) (float64, int) {
 	key := calibrationKey(provider, model)
 	if r, ok := c.ratios[key]; ok && r > 0 {
 		return r, c.samples[key]
+	}
+	if r, n := c.familyRatioLocked(model); r > 0 {
+		return r, n
 	}
 	return defaultCharsPerToken, 0
 }

--- a/cli/usage_normalization_test.go
+++ b/cli/usage_normalization_test.go
@@ -238,3 +238,45 @@ func TestCalibratorExactPairWins(t *testing.T) {
 		t.Fatalf("own samples lost to the sibling: %v", ratio)
 	}
 }
+
+// TestCacheAccountingFollowsThePayload: MiniMax serves the same model over
+// an OpenAI-shaped and an Anthropic-shaped endpoint. The model name cannot
+// tell them apart; the payload can, and the cache hit ratio depends on it.
+func TestCacheAccountingFollowsThePayload(t *testing.T) {
+	anthropicSurface := &models.UsageInfo{PromptTokens: 400, CompletionTokens: 20,
+		CacheCreationInputTokens: 1000, CacheReadInputTokens: 9000, IsReal: true}
+	anthropicSurface.Normalize(models.CacheAdditive)
+
+	openaiSurface := &models.UsageInfo{PromptTokens: 10400, CompletionTokens: 20,
+		CacheReadInputTokens: 9000, IsReal: true}
+	openaiSurface.Normalize(models.CacheSubset)
+
+	if !usageCacheAccounting("MINIMAX", "MiniMax-M2.7", anthropicSurface) {
+		t.Fatal("Anthropic-shaped payload read as subset")
+	}
+	if usageCacheAccounting("MINIMAX", "MiniMax-M2.7", openaiSurface) {
+		t.Fatal("OpenAI-shaped payload read as additive")
+	}
+
+	// Both describe the same 10.4K input with 9K served from cache: the hit
+	// ratio must match, whichever endpoint answered.
+	a, okA := TurnCacheHitPct("MINIMAX", "MiniMax-M2.7", anthropicSurface)
+	b, okB := TurnCacheHitPct("MINIMAX", "MiniMax-M2.7", openaiSurface)
+	if !okA || !okB {
+		t.Fatal("cache telemetry unreported")
+	}
+	if clampPct(a) != clampPct(b) {
+		t.Fatalf("same cache state read differently: %.1f%% vs %.1f%%", a, b)
+	}
+}
+
+// TestCacheAccountingFallsBackWithoutCacheActivity: with no cache tokens the
+// payload cannot say which schema it is, and nothing was cached anyway — the
+// provider/model heuristic stays in charge.
+func TestCacheAccountingFallsBackWithoutCacheActivity(t *testing.T) {
+	u := &models.UsageInfo{PromptTokens: 500, CompletionTokens: 10, IsReal: true}
+	u.Normalize(models.CacheSubset)
+	if !usageCacheAccounting("CLAUDEAI", "claude-sonnet-4-6", u) {
+		t.Fatal("heuristic not consulted when the payload is silent")
+	}
+}

--- a/cli/usage_normalization_test.go
+++ b/cli/usage_normalization_test.go
@@ -1,0 +1,240 @@
+/*
+ * ChatCLI - Cross-provider usage normalization (CLI side)
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * The provider adapters classify their own payloads (models.UsageInfo.
+ * Normalize); these tests pin what the CLI does with that classification:
+ * one comparable input figure on screen, in /cost and in the window math,
+ * whatever provider served the turn.
+ */
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+)
+
+// additiveUsage is a Bedrock/Anthropic turn: a 19K prefix written to cache,
+// 3 uncached tokens on top. subsetUsage is the same conversation on an
+// OpenAI-schema provider.
+func additiveUsage() *models.UsageInfo {
+	u := &models.UsageInfo{PromptTokens: 3, CompletionTokens: 53,
+		CacheCreationInputTokens: 19130, IsReal: true}
+	u.Normalize(models.CacheAdditive)
+	return u
+}
+
+func subsetUsage() *models.UsageInfo {
+	u := &models.UsageInfo{PromptTokens: 19133, CompletionTokens: 53,
+		CacheReadInputTokens: 19130, IsReal: true}
+	u.Normalize(models.CacheSubset)
+	return u
+}
+
+// TestContextTokensPrefersTheAdapterClassification: the normalized field wins
+// over any guess made from the provider/model strings.
+func TestContextTokensPrefersTheAdapterClassification(t *testing.T) {
+	u := additiveUsage()
+	// Deliberately a provider/model pair whose heuristic says "subset": the
+	// adapter already said otherwise, and the adapter read the payload.
+	if got := contextTokens("OPENAI", "gpt-6-astra", u); got != 19133 {
+		t.Fatalf("contextTokens = %d, want 19133 (adapter's classification)", got)
+	}
+}
+
+// TestContextTokensFallsBackForLegacyUsage: a record persisted before the
+// field existed must keep behaving exactly as it did.
+func TestContextTokensFallsBackForLegacyUsage(t *testing.T) {
+	legacy := &models.UsageInfo{PromptTokens: 3, CompletionTokens: 53,
+		CacheCreationInputTokens: 19130, IsReal: true} // no InputTokensTotal
+	if got := contextTokens("BEDROCK", "anthropic.claude-sonnet-4-6", legacy); got != 19133 {
+		t.Fatalf("additive fallback = %d, want 19133", got)
+	}
+	if got := contextTokens("OPENAI", "gpt-6-astra", legacy); got != 3 {
+		t.Fatalf("subset fallback = %d, want 3", got)
+	}
+}
+
+// TestBothSchemasRecordTheSameTokens is the headline regression: the same
+// conversation must not read as 3 tokens on one provider and 19K on another.
+func TestBothSchemasRecordTheSameTokens(t *testing.T) {
+	ct := NewCostTracker()
+	ct.RecordRealUsage("BEDROCK", "global.anthropic.claude-sonnet-4-6", additiveUsage())
+	ct.RecordRealUsage("OPENAI", "gpt-6-astra", subsetUsage())
+
+	snap := ct.Snapshot()
+	bedrock := snap.ModelUsage[modelKey("BEDROCK", "global.anthropic.claude-sonnet-4-6")]
+	openai := snap.ModelUsage[modelKey("OPENAI", "gpt-6-astra")]
+
+	if bedrock.InputTokens != openai.InputTokens {
+		t.Fatalf("same input recorded differently: bedrock=%d openai=%d",
+			bedrock.InputTokens, openai.InputTokens)
+	}
+	if bedrock.InputTokens != 19133 {
+		t.Fatalf("InputTokens = %d, want 19133", bedrock.InputTokens)
+	}
+	if bedrock.TotalTokens != 19186 {
+		t.Fatalf("TotalTokens = %d, want 19186 (the old math said 56)", bedrock.TotalTokens)
+	}
+	// The raw split must survive untouched — the cost math is built on it.
+	if bedrock.PromptTokens != 3 || bedrock.CacheCreationTokens != 19130 {
+		t.Fatalf("raw provider counts altered: %+v", bedrock)
+	}
+	if snap.TotalTokens != 19186*2 {
+		t.Fatalf("session total = %d, want %d", snap.TotalTokens, 19186*2)
+	}
+}
+
+// TestRecordedCostIsUnchangedByNormalization: normalization is a reporting
+// change, never a billing one.
+func TestRecordedCostIsUnchangedByNormalization(t *testing.T) {
+	withField := NewCostTracker()
+	withField.RecordRealUsage("CLAUDEAI", "claude-sonnet-4-6", additiveUsage())
+
+	legacy := &models.UsageInfo{PromptTokens: 3, CompletionTokens: 53,
+		CacheCreationInputTokens: 19130, IsReal: true}
+	withoutField := NewCostTracker()
+	withoutField.RecordRealUsage("CLAUDEAI", "claude-sonnet-4-6", legacy)
+
+	if a, b := withField.TotalCost(), withoutField.TotalCost(); a != b {
+		t.Fatalf("cost changed with normalization: %v vs %v", a, b)
+	}
+}
+
+// TestLegacyRecordsStillCountInTheSessionTotal: sessions restored from disk
+// have no InputTokens field; their PromptTokens must still be counted.
+func TestLegacyRecordsStillCountInTheSessionTotal(t *testing.T) {
+	rec := &ModelUsageRecord{PromptTokens: 500, CompletionTokens: 50}
+	if got := recordInputTokens(rec); got != 500 {
+		t.Fatalf("recordInputTokens = %d, want 500", got)
+	}
+	rec.InputTokens = 700
+	if got := recordInputTokens(rec); got != 700 {
+		t.Fatalf("recordInputTokens = %d, want 700", got)
+	}
+}
+
+// TestLongContextTierIgnoresCachedTokensOnSubsetSchemas: cached tokens are
+// already inside prompt_tokens there, and adding them could tip a request
+// over a pricing threshold it never crossed.
+func TestLongContextTierIgnoresCachedTokensOnSubsetSchemas(t *testing.T) {
+	// 150K prompt of which 120K cached: under Gemini's 200K long-context
+	// threshold. The old math summed to 270K and applied the 2x tier.
+	u := &models.UsageInfo{PromptTokens: 150000, CompletionTokens: 100,
+		CacheReadInputTokens: 120000, IsReal: true}
+	u.Normalize(models.CacheSubset)
+
+	plain := estimateTurnCostUSD("GOOGLEAI", "gemini-2.5-pro", u)
+
+	over := &models.UsageInfo{PromptTokens: 250000, CompletionTokens: 100, IsReal: true}
+	over.Normalize(models.CacheSubset)
+	tiered := estimateTurnCostUSD("GOOGLEAI", "gemini-2.5-pro", over)
+
+	if plain <= 0 || tiered <= 0 {
+		t.Skip("no pricing for this model in the catalog")
+	}
+	// Per-token, the genuinely-long request must cost more than the one that
+	// only looked long because its cache was double-counted.
+	perTokenPlain := plain / 150000
+	perTokenTiered := tiered / 250000
+	if perTokenPlain >= perTokenTiered {
+		t.Fatalf("cached tokens still tipping the long-context tier: %v vs %v",
+			perTokenPlain, perTokenTiered)
+	}
+}
+
+// TestFormatTokenSummaryShowsTheWholeInput pins the envelope header.
+func TestFormatTokenSummaryShowsTheWholeInput(t *testing.T) {
+	got := formatTokenSummary(additiveUsage())
+	if got == formatTokenSummary(&models.UsageInfo{PromptTokens: 3, CompletionTokens: 53}) {
+		t.Fatalf("header still rendering the uncached delta: %q", got)
+	}
+}
+
+// TestTelemetryPartsSizesAgainstTheServedModel: a skill hint or route
+// override can serve a turn on a different model than the session's. The
+// cost was already attributed to the served pair; the window and cache
+// semantics beside it must follow, or one turn is described by two models.
+func TestTelemetryPartsSizesAgainstTheServedModel(t *testing.T) {
+	session := &ChatCLI{Provider: "OPENAI", Model: "gpt-4o"} // 128K window
+	usage := &models.UsageInfo{PromptTokens: 64000, CompletionTokens: 100, IsReal: true}
+	usage.Normalize(models.CacheSubset)
+
+	own := strings.Join(session.telemetryParts("", "", usage, 0, false), " · ")
+	served := strings.Join(session.telemetryParts("BEDROCK", "global.anthropic.claude-sonnet-5", usage, 0, false), " · ")
+
+	if own == served {
+		t.Fatalf("served pair ignored: both rendered %q", own)
+	}
+	if !strings.Contains(own, "ctx 50%") {
+		t.Fatalf("session pair: %q, want ctx 50%% of the 128K window", own)
+	}
+	if !strings.Contains(served, "ctx 6%") {
+		t.Fatalf("served pair: %q, want ctx 6%% of the 1M window", served)
+	}
+}
+
+// TestModelFamilyKey: a ratio measured for a model must be findable from any
+// provider's spelling of that same model.
+func TestModelFamilyKey(t *testing.T) {
+	cases := map[string]string{
+		"global.anthropic.claude-sonnet-4-6-20260115-v1:0": "claude-sonnet-4-6",
+		"us.anthropic.claude-opus-5":                       "claude-opus-5",
+		"anthropic.claude-sonnet-4-6":                      "claude-sonnet-4-6",
+		"claude-sonnet-4-6":                                "claude-sonnet-4-6",
+		"gpt-6-astra":                                      "gpt-6-astra",
+		"gpt-5.6-luna":                                     "gpt-5.6-luna",
+		"MiniMax-M2.7":                                     "minimax-m2.7",
+	}
+	for in, want := range cases {
+		if got := modelFamilyKey(in); got != want {
+			t.Errorf("modelFamilyKey(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestCalibratorBorrowsTheSameModelsRatio: without this, a provider that has
+// never been sampled runs on the blind 4.0 default while a sibling entry has
+// already measured the very same tokenizer — which is how one conversation
+// showed a different ctx% on each provider.
+func TestCalibratorBorrowsTheSameModelsRatio(t *testing.T) {
+	c := newTokenCalibrator()
+	// 47 samples learned on the direct Anthropic surface.
+	for i := 0; i < 47; i++ {
+		c.Observe("CLAUDEAI", "claude-sonnet-4-6", 3170, 1000)
+	}
+
+	ratio, samples := c.CharsPerToken("BEDROCK", "global.anthropic.claude-sonnet-4-6-20260115-v1:0")
+	if ratio == defaultCharsPerToken {
+		t.Fatalf("Bedrock still on the blind default: %v", ratio)
+	}
+	if samples == 0 {
+		t.Fatalf("borrowed ratio reported as unsampled")
+	}
+	if ratio < 3.0 || ratio > 3.4 {
+		t.Fatalf("borrowed ratio = %v, want ~3.17", ratio)
+	}
+
+	// An unrelated model still gets the default — the fallback matches the
+	// model, not merely "something was learned once".
+	if r, _ := c.CharsPerToken("DEVIN", "kimi-k3"); r != defaultCharsPerToken {
+		t.Fatalf("unrelated model borrowed a ratio: %v", r)
+	}
+}
+
+// TestCalibratorExactPairWins: a measured pair is never overridden by a
+// sibling's ratio.
+func TestCalibratorExactPairWins(t *testing.T) {
+	c := newTokenCalibrator()
+	for i := 0; i < 5; i++ {
+		c.Observe("CLAUDEAI", "claude-sonnet-4-6", 3170, 1000) // 3.17
+		c.Observe("BEDROCK", "anthropic.claude-sonnet-4-6", 2000, 1000)
+	}
+	ratio, _ := c.CharsPerToken("BEDROCK", "anthropic.claude-sonnet-4-6")
+	if ratio > 2.5 {
+		t.Fatalf("own samples lost to the sibling: %v", ratio)
+	}
+}

--- a/i18n/locales/en-US.usage-normalization.json
+++ b/i18n/locales/en-US.usage-normalization.json
@@ -1,0 +1,3 @@
+{
+  "context.status.measured_input": "Measured input (provider)"
+}

--- a/i18n/locales/en.usage-normalization.json
+++ b/i18n/locales/en.usage-normalization.json
@@ -1,0 +1,3 @@
+{
+  "context.status.measured_input": "Measured input (provider)"
+}

--- a/i18n/locales/pt-BR.usage-normalization.json
+++ b/i18n/locales/pt-BR.usage-normalization.json
@@ -1,0 +1,3 @@
+{
+  "context.status.measured_input": "Input medido (provider)"
+}

--- a/llm/bedrock/usage.go
+++ b/llm/bedrock/usage.go
@@ -88,6 +88,10 @@ func (c *BedrockClient) captureConverseUsage(out *bedrockruntime.ConverseOutput)
 			info.CacheCreation1hInputTokens += deref(d.InputTokens)
 		}
 	}
+	// Converse documents "total input tokens = inputTokens +
+	// cacheReadInputTokens + cacheWriteInputTokens" for every vendor served
+	// through it, so inputTokens alone is the uncached delta.
+	info.Normalize(models.CacheAdditive)
 	c.usage.StoreUsage(info)
 	if out.StopReason != "" {
 		c.usage.StoreStopReason(string(out.StopReason))

--- a/llm/bedrock/usage_normalization_test.go
+++ b/llm/bedrock/usage_normalization_test.go
@@ -1,0 +1,61 @@
+/*
+ * ChatCLI - Bedrock usage schema contract
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * All three Bedrock request families must agree on what "the input" is.
+ * Converse and the Anthropic InvokeModel/Mantle envelope count cache tokens
+ * BESIDE inputTokens; the OpenAI-compatible family (gpt-oss) counts them
+ * inside prompt_tokens.
+ */
+package bedrock
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+	bedrockruntimetypes "github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+)
+
+func TestConverseUsageIsAdditive(t *testing.T) {
+	c := newUsageTestClient(t)
+	c.captureConverseUsage(&bedrockruntime.ConverseOutput{
+		Usage: &bedrockruntimetypes.TokenUsage{
+			InputTokens:           aws.Int32(3),
+			OutputTokens:          aws.Int32(53),
+			TotalTokens:           aws.Int32(56),
+			CacheWriteInputTokens: aws.Int32(19130),
+			CacheReadInputTokens:  aws.Int32(0),
+		},
+		StopReason: bedrockruntimetypes.StopReasonEndTurn,
+	})
+
+	u := c.LastUsage()
+	if u.InputTokensTotal != 19133 {
+		t.Fatalf("InputTokensTotal = %d, want 19133 (3 uncached + 19130 written)", u.InputTokensTotal)
+	}
+	if u.TotalTokens != 19186 {
+		t.Fatalf("TotalTokens = %d, want 19186 — the 56 Converse reports excludes the cache", u.TotalTokens)
+	}
+}
+
+func TestInvokeModelAnthropicUsageIsAdditive(t *testing.T) {
+	c := newUsageTestClient(t)
+	c.captureAnthropicUsage([]byte(`{"usage":{"input_tokens":120,"output_tokens":30,
+		"cache_creation_input_tokens":10,"cache_read_input_tokens":40}}`))
+
+	if got := c.LastUsage().InputTokensTotal; got != 170 {
+		t.Fatalf("InputTokensTotal = %d, want 170", got)
+	}
+}
+
+func TestOpenAIFamilyUsageIsSubset(t *testing.T) {
+	c := newUsageTestClient(t)
+	c.captureOpenAIUsage([]byte(`{"usage":{"prompt_tokens":900,"completion_tokens":20,
+		"prompt_tokens_details":{"cached_tokens":800}}}`))
+
+	if got := c.LastUsage().InputTokensTotal; got != 900 {
+		t.Fatalf("InputTokensTotal = %d, want 900 — gpt-oss keeps OpenAI semantics", got)
+	}
+}

--- a/llm/bedrock/usage_test.go
+++ b/llm/bedrock/usage_test.go
@@ -58,9 +58,14 @@ func TestCaptureConverseUsage(t *testing.T) {
 	c.captureConverseUsage(out)
 
 	u := c.LastUsage()
-	if u == nil || u.PromptTokens != 200 || u.CompletionTokens != 50 || u.TotalTokens != 250 ||
+	if u == nil || u.PromptTokens != 200 || u.CompletionTokens != 50 ||
 		u.CacheReadInputTokens != 80 || !u.IsReal {
 		t.Fatalf("wrong converse usage: %+v", u)
+	}
+	// Converse's own totalTokens (250) leaves the cache out. The normalized
+	// total is the input the model actually held plus the output.
+	if u.InputTokensTotal != 280 || u.TotalTokens != 330 {
+		t.Fatalf("usage not normalized: %+v", u)
 	}
 }
 

--- a/llm/claudeai/usage_stream_test.go
+++ b/llm/claudeai/usage_stream_test.go
@@ -27,9 +27,13 @@ func TestStreamUsageAccumulator(t *testing.T) {
 		t.Fatalf("no real usage committed: %+v", u)
 	}
 	if u.PromptTokens != 150 || u.CompletionTokens != 37 ||
-		u.CacheCreationInputTokens != 20 || u.CacheReadInputTokens != 90 ||
-		u.TotalTokens != 187 {
+		u.CacheCreationInputTokens != 20 || u.CacheReadInputTokens != 90 {
 		t.Fatalf("wrong accumulated usage: %+v", u)
+	}
+	// Anthropic counts cache reads and writes BESIDE input_tokens, so the
+	// input this turn held is 150+20+90 and the total grows with it.
+	if u.InputTokensTotal != 260 || u.TotalTokens != 297 {
+		t.Fatalf("stream usage not normalized: %+v", u)
 	}
 	if c.LastStopReason() != "end_turn" {
 		t.Fatalf("stop reason = %q", c.LastStopReason())

--- a/llm/claudeai/usage_tracker.go
+++ b/llm/claudeai/usage_tracker.go
@@ -161,6 +161,8 @@ func (a *streamUsageAccumulator) commit(c *ClaudeClient) {
 	info := a.info
 	info.TotalTokens = info.PromptTokens + info.CompletionTokens
 	info.IsReal = true
+	// message_start reports cache reads/writes beside input_tokens.
+	info.Normalize(models.CacheAdditive)
 	c.storeUsage(&info)
 	if a.stopReason != "" {
 		c.usage.StoreStopReason(a.stopReason)

--- a/llm/client/usage_schema_normalization_test.go
+++ b/llm/client/usage_schema_normalization_test.go
@@ -1,0 +1,94 @@
+/*
+ * ChatCLI - Shared usage-parser schema contract
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * Every provider that speaks an OpenAI- or Anthropic-shaped envelope reads
+ * its usage through these three parsers (openai, openairesponses,
+ * openaiassistant, xai, zai, moonshot, minimax — both of its surfaces —,
+ * copilot, bedrock's InvokeModel bodies and claudeai's buffered path). The
+ * contract they must all keep: InputTokensTotal is the whole input of the
+ * call, cache included, whatever the schema's split looks like.
+ */
+package client
+
+import "testing"
+
+func TestParseOpenAIUsage_NormalizesSubsetSchema(t *testing.T) {
+	// cached_tokens is a SHARE of prompt_tokens, not an extra charge.
+	info := ParseOpenAIUsage(map[string]interface{}{
+		"usage": map[string]interface{}{
+			"prompt_tokens":         float64(22858),
+			"completion_tokens":     float64(28),
+			"total_tokens":          float64(22886),
+			"prompt_tokens_details": map[string]interface{}{"cached_tokens": float64(10515)},
+		},
+	})
+	if info == nil {
+		t.Fatal("no usage parsed")
+	}
+	if info.InputTokensTotal != 22858 {
+		t.Fatalf("InputTokensTotal = %d, want 22858 (cached is already inside)", info.InputTokensTotal)
+	}
+	if info.TotalTokens != 22886 {
+		t.Fatalf("TotalTokens = %d, want 22886", info.TotalTokens)
+	}
+}
+
+func TestParseOpenAIResponsesUsage_NormalizesSubsetSchema(t *testing.T) {
+	info, err := ParseOpenAIResponsesUsage([]byte(`{"usage":{
+		"input_tokens": 5000, "output_tokens": 100,
+		"input_tokens_details": {"cached_tokens": 4000}}}`))
+	if err != nil || info == nil {
+		t.Fatalf("parse: %v %+v", err, info)
+	}
+	if info.InputTokensTotal != 5000 {
+		t.Fatalf("InputTokensTotal = %d, want 5000", info.InputTokensTotal)
+	}
+}
+
+func TestParseAnthropicUsage_NormalizesAdditiveSchema(t *testing.T) {
+	// The real shape behind "3 tokens in" on a 19K-token turn.
+	info := ParseAnthropicUsage(map[string]interface{}{
+		"usage": map[string]interface{}{
+			"input_tokens":                float64(3),
+			"output_tokens":               float64(53),
+			"cache_creation_input_tokens": float64(19130),
+			"cache_read_input_tokens":     float64(0),
+		},
+	})
+	if info == nil {
+		t.Fatal("no usage parsed")
+	}
+	if info.InputTokensTotal != 19133 {
+		t.Fatalf("InputTokensTotal = %d, want 19133", info.InputTokensTotal)
+	}
+	if info.TotalTokens != 19186 {
+		t.Fatalf("TotalTokens = %d, want 19186", info.TotalTokens)
+	}
+	if info.PromptTokens != 3 {
+		t.Fatalf("PromptTokens = %d — the raw split must survive for cost math", info.PromptTokens)
+	}
+}
+
+// TestBothSchemasAgreeOnTheSamePrefix is the regression this whole change
+// exists for: two providers holding the same ~22K prefix must report the same
+// input, however each one splits its counters.
+func TestBothSchemasAgreeOnTheSamePrefix(t *testing.T) {
+	additive := ParseAnthropicUsage(map[string]interface{}{
+		"usage": map[string]interface{}{
+			"input_tokens": float64(1000), "output_tokens": float64(10),
+			"cache_read_input_tokens": float64(21000),
+		},
+	})
+	subset := ParseOpenAIUsage(map[string]interface{}{
+		"usage": map[string]interface{}{
+			"prompt_tokens": float64(22000), "completion_tokens": float64(10),
+			"prompt_tokens_details": map[string]interface{}{"cached_tokens": float64(21000)},
+		},
+	})
+	if additive.InputTokensTotal != subset.InputTokensTotal {
+		t.Fatalf("same prefix reported differently: additive=%d subset=%d",
+			additive.InputTokensTotal, subset.InputTokensTotal)
+	}
+}

--- a/llm/client/usage_state.go
+++ b/llm/client/usage_state.go
@@ -108,6 +108,8 @@ func ParseOpenAIUsage(result map[string]interface{}) *models.UsageInfo {
 	if info.TotalTokens == 0 && (info.PromptTokens > 0 || info.CompletionTokens > 0) {
 		info.TotalTokens = info.PromptTokens + info.CompletionTokens
 	}
+	// OpenAI counts cached_tokens INSIDE prompt_tokens.
+	info.Normalize(models.CacheSubset)
 
 	return info
 }
@@ -174,6 +176,9 @@ func ParseOpenAIResponsesUsage(data []byte) (*models.UsageInfo, error) {
 	if info.TotalTokens == 0 && (info.PromptTokens > 0 || info.CompletionTokens > 0) {
 		info.TotalTokens = info.PromptTokens + info.CompletionTokens
 	}
+	// Responses API: input_tokens_details.cached_tokens is a subset of
+	// input_tokens, exactly as on Chat Completions.
+	info.Normalize(models.CacheSubset)
 	return info, nil
 }
 
@@ -208,6 +213,9 @@ func ParseAnthropicUsage(result map[string]interface{}) *models.UsageInfo {
 	}
 
 	info.TotalTokens = info.PromptTokens + info.CompletionTokens
+	// Anthropic reports cache reads and writes ALONGSIDE input_tokens, so
+	// the normalized input is the sum — and TotalTokens grows with it.
+	info.Normalize(models.CacheAdditive)
 	return info
 }
 

--- a/llm/client/usage_state_test.go
+++ b/llm/client/usage_state_test.go
@@ -78,13 +78,18 @@ func TestParseOpenAIResponsesUsage(t *testing.T) {
 	// Responses API uses input_tokens / output_tokens — NOT prompt_/completion_.
 	// Reasoning models populate output_tokens_details.reasoning_tokens (already
 	// counted inside output_tokens).
+	//
+	// cached_tokens is a SUBSET of input_tokens on this schema, so the fixture
+	// keeps them consistent (1024 of the 1075 input tokens came from cache).
+	// The earlier numbers had more cached tokens than input, which the API
+	// cannot emit and which now trips the normalizer's defensive branch.
 	const body = `{
 		"usage": {
-			"input_tokens": 75,
+			"input_tokens": 1075,
 			"input_tokens_details": {"cached_tokens": 1024},
 			"output_tokens": 1186,
 			"output_tokens_details": {"reasoning_tokens": 1024},
-			"total_tokens": 1261
+			"total_tokens": 2261
 		}
 	}`
 
@@ -92,9 +97,10 @@ func TestParseOpenAIResponsesUsage(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, got, "Responses API usage block must parse")
 	assert.True(t, got.IsReal)
-	assert.Equal(t, 75, got.PromptTokens, "input_tokens → PromptTokens")
+	assert.Equal(t, 1075, got.PromptTokens, "input_tokens → PromptTokens")
 	assert.Equal(t, 1186, got.CompletionTokens, "output_tokens → CompletionTokens")
-	assert.Equal(t, 1261, got.TotalTokens)
+	assert.Equal(t, 2261, got.TotalTokens)
+	assert.Equal(t, 1075, got.InputTokensTotal, "cached_tokens is inside input_tokens here")
 	assert.Equal(t, 1024, got.CacheReadInputTokens, "input_tokens_details.cached_tokens → CacheReadInputTokens")
 	assert.Equal(t, 1024, got.ReasoningTokens, "output_tokens_details.reasoning_tokens → ReasoningTokens")
 }
@@ -170,5 +176,9 @@ func TestParseAnthropicUsage_StaysUntouched(t *testing.T) {
 	assert.Equal(t, 50, got.CompletionTokens)
 	assert.Equal(t, 20, got.CacheCreationInputTokens)
 	assert.Equal(t, 80, got.CacheReadInputTokens)
-	assert.Equal(t, 150, got.TotalTokens, "Anthropic parser sums input+output (API doesn't include total)")
+	// The Anthropic API sends no total, so the parser builds one — over the
+	// SCHEMA-NORMALIZED input (input + cache read + cache write), not over
+	// input_tokens alone, which on this schema is only the uncached delta.
+	assert.Equal(t, 200, got.InputTokensTotal, "cache reads/writes are input on the Anthropic schema")
+	assert.Equal(t, 250, got.TotalTokens, "normalized input + output")
 }

--- a/llm/copilot/usage_normalization_test.go
+++ b/llm/copilot/usage_normalization_test.go
@@ -1,0 +1,31 @@
+/*
+ * ChatCLI - GitHub Copilot usage schema contract
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package copilot
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCopilotUsageIsSubset(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":2000,"completion_tokens":25,"total_tokens":2025,
+			"prompt_tokens_details":{"cached_tokens":1800}}}`))
+	}))
+	defer server.Close()
+
+	c := NewClient(testProvider("test-token"), "gpt-4o", testLogger(), 1, 0)
+	c.baseURL = server.URL
+	if _, err := c.SendPrompt(context.Background(), "Hello", nil, 0); err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+	if u := c.LastUsage(); u == nil || u.InputTokensTotal != 2000 {
+		t.Fatalf("usage not normalized: %+v", u)
+	}
+}

--- a/llm/devincli/devincli_usage.go
+++ b/llm/devincli/devincli_usage.go
@@ -87,6 +87,11 @@ func parseTrajectoryUsage(raw []byte) (turnUsage, error) {
 
 	var out turnUsage
 	usage := &models.UsageInfo{IsReal: true}
+	// inputTotal is accumulated PER STEP, because one trajectory can mix
+	// both metric shapes (and, across steps, backends): summing first and
+	// classifying once would apply one schema to counters written under
+	// another.
+	inputTotal := 0
 	for _, step := range doc.Steps {
 		if step.Metadata.IsUserInput || strings.EqualFold(step.Source, "user") {
 			continue
@@ -105,12 +110,23 @@ func parseTrajectoryUsage(raw []byte) (turnUsage, error) {
 			if step.Metrics != nil {
 				usage.CostUSD += step.Metrics.CostUSD
 			}
+			stepModel := step.Metadata.GenerationModel
+			if stepModel == "" {
+				stepModel = doc.Agent.ModelName
+			}
+			inputTotal += int(m.InputTokens)
+			if devinCacheAccounting(true, stepModel) == models.CacheAdditive {
+				inputTotal += int(m.CacheCreationTokens) + int(m.CacheReadTokens)
+			}
 		case step.Metrics != nil:
 			m := step.Metrics
 			usage.PromptTokens += int(m.PromptTokens)
 			usage.CompletionTokens += int(m.CompletionTokens)
 			usage.CacheReadInputTokens += int(m.CachedTokens)
 			usage.CostUSD += m.CostUSD
+			// ATIF standard block: cached_tokens is a subset of
+			// prompt_tokens, whatever model produced the step.
+			inputTotal += int(m.PromptTokens)
 		}
 	}
 	if usage.PromptTokens == 0 && usage.CompletionTokens == 0 && doc.FinalMetrics != nil {
@@ -118,6 +134,8 @@ func parseTrajectoryUsage(raw []byte) (turnUsage, error) {
 		usage.CompletionTokens = int(doc.FinalMetrics.TotalCompletionTokens)
 		usage.CacheReadInputTokens = int(doc.FinalMetrics.TotalCachedTokens)
 		usage.CostUSD = doc.FinalMetrics.TotalCostUSD
+		// final_metrics is the ATIF standard block's shape: subset.
+		inputTotal = usage.PromptTokens
 	}
 	if out.Model == "" {
 		out.Model = doc.Agent.ModelName
@@ -125,7 +143,36 @@ func parseTrajectoryUsage(raw []byte) (turnUsage, error) {
 	if usage.PromptTokens == 0 && usage.CompletionTokens == 0 {
 		return out, nil
 	}
-	usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
+	if inputTotal < usage.PromptTokens {
+		inputTotal = usage.PromptTokens
+	}
+	usage.InputTokensTotal = inputTotal
+	usage.TotalTokens = inputTotal + usage.CompletionTokens
 	out.Usage = usage
 	return out, nil
+}
+
+// devinCacheAccounting classifies ONE step's token counts.
+//
+// The Devin CLI fronts several backends and copies each one's counters into
+// the same ATIF fields, so the field names alone do not settle the
+// semantics — the model that generated does. An Anthropic backend reports
+// cache reads and writes BESIDE input_tokens (they must be added to get the
+// real input); the OpenAI/Kimi backends report the cached share INSIDE it
+// (adding would double-count it). The trajectory names that model
+// (step.metadata.generation_model, else agent.model_name), which is the
+// right thing to classify on: the ChatCLI-facing alias may be an opaque
+// account-level name that says nothing about the backend.
+//
+// The ATIF standard block is OpenAI-shaped by definition (prompt_tokens /
+// cached_tokens), so it is always subset regardless of the model.
+func devinCacheAccounting(nativeMetrics bool, model string) models.CacheAccounting {
+	if !nativeMetrics {
+		return models.CacheSubset
+	}
+	m := strings.ToLower(model)
+	if strings.Contains(m, "claude") || strings.Contains(m, "fable") || strings.Contains(m, "anthropic") {
+		return models.CacheAdditive
+	}
+	return models.CacheSubset
 }

--- a/llm/devincli/devincli_usage_test.go
+++ b/llm/devincli/devincli_usage_test.go
@@ -44,7 +44,11 @@ func TestParseTrajectoryUsage_SumsAgentSteps(t *testing.T) {
 	assert.True(t, got.Usage.IsReal)
 	assert.Equal(t, 13500, got.Usage.PromptTokens, "user steps never count")
 	assert.Equal(t, 500, got.Usage.CompletionTokens)
-	assert.Equal(t, 14000, got.Usage.TotalTokens)
+	// Normalized: the Anthropic-backed step's cache write and read ARE
+	// input (12000+500+11000), the ATIF-standard step's cached_tokens are
+	// already inside its 1500 — 25000 input, 500 output.
+	assert.Equal(t, 25000, got.Usage.InputTokensTotal)
+	assert.Equal(t, 25500, got.Usage.TotalTokens)
 	assert.Equal(t, 500, got.Usage.CacheCreationInputTokens)
 	assert.Equal(t, 12000, got.Usage.CacheReadInputTokens, "ATIF cached_tokens folds into cache reads")
 	assert.InDelta(t, 0.0125, got.Usage.CostUSD, 1e-9)

--- a/llm/devincli/usage_normalization_test.go
+++ b/llm/devincli/usage_normalization_test.go
@@ -1,0 +1,97 @@
+/*
+ * ChatCLI - Devin trajectory usage schema contract
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * The Devin CLI fronts several backends and copies each one's counters into
+ * the same ATIF fields, so the schema follows the model that generated —
+ * which the trajectory names.
+ */
+package devincli
+
+import "testing"
+
+func TestTrajectoryUsage_AnthropicBackendIsAdditive(t *testing.T) {
+	raw := []byte(`{
+	  "agent": {"model_name": "claude-sonnet-4-6"},
+	  "steps": [
+	    {"source": "user", "metadata": {"is_user_input": true}},
+	    {"source": "agent", "metadata": {"generation_model": "claude-sonnet-4-6",
+	      "metrics": {"input_tokens": 1000, "output_tokens": 200,
+	                  "cache_creation_tokens": 500, "cache_read_tokens": 11000}}}
+	  ]}`)
+	got, err := parseTrajectoryUsage(raw)
+	if err != nil || got.Usage == nil {
+		t.Fatalf("parse: %v %+v", err, got.Usage)
+	}
+	if got.Usage.InputTokensTotal != 12500 {
+		t.Fatalf("InputTokensTotal = %d, want 12500", got.Usage.InputTokensTotal)
+	}
+}
+
+func TestTrajectoryUsage_OpenAIBackendIsSubset(t *testing.T) {
+	// Same field names, OpenAI backend: cache_read_tokens is the cached
+	// SHARE of input_tokens — adding it would invent 10K tokens per turn.
+	raw := []byte(`{
+	  "agent": {"model_name": "gpt-6-astra"},
+	  "steps": [
+	    {"source": "agent", "metadata": {"generation_model": "gpt-6-astra",
+	      "metrics": {"input_tokens": 22858, "output_tokens": 28,
+	                  "cache_read_tokens": 10515}}}
+	  ]}`)
+	got, err := parseTrajectoryUsage(raw)
+	if err != nil || got.Usage == nil {
+		t.Fatalf("parse: %v %+v", err, got.Usage)
+	}
+	if got.Usage.InputTokensTotal != 22858 {
+		t.Fatalf("InputTokensTotal = %d, want 22858", got.Usage.InputTokensTotal)
+	}
+}
+
+// TestTrajectoryUsage_ATIFStandardBlockIsSubset: prompt_tokens/cached_tokens
+// is OpenAI-shaped by definition, whatever model produced it.
+func TestTrajectoryUsage_ATIFStandardBlockIsSubset(t *testing.T) {
+	raw := []byte(`{
+	  "agent": {"model_name": "claude-sonnet-4-6"},
+	  "steps": [
+	    {"source": "agent", "metrics": {"prompt_tokens": 5000, "completion_tokens": 100,
+	                                     "cached_tokens": 4000, "cost_usd": 0.01}}
+	  ]}`)
+	got, err := parseTrajectoryUsage(raw)
+	if err != nil || got.Usage == nil {
+		t.Fatalf("parse: %v %+v", err, got.Usage)
+	}
+	if got.Usage.InputTokensTotal != 5000 {
+		t.Fatalf("InputTokensTotal = %d, want 5000", got.Usage.InputTokensTotal)
+	}
+}
+
+func TestDevinCacheAccountingClassification(t *testing.T) {
+	cases := []struct {
+		native   bool
+		model    string
+		additive bool
+	}{
+		{true, "claude-sonnet-4-6", true},
+		{true, "claude-fable-5-1", true},
+		{true, "anthropic/claude-opus-5", true},
+		{true, "gpt-6-astra", false},
+		{true, "kimi-k3", false},
+		{false, "claude-sonnet-4-6", false}, // ATIF standard block
+		{true, "", false},                   // unknown backend: never inflate
+	}
+	for _, c := range cases {
+		got := devinCacheAccounting(c.native, c.model)
+		want := "subset"
+		if c.additive {
+			want = "additive"
+		}
+		gotName := "subset"
+		if got == 1 { // models.CacheAdditive
+			gotName = "additive"
+		}
+		if gotName != want {
+			t.Errorf("devinCacheAccounting(%v, %q) = %s, want %s", c.native, c.model, gotName, want)
+		}
+	}
+}

--- a/llm/googleai/gemini_client.go
+++ b/llm/googleai/gemini_client.go
@@ -398,14 +398,18 @@ func (c *GeminiClient) parseResponse(bodyBytes []byte) (string, error) {
 
 	// Store usage info
 	if result.UsageMetadata.TotalTokenCount > 0 || result.UsageMetadata.PromptTokenCount > 0 {
-		c.usageState.StoreUsage(&models.UsageInfo{
+		usage := &models.UsageInfo{
 			PromptTokens:         result.UsageMetadata.PromptTokenCount,
 			CompletionTokens:     result.UsageMetadata.CandidatesTokenCount,
 			TotalTokens:          result.UsageMetadata.TotalTokenCount,
 			CacheReadInputTokens: result.UsageMetadata.CachedContentTokenCount,
 			ReasoningTokens:      result.UsageMetadata.ThoughtsTokenCount,
 			IsReal:               true,
-		})
+		}
+		// cachedContentTokenCount is the cached SHARE of promptTokenCount,
+		// not an extra charge beside it.
+		usage.Normalize(models.CacheSubset)
+		c.usageState.StoreUsage(usage)
 	}
 
 	// Store stop reason

--- a/llm/googleai/usage_normalization_test.go
+++ b/llm/googleai/usage_normalization_test.go
@@ -1,0 +1,47 @@
+/*
+ * ChatCLI - Gemini usage schema contract
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package googleai
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+// TestGeminiUsageIsSubset: cachedContentTokenCount is the cached SHARE of
+// promptTokenCount, so the normalized input is promptTokenCount itself.
+func TestGeminiUsageIsSubset(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"ok"}]},"finishReason":"STOP"}],
+			"usageMetadata":{"promptTokenCount":9000,"candidatesTokenCount":120,
+			"cachedContentTokenCount":8000,"thoughtsTokenCount":300,"totalTokenCount":9420}}`))
+	}))
+	defer server.Close()
+
+	c := NewGeminiClient(testProvider("k"), "gemini-3-pro", zap.NewNop(), 1, 0)
+	c.baseURL = server.URL
+	if _, err := c.SendPrompt(context.Background(), "Hi",
+		[]models.Message{{Role: "user", Content: "Hi"}}, 0); err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+
+	u := c.LastUsage()
+	if u == nil {
+		t.Fatal("no usage captured")
+	}
+	if u.InputTokensTotal != 9000 {
+		t.Fatalf("InputTokensTotal = %d, want 9000 (cached is already inside)", u.InputTokensTotal)
+	}
+	// Gemini folds thoughtsTokenCount into its own total — normalization may
+	// raise a total, never shrink it.
+	if u.TotalTokens != 9420 {
+		t.Fatalf("TotalTokens = %d, want the provider's 9420", u.TotalTokens)
+	}
+}

--- a/llm/minimax/usage_normalization_test.go
+++ b/llm/minimax/usage_normalization_test.go
@@ -1,0 +1,63 @@
+/*
+ * ChatCLI - MiniMax usage schema contract
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ *
+ * MiniMax is the case that proves the schema is not a property of the model
+ * name: the SAME model reports OpenAI-shaped counts on the Chat Completions
+ * surface and Anthropic-shaped ones on the Anthropic-compatible surface. A
+ * heuristic keyed on "claude" in the model string gets the second one wrong;
+ * the adapter that read the payload does not.
+ */
+package minimax
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+)
+
+func TestMiniMaxOpenAISurfaceIsSubset(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":5000,"completion_tokens":30,"total_tokens":5030,
+			"prompt_tokens_details":{"cached_tokens":4500}}}`))
+	}))
+	defer server.Close()
+
+	c := newTestClient(server.URL)
+	if _, err := c.SendPrompt(context.Background(), "Hi",
+		[]models.Message{{Role: "user", Content: "Hi"}}, 0); err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+	if u := c.LastUsage(); u == nil || u.InputTokensTotal != 5000 {
+		t.Fatalf("usage not normalized: %+v", u)
+	}
+}
+
+// TestMiniMaxAnthropicSurfaceIsAdditive: same client, same model name, the
+// other endpoint — and here cache reads/writes sit BESIDE input_tokens. The
+// old model-name heuristic classified this as subset and undercounted the
+// input by the whole cached prefix.
+func TestMiniMaxAnthropicSurfaceIsAdditive(t *testing.T) {
+	c := newTestClient("http://unused.invalid")
+	body := `{"content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn",
+		"usage":{"input_tokens":400,"output_tokens":20,
+		"cache_creation_input_tokens":1000,"cache_read_input_tokens":9000}}`
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+	if _, err := c.processAnthropicResponse(resp); err != nil {
+		t.Fatalf("processAnthropicResponse: %v", err)
+	}
+	u := c.LastUsage()
+	if u == nil || u.InputTokensTotal != 10400 {
+		t.Fatalf("InputTokensTotal = %+v, want 10400", u)
+	}
+}

--- a/llm/moonshot/usage_normalization_test.go
+++ b/llm/moonshot/usage_normalization_test.go
@@ -1,0 +1,33 @@
+/*
+ * ChatCLI - Moonshot usage schema contract
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package moonshot
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+)
+
+func TestMoonshotUsageIsSubset(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":30000,"completion_tokens":80,"total_tokens":30080,
+			"prompt_tokens_details":{"cached_tokens":29000}}}`))
+	}))
+	defer server.Close()
+
+	c := newTestClient(server.URL)
+	if _, err := c.SendPrompt(context.Background(), "Hi",
+		[]models.Message{{Role: "user", Content: "Hi"}}, 0); err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+	if u := c.LastUsage(); u == nil || u.InputTokensTotal != 30000 {
+		t.Fatalf("usage not normalized: %+v", u)
+	}
+}

--- a/llm/ollama/ollama_client.go
+++ b/llm/ollama/ollama_client.go
@@ -193,12 +193,16 @@ func (c *Client) SendPrompt(ctx context.Context, prompt string, history []models
 
 		// Extract usage from Ollama's custom format
 		if result.EvalCount > 0 || result.PromptEvalCount > 0 {
-			c.usageState.StoreUsage(&models.UsageInfo{
+			usage := &models.UsageInfo{
 				PromptTokens:     result.PromptEvalCount,
 				CompletionTokens: result.EvalCount,
 				TotalTokens:      result.PromptEvalCount + result.EvalCount,
 				IsReal:           true,
-			})
+			}
+			// Ollama reports no cache split: prompt_eval_count already is
+			// the whole input.
+			usage.Normalize(models.CacheSubset)
+			c.usageState.StoreUsage(usage)
 		}
 		if result.DoneReason != "" {
 			c.usageState.StoreStopReason(result.DoneReason)

--- a/llm/ollama/usage_normalization_test.go
+++ b/llm/ollama/usage_normalization_test.go
@@ -1,0 +1,38 @@
+/*
+ * ChatCLI - Ollama usage schema contract
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package ollama
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+// TestOllamaUsageIsWholeInput: Ollama reports no cache split, so
+// prompt_eval_count already IS the input the model held.
+func TestOllamaUsageIsWholeInput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"message":{"role":"assistant","content":"hi"},"done":true,
+			"prompt_eval_count":4321,"eval_count":77,"done_reason":"stop"}`)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "llama3.1:8b", zap.NewNop(), 1, 0)
+	if _, err := c.SendPrompt(context.Background(), "Hi",
+		[]models.Message{{Role: "user", Content: "Hi"}}, 0); err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+
+	u := c.LastUsage()
+	if u == nil || u.InputTokensTotal != 4321 || u.TotalTokens != 4398 {
+		t.Fatalf("usage not normalized: %+v", u)
+	}
+}

--- a/llm/openai/tool_use.go
+++ b/llm/openai/tool_use.go
@@ -272,27 +272,14 @@ func parseToolResponse(body string, logger *zap.Logger) (*models.LLMResponse, er
 		}
 	}
 
-	// Extract usage. OpenAI reports the auto-caching hit through
-	// prompt_tokens_details.cached_tokens — surface it via
-	// UsageInfo.CacheReadInputTokens so the cost tracker and any
-	// user-facing metrics reflect the savings consistently with
-	// Anthropic's explicit cache_read_input_tokens.
-	if usage, ok := result["usage"].(map[string]interface{}); ok {
-		response.Usage = &models.UsageInfo{IsReal: true}
-		if pt, ok := usage["prompt_tokens"].(float64); ok {
-			response.Usage.PromptTokens = int(pt)
-		}
-		if ct, ok := usage["completion_tokens"].(float64); ok {
-			response.Usage.CompletionTokens = int(ct)
-		}
-		if tt, ok := usage["total_tokens"].(float64); ok {
-			response.Usage.TotalTokens = int(tt)
-		}
-		if details, ok := usage["prompt_tokens_details"].(map[string]interface{}); ok {
-			if cached, ok := details["cached_tokens"].(float64); ok {
-				response.Usage.CacheReadInputTokens = int(cached)
-			}
-		}
+	// Extract usage through the shared OpenAI parser: it surfaces the
+	// auto-caching hit (prompt_tokens_details.cached_tokens) as
+	// CacheReadInputTokens, the reasoning tokens the hand-rolled block
+	// dropped, and the schema-normalized input every display and budget
+	// site reads. Cached tokens are a SUBSET of prompt_tokens here, which
+	// is what the parser records.
+	if usage := client.ParseOpenAIUsage(result); usage != nil {
+		response.Usage = usage
 	}
 
 	return response, nil

--- a/llm/openai/usage_normalization_test.go
+++ b/llm/openai/usage_normalization_test.go
@@ -1,0 +1,59 @@
+/*
+ * ChatCLI - OpenAI usage schema contract
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package openai
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+func TestOpenAIUsageIsSubset(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":22858,"completion_tokens":28,"total_tokens":22886,
+			"prompt_tokens_details":{"cached_tokens":10515},
+			"completion_tokens_details":{"reasoning_tokens":12}}}`))
+	}))
+	defer server.Close()
+	t.Setenv("OPENAI_API_URL", server.URL)
+
+	c := NewOpenAIClient(testProvider("test-api-key"), "gpt-6-astra", zap.NewNop(), 1, 0)
+	if _, err := c.SendPrompt(context.Background(), "Hi",
+		[]models.Message{{Role: "user", Content: "Hi"}}, 0); err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+	u := c.LastUsage()
+	if u == nil || u.InputTokensTotal != 22858 || u.TotalTokens != 22886 {
+		t.Fatalf("usage not normalized: %+v", u)
+	}
+}
+
+// TestOpenAIToolPathUsageIsSubset covers the tool-calling path, which used to
+// hand-roll its own usage block (dropping reasoning tokens) instead of going
+// through the shared parser.
+func TestOpenAIToolPathUsageIsSubset(t *testing.T) {
+	resp, err := parseToolResponse(`{"choices":[{"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],
+		"usage":{"prompt_tokens":900,"completion_tokens":40,"total_tokens":940,
+		"prompt_tokens_details":{"cached_tokens":800},
+		"completion_tokens_details":{"reasoning_tokens":16}}}`, zap.NewNop())
+	if err != nil {
+		t.Fatalf("parseToolResponse: %v", err)
+	}
+	if resp.Usage == nil || resp.Usage.InputTokensTotal != 900 {
+		t.Fatalf("usage not normalized: %+v", resp.Usage)
+	}
+	if resp.Usage.ReasoningTokens != 16 {
+		t.Fatalf("reasoning tokens dropped: %+v", resp.Usage)
+	}
+	if !resp.Usage.IsReal {
+		t.Fatalf("tool-path usage must be marked real: %+v", resp.Usage)
+	}
+}

--- a/llm/openairesponses/usage_normalization_test.go
+++ b/llm/openairesponses/usage_normalization_test.go
@@ -1,0 +1,40 @@
+/*
+ * ChatCLI - OpenAI Responses usage schema contract
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package openairesponses
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+// TestResponsesUsageIsSubset: the Responses schema renames the fields
+// (input_tokens / input_tokens_details.cached_tokens) but keeps OpenAI's
+// subset semantics.
+func TestResponsesUsageIsSubset(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"output_text":"hi","usage":{"input_tokens":40000,"output_tokens":150,
+			"input_tokens_details":{"cached_tokens":38000},
+			"output_tokens_details":{"reasoning_tokens":90},"total_tokens":40150}}`)
+	}))
+	defer server.Close()
+	t.Setenv("OPENAI_RESPONSES_API_URL", server.URL)
+
+	c := NewOpenAIResponsesClient(testProvider("test-api-key"), "gpt-5.6-luna", zap.NewNop(), 1, 0)
+	if _, err := c.SendPrompt(context.Background(), "Hi",
+		[]models.Message{{Role: "user", Content: "Hi"}}, 0); err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+	u := c.LastUsage()
+	if u == nil || u.InputTokensTotal != 40000 || u.TotalTokens != 40150 {
+		t.Fatalf("usage not normalized: %+v", u)
+	}
+}

--- a/llm/openrouter/openrouter_client.go
+++ b/llm/openrouter/openrouter_client.go
@@ -509,6 +509,9 @@ func (c *OpenRouterClient) processResponse(resp *http.Response) (string, error) 
 		if result.Usage.CompletionTokensDetails != nil {
 			info.ReasoningTokens = result.Usage.CompletionTokensDetails.ReasoningTokens
 		}
+		// OpenAI-compatible envelope regardless of which vendor's model
+		// served the request: cached_tokens is a subset of prompt_tokens.
+		info.Normalize(models.CacheSubset)
 		c.usageState.StoreUsage(info)
 		c.logger.Debug("OpenRouter usage",
 			zap.Int("prompt_tokens", result.Usage.PromptTokens),

--- a/llm/openrouter/usage_normalization_test.go
+++ b/llm/openrouter/usage_normalization_test.go
@@ -1,0 +1,38 @@
+/*
+ * ChatCLI - OpenRouter usage schema contract
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package openrouter
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+)
+
+// TestOpenRouterUsageIsSubset: OpenRouter speaks the OpenAI envelope for
+// every vendor it fronts — including Anthropic models, whose cached tokens
+// arrive as a SUBSET of prompt_tokens here, not beside them.
+func TestOpenRouterUsageIsSubset(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":12000,"completion_tokens":90,"total_tokens":12090,
+			"cost":0.0031,"prompt_tokens_details":{"cached_tokens":11000}}}`))
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+	if _, err := c.SendPrompt(context.Background(), "Hi",
+		[]models.Message{{Role: "user", Content: "Hi"}}, 100); err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+
+	u := c.LastUsage()
+	if u == nil || u.InputTokensTotal != 12000 || u.TotalTokens != 12090 {
+		t.Fatalf("usage not normalized: %+v", u)
+	}
+}

--- a/llm/stackspotai/stackspot_client.go
+++ b/llm/stackspotai/stackspot_client.go
@@ -152,12 +152,16 @@ func (c *StackSpotClient) sendChatRequest(ctx context.Context, prompt, accessTok
 	// Store usage info (StackSpot custom format)
 	promptTokens := response.Tokens.User + response.Tokens.Enrichment
 	if promptTokens > 0 || response.Tokens.Output > 0 {
-		c.usageState.StoreUsage(&models.UsageInfo{
+		usage := &models.UsageInfo{
 			PromptTokens:     promptTokens,
 			CompletionTokens: response.Tokens.Output,
 			TotalTokens:      promptTokens + response.Tokens.Output,
 			IsReal:           true,
-		})
+		}
+		// StackSpot reports user+enrichment as the whole input; no cache
+		// split exists on this API.
+		usage.Normalize(models.CacheSubset)
+		c.usageState.StoreUsage(usage)
 	}
 	if response.StopReason != "" {
 		c.usageState.StoreStopReason(response.StopReason)

--- a/llm/stackspotai/usage_normalization_test.go
+++ b/llm/stackspotai/usage_normalization_test.go
@@ -1,0 +1,43 @@
+/*
+ * ChatCLI - StackSpot usage schema contract
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package stackspotai
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/diillson/chatcli/llm/token"
+	"github.com/diillson/chatcli/models"
+	"github.com/stretchr/testify/mock"
+	"go.uber.org/zap"
+)
+
+// TestStackSpotUsageIsWholeInput: user+enrichment is the whole input; this
+// API has no cache split to double-count.
+func TestStackSpotUsageIsWholeInput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, `{"message":"hi","tokens":{"user":300,"enrichment":1200,"output":45}}`)
+	}))
+	defer server.Close()
+
+	tm := new(token.MockTokenManager)
+	tm.On("GetAccessToken", mock.Anything).Return("fake-token", nil)
+	c := NewStackSpotClient(tm, "agent-id", zap.NewNop(), 1, 0)
+	c.baseURL = server.URL + "/v1"
+
+	if _, err := c.SendPrompt(context.Background(), "Hi",
+		[]models.Message{{Role: "user", Content: "Hi"}}, 0); err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+
+	u := c.LastUsage()
+	if u == nil || u.InputTokensTotal != 1500 || u.TotalTokens != 1545 {
+		t.Fatalf("usage not normalized: %+v", u)
+	}
+}

--- a/llm/xai/usage_normalization_test.go
+++ b/llm/xai/usage_normalization_test.go
@@ -1,0 +1,38 @@
+/*
+ * ChatCLI - xAI usage schema contract
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package xai
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+	"go.uber.org/zap"
+)
+
+// TestXAIUsageIsSubset: Grok speaks the OpenAI envelope — cached_tokens is
+// inside prompt_tokens, and the long-context tier must be judged on that
+// figure alone, never on prompt+cached.
+func TestXAIUsageIsSubset(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":150000,"completion_tokens":40,"total_tokens":150040,
+			"prompt_tokens_details":{"cached_tokens":120000}}}`))
+	}))
+	defer server.Close()
+
+	c := NewXAIClient(testProvider("test-xai-key"), "grok-4.6", zap.NewNop(), 1, 0)
+	c.apiURL = server.URL
+	if _, err := c.SendPrompt(context.Background(), "Hi",
+		[]models.Message{{Role: "user", Content: "Hi"}}, 0); err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+	if u := c.LastUsage(); u == nil || u.InputTokensTotal != 150000 {
+		t.Fatalf("usage not normalized: %+v", u)
+	}
+}

--- a/llm/zai/usage_normalization_test.go
+++ b/llm/zai/usage_normalization_test.go
@@ -1,0 +1,33 @@
+/*
+ * ChatCLI - Z.AI usage schema contract
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package zai
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/diillson/chatcli/models"
+)
+
+func TestZAIUsageIsSubset(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":8000,"completion_tokens":60,"total_tokens":8060,
+			"prompt_tokens_details":{"cached_tokens":7000}}}`))
+	}))
+	defer server.Close()
+
+	c := newTestClient(server.URL)
+	if _, err := c.SendPrompt(context.Background(), "Hi",
+		[]models.Message{{Role: "user", Content: "Hi"}}, 0); err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+	if u := c.LastUsage(); u == nil || u.InputTokensTotal != 8000 {
+		t.Fatalf("usage not normalized: %+v", u)
+	}
+}

--- a/models/models.go
+++ b/models/models.go
@@ -296,7 +296,9 @@ func (u *UsageInfo) Merge(other *UsageInfo) {
 	if other == nil {
 		return
 	}
-	u.InputTokensTotal += other.InputTotal()
+	// InputTotal on both sides: a legacy operand carries no normalized
+	// field, and += would silently drop its own input.
+	u.InputTokensTotal = u.InputTotal() + other.InputTotal()
 	u.PromptTokens += other.PromptTokens
 	u.CompletionTokens += other.CompletionTokens
 	u.TotalTokens += other.TotalTokens

--- a/models/models.go
+++ b/models/models.go
@@ -264,6 +264,22 @@ type UsageInfo struct {
 	// output, so the cost tracker adds them for Gemini.
 	ReasoningTokens int `json:"reasoning_tokens,omitempty"`
 
+	// InputTokensTotal is the SCHEMA-NORMALIZED input of this call: every
+	// token the model held, cache included, regardless of how the provider
+	// splits the counts. Providers disagree about what PromptTokens means —
+	// the Anthropic Messages schema (direct, Bedrock, MiniMax's Anthropic
+	// surface) excludes cache reads and writes from input_tokens, while the
+	// OpenAI schema (and Gemini, Ollama, StackSpot, OpenRouter) reports the
+	// cached share INSIDE prompt_tokens. Rendering PromptTokens as "the
+	// input" therefore showed 3 tokens on Bedrock and 22.858 on Devin for
+	// the same ~22K prefix.
+	//
+	// Every provider adapter fills this via Normalize, where the schema is
+	// a fact rather than a guess about the model name. Zero means "not
+	// normalized" (a usage record persisted before this field existed);
+	// readers fall back to the provider/model heuristic.
+	InputTokensTotal int `json:"input_tokens_total,omitempty"`
+
 	// CostUSD is the actual billed cost reported by the provider for this
 	// call, when the API surfaces one (OpenRouter's usage.cost). Zero means
 	// "not reported" — cost is then derived from the local pricing tables.
@@ -280,6 +296,7 @@ func (u *UsageInfo) Merge(other *UsageInfo) {
 	if other == nil {
 		return
 	}
+	u.InputTokensTotal += other.InputTotal()
 	u.PromptTokens += other.PromptTokens
 	u.CompletionTokens += other.CompletionTokens
 	u.TotalTokens += other.TotalTokens
@@ -302,6 +319,71 @@ func EstimateFromChars(inputChars, outputChars int) *UsageInfo {
 		PromptTokens:     prompt,
 		CompletionTokens: completion,
 		TotalTokens:      prompt + completion,
+		InputTokensTotal: prompt,
 		IsReal:           false,
 	}
+}
+
+// CacheAccounting says how a provider's usage payload counts prompt-cache
+// tokens relative to its prompt count. It belongs to the REPORTING SCHEMA,
+// not to the model: the same Claude model reports additive counts on the
+// Anthropic Messages API and subset counts through an OpenAI-compatible
+// gateway, so only the adapter that read the payload can classify it.
+type CacheAccounting int
+
+const (
+	// CacheSubset: the cached share is already counted INSIDE PromptTokens.
+	// OpenAI (prompt_tokens_details.cached_tokens), Gemini
+	// (cachedContentTokenCount), OpenRouter, and every provider that
+	// reports no cache at all (Ollama, StackSpot) — for those the prompt
+	// count already IS the whole input.
+	CacheSubset CacheAccounting = iota
+
+	// CacheAdditive: cache reads and writes are counted ALONGSIDE
+	// PromptTokens, which then holds only the uncached delta. The Anthropic
+	// Messages schema and Bedrock's Converse TokenUsage both document
+	// "total input = input_tokens + cache_read + cache_write".
+	CacheAdditive
+)
+
+// Normalize fills InputTokensTotal from the counts the provider reported,
+// given how that provider's schema accounts for cache tokens. Call it in
+// the adapter, right where the payload was parsed — that is the only place
+// the schema is known as a fact instead of guessed from a model name.
+//
+// TotalTokens is raised to match when the normalized input makes it bigger,
+// and never lowered: providers that fold extra counts into their own total
+// (Gemini adds thoughtsTokenCount) keep it.
+func (u *UsageInfo) Normalize(acct CacheAccounting) {
+	if u == nil {
+		return
+	}
+	total := u.PromptTokens
+	cached := u.CacheReadInputTokens + u.CacheCreationInputTokens
+	if acct == CacheAdditive {
+		total += cached
+	} else if cached > total {
+		// A subset schema cannot report more cached tokens than the prompt
+		// count they are a subset of. Believe the larger number rather than
+		// render an input smaller than its own cache.
+		total = cached
+	}
+	u.InputTokensTotal = total
+	if t := total + u.CompletionTokens; t > u.TotalTokens {
+		u.TotalTokens = t
+	}
+}
+
+// InputTotal is the whole input of this call — what belongs on screen as
+// "tokens in" and what the context-window math must measure. Falls back to
+// PromptTokens for usage that predates normalization (a session record
+// written by an older build), which is exactly the old behavior.
+func (u *UsageInfo) InputTotal() int {
+	if u == nil {
+		return 0
+	}
+	if u.InputTokensTotal > 0 {
+		return u.InputTokensTotal
+	}
+	return u.PromptTokens
 }

--- a/models/usage_normalization_test.go
+++ b/models/usage_normalization_test.go
@@ -97,3 +97,15 @@ func TestEstimateFromCharsCarriesInputTotal(t *testing.T) {
 		t.Fatalf("InputTotal = %d, want 1000", u.InputTotal())
 	}
 }
+
+// TestMergeLegacyLeftOperandKeepsItsInput: a += on the normalized field
+// would drop the left side's own input when only the right side carries one.
+func TestMergeLegacyLeftOperandKeepsItsInput(t *testing.T) {
+	a := &UsageInfo{PromptTokens: 50, CompletionTokens: 1} // legacy
+	b := &UsageInfo{PromptTokens: 100, CompletionTokens: 2}
+	b.Normalize(CacheSubset)
+	a.Merge(b)
+	if got := a.InputTotal(); got != 150 {
+		t.Fatalf("merged InputTotal = %d, want 150", got)
+	}
+}

--- a/models/usage_normalization_test.go
+++ b/models/usage_normalization_test.go
@@ -1,0 +1,99 @@
+/*
+ * ChatCLI - Usage schema normalization tests
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+package models
+
+import "testing"
+
+// TestNormalizeAdditive: the Anthropic/Bedrock schema reports cache reads and
+// writes BESIDE the prompt count, so the normalized input is the sum. This is
+// the case that rendered a 22K-token turn as "3 tokens in".
+func TestNormalizeAdditive(t *testing.T) {
+	u := &UsageInfo{PromptTokens: 3, CompletionTokens: 53,
+		CacheCreationInputTokens: 19130, CacheReadInputTokens: 0, TotalTokens: 56}
+	u.Normalize(CacheAdditive)
+
+	if got := u.InputTotal(); got != 19133 {
+		t.Fatalf("InputTotal = %d, want 19133", got)
+	}
+	if u.TotalTokens != 19186 {
+		t.Fatalf("TotalTokens = %d, want 19186", u.TotalTokens)
+	}
+	if u.PromptTokens != 3 {
+		t.Fatalf("PromptTokens must stay as the provider reported it (cost math): %d", u.PromptTokens)
+	}
+}
+
+// TestNormalizeSubset: OpenAI-family cached tokens are already inside the
+// prompt count — adding them would double-count.
+func TestNormalizeSubset(t *testing.T) {
+	u := &UsageInfo{PromptTokens: 22858, CompletionTokens: 28,
+		CacheReadInputTokens: 10515, TotalTokens: 22886}
+	u.Normalize(CacheSubset)
+
+	if got := u.InputTotal(); got != 22858 {
+		t.Fatalf("InputTotal = %d, want 22858", got)
+	}
+	if u.TotalTokens != 22886 {
+		t.Fatalf("TotalTokens = %d, want 22886", u.TotalTokens)
+	}
+}
+
+// TestNormalizeSubsetNeverSmallerThanItsCache guards the defensive branch: a
+// subset schema cannot hold more cached tokens than the prompt count they are
+// a subset of, so the bigger number wins instead of an impossible input.
+func TestNormalizeSubsetNeverSmallerThanItsCache(t *testing.T) {
+	u := &UsageInfo{PromptTokens: 100, CompletionTokens: 10, CacheReadInputTokens: 900}
+	u.Normalize(CacheSubset)
+	if got := u.InputTotal(); got != 900 {
+		t.Fatalf("InputTotal = %d, want 900", got)
+	}
+}
+
+// TestNormalizeKeepsProviderTotal: Gemini folds thoughtsTokenCount into its own
+// totalTokenCount. Normalization may raise a total, never shrink one.
+func TestNormalizeKeepsProviderTotal(t *testing.T) {
+	u := &UsageInfo{PromptTokens: 1000, CompletionTokens: 200, ReasoningTokens: 500, TotalTokens: 1700}
+	u.Normalize(CacheSubset)
+	if u.TotalTokens != 1700 {
+		t.Fatalf("TotalTokens = %d, want the provider's 1700", u.TotalTokens)
+	}
+}
+
+// TestInputTotalFallsBackToPromptTokens: usage restored from a session written
+// before the field existed must read exactly as it did then.
+func TestInputTotalFallsBackToPromptTokens(t *testing.T) {
+	u := &UsageInfo{PromptTokens: 500, CompletionTokens: 10}
+	if got := u.InputTotal(); got != 500 {
+		t.Fatalf("InputTotal = %d, want 500", got)
+	}
+	var nilUsage *UsageInfo
+	if got := nilUsage.InputTotal(); got != 0 {
+		t.Fatalf("nil InputTotal = %d, want 0", got)
+	}
+}
+
+// TestMergeAccumulatesNormalizedInput keeps a merged pair honest even when one
+// side predates normalization.
+func TestMergeAccumulatesNormalizedInput(t *testing.T) {
+	a := &UsageInfo{PromptTokens: 10, CompletionTokens: 1, CacheReadInputTokens: 90}
+	a.Normalize(CacheAdditive)
+	b := &UsageInfo{PromptTokens: 7, CompletionTokens: 2} // legacy: not normalized
+	a.Merge(b)
+
+	if got := a.InputTotal(); got != 107 {
+		t.Fatalf("merged InputTotal = %d, want 107", got)
+	}
+}
+
+// TestEstimateFromCharsCarriesInputTotal: an estimate has no cache split, so
+// the normalized input is the estimate itself — never zero, which would make
+// the envelope drop the telemetry.
+func TestEstimateFromCharsCarriesInputTotal(t *testing.T) {
+	u := EstimateFromChars(4000, 400)
+	if u.InputTotal() != 1000 {
+		t.Fatalf("InputTotal = %d, want 1000", u.InputTotal())
+	}
+}


### PR DESCRIPTION
## Problem

The same conversation reported wildly different token usage depending on the provider:

```
Bedrock (Claude Sonnet 4.6)    3↑  53↓   ctx 11%  cache 0%
Devin   (GPT-6 Astra)     22.858↑  28↓   ctx  2%  cache 46%
```

Both were holding the same ~22K prefix. Neither number was wrong — they measured
different things, and the UI treated them as the same thing.

Providers disagree about what the prompt count means:

| Schema | Providers | `prompt_tokens` means |
|---|---|---|
| **Additive** | Anthropic direct, Bedrock (Converse + InvokeModel + Mantle), MiniMax's Anthropic surface | the **uncached delta** — cache reads/writes are counted beside it |
| **Subset** | OpenAI, Responses, Assistants, Copilot, xAI, Z.AI, Moonshot, MiniMax (Chat Completions), Gemini, OpenRouter, Ollama, StackSpot, Devin (per backend) | the **whole input** — the cached share is already inside it |

Evidence from a real session record:

```json
"claudeai:claude-sonnet-4-6": { "prompt_tokens": 2,      "cache_creation_tokens": 19130,
                                "total_tokens": 1267,    "cache_cost_usd": 0.0717 }
"openai:gpt-6-astra":         { "prompt_tokens": 151384, "cache_creation_tokens": 0 }
```

A turn that put **19.132 tokens** on the wire displayed **2 tokens in** and recorded a
total of **1.267** — while the most expensive part of it, a 19K cache write billed at
1.25x, was rendered as `cache 0%`.

## What changed

**Normalization at the source.** Every adapter classifies its own payload where the
schema is a fact, not a guess about the model name, and fills `UsageInfo.InputTokensTotal`
via `Normalize(CacheAdditive | CacheSubset)`. The raw provider split survives untouched —
the cost math is built on it. `PromptTokens` still means exactly what the provider said.

Covered: claudeai (buffered + streaming + tool path), openai (chat + stream + tool path),
openairesponses, openaiassistant, copilot, xai, zai, moonshot, minimax (**both** surfaces),
googleai, openrouter, ollama, stackspotai, devincli, bedrock (**all three** request families).

**Consumers read the normalized figure**: the chat envelope header, the agent/coder turn
line, the cost records and session totals, and the audit trail. `contextTokens` prefers the
adapter's classification and keeps the provider/model heuristic as the fallback for usage
restored from sessions written by older builds.

**Devin** classifies per step: the CLI fronts several backends and copies each one's
counters into the same ATIF fields, so an Anthropic-backed step is additive while an
OpenAI-backed one is subset — and the ATIF standard block is OpenAI-shaped by definition.
One trajectory can mix both.

**Cache telemetry** now reads the accounting from the payload too. MiniMax serves the same
model over an OpenAI-shaped and an Anthropic-shaped endpoint; the model name cannot tell
them apart, and the Anthropic surface was being measured with a subset denominator — wrong
hit ratio, wrong miss detection, wrong rebuild counting.

### Fixes that ride along

- **Long-context pricing tier no longer double-counts cached tokens.** `tieredCallCostUSD`
  summed prompt + cache reads + cache writes unconditionally, so a Gemini 2.5 Pro request
  with 150K prompt of which 120K cached scored 270K and took the 2x multiplier for a
  threshold it never crossed. This one changes money.
- **Telemetry sizes against the pair that served the turn.** Cost was already attributed to
  the served provider/model; the window and cache semantics beside it still used the
  session's pair, so a skill hint or route override made one turn be described by two models.
- **Chars-per-token ratios are seeded across providers of the same model.** Tokenization
  belongs to the model, not to who serves it: a ratio measured on `claudeai:claude-sonnet-4-6`
  now seeds `bedrock:global.anthropic.claude-sonnet-4-6-...`. Previously every provider
  started at the blind 4.0 default even when a sibling had 47 samples — which is how one
  conversation showed a different `ctx%` on each provider.
- **`/context status` shows what the provider counted** next to the local projection, so the
  estimate can be seen drifting instead of discovered when compaction fires early.

## Tests

Per-provider contract tests, not just the shared parsers — one per package, driven through
each client's real response path (httptest where the client owns the HTTP call, the typed
Converse output for Bedrock, the ATIF document for Devin):

`llm/client` (the 3 shared parsers) · `llm/bedrock` (3 surfaces) · `llm/claudeai` (stream) ·
`llm/openai` (client + tool path) · `llm/openairesponses` · `llm/copilot` · `llm/xai` ·
`llm/zai` · `llm/moonshot` · `llm/minimax` (both surfaces) · `llm/googleai` ·
`llm/openrouter` · `llm/ollama` · `llm/stackspotai` · `llm/devincli` · `models` · `cli`

The headline regression is pinned directly: two providers holding the same prefix must
record the same input, and the recorded **cost must not change** by normalization.

## Compatibility

- Nothing is removed and no signature narrows; `InputTokensTotal` is additive and omitempty.
- Sessions and cost records written by older builds have no normalized field: every reader
  falls back to the previous behavior, and `recordInputTokens` keeps their totals readable.
- `TotalTokens` may now be **larger** on additive schemas — that is the fix, not a break: it
  was excluding the cache. It is never lowered, so a provider that folds extra counts into
  its own total (Gemini's thinking tokens) keeps it.

## Not in this PR

The measurement of what actually fills the prefix is done and points at skill injection
(72% of a 12K-char turn-context block was three full skill bodies) and the MCP tool catalog
in chat mode, which is tool-less by design. Those are model-facing behavior changes and get
their own PR.
