### PR TITLE
test: keep the suite out of the developer's home store and keychain

### DIFF
--- a/auth/keychain.go
+++ b/auth/keychain.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+	"testing"
 )
 
 // KeychainBackend specifies which keychain to use.
@@ -56,15 +57,32 @@ func NewKeychainStore() *KeychainStore {
 		}
 	}
 
-	return &KeychainStore{backend: backend, ops: osKeychain{}}
+	return &KeychainStore{backend: backend, ops: osKeychain{forced: backend == KeychainNative}}
 }
 
 // osKeychain is the real platform store: a thin adapter over the existing
 // per-platform helpers, so the interface adds a seam without rewriting the
 // code that talks to macOS, Linux or Windows.
-type osKeychain struct{ store KeychainStore }
+//
+// forced records that the operator pinned CHATCLI_KEYCHAIN_BACKEND=keychain.
+// It is the one way a test binary reaches the real credential store: by
+// default Available answers false inside tests, because a test process that
+// resolves the encryption key with no file key at hand would otherwise
+// write a fresh key over the developer's own (macSet deletes and re-adds
+// the item), and on macOS every rebuilt test binary first triggers the
+// keychain's permission prompt. Fakes wired through keychainOps are not
+// affected — they are how the native paths are exercised in tests.
+type osKeychain struct {
+	store  KeychainStore
+	forced bool
+}
 
-func (osKeychain) Available() bool { return nativeKeychainAvailable() }
+func (o osKeychain) Available() bool {
+	if testing.Testing() && !o.forced {
+		return false
+	}
+	return nativeKeychainAvailable()
+}
 
 func (o osKeychain) Get(account string) ([]byte, error) { return o.store.nativeGet(account) }
 

--- a/auth/keychain_platform_test.go
+++ b/auth/keychain_platform_test.go
@@ -106,3 +106,22 @@ func TestKeychainStore_GetFallbackPathsAreDistinct(t *testing.T) {
 		t.Error("a missing account returned no error under the keychain backend")
 	}
 }
+
+// A test binary must never reach the developer's real credential store
+// unless the backend is pinned to the keychain on purpose: the default
+// store reports no native keychain here, while the forced one answers
+// whatever the machine has.
+func TestNewKeychainStore_NeverUsesTheNativeStoreFromATestBinary(t *testing.T) {
+	t.Setenv("CHATCLI_KEYCHAIN_BACKEND", "")
+	if NewKeychainStore().IsNativeAvailable() {
+		t.Fatal("the default store reached the real keychain from a test binary")
+	}
+	t.Setenv("CHATCLI_KEYCHAIN_BACKEND", "auto")
+	if NewKeychainStore().IsNativeAvailable() {
+		t.Fatal("auto reached the real keychain from a test binary")
+	}
+	t.Setenv("CHATCLI_KEYCHAIN_BACKEND", "keychain")
+	if got, want := NewKeychainStore().IsNativeAvailable(), nativeKeychainAvailable(); got != want {
+		t.Fatalf("forced backend: IsNativeAvailable = %v, machine has native = %v", got, want)
+	}
+}

--- a/auth/main_test.go
+++ b/auth/main_test.go
@@ -1,0 +1,18 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+package auth
+
+import (
+	"testing"
+
+	"github.com/diillson/chatcli/pkg/testenv"
+)
+
+// TestMain keeps this package's tests hermetic. The credential-encryption key is read from the OS keychain unless the file backend is pinned; on macOS that read prompts once per rebuilt test binary.
+func TestMain(m *testing.M) {
+	testenv.Main(m)
+}

--- a/cli/agent/main_test.go
+++ b/cli/agent/main_test.go
@@ -15,13 +15,14 @@
 package agent
 
 import (
-	"os"
 	"testing"
 
+	"github.com/diillson/chatcli/pkg/testenv"
 	"github.com/diillson/chatcli/ui/theme"
 )
 
 func TestMain(m *testing.M) {
-	theme.SetProfile(theme.ProfileANSI)
-	os.Exit(m.Run())
+	// Checkpoint tests init git stores under the home directory; keep them
+	// out of the developer's real ~/.chatcli.
+	testenv.Main(m, func() { theme.SetProfile(theme.ProfileANSI) })
 }

--- a/cli/agent/trajectory/main_test.go
+++ b/cli/agent/trajectory/main_test.go
@@ -1,0 +1,18 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+package trajectory
+
+import (
+	"testing"
+
+	"github.com/diillson/chatcli/pkg/testenv"
+)
+
+// TestMain keeps this package's tests hermetic. Trajectory files and cost snapshots resolve ~/.chatcli on first use.
+func TestMain(m *testing.M) {
+	testenv.Main(m)
+}

--- a/cli/config_sections_test.go
+++ b/cli/config_sections_test.go
@@ -11,12 +11,20 @@ import (
 	"path/filepath"
 
 	"github.com/diillson/chatcli/i18n"
+	"github.com/diillson/chatcli/pkg/testenv"
 	"go.uber.org/zap"
 )
 
 // TestMain ensures i18n is initialized before any test runs so T() returns
 // real translations instead of the raw key strings.
 func TestMain(m *testing.M) {
+	// Hermetic home and file keychain first: constructors reached by these
+	// tests (cost tracker, checkpoints, skills, memory, the logger) resolve
+	// ~/.chatcli on first use, and the credential key otherwise comes from
+	// the OS keychain — which on macOS prompts once per rebuilt test binary.
+	_, cleanupHome := testenv.Isolate()
+	defer cleanupHome()
+
 	// Force English for stable, locale-independent test assertions.
 	_ = os.Setenv("CHATCLI_LANG", "en")
 
@@ -37,6 +45,7 @@ func TestMain(m *testing.M) {
 	if boardDirErr == nil {
 		_ = os.RemoveAll(boardDir)
 	}
+	cleanupHome()
 	os.Exit(code)
 }
 

--- a/cli/mcp/main_test.go
+++ b/cli/mcp/main_test.go
@@ -1,0 +1,20 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+package mcp
+
+import (
+	"testing"
+
+	"github.com/diillson/chatcli/pkg/testenv"
+)
+
+// TestMain keeps this package's tests hermetic. The OAuth token store
+// encrypts with the credential key, which is resolved through the OS
+// keychain unless the file backend is pinned.
+func TestMain(m *testing.M) {
+	testenv.Main(m)
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/diillson/chatcli/auth"
+	"github.com/diillson/chatcli/pkg/testenv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -35,10 +36,19 @@ func TestMain(m *testing.M) {
 		panic("failed to build chatcli binary: " + err.Error() + "\nOutput:\n" + string(output))
 	}
 
+	// Isolate only after the build: go build needs the real module and
+	// build caches under the developer's home. From here on the binary the
+	// tests spawn inherits a throwaway HOME, so its logger, cost snapshots,
+	// memory store, scheduler audit and update check never touch the real
+	// ~/.chatcli — one run of this package used to leave a dozen files there.
+	_, cleanupHome := testenv.Isolate()
+
 	// Executar os testes
 	exitCode := m.Run()
 
-	defer os.Remove(chatcliBinary)
+	// A deferred call never runs past os.Exit; remove the binary here.
+	cleanupHome()
+	_ = os.Remove(chatcliBinary)
 	os.Exit(exitCode)
 }
 

--- a/pkg/coder/engine/main_test.go
+++ b/pkg/coder/engine/main_test.go
@@ -1,0 +1,18 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/diillson/chatcli/pkg/testenv"
+)
+
+// TestMain keeps this package's tests hermetic. Checkpoints init a git store per workspace under ~/.chatcli/checkpoints — one run of this package left hundreds of them in the developer's real home.
+func TestMain(m *testing.M) {
+	testenv.Main(m)
+}

--- a/pkg/testenv/testenv.go
+++ b/pkg/testenv/testenv.go
@@ -1,0 +1,68 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+// Package testenv makes a test process hermetic. ChatCLI keeps its state
+// under the user's home (~/.chatcli: costs, checkpoints, memory, logs,
+// skills, scheduler) and its credential key in the OS keychain, and every
+// constructor that reaches those defaults does so through os.UserHomeDir
+// and CHATCLI_KEYCHAIN_BACKEND. A test that builds such an object without
+// redirecting them writes into the developer's real store — one full run
+// of the suite left 724 files under ~/.chatcli — and on macOS makes the
+// keychain ask, once per rebuilt test binary, whether it may read the key
+// the real chatcli stored.
+//
+// Isolate points the home directory at a throwaway directory and pins the
+// file keychain backend for the rest of the process. Call it from
+// TestMain, before any test runs, because several stores latch their path
+// on first use.
+package testenv
+
+import (
+	"os"
+	"runtime"
+	"testing"
+)
+
+// KeychainBackendEnv is the variable auth.NewKeychainStore reads; "file"
+// keeps every test away from the OS credential store.
+const KeychainBackendEnv = "CHATCLI_KEYCHAIN_BACKEND"
+
+// Isolate redirects the process home directory to a fresh temporary
+// directory and selects the file keychain backend. It returns the
+// directory and a cleanup that removes it. Environment changes are
+// process-wide on purpose: TestMain has no *testing.T to scope them to,
+// and the redirect must precede the first test.
+func Isolate() (home string, cleanup func()) {
+	home, err := os.MkdirTemp("", "chatcli-test-home-*")
+	if err != nil {
+		// No temp dir means no isolation is possible; the caller's tests
+		// still run, against the real home, as they did before.
+		return "", func() {}
+	}
+	_ = os.Setenv("HOME", home)
+	if runtime.GOOS == "windows" {
+		// os.UserHomeDir reads USERPROFILE there, and the per-user app
+		// data dirs some stores prefer live beside it.
+		_ = os.Setenv("USERPROFILE", home)
+		_ = os.Setenv("LOCALAPPDATA", home)
+		_ = os.Setenv("APPDATA", home)
+	}
+	_ = os.Setenv(KeychainBackendEnv, "file")
+	return home, func() { _ = os.RemoveAll(home) }
+}
+
+// Main is the TestMain body for a package whose tests reach the home
+// store or the keychain: isolate, run the package's own setup hooks (i18n
+// initialization, theme profile, ...), run the tests, clean up, exit.
+func Main(m *testing.M, setup ...func()) {
+	_, cleanup := Isolate()
+	for _, fn := range setup {
+		fn()
+	}
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
+}

--- a/pkg/testenv/testenv_test.go
+++ b/pkg/testenv/testenv_test.go
@@ -1,0 +1,42 @@
+/*
+ * ChatCLI - Command Line Interface for LLM interaction
+ * Copyright (c) 2024 Edilson Freitas
+ * License: Apache-2.0
+ */
+
+package testenv
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestIsolate_RedirectsHomeAndPinsTheFileKeychain(t *testing.T) {
+	realHome, _ := os.UserHomeDir()
+	t.Setenv("HOME", realHome) // restored by the test framework afterwards
+	t.Setenv(KeychainBackendEnv, "")
+
+	home, cleanup := Isolate()
+	if home == "" {
+		t.Fatal("no isolated home")
+	}
+	got, err := os.UserHomeDir()
+	if err != nil || got != home {
+		t.Fatalf("UserHomeDir = %q, %v; want the isolated %q", got, err, home)
+	}
+	if strings.HasPrefix(home, realHome+string(filepath.Separator)+".chatcli") {
+		t.Fatalf("isolated home %q is inside the real store", home)
+	}
+	if v := os.Getenv(KeychainBackendEnv); v != "file" {
+		t.Fatalf("%s = %q, want file", KeychainBackendEnv, v)
+	}
+	if err := os.WriteFile(filepath.Join(home, "probe"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("isolated home is not writable: %v", err)
+	}
+	cleanup()
+	if _, err := os.Stat(home); !os.IsNotExist(err) {
+		t.Fatalf("cleanup left %q behind (%v)", home, err)
+	}
+}


### PR DESCRIPTION
## Why

Running the test suite on a developer machine was not hermetic:

- **724 files landed in the real `~/.chatcli`** per full run — cost snapshots (41 in one minute in the store's history), a git checkpoint store per coder test, memory index and pending segments, scheduler audit, skills manifest, `app.log`, and the update-check cache. The writers were `cli`, `cli/agent`, `cli/agent/trajectory`, `pkg/coder/engine` (627 files alone) and `e2e`, whose real binary ran with the real HOME.
- **macOS asked for keychain access on every run.** Any test that resolves the credential-encryption key without a file key at hand went `find-generic-password` → prompt → `delete-generic-password` + `add-generic-password -U` on the developer's real `auth-key` item (`macSet` deletes and re-adds). Traced with a `security` shim in `PATH`: 17 calls per run from `cli`, `cli/mcp` and `auth`.

## What

- **`pkg/testenv`** — `Isolate()` points HOME (and the Windows profile dirs) at a throwaway directory and pins `CHATCLI_KEYCHAIN_BACKEND=file`; `Main(m, setup...)` is the one-line TestMain for a package that reaches the home store or the keychain.
- **TestMain** in `cli` (extended), `cli/agent` (extended), `cli/agent/trajectory`, `cli/mcp`, `pkg/coder/engine`, `auth`, and `e2e` — where isolation happens *after* `go build`, so the build keeps the real module/build caches and the spawned binary inherits the throwaway HOME. The e2e binary is now actually removed (the old `defer` sat behind `os.Exit`).
- **`auth`: a test binary never reaches the real keychain by default.** `osKeychain.Available` answers false under `testing.Testing()` unless the operator forced `CHATCLI_KEYCHAIN_BACKEND=keychain`. The env pin alone was not enough: reload tests clear the reloadable variables mid-package. Fakes wired through `keychainOps` are unaffected, so the native-path tests still run.

## Proof

Full suite, marker on `~/.chatcli`, `security` shimmed to log every call:

| | before | after |
|---|---|---|
| files written under the real `~/.chatcli` | 724 | 0 |
| `security` calls touching `auth-key` | 15 | 0 |
| `security` calls total | 17 | 2 (auth's explicit probes of a non-existent account — no prompt) |

Tests: `TestIsolate_RedirectsHomeAndPinsTheFileKeychain`, `TestNewKeychainStore_NeverUsesTheNativeStoreFromATestBinary`.
