### PR TITLE
feat(agent): split the workspace block by lifetime and de-duplicate skills across runs

### DIFF
--- a/cli/agent_mode.go
+++ b/cli/agent_mode.go
@@ -1115,11 +1115,13 @@ func (a *AgentMode) Run(ctx context.Context, query string, additionalContext str
 
 	// Block 3 — workspace / retrieval context. Built only when we actually
 	// have a context builder; empty string means "skip this block".
+	// The workspace context comes back split by lifetime: the half that does
+	// not depend on the query (bootstrap files, memory index, graph card)
+	// earns a cache breakpoint, the query-driven half trails uncached.
 	// dynamicText (wall-clock time + cwd disambiguation) is captured
-	// SEPARATELY from workspaceText: the timestamp changes every turn, so
-	// bundling it into the cacheable workspace block would bust the prefix
-	// cache. It is emitted as its own uncached trailing block instead.
-	workspaceText, dynamicText := a.buildWorkspaceBlocks(ctx, query)
+	// SEPARATELY from both: the timestamp changes every turn, so bundling it
+	// into a cacheable block would bust the prefix cache.
+	workspaceStable, workspaceTurn, dynamicText := a.buildWorkspaceBlocks(ctx, query)
 
 	// Block 2 — tool descriptions (plugins) + session workspace hint.
 	// Merged into one cacheable block since they're always emitted as a pair.
@@ -1265,7 +1267,8 @@ func (a *AgentMode) Run(ctx context.Context, query string, additionalContext str
 	// before the query (turn_context.go), so the system prompt stays
 	// byte-stable and the prefix cache keeps hitting across runs.
 	turnContextText := composeTurnContext(channelsText, dynamicText)
-	sysMsg := buildAgentSystemMessage(coreText, toolsText, workspaceText, skillsText, orchestratorText, "", "")
+	sysMsg := buildAgentSystemMessage(coreText, toolsText, workspaceStable, workspaceTurn,
+		skillsText, orchestratorText, "", "")
 	breakdownMode := "agent"
 	if isCoder {
 		breakdownMode = "coder"
@@ -1274,7 +1277,8 @@ func (a *AgentMode) Run(ctx context.Context, query string, additionalContext str
 		{Name: "core", Chars: len(strings.TrimSpace(coreText)), Cached: true},
 		{Name: "tools", Chars: len(strings.TrimSpace(toolsText)), Cached: true},
 		{Name: "orchestrator", Chars: len(strings.TrimSpace(orchestratorText)), Cached: true},
-		{Name: "workspace_memory", Chars: len(strings.TrimSpace(workspaceText))},
+		{Name: "workspace_stable", Chars: len(strings.TrimSpace(workspaceStable)), Cached: true},
+		{Name: "workspace_memory", Chars: len(strings.TrimSpace(workspaceTurn))},
 		{Name: "skills", Chars: len(strings.TrimSpace(skillsText))},
 		{Name: "turn_context", Chars: len(strings.TrimSpace(turnContextText))},
 	})
@@ -1511,9 +1515,9 @@ func (a *AgentMode) composeCoreText(isCoder, hasActivePersona bool) string {
 // buildWorkspaceBlocks builds Block 3 of the agent system prompt: the
 // workspace/retrieval context plus the separately-cached dynamic (wall-clock)
 // context. Returns empty strings when no context builder is configured.
-func (a *AgentMode) buildWorkspaceBlocks(ctx context.Context, query string) (string, string) {
+func (a *AgentMode) buildWorkspaceBlocks(ctx context.Context, query string) (stable, turn, dynamic string) {
 	if a.cli.contextBuilder == nil {
-		return "", ""
+		return "", "", ""
 	}
 	var hints []string
 	hintWindow := 3
@@ -1546,20 +1550,14 @@ func (a *AgentMode) buildWorkspaceBlocks(ctx context.Context, query string) (str
 	if mode == memModeIndex {
 		recallHint = memoryRecallHint
 	}
-	workspaceText := a.cli.contextBuilder.BuildWorkspaceContextMode(ctx, query, hints, aug, mode, recallHint)
-
-	// Append the knowledge-graph map-of-content card next to the memory index.
-	// It is tiny and deterministic (so prompt-cache friendly), and agent/coder
-	// can pull a subject's neighborhood on demand via @graph.
-	if mode != memModeOff {
-		if gb := a.cli.graphIndexBlock(); gb != "" {
-			if strings.TrimSpace(workspaceText) == "" {
-				workspaceText = gb
-			} else {
-				workspaceText = strings.TrimRight(workspaceText, "\n") + "\n\n" + gb
-			}
-		}
-	}
+	// Split by lifetime, same as chat: the bootstrap files, the memory index
+	// and the graph card do not depend on the query, so they earn a cache
+	// breakpoint and are read warm for the rest of the run instead of being
+	// re-sent at full price on every turn of it. The knowledge-graph card
+	// rides with them — tiny, deterministic, and pull-oriented (@graph
+	// expands any subject on demand).
+	workspaceStable := a.cli.workspaceStableText(ctx, mode, recallHint)
+	_, workspaceTurn := a.cli.contextBuilder.SplitWorkspaceContextMode(ctx, query, hints, aug, mode, recallHint)
 
 	dynamicText := a.cli.contextBuilder.BuildDynamicContext()
 	// Proactive recall (index mode only): the top hint-matching facts ride in
@@ -1593,7 +1591,7 @@ func (a *AgentMode) buildWorkspaceBlocks(ctx context.Context, query string) (str
 			dynamicText = sr + "\n\n" + dynamicText
 		}
 	}
-	return workspaceText, dynamicText
+	return workspaceStable, workspaceTurn, dynamicText
 }
 
 // applyManualSkillAndCommandHints consumes the pending manual-skill
@@ -4753,7 +4751,7 @@ func (a *AgentMode) buildAgentSkillBlocks(query, additionalContext string) strin
 	autoActivated := mgr.FindAutoActivatedSkills(query, filePaths)
 	autoActivated = dedupAutoAgainstPinned(autoActivated, pinned)
 
-	skillsText := concatSkillBlocks(pinned, autoActivated)
+	skillsText := a.concatSkillBlocksCurated(pinned, autoActivated)
 
 	merged := append([]*persona.Skill(nil), pinned...)
 	merged = append(merged, autoActivated...)
@@ -4795,6 +4793,40 @@ func concatSkillBlocks(pinned, autoActivated []*persona.Skill) string {
 				out += "\n\n"
 			}
 			out += block
+		}
+	}
+	return out
+}
+
+// concatSkillBlocksCurated is concatSkillBlocks with cross-run
+// de-duplication.
+//
+// The mid-loop re-scan already guarantees a skill fires at most once per Run
+// (rescanNewSkills' dedup set) and ages its blocks afterwards. What it cannot
+// see is the run BEFORE it: a session with several /coder runs rebuilt this
+// block from scratch each time and re-shipped bodies the conversation was
+// already carrying. The check is the same one chat uses — the live history,
+// so compaction, /clear, /rewind and a session load all restore the full
+// body — and here the deferred form points at the skill's source path, which
+// agent and coder can simply read.
+func (a *AgentMode) concatSkillBlocksCurated(pinned, autoActivated []*persona.Skill) string {
+	cur := a.cli.agentSkillCuration()
+	var out string
+	if len(pinned) > 0 {
+		block, inlined := buildPinnedSkillInjectionBlockCurated(pinned, cur)
+		if block != "" {
+			out = block
+			a.cli.rememberInjectedSkillBodies(inlined)
+		}
+	}
+	if len(autoActivated) > 0 {
+		block, inlined := buildSkillInjectionBlockCurated(autoActivated, cur)
+		if block != "" {
+			if out != "" {
+				out += "\n\n"
+			}
+			out += block
+			a.cli.rememberInjectedSkillBodies(inlined)
 		}
 	}
 	return out

--- a/cli/agent_system_prompt.go
+++ b/cli/agent_system_prompt.go
@@ -52,14 +52,18 @@ import (
 //
 // Cache budget: Anthropic allows up to 4 cache_control breakpoints; the three
 // stable blocks fit with one to spare, and any empty block simply collapses.
-func buildAgentSystemMessage(core, tools, workspace, skills, orchestrator, channels, dynamic string) models.Message {
+func buildAgentSystemMessage(core, tools, workspaceStable, workspaceTurn, skills, orchestrator, channels, dynamic string) models.Message {
+	// workspaceStable goes LAST in the cached region on purpose: appending
+	// leaves core/tools/orchestrator byte-identical, so the prefix they
+	// already earned keeps hitting instead of shifting by a block.
 	stable := []string{
 		strings.TrimSpace(core),
 		strings.TrimSpace(tools),
 		strings.TrimSpace(orchestrator),
+		strings.TrimSpace(workspaceStable),
 	}
 	volatile := []string{
-		strings.TrimSpace(workspace),
+		strings.TrimSpace(workspaceTurn),
 		strings.TrimSpace(skills),
 		strings.TrimSpace(channels),
 		strings.TrimSpace(dynamic),

--- a/cli/agent_system_prompt_test.go
+++ b/cli/agent_system_prompt_test.go
@@ -14,7 +14,8 @@ func TestBuildAgentSystemMessage_AllBlocksPresent(t *testing.T) {
 	msg := buildAgentSystemMessage(
 		"core text",
 		"tools text",
-		"workspace text",
+		"workspace stable text",
+		"workspace turn text",
 		"skills text",
 		"orchestrator text",
 		"channels text",
@@ -23,19 +24,19 @@ func TestBuildAgentSystemMessage_AllBlocksPresent(t *testing.T) {
 	if msg.Role != "system" {
 		t.Errorf("Role = %q, want system", msg.Role)
 	}
-	// 3 stable (core, tools, orchestrator) + 4 volatile
-	// (workspace, skills, channels, dynamic) = 7 parts.
-	if got := len(msg.SystemParts); got != 7 {
-		t.Fatalf("len(SystemParts) = %d, want 7", got)
+	// 4 stable (core, tools, orchestrator, workspace-stable) + 4 volatile
+	// (workspace-turn, skills, channels, dynamic) = 8 parts.
+	if got := len(msg.SystemParts); got != 8 {
+		t.Fatalf("len(SystemParts) = %d, want 8", got)
 	}
-	// The first three parts are the stable cached prefix.
-	for i := 0; i < 3; i++ {
+	// The first four parts are the stable cached prefix.
+	for i := 0; i < 4; i++ {
 		if msg.SystemParts[i].CacheControl == nil {
 			t.Errorf("stable SystemParts[%d] missing CacheControl", i)
 		}
 	}
 	// The trailing four are volatile and MUST NOT carry a cache hint.
-	for i := 3; i < 7; i++ {
+	for i := 4; i < 8; i++ {
 		if msg.SystemParts[i].CacheControl != nil {
 			t.Errorf("volatile SystemParts[%d] must be uncached, got %+v",
 				i, msg.SystemParts[i].CacheControl)
@@ -43,8 +44,8 @@ func TestBuildAgentSystemMessage_AllBlocksPresent(t *testing.T) {
 	}
 	// Flat content emits stable prefix first, then the volatile suffix.
 	wantOrder := []string{
-		"core text", "tools text", "orchestrator text", // stable
-		"workspace text", "skills text", "channels text", "dynamic text", // volatile
+		"core text", "tools text", "orchestrator text", "workspace stable text", // stable
+		"workspace turn text", "skills text", "channels text", "dynamic text", // volatile
 	}
 	prev := -1
 	for _, w := range wantOrder {
@@ -57,7 +58,7 @@ func TestBuildAgentSystemMessage_AllBlocksPresent(t *testing.T) {
 }
 
 func TestBuildAgentSystemMessage_OmitsEmptyBlocks(t *testing.T) {
-	msg := buildAgentSystemMessage("core", "", "", "", "", "", "")
+	msg := buildAgentSystemMessage("core", "", "", "", "", "", "", "")
 	if len(msg.SystemParts) != 1 {
 		t.Fatalf("want 1 part, got %d", len(msg.SystemParts))
 	}
@@ -67,7 +68,7 @@ func TestBuildAgentSystemMessage_OmitsEmptyBlocks(t *testing.T) {
 }
 
 func TestBuildAgentSystemMessage_OnlyChannelsBlock(t *testing.T) {
-	msg := buildAgentSystemMessage("", "", "", "", "", "## Channels", "")
+	msg := buildAgentSystemMessage("", "", "", "", "", "", "## Channels", "")
 	if len(msg.SystemParts) != 1 {
 		t.Fatalf("want 1 part, got %d", len(msg.SystemParts))
 	}
@@ -79,7 +80,7 @@ func TestBuildAgentSystemMessage_OnlyChannelsBlock(t *testing.T) {
 // The wall-clock timestamp block is the most volatile input and must never
 // carry a cache hint, even when it is the only block present.
 func TestBuildAgentSystemMessage_DynamicBlockUncached(t *testing.T) {
-	msg := buildAgentSystemMessage("", "", "", "", "", "", "now: 2026-06-01")
+	msg := buildAgentSystemMessage("", "", "", "", "", "", "", "now: 2026-06-01")
 	if len(msg.SystemParts) != 1 {
 		t.Fatalf("want 1 part, got %d", len(msg.SystemParts))
 	}
@@ -88,11 +89,12 @@ func TestBuildAgentSystemMessage_DynamicBlockUncached(t *testing.T) {
 	}
 }
 
-// Workspace (memory) is volatile under the new layout: it carries no cache
-// hint and trails the stable prefix.
+// The QUERY-DRIVEN half of the workspace stays volatile: it carries no cache
+// hint and trails the stable prefix. (Its turn-independent half is cached —
+// see TestBuildAgentSystemMessage_StableWorkspaceIsCached.)
 func TestBuildAgentSystemMessage_WorkspaceIsVolatile(t *testing.T) {
-	msg := buildAgentSystemMessage("core", "tools", "workspace mem", "", "orch", "", "")
-	// stable: core, tools, orch (3) + volatile: workspace (1) = 4
+	msg := buildAgentSystemMessage("core", "tools", "", "workspace mem", "", "orch", "", "")
+	// stable: core, tools, orch (3) + volatile: workspace-turn (1) = 4
 	if len(msg.SystemParts) != 4 {
 		t.Fatalf("want 4 parts, got %d", len(msg.SystemParts))
 	}
@@ -113,5 +115,41 @@ func TestBuildAgentSystemMessage_WorkspaceIsVolatile(t *testing.T) {
 	}
 	if wsIdx < 3 {
 		t.Errorf("workspace block must trail the stable prefix; got index %d", wsIdx)
+	}
+}
+
+// TestBuildAgentSystemMessage_StableWorkspaceIsCached: the half that does not
+// depend on the query earns a breakpoint, and lands AFTER the blocks that
+// already had one so their prefix stays byte-identical.
+func TestBuildAgentSystemMessage_StableWorkspaceIsCached(t *testing.T) {
+	msg := buildAgentSystemMessage("core", "tools", "bootstrap + index", "matched rules", "", "orch", "", "")
+
+	var stableIdx, turnIdx = -1, -1
+	for i, p := range msg.SystemParts {
+		switch {
+		case strings.Contains(p.Text, "bootstrap + index"):
+			stableIdx = i
+		case strings.Contains(p.Text, "matched rules"):
+			turnIdx = i
+		}
+	}
+	if stableIdx == -1 || turnIdx == -1 {
+		t.Fatalf("blocks missing: stable=%d turn=%d", stableIdx, turnIdx)
+	}
+	if msg.SystemParts[stableIdx].CacheControl == nil {
+		t.Error("the turn-independent workspace half must carry a cache hint")
+	}
+	if msg.SystemParts[turnIdx].CacheControl != nil {
+		t.Error("the query-driven half must stay uncached")
+	}
+	if stableIdx > turnIdx {
+		t.Error("a cached block after a volatile one breaks the contiguous prefix")
+	}
+	// core/tools/orchestrator keep their positions, so the prefix they earned
+	// is not shifted by the new block.
+	if !strings.Contains(msg.SystemParts[0].Text, "core") ||
+		!strings.Contains(msg.SystemParts[1].Text, "tools") ||
+		!strings.Contains(msg.SystemParts[2].Text, "orch") {
+		t.Errorf("stable prefix reordered: %+v", msg.SystemParts)
 	}
 }

--- a/cli/chat_pipeline.go
+++ b/cli/chat_pipeline.go
@@ -266,22 +266,30 @@ func (cli *ChatCLI) modeAndLanguagePart() models.ContentBlock {
 // workspaceStablePart is the half of the workspace context that does not
 // change with the question: bootstrap files, the memory index, and the
 // knowledge-graph card. It carries a cache hint and is memoized for the
-// conversation — see ChatCLI.chatWorkspaceStable for why the freeze is what
+// conversation — see ChatCLI.workspaceStableMemo for why the freeze is what
 // makes caching it worthwhile.
 func (cli *ChatCLI) workspaceStablePart(ctx context.Context) (models.ContentBlock, bool) {
-	if cli.contextBuilder == nil {
-		return models.ContentBlock{}, false
-	}
-	if cli.chatWorkspaceStable != nil {
-		if *cli.chatWorkspaceStable == "" {
-			return models.ContentBlock{}, false
-		}
-		return cachedTextBlock(*cli.chatWorkspaceStable), true
-	}
 	mode := cli.chatEffectiveMemoryMode()
 	recallHint := ""
 	if mode == memModeIndex {
 		recallHint = chatMemoryRecallHint
+	}
+	stable := cli.workspaceStableText(ctx, mode, recallHint)
+	if stable == "" {
+		return models.ContentBlock{}, false
+	}
+	return cachedTextBlock(stable), true
+}
+
+// workspaceStableText is the shared turn-independent workspace text, memoized
+// for the conversation. Chat and agent/coder both place it in their cached
+// region; only the surrounding prompt differs.
+func (cli *ChatCLI) workspaceStableText(ctx context.Context, mode, recallHint string) string {
+	if cli.contextBuilder == nil {
+		return ""
+	}
+	if cli.workspaceStableMemo != nil {
+		return *cli.workspaceStableMemo
 	}
 	stable, _ := cli.contextBuilder.SplitWorkspaceContextMode(ctx, "", nil, nil, mode, recallHint)
 	// The graph card is a deterministic map of content, not a retrieval:
@@ -289,11 +297,8 @@ func (cli *ChatCLI) workspaceStablePart(ctx context.Context) (models.ContentBloc
 	if mode != memModeOff {
 		stable = joinPromptBlocks(stable, cli.graphIndexBlock())
 	}
-	cli.chatWorkspaceStable = &stable
-	if stable == "" {
-		return models.ContentBlock{}, false
-	}
-	return cachedTextBlock(stable), true
+	cli.workspaceStableMemo = &stable
+	return stable
 }
 
 // workspaceTurnPart is the remainder that genuinely varies with the turn:
@@ -623,6 +628,19 @@ func (cli *ChatCLI) skillBodyStillInHistory(skill *persona.Skill) bool {
 // Long enough not to collide across skills, short enough to survive a
 // trailing trim.
 const skillVisibilityProbeChars = 160
+
+// agentSkillCuration is the policy for the agent/coder skills block. Unlike
+// chat it always arms: the deferred form cites the skill's source path, and
+// both loops have file tools to read it with, so nothing depends on an
+// optional exception being enabled.
+func (cli *ChatCLI) agentSkillCuration() skillCuration {
+	return skillCuration{
+		Budget:       skillInjectBudget(),
+		Injected:     cli.skillBodiesInjected,
+		StillVisible: cli.skillBodyStillInHistory,
+		Recovery:     "re-read it from the source path above",
+	}
+}
 
 // rememberInjectedSkillBodies records the bodies this turn actually inlined.
 func (cli *ChatCLI) rememberInjectedSkillBodies(inlined map[string]string) {

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -341,15 +341,19 @@ type ChatCLI struct {
 	// first copy sat in the history the model still reads. Cleared with the
 	// history, since a cleared conversation no longer carries those copies.
 	skillBodiesInjected map[string]string
-	// chatWorkspaceStable memoizes the turn-independent half of the
-	// workspace context (bootstrap files + memory index) for the life of a
-	// conversation. It is cached prefix bytes now, and the memory index
-	// carries live counters that tick as the memory worker writes: without
-	// the freeze the prefix would be invalidated by its own bookkeeping on
-	// almost every turn, paying a full rewrite to report a changed number.
-	// Fresh facts still reach the model through the volatile auto-recall
-	// block, which is where per-turn memory belongs.
-	chatWorkspaceStable *string
+	// workspaceStableMemo memoizes the turn-independent half of the
+	// workspace context (bootstrap files + memory index + graph card) for
+	// the life of a conversation. It is cached prefix bytes now, and the
+	// memory index carries live counters that tick as the memory worker
+	// writes: without the freeze the prefix would be invalidated by its own
+	// bookkeeping on almost every turn, paying a full rewrite to report a
+	// changed number. Fresh facts still reach the model through the
+	// volatile auto-recall block, which is where per-turn memory belongs.
+	//
+	// Shared by chat and agent/coder on purpose: the block is the same text
+	// on both surfaces, and one memo means a session that alternates modes
+	// does not rebuild it differently on each crossing.
+	workspaceStableMemo *string
 	// chatPullSkillsAvailable memoizes whether any skill is installed, so
 	// the per-turn prompt assembly does not walk the skill directories
 	// several times to answer a question whose answer does not change.

--- a/cli/cli_session.go
+++ b/cli/cli_session.go
@@ -225,7 +225,7 @@ func (cli *ChatCLI) handleLoadSession(ctx context.Context, name string) {
 // that no longer exists, and keeping either would make the next prompt
 // point at content the model cannot see.
 func (cli *ChatCLI) resetChatPrefixMemo() {
-	cli.chatWorkspaceStable = nil
+	cli.workspaceStableMemo = nil
 	cli.skillBodiesInjected = nil
 	cli.chatPullSkillsAvailable = nil
 }

--- a/cli/memory_autorecall_agent_test.go
+++ b/cli/memory_autorecall_agent_test.go
@@ -39,12 +39,15 @@ func TestBuildWorkspaceBlocks_InjectsAutoRecallInIndexMode(t *testing.T) {
 	t.Setenv("CHATCLI_MEMORY_MODE", "index")
 	cli, a := newAgentAutoRecallCLI(t)
 
-	workspaceText, dynamicText := a.buildWorkspaceBlocks(context.Background(), "embed windows")
+	workspaceStable, workspaceTurn, dynamicText := a.buildWorkspaceBlocks(context.Background(), "embed windows")
 	if !strings.Contains(dynamicText, "[MEMORY AUTO-RECALL]") || !strings.Contains(dynamicText, "forward slashes") {
 		t.Errorf("index mode must inject auto-recall into the UNCACHED dynamic block, got: %s", dynamicText)
 	}
-	if strings.Contains(workspaceText, "[MEMORY AUTO-RECALL]") {
-		t.Errorf("auto-recall must NEVER land in the cacheable workspace block: %s", workspaceText)
+	if strings.Contains(workspaceStable, "[MEMORY AUTO-RECALL]") {
+		t.Errorf("auto-recall must NEVER land in the cacheable workspace block: %s", workspaceStable)
+	}
+	if strings.Contains(workspaceTurn, "[MEMORY AUTO-RECALL]") {
+		t.Errorf("auto-recall belongs to the dynamic block, not the workspace one: %s", workspaceTurn)
 	}
 	if !strings.Contains(dynamicText, "Current date:") {
 		t.Errorf("the date context must survive alongside auto-recall: %s", dynamicText)
@@ -56,7 +59,7 @@ func TestBuildWorkspaceBlocks_NoAutoRecallInFullMode(t *testing.T) {
 	t.Setenv("CHATCLI_MEMORY_MODE", "full")
 	_, a := newAgentAutoRecallCLI(t)
 
-	_, dynamicText := a.buildWorkspaceBlocks(context.Background(), "embed windows")
+	_, _, dynamicText := a.buildWorkspaceBlocks(context.Background(), "embed windows")
 	if strings.Contains(dynamicText, "[MEMORY AUTO-RECALL]") {
 		t.Errorf("full mode already pushes retrieval; auto-recall must not double-inject: %s", dynamicText)
 	}

--- a/cli/prefix_curation_test.go
+++ b/cli/prefix_curation_test.go
@@ -257,12 +257,12 @@ func TestStableWorkspaceBlockIsDroppedWithTheHistory(t *testing.T) {
 	if _, ok := cli.workspaceStablePart(testCtx()); !ok {
 		t.Fatal("no stable block to begin with")
 	}
-	if cli.chatWorkspaceStable == nil {
+	if cli.workspaceStableMemo == nil {
 		t.Fatal("stable block was not memoized")
 	}
 	cli.skillBodiesInjected = map[string]string{"x": "y"}
 	cli.resetChatPrefixMemo()
-	if cli.chatWorkspaceStable != nil || cli.skillBodiesInjected != nil {
+	if cli.workspaceStableMemo != nil || cli.skillBodiesInjected != nil {
 		t.Fatal("prefix memo survived the conversation it describes")
 	}
 }
@@ -296,5 +296,48 @@ func TestCachedPrefixStaysContiguous(t *testing.T) {
 	}
 	if !sawStableWorkspace {
 		t.Fatal("the stable workspace half never reached the cached prefix")
+	}
+}
+
+// TestAgentSkillCurationAlwaysArms: unlike chat, agent and coder have file
+// tools, so the deferred form is reachable without any optional exception.
+func TestAgentSkillCurationAlwaysArms(t *testing.T) {
+	t.Setenv(chatContextPullEnvVar, "false")
+	cli := &ChatCLI{}
+	cur := cli.agentSkillCuration()
+	if cur.StillVisible == nil || cur.Recovery == "" {
+		t.Fatalf("agent curation must arm regardless of the chat exception: %+v", cur)
+	}
+	if !strings.Contains(cur.Recovery, "source path") {
+		t.Errorf("agent recovery must point at the file it can read: %q", cur.Recovery)
+	}
+}
+
+// TestAgentSkillDedupIsCrossRun: the mid-loop re-scan already dedups within a
+// run; the gap this closes is the run BEFORE it, whose bodies are still in
+// the session history.
+func TestAgentSkillDedupIsCrossRun(t *testing.T) {
+	skill := curationSkill("patch-flow", curationBody)
+	cli := &ChatCLI{
+		skillBodiesInjected: map[string]string{"patch-flow": skillBodyFingerprint(skill)},
+		history: []models.Message{
+			{Role: "user", Content: "## Skill: patch-flow\n\n" + curationBody},
+		},
+	}
+	a := &AgentMode{cli: cli}
+
+	out := a.concatSkillBlocksCurated(nil, []*persona.Skill{skill})
+	if strings.Contains(out, "Step 1") {
+		t.Error("a body already in the session history was shipped again in a new run")
+	}
+	if !strings.Contains(out, "patch-flow") {
+		t.Error("the activation itself must still be announced")
+	}
+
+	// Same run, but the earlier copy is gone: the body comes back in full.
+	cli.history = nil
+	out = a.concatSkillBlocksCurated(nil, []*persona.Skill{skill})
+	if !strings.Contains(out, "Step 1") {
+		t.Fatal("body withheld with no copy left in history")
 	}
 }

--- a/cli/skill_activation.go
+++ b/cli/skill_activation.go
@@ -298,16 +298,23 @@ func buildPinnedSkillInjectionBlock(skills []*persona.Skill) string {
 // buildPinnedSkillInjectionBlockLimited is buildPinnedSkillInjectionBlock
 // under an explicit body budget.
 func buildPinnedSkillInjectionBlockLimited(skills []*persona.Skill, budget int) string {
+	block, _ := buildPinnedSkillInjectionBlockCurated(skills, skillCuration{Budget: budget})
+	return block
+}
+
+// buildPinnedSkillInjectionBlockCurated is the pinned block under a curation
+// policy, returning the bodies it inlined.
+func buildPinnedSkillInjectionBlockCurated(skills []*persona.Skill, cur skillCuration) (string, map[string]string) {
 	if len(skills) == 0 {
-		return ""
+		return "", nil
 	}
 	var b strings.Builder
 	b.WriteString("# Pinned Skills\n\n")
 	b.WriteString("The user pinned the following skills for this session via ")
 	b.WriteString("`/skill pin <name>`. They apply to every turn regardless of ")
 	b.WriteString("input triggers or file paths — treat them as standing instructions.\n\n")
-	renderSkillEntriesLimited(&b, skills, budget, false)
-	return b.String()
+	inlined := renderSkillEntriesCurated(&b, skills, cur)
+	return b.String(), inlined
 }
 
 // dedupAutoAgainstPinned filters an auto-activated skill slice to exclude any

--- a/cli/turn_context_test.go
+++ b/cli/turn_context_test.go
@@ -107,7 +107,7 @@ func TestPrefixBudget_RatioFrozenPerSession(t *testing.T) {
 }
 
 func TestAgentSystemMessage_NoVolatileBlocks(t *testing.T) {
-	msg := buildAgentSystemMessage("core", "tools", "workspace", "skills", "orch", "", "")
+	msg := buildAgentSystemMessage("core", "tools", "", "workspace", "skills", "orch", "", "")
 	for _, p := range msg.SystemParts {
 		if strings.Contains(p.Text, "Current date") {
 			t.Fatal("agent system message must not carry the date")


### PR DESCRIPTION
## Was this already solved?

Partly — which is why this PR is small. Re-reading agent/coder turned up an existing mechanism in one case and the same misplacement as chat in the other.

**Already there, and reused:** `buildAgentSystemMessage` owns a stable-prefix / volatile-suffix split, and its own comment says hint-driven text must never enter the cached region. `renderSkillBodyPointer` and `deferAll` already implement read-on-demand bodies. `rescanNewSkills` keeps a **per-run dedup set**, `skillRunBudget` bounds the bytes, `ApplySkillAging` collapses stale blocks and `releaseCollapsedSkills` re-arms a skill afterwards.

**Not there:** the workspace block sat wholly on the volatile side, and nothing looked across runs.

## 1. The workspace split — same misplacement as chat

Half of that block does not depend on the query at all: bootstrap files, the memory index, the knowledge-graph card. It was re-sent at full price on every turn of a run.

It now carries a cache breakpoint, placed **last in the cached region** so `core`, `tools` and `orchestrator` keep their exact positions and the prefix they already earned keeps hitting — appending cannot shift what precedes it. The query-driven half (path-matched rules, and in `full` mode the retrieval) trails uncached.

Agent runs have many turns, so this compounds further than the chat equivalent.

The memo behind the stable text is now shared with chat (`workspaceStableMemo`), so a session that alternates chat and coder does not rebuild the same text differently on each crossing — the same reasoning the prompt-cache TTL hold already applies to lifetimes.

## 2. Skill de-duplication — the gap was cross-run, not in-run

The existing machinery covers a single run well. What it cannot see is the run *before* it: `buildAgentSkillBlocks` rebuilds the initial block from scratch on every `Run`, re-shipping bodies the session history is still carrying.

Closed with the same live-history check chat uses, so compaction, `/clear`, `/rewind`, a checkpoint restore and a session load all restore the full body, and a fingerprint catches an edit on disk. Here the deferred form points at the skill's **source path** — which agent and coder can read — so it arms unconditionally, with no dependency on the chat `context_pull` exception.

The per-run dedup set, run budget and aging are untouched and still do their jobs; this only stops the *first* block of a run from repeating what an earlier run already sent. A shorter initial block also leaves more of the run budget for mid-loop activations.

## Not touched

The MCP catalog: agent and coder receive real tool definitions, not the prose catalog chat gets, so there is nothing to summarize there.

## Tests

- the turn-independent half is cached, the query-driven half is not, and the cached one never lands after a volatile block
- `core`/`tools`/`orchestrator` keep their positions, so the earned prefix is not shifted
- auto-recall never reaches either workspace half (existing invariant, extended to both)
- agent curation arms even with `CHATCLI_CHAT_CONTEXT_PULL=false`, and its recovery names the source path
- a body already in the session history is not re-shipped by a new run; with the copy gone it comes back in full

Docs updated on chatcli.ai in both languages (the page previously said these surfaces were out of scope).
